### PR TITLE
Test on JDK9 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,28 @@
 language: java
 sudo: false
-jdk:
-  - oraclejdk8
+jdk: oraclejdk8
 
-# Java 9 is nt supported by Travis yet... add manual install?
-#env:
-#  matrix:
-#    - JDK_FOR_TEST=oraclejdk8
+env:
+  matrix:
+    - JDK_FOR_TEST=oraclejdk8
 #    - JDK_FOR_TEST=oraclejdk9
+
+# Java 9 is not currently officially supported, so install it manually
+matrix:
+  include:
+     env: JDK_FOR_TEST=oraclejdk9
+     addons:
+       apt:
+         packages:
+           - oracle-java9-installer
+     
 install:
   - wget http://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops/R-3.6.2-201102101200/eclipse-SDK-3.6.2-linux-gtk-x86_64.tar.gz -O eclipse-3.6.2-linux64.tar.gz
   - tar xzvf eclipse-3.6.2-linux64.tar.gz eclipse
   - echo eclipsePlugin.dir=$(pwd)/eclipse/plugins > eclipsePlugin/local.properties
+
 script:
   - ant build
-#  - jdk_switcher use $JDK_FOR_TEST
+  # Manually switch to JDK9 for tests if needed
+  - if [[ $JDK_FOR_TEST == "oraclejdk9" ]]; then remove_dir_from_path $JAVA_HOME/bin; export JAVA_HOME=/usr/lib/jvm/java-9-oracle; export JAVA_HOME=/usr/lib/jvm/java-9-oracle; fi
   - ant test

--- a/plugins/googlecode/build.xml
+++ b/plugins/googlecode/build.xml
@@ -87,7 +87,7 @@
     <target name="compile-tests" depends="compile">
         <mkdir dir="build/classes-tests-ant"/>
 
-        <javac srcdir="src/junit" destdir="build/classes-tests-ant" source="1.5" target="1.5" debug="on" includeantruntime="false">
+        <javac srcdir="src/junit" destdir="build/classes-tests-ant" source="1.8" target="1.8" debug="on" includeantruntime="false">
             <classpath>
                 <path refid="client.classpath"/>
                 <path location="${classes.dir}"/>

--- a/plugins/jira/build.xml
+++ b/plugins/jira/build.xml
@@ -86,7 +86,7 @@
     <target name="compile-tests" depends="compile">
         <mkdir dir="build/classes-tests-ant"/>
 
-        <javac srcdir="src/junit" destdir="build/classes-tests-ant" source="1.5" target="1.5" debug="on" includeantruntime="false">
+        <javac srcdir="src/junit" destdir="build/classes-tests-ant" source="1.8" target="1.8" debug="on" includeantruntime="false">
             <classpath>
                 <path refid="client.classpath"/>
                 <path location="${classes.dir}"/>

--- a/plugins/webCloudClient/build.xml
+++ b/plugins/webCloudClient/build.xml
@@ -91,7 +91,7 @@
     <target name="compile-tests" depends="compile">
         <mkdir dir="build/classes-tests-ant"/>
 
-        <javac srcdir="src/junit" destdir="build/classes-tests-ant" source="1.5" target="1.5" debug="on"
+        <javac srcdir="src/junit" destdir="build/classes-tests-ant" source="1.8" target="1.8" debug="on"
                includeantruntime="false"
                >
             <classpath>


### PR DESCRIPTION
I finally managed to get JDK9 and Ant 1.9.7 on Travis. It was harder than expected.

The build however is failing for Java 9, with.

> /home/travis/build/spotbugs/spotbugs/findbugs/build.xml:602: Test edu.umd.cs.findbugs.BugInstanceTest failed

@iloveeclipse am I missing something, or was it broken on your tests too when working on Java 9 support?