### PR TITLE
Fix issue #17

### DIFF
--- a/findbugs/src/java/edu/umd/cs/findbugs/BugInstance.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/BugInstance.java
@@ -27,6 +27,7 @@ import java.io.UnsupportedEncodingException;
 import java.math.BigInteger;
 import java.security.MessageDigest;
 import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -214,7 +215,7 @@ public class BugInstance implements Comparable<BugInstance>, XMLWriteable, Seria
     }
 
     public static DateFormat firstSeenXMLFormat() {
-        return DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT, Locale.ENGLISH);
+        return new SimpleDateFormat("M/d/yy h:mm a", Locale.ENGLISH);
     }
 
     /*


### PR DESCRIPTION
 - Since we have a hardwired Locale, and are already assuming the format,
    just use that format directly. This avoids issues with the LocaleProvider
    changes in JRE9.

Confirmed, the failing test passes with this change on all tested JRE versions.