### PR TITLE
Load findbugs.xml from core plugin JAR file.

### DIFF
--- a/findbugs/src/java/edu/umd/cs/findbugs/PluginLoader.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/PluginLoader.java
@@ -54,6 +54,7 @@ import java.util.zip.ZipFile;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.WillClose;
 
 import org.dom4j.Document;
@@ -423,6 +424,7 @@ public class PluginLoader {
         plugin = null;
     }
 
+    @Nonnull
     private static URL computeCoreUrl() {
         URL from;
         String findBugsClassFile = ClassName.toSlashedClassName(FindBugs.class) + ".class";
@@ -590,12 +592,60 @@ public class PluginLoader {
         if (u != null) {
             return u;
         }
+        u = resourceFromFindbugsJar(name);
+        if (u != null) {
+            return u;
+        }
         u = PluginLoader.class.getResource(name);
         if (u != null) {
             return u;
         }
         u = PluginLoader.class.getResource("/"+name);
         return u;
+    }
+
+    /**
+     * Try to load resource from JAR file of Findbugs core plugin.
+     * @param slashedResourceName Name of resource to load
+     * @return URL which points resource in jar file, or null if JAR file not found
+     */
+    @CheckForNull
+    private static URL resourceFromFindbugsJar(String slashedResourceName) {
+        try {
+            @Nullable
+            URL findbugsJar = getFindbugsJar();
+            if (findbugsJar == null) {
+                return null;
+            }
+            return resourceFromPlugin(findbugsJar, slashedResourceName);
+        } catch (MalformedURLException e) {
+            if (DEBUG) {
+                System.out.printf("Failed to load resourceFromFindbugsJar. "
+                        + "Resource name is %s, exception message is %s.%n",
+                        slashedResourceName, e.getMessage());
+            }
+            return null;
+        }
+    }
+
+    /**
+     * @return URL with 'jar:' which points location of findbugs.jar,
+     * or null if found no jar file which contains FindBugs.class
+     * @throws MalformedURLException
+     */
+    @CheckForNull
+    private static URL getFindbugsJar() throws MalformedURLException {
+        String findBugsClassFile = ClassName.toSlashedClassName(FindBugs.class) + ".class";
+        URL me = FindBugs.class.getClassLoader().getResource(findBugsClassFile);
+        if (me == null) {
+            return null;
+        }
+        if (!"jar".equals(me.getProtocol())) {
+            return null;
+        }
+        String u = me.toString();
+        String jarPath = u.substring(4, u.indexOf("!/"));
+        return new URL(jarPath);
     }
 
     public static @CheckForNull

--- a/findbugs/src/java/edu/umd/cs/findbugs/PluginLoader.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/PluginLoader.java
@@ -622,7 +622,7 @@ public class PluginLoader {
             try (ZipFile jarFile = new ZipFile(new File(findbugsJar.toURI()))) {
                 ZipEntry entry = jarFile.getEntry(slashedResourceName);
                 if (entry != null) {
-            return resourceFromPlugin(findbugsJar, slashedResourceName);
+                    return resourceFromPlugin(findbugsJar, slashedResourceName);
                 }
             } catch (ZipException e) {
                 if (DEBUG) {

--- a/findbugs/src/java/edu/umd/cs/findbugs/PluginLoader.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/PluginLoader.java
@@ -644,7 +644,7 @@ public class PluginLoader {
     }
 
     /**
-     * @return URL with 'jar:' which points location of findbugs.jar,
+     * @return URL of findbugs.jar,
      * or null if found no jar file which contains FindBugs.class
      * @throws MalformedURLException
      */


### PR DESCRIPTION
This PR is same with https://github.com/findbugsproject/findbugs/pull/102
This change lets implementation follows documentation, but actually it's breaking change. It's better to merge after build and test become stable.

----

Even though javadoc of #getResource(String) says as follows, current
implementation of #getCoreResource(String) loads resource from
filesystem first, even though we have it in JAR file.

> We try findResource because (based on experiment) we can trust it
> to prefer resources in the jarfile to resources on the filesystem

This is why we have problem discussed in FB-Discuss mailing list:
https://mailman.cs.umd.edu/pipermail/findbugs-discuss/2012-September/003632.html