### PR TITLE
Fallback to findbugs.home if spotbugs.home not set

### DIFF
--- a/findbugs/src/java/edu/umd/cs/findbugs/FindBugs.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/FindBugs.java
@@ -137,7 +137,7 @@ public abstract class FindBugs {
     /**
      * FindBugs home directory.
      */
-    private static String home = System.getProperty("spotbugs.home");
+    private static String home = System.getProperty("spotbugs.home", System.getProperty("findbugs.home"));
 
     private static boolean noAnalysis = Boolean.getBoolean("findbugs.noAnalysis");
 


### PR DESCRIPTION
As stated in https://github.com/spotbugs/spotbugs/pull/32#issuecomment-262114550 by @KengoTODA, we privilege `spotbugs.home`, but fallback to `findbugs.home` if not set.