### PR TITLE
fix NPE

### DIFF
--- a/findbugs/src/java/edu/umd/cs/findbugs/DetectorFactoryCollection.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/DetectorFactoryCollection.java
@@ -347,7 +347,7 @@ public class DetectorFactoryCollection implements UpdateCheckCallback {
             if (findbugsJarCodeBase != null) {
                 File findbugsJar = new File(findbugsJarCodeBase);
                 File libDir = findbugsJar.getParentFile();
-                if ("lib".equals(libDir.getName())) {
+                if (libDir != null && "lib".equals(libDir.getName())) {
                     String fbHome = libDir.getParent();
                     FindBugs.setHome(fbHome);
                     return fbHome;


### PR DESCRIPTION
`File#getParentFile()` may return null, so we should check its nullness before we refer it.
https://docs.oracle.com/javase/8/docs/api/java/io/File.html#getParentFile--

In my case, `findbugsJar` was `/home/kengo/GitHub/spotbugs/findbugs/lib/spotbugs.jar` and `libDir` was `null`. Tested with `1.8.0_112-b15` on Ubuntu 14.04.

### How to reproduce

1. run `ant build` to make package
2. `cd findbugs/lib`
3. execute `java -jar spotbugs.jar`, then you'll find NPE