### PR TITLE
Fix Travis flakyness

### DIFF
--- a/findbugs/build.gradle
+++ b/findbugs/build.gradle
@@ -236,6 +236,7 @@ tasks['assembleDist'].finalizedBy distSrcZip
 
 test {
   dependsOn ':findbugsTestCases:build'
+  maxHeapSize = '1G'
 }
 
 task unzipDist(type:Copy, dependsOn:distZip) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+org.gradle.configureondeman=true
+org.gradle.jvmargs=-XX:+CMSClassUnloadingEnabled -XX:+HeapDumpOnOutOfMemoryError -Xmx1G


### PR DESCRIPTION
 - It's randomly failing under JRE9 due to memory pressure