### PR TITLE
Definitely load ASM / Bcel from maven central

### DIFF
--- a/eclipsePlugin/build.gradle
+++ b/eclipsePlugin/build.gradle
@@ -29,7 +29,6 @@ localProps.load(new FileInputStream("$projectDir/local.properties"))
 // TODO : convert these to external dependencies
 def requiredLibs = fileTree(dir:'lib', include:[
   'jsr305.jar',
-  'bcel.jar',
   'jFormatString.jar',
   'commons-lang-2.6.jar',
   'dom4j-1.6.1.jar',

--- a/findbugs/build.gradle
+++ b/findbugs/build.gradle
@@ -57,7 +57,7 @@ jar {
   manifest {
     attributes 'Main-Class': 'edu.umd.cs.findbugs.LaunchAppropriateUI',
                'Bundle-Version': project.version,
-               'Class-Path': 'bcel.jar dom4j-1.6.1.jar jaxen-1.1.6.jar asm-debug-all-6.0_ALPHA jsr305.jar jFormatString.jar commons-lang-2.6.jar'
+               'Class-Path': 'bcel-6.0.jar dom4j-1.6.1.jar jaxen-1.1.6.jar asm-debug-all-6.0_ALPHA.jar jsr305.jar jFormatString.jar commons-lang-2.6.jar'
   }
 }
 
@@ -205,7 +205,7 @@ distributions {
       }
       from 'README.txt'
       from 'licenses'
-      from('lib') {
+      from(configurations.compile) {
         into 'lib'
 
         // TODO : These exclusions can be removed when we move dependencies from lib to dependency management


### PR DESCRIPTION
 - now ant is dead we can stop assuming they are in lib
 - Fix a typo in the manifest, asm dependency was missing a '.jar'

Test plan: ./gradlew clean assembleDist && cd findbugs/build/distributions/ && tar -xzf spotbugs-3.1.0-SNAPSHOT.tgz && cd spotbugs-3.1.0-SNAPSHOT && bin/spotbugs

The spotbugs GUI should load with no errors.