### PR TITLE
Fix ignored javadoc error

### DIFF
--- a/findbugs/src/antTask/edu/umd/cs/findbugs/anttask/FindBugsTask.java
+++ b/findbugs/src/antTask/edu/umd/cs/findbugs/anttask/FindBugsTask.java
@@ -37,62 +37,61 @@ import edu.umd.cs.findbugs.ExitCodes;
 /**
  * FindBugs in Java class files. This task can take the following arguments:
  * <ul>
- * <li>adjustExperimental (boolean default false)
- * <li>adjustPriority (passed to -adjustPriority)
+ * <li>adjustExperimental (boolean default false)</li>
+ * <li>adjustPriority (passed to -adjustPriority)</li>
  * <li>applySuppression (exclude any warnings that match a suppression filter
- * supplied in a project file)
+ * supplied in a project file)</li>
  * <li>auxAnalyzepath (class, jar, zip files or directories containing classes
- * to analyze)
- * <li>auxClasspath (classpath or classpathRef)
- * <li>baselineBugs (xml file containing baseline bugs)
- * <li>class (class, jar, zip or directory containing classes to analyze)
- * <li>classpath (classpath for running FindBugs)
- * <li>cloud (cloud id)
+ * to analyze)</li>
+ * <li>auxClasspath (classpath or classpathRef)</li>
+ * <li>baselineBugs (xml file containing baseline bugs)</li>
+ * <li>class (class, jar, zip or directory containing classes to analyze)</li>
+ * <li>classpath (classpath for running FindBugs)</li>
+ * <li>cloud (cloud id)</li>
  * <li>conserveSpace (boolean - default false)</li>
- * <li>debug (boolean default false)
+ * <li>debug (boolean default false)</li>
  * <li>effort (enum min|default|max)</li>
- * <li>excludeFilter (filter filename)
- * <li>excludePath (classpath or classpathRef to filters)
- * <li>failOnError (boolean - default false)
- * <li>home (findbugs install dir)
- * <li>includeFilter (filter filename)
- * <li>includePath (classpath or classpathRef to filters)
- * <li>maxRank (maximum rank issue to be reported)
- * <li>jvm (Set the command used to start the VM)
- * <li>jvmargs (any additional jvm arguments)
- * <li>omitVisitors (collection - comma separated)
+ * <li>excludeFilter (filter filename)</li>
+ * <li>excludePath (classpath or classpathRef to filters)</li>
+ * <li>failOnError (boolean - default false)</li>
+ * <li>home (findbugs install dir)</li>
+ * <li>includeFilter (filter filename)</li>
+ * <li>includePath (classpath or classpathRef to filters)</li>
+ * <li>maxRank (maximum rank issue to be reported)</li>
+ * <li>jvm (Set the command used to start the VM)</li>
+ * <li>jvmargs (any additional jvm arguments)</li>
+ * <li>omitVisitors (collection - comma separated)</li>
  * <li>onlyAnalyze (restrict analysis to find bugs to given comma-separated list
- * of classes and packages - See the textui argument description for details)
- * <li>output (enum text|xml|xml:withMessages|html - default xml)
- * <li>outputFile (name of output file to create)
- * <li>nested (boolean default true)
- * <li>noClassOk (boolean default false)
- * <li>pluginList (list of plugin Jar files to load)
- * <li>projectFile (project filename)
- * <li>projectName (project name, for display in generated HTML)
- * <li>userPrefs (user preferences filename)
- * <li>quietErrors (boolean - default false)
- * <li>relaxed (boolean - default false)
- * <li>reportLevel (enum experimental|low|medium|high)
- * <li>sort (boolean default true)
+ * of classes and packages - See the textui argument description for details)</li>
+ * <li>output (enum text|xml|xml:withMessages|html - default xml)</li>
+ * <li>outputFile (name of output file to create)</li>
+ * <li>nested (boolean default true)</li>
+ * <li>noClassOk (boolean default false)</li>
+ * <li>pluginList (list of plugin Jar files to load)</li>
+ * <li>projectFile (project filename)</li>
+ * <li>projectName (project name, for display in generated HTML)</li>
+ * <li>userPrefs (user preferences filename)</li>
+ * <li>quietErrors (boolean - default false)</li>
+ * <li>relaxed (boolean - default false)</li>
+ * <li>reportLevel (enum experimental|low|medium|high)</li>
+ * <li>sort (boolean default true)</li>
  * <li>stylesheet (name of stylesheet to generate HTML: default is
- * "default.xsl")
- * <li>systemProperty (a system property to set)
- * <li>timestampNow (boolean - default false)
- * <li>visitors (collection - comma separated)
- * <li>chooseVisitors (selectively enable/disable visitors)
- * <li>workHard (boolean default false)
- * <li>setSetExitCode (boolean default true)
+ * "default.xsl")</li>
+ * <li>systemProperty (a system property to set)</li>
+ * <li>timestampNow (boolean - default false)</li>
+ * <li>visitors (collection - comma separated)</li>
+ * <li>chooseVisitors (selectively enable/disable visitors)</li>
+ * <li>workHard (boolean default false)</li>
+ * <li>setSetExitCode (boolean default true)</li>
  * </ul>
- * Of these arguments, the <b>home</b> is required. <b>projectFile</b> is
- * required if nested &lt;class&gt; or &lt;auxAnalyzepath&gt elements are not
+ * <p>Of these arguments, the <b>home</b> is required. <b>projectFile</b> is
+ * required if nested &lt;class&gt; or &lt;auxAnalyzepath&gt; elements are not
  * specified. the &lt;class&gt; tag defines the location of either a class, jar
  * file, zip file, or directory containing classes.
- * <p>
+ * </p>
  *
  * @author Mike Fagan <a href="mailto:mfagan@tde.com">mfagan@tde.com</a>
- * @author Michael Tamm <a
- *         href="mailto:mail@michaeltamm.de">mail@michaeltamm.de</a>
+ * @author Michael Tamm <a href="mailto:mail@michaeltamm.de">mail@michaeltamm.de</a>
  * @author Scott Wolk
  * @version $Revision: 1.56 $
  *

--- a/findbugs/src/antTask/edu/umd/cs/findbugs/anttask/FindBugsViewerTask.java
+++ b/findbugs/src/antTask/edu/umd/cs/findbugs/anttask/FindBugsViewerTask.java
@@ -46,18 +46,17 @@ import edu.umd.cs.findbugs.ExitCodes;
  *
  * The below is an example of how this could be done in an ant script:
  *
- * <taskdef name="findbugs" classname="edu.umd.cs.findbugs.anttask.FindBugsTask"
- * classpath="C:\dev\cvs.sourceforge.net\findbugs\lib\findbugs-ant.jar" />
- * <taskdef name="findbugs-viewer"
+ * {@literal <taskdef name="findbugs" classname="edu.umd.cs.findbugs.anttask.FindBugsTask" classpath="C:\dev\cvs.sourceforge.net\findbugs\lib\findbugs-ant.jar" />}
+ * {@literal <taskdef name="findbugs-viewer"
  * classname="edu.umd.cs.findbugs.anttask.FindBugsViewerTask"
- * classpath="C:\dev\cvs.sourceforge.net\findbugs\lib\findbugs-ant.jar" />
+ * classpath="C:\dev\cvs.sourceforge.net\findbugs\lib\findbugs-ant.jar" />}
  *
- * <property name="findbugs.home" location="C:\dev\cvs.sourceforge.net\findbugs"
- * /> <property name="findbugs.bugReport" location="bcel-fb.xml" />
+ * {@literal <property name="findbugs.home" location="C:\dev\cvs.sourceforge.net\findbugs"
+ * /> <property name="findbugs.bugReport" location="bcel-fb.xml" />}
  *
- * <target name="findbugs-viewer" depends="jar"> <findbugs-viewer
+ * {@literal <target name="findbugs-viewer" depends="jar"> <findbugs-viewer
  * home="${findbugs.home}" look="native" loadbugs="${findbugs.bugReport}"/>
- * </target>
+ * </target>}
  *
  * Created on March 21, 2006, 12:57 PM
  *

--- a/findbugs/src/antTask/edu/umd/cs/findbugs/anttask/UnionBugs.java
+++ b/findbugs/src/antTask/edu/umd/cs/findbugs/anttask/UnionBugs.java
@@ -37,11 +37,11 @@ import edu.umd.cs.findbugs.workflow.UnionResults;
  * An ant task that is wraps the behavior of the UnionResults executable into an
  * ant task.
  *
- * <taskdef name="UnionBugs" classname="edu.umd.cs.findbugs.anttask.UnionBugs"
- * classpath="...">
+ * {@literal <taskdef name="UnionBugs" classname="edu.umd.cs.findbugs.anttask.UnionBugs"
+ * classpath="...">}
  *
- * <UnionBugs to="${basedir}/findbugs.xml" > <fileset dir="plugins"> <include
- * name="*_findbugs_partial.xml" /> </fileset> </UnionBugs>
+ * {@literal <UnionBugs to="${basedir}/findbugs.xml" > <fileset dir="plugins"> <include
+ * name="*_findbugs_partial.xml" /> </fileset> </UnionBugs>}
  *
  * @author Peter Franza <a href="mailto:pfranza@gmail.com">pfranza@gmail.com</a>
  * @version 1.0

--- a/findbugs/src/antTask/edu/umd/cs/findbugs/anttask/UnionBugs2.java
+++ b/findbugs/src/antTask/edu/umd/cs/findbugs/anttask/UnionBugs2.java
@@ -29,12 +29,11 @@ import org.apache.tools.ant.types.FileSet;
  * An ant task that is wraps the behavior of the UnionResults executable into an
  * ant task.
  *
- * <taskdef name="UnionBugs2" classname="edu.umd.cs.findbugs.anttask.UnionBugs2"
- * classpath="...">
+ * {@literal <taskdef name="UnionBugs2" classname="edu.umd.cs.findbugs.anttask.UnionBugs2"
+ * classpath="...">}
  *
- * <UnionBugs2 to="${basedir}/findbugs.xml" > <fileset dir="plugins"> <include
- * name="*_findbugs_partial.xml" /> </fileset> </UnionBugs>
- *
+ * {@literal <UnionBugs2 to="${basedir}/findbugs.xml" > <fileset dir="plugins"> <include
+ * name="*_findbugs_partial.xml" /> </fileset> </UnionBugs>}
  *
  * @ant.task category="utility"
  *

--- a/findbugs/src/gui/edu/umd/cs/findbugs/gui2/BugAspects.java
+++ b/findbugs/src/gui/edu/umd/cs/findbugs/gui2/BugAspects.java
@@ -27,11 +27,12 @@ import edu.umd.cs.findbugs.filter.Matcher;
 /**
  * These are the branches in our tree, each branch forms a complete query that
  * could be sent to the main bugset to return all the bugs it contains For
- * example, a single bugAspects could be <priority,high> or it could be
- * <priority,high>, <designation,must fix>,<class,fishpond>,<package,default>
+ * example, a single bugAspects could be {@literal <priority,high>} or it could be
+ * {@literal <priority,high>}, {@literal <designation,must fix>},{@literal <class,fishpond>},
+ * {@literal <package,default>}
  *
- * In this implementation, <priority,high>,<designation,unclassified> is
- * different from <designation,unclassified>,<priority,high>. (I'm not talking
+ * In this implementation, {@literal <priority,high>},{@literal <designation,unclassified>} is
+ * different from {@literal <designation,unclassified>},{@literal <priority,high>}. (I'm not talking
  * about the fact we use the .equals from ArrayList, I'm talking about what a
  * query would return, though both are true) For a speed boost, this class could
  * be rewritten to make these equal, BugSet could be rewritten to cache full

--- a/findbugs/src/gui/edu/umd/cs/findbugs/gui2/BugSet.java
+++ b/findbugs/src/gui/edu/umd/cs/findbugs/gui2/BugSet.java
@@ -42,8 +42,8 @@ import edu.umd.cs.findbugs.gui2.BugAspects.SortableValue;
  * can't be a set because we need to be able to sort it, also, HashList is great
  * for doing contains and indexOf, its just slow for removing which we never
  * need to do) The power of BugSet is in query. You can query a BugSet with a
- * BugAspects, a list of StringPairs like <priority,high>,
- * <designation,unclassified> and you will get out a new BugSet containing all
+ * BugAspects, a list of StringPairs like {@literal <priority,high>},
+ * {@literal <designation,unclassified>} and you will get out a new BugSet containing all
  * of the bugs that are both high priority and unclassified. Also, after the
  * first time a query is made, the results will come back instantly on future
  * calls because the old queries are cached. Note that this caching can also

--- a/findbugs/src/java/edu/umd/cs/findbugs/BugInstance.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/BugInstance.java
@@ -93,25 +93,24 @@ import edu.umd.cs.findbugs.xml.XMLOutput;
 import edu.umd.cs.findbugs.xml.XMLWriteable;
 
 /**
- * An instance of a bug pattern. A BugInstance consists of several parts:
- * <p/>
+ * <p>An instance of a bug pattern. A BugInstance consists of several parts:</p>
  * <ul>
  * <li>the type, which is a string indicating what kind of bug it is; used as a
- * key for the FindBugsMessages resource bundle
- * <li>the priority; how likely this instance is to actually be a bug
- * <li>a list of <em>annotations</em>
+ * key for the FindBugsMessages resource bundle</li>
+ * <li>the priority; how likely this instance is to actually be a bug</li>
+ * <li>a list of <em>annotations</em></li>
  * </ul>
- * <p/>
+ * <p>
  * The annotations describe classes, methods, fields, source locations, and
  * other relevant context information about the bug instance. Every BugInstance
  * must have at least one ClassAnnotation, which describes the class in which
  * the instance was found. This is the "primary class annotation".
- * <p/>
+ * </p>
  * <p>
  * BugInstance objects are built up by calling a string of <code>add</code>
  * methods. (These methods all "return this", so they can be chained). Some of
  * the add methods are specialized to get information automatically from a
- * BetterVisitor or DismantleBytecode object.
+ * BetterVisitor or DismantleBytecode object.</p>
  *
  * @author David Hovemeyer
  * @see BugAnnotation

--- a/findbugs/src/java/edu/umd/cs/findbugs/BugRanker.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/BugRanker.java
@@ -45,7 +45,7 @@ import edu.umd.cs.findbugs.util.Util;
  * The following bug rankers may exist:
  * <ul>
  * <li>core bug ranker (loaded from etc/bugrank.txt)
- * <li>a bug ranker for each plugin (loaded from <plugin>/etc/bugrank.txt)
+ * <li>a bug ranker for each plugin (loaded from {@literal <plugin>}/etc/bugrank.txt)
  * <li>A global adjustment ranker (loaded from plugins/adjustBugrank.txt)
  * </ul>
  *

--- a/findbugs/src/java/edu/umd/cs/findbugs/ByteCodePatternDetector.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/ByteCodePatternDetector.java
@@ -123,7 +123,7 @@ public abstract class ByteCodePatternDetector implements Detector {
     public abstract ByteCodePattern getPattern();
 
     /**
-     * Prescreen a method. It is a valid, but dumb, implementation simply to
+     * <p>Prescreen a method. It is a valid, but dumb, implementation simply to
      * return true unconditionally. A better implementation is to call
      * ClassContext.getBytecodeSet() to check whether the method actually
      * contains the bytecode instructions that the pattern will look for. The
@@ -131,11 +131,11 @@ public abstract class ByteCodePatternDetector implements Detector {
      * MethodGen, CFG, ValueNumberAnalysis, etc. objects required to match
      * ByteCodePatterns is slow, and the bytecode pattern matching algorithm is
      * also not particularly fast.
-     * <p/>
+     * </p>
      * <p>
      * As a datapoint, prescreening speeds up the BCPDoubleCheck detector <b>by
      * a factor of 5</b> with no loss of generality and only a dozen or so extra
-     * lines of code.
+     * lines of code.</p>
      *
      * @param method
      *            the method

--- a/findbugs/src/java/edu/umd/cs/findbugs/FindBugsMessageFormat.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/FindBugsMessageFormat.java
@@ -26,13 +26,13 @@ package edu.umd.cs.findbugs;
  * formatted.
  * </p>
  * <p>
- * Example:
+ * Example:</p>
  *
  * <pre>
  * new FindBugsMessageFormat(&quot;BUG: {1} does something bad to field {2.fullField}&quot;)
  * </pre>
  *
- * In this example, the method annotation at position 1 is formatted using the
+ * <p>In this example, the method annotation at position 1 is formatted using the
  * empty (default) key. The field annotation at position 2 is formatted using
  * the "fullField" key, which uses the long format for the field rather than the
  * usual "class.fieldname" format.</p>

--- a/findbugs/src/java/edu/umd/cs/findbugs/FindBugsMessageFormat.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/FindBugsMessageFormat.java
@@ -20,11 +20,11 @@
 package edu.umd.cs.findbugs;
 
 /**
- * Format the message for a BugInstance. This class works in much the same way
+ * <p>Format the message for a BugInstance. This class works in much the same way
  * as <code>java.text.MessageFormat</code>; however, each placeholder may have
  * an optional "key" which specifies how the object at that position should be
  * formatted.
- * <p/>
+ * </p>
  * <p>
  * Example:
  *
@@ -35,7 +35,7 @@ package edu.umd.cs.findbugs;
  * In this example, the method annotation at position 1 is formatted using the
  * empty (default) key. The field annotation at position 2 is formatted using
  * the "fullField" key, which uses the long format for the field rather than the
- * usual "class.fieldname" format.
+ * usual "class.fieldname" format.</p>
  *
  * @author David Hovemeyer
  * @see BugInstance

--- a/findbugs/src/java/edu/umd/cs/findbugs/Project.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/Project.java
@@ -79,7 +79,7 @@ import edu.umd.cs.findbugs.xml.XMLWriteable;
  * </p>
  * <ul>
  * <li>some number of source directories, for locating the program's source code</li>
- * <li>some number of auxiliary classpath entries, for locating classes</li>
+ * <li>some number of auxiliary classpath entries, for locating classes
  * referenced by the program which the user doesn't want to analyze</li>
  * <li>some number of boolean options</li>
  * </ul>
@@ -1089,7 +1089,7 @@ public class Project implements XMLWriteable {
         }
     }
 
-    /**
+    /*
      * Make the given list of pathnames absolute relative to the absolute path
      * of the project file.
      *

--- a/findbugs/src/java/edu/umd/cs/findbugs/Project.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/Project.java
@@ -74,14 +74,14 @@ import edu.umd.cs.findbugs.xml.XMLOutputUtil;
 import edu.umd.cs.findbugs.xml.XMLWriteable;
 
 /**
- * A project in the GUI. This consists of some number of Jar files to analyze
+ * <p>A project in the GUI. This consists of some number of Jar files to analyze
  * for bugs, and optionally
- * <p/>
+ * </p>
  * <ul>
- * <li>some number of source directories, for locating the program's source code
- * <li>some number of auxiliary classpath entries, for locating classes
- * referenced by the program which the user doesn't want to analyze
- * <li>some number of boolean options
+ * <li>some number of source directories, for locating the program's source code</li>
+ * <li>some number of auxiliary classpath entries, for locating classes</li>
+ * referenced by the program which the user doesn't want to analyze</li>
+ * <li>some number of boolean options</li>
  * </ul>
  *
  * @author David Hovemeyer

--- a/findbugs/src/java/edu/umd/cs/findbugs/annotations/DesireNoWarning.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/annotations/DesireNoWarning.java
@@ -15,7 +15,7 @@ import java.lang.annotation.RetentionPolicy;
  * See http://code.google.com/p/findbugs/wiki/FindbugsTestCases
  *
  * @author David Hovemeyer
- * @deprecated The annotation based approach is useless for lambdas. Write expectations using {@link com.h3xstream.findbugs.test.matcher.BugInstanceMatcher} matchers
+ * @deprecated The annotation based approach is useless for lambdas. Write expectations using {@link edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher} matchers
  */
 @Deprecated
 @Retention(RetentionPolicy.CLASS)

--- a/findbugs/src/java/edu/umd/cs/findbugs/annotations/DesireNoWarning.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/annotations/DesireNoWarning.java
@@ -15,7 +15,7 @@ import java.lang.annotation.RetentionPolicy;
  * See http://code.google.com/p/findbugs/wiki/FindbugsTestCases
  *
  * @author David Hovemeyer
- * @deprecated The annotation based approach is useless for lambdas. Write expectations using {@link edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher} matchers
+ * @deprecated The annotation based approach is useless for lambdas. Write expectations using {@code edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher} matchers in test source directory
  */
 @Deprecated
 @Retention(RetentionPolicy.CLASS)

--- a/findbugs/src/java/edu/umd/cs/findbugs/annotations/DesireWarning.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/annotations/DesireWarning.java
@@ -14,7 +14,7 @@ import java.lang.annotation.RetentionPolicy;
  * See http://code.google.com/p/findbugs/wiki/FindbugsTestCases
  *
  * @author David Hovemeyer
- * @deprecated The annotation based approach is useless for lambdas. Write expectations using {@link com.h3xstream.findbugs.test.matcher.BugInstanceMatcher} matchers
+ * @deprecated The annotation based approach is useless for lambdas. Write expectations using {@link edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher} matchers
  */
 @Deprecated
 @Retention(RetentionPolicy.CLASS)

--- a/findbugs/src/java/edu/umd/cs/findbugs/annotations/DesireWarning.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/annotations/DesireWarning.java
@@ -14,7 +14,7 @@ import java.lang.annotation.RetentionPolicy;
  * See http://code.google.com/p/findbugs/wiki/FindbugsTestCases
  *
  * @author David Hovemeyer
- * @deprecated The annotation based approach is useless for lambdas. Write expectations using {@link edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher} matchers
+ * @deprecated The annotation based approach is useless for lambdas. Write expectations using {@code edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher} matchers in test source directory
  */
 @Deprecated
 @Retention(RetentionPolicy.CLASS)

--- a/findbugs/src/java/edu/umd/cs/findbugs/annotations/ExpectWarning.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/annotations/ExpectWarning.java
@@ -14,7 +14,7 @@ import java.lang.annotation.RetentionPolicy;
  * See http://code.google.com/p/findbugs/wiki/FindbugsTestCases
  *
  * @author David Hovemeyer
- * @deprecated The annotation based approach is useless for lambdas. Write expectations using {@link com.h3xstream.findbugs.test.matcher.BugInstanceMatcher} matchers
+ * @deprecated The annotation based approach is useless for lambdas. Write expectations using {@link edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher} matchers
  */
 @Deprecated
 @Retention(RetentionPolicy.CLASS)

--- a/findbugs/src/java/edu/umd/cs/findbugs/annotations/ExpectWarning.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/annotations/ExpectWarning.java
@@ -14,7 +14,7 @@ import java.lang.annotation.RetentionPolicy;
  * See http://code.google.com/p/findbugs/wiki/FindbugsTestCases
  *
  * @author David Hovemeyer
- * @deprecated The annotation based approach is useless for lambdas. Write expectations using {@link edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher} matchers
+ * @deprecated The annotation based approach is useless for lambdas. Write expectations using {@code edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher} matchers in test source directory
  */
 @Deprecated
 @Retention(RetentionPolicy.CLASS)

--- a/findbugs/src/java/edu/umd/cs/findbugs/annotations/NoWarning.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/annotations/NoWarning.java
@@ -14,7 +14,7 @@ import java.lang.annotation.RetentionPolicy;
  * See http://code.google.com/p/findbugs/wiki/FindbugsTestCases
  *
  * @author David Hovemeyer
- * @deprecated The annotation based approach is useless for lambdas. Write expectations using {@link com.h3xstream.findbugs.test.matcher.BugInstanceMatcher} matchers
+ * @deprecated The annotation based approach is useless for lambdas. Write expectations using {@link edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher} matchers
  */
 @Deprecated
 @Retention(RetentionPolicy.CLASS)

--- a/findbugs/src/java/edu/umd/cs/findbugs/annotations/NoWarning.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/annotations/NoWarning.java
@@ -14,7 +14,7 @@ import java.lang.annotation.RetentionPolicy;
  * See http://code.google.com/p/findbugs/wiki/FindbugsTestCases
  *
  * @author David Hovemeyer
- * @deprecated The annotation based approach is useless for lambdas. Write expectations using {@link edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher} matchers
+ * @deprecated The annotation based approach is useless for lambdas. Write expectations using {@code edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher} matchers in test source directory
  */
 @Deprecated
 @Retention(RetentionPolicy.CLASS)

--- a/findbugs/src/java/edu/umd/cs/findbugs/ba/AbstractDominatorsAnalysis.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/ba/AbstractDominatorsAnalysis.java
@@ -28,15 +28,14 @@ import org.apache.bcel.generic.InstructionHandle;
 
 
 /**
- * A dataflow analysis to compute dominator relationships between basic blocks.
+ * <p>A dataflow analysis to compute dominator relationships between basic blocks.
  * Use the {@link #getResultFact} method to get the dominator set for a given
  * basic block. The dominator sets are represented using the
  * {@link java.util.BitSet} class, with the individual bits corresponding to the
- * IDs of basic blocks.
- * <p/>
+ * IDs of basic blocks.</p>
  * <p>
  * Subclasses extend this class to compute either dominators or postdominators.
- * <p/>
+ * </p>
  * <p>
  * An EdgeChooser may be specified to select which edges to take into account.
  * For example, exception edges could be ignored.

--- a/findbugs/src/java/edu/umd/cs/findbugs/ba/AbstractFrameModelingVisitor.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/ba/AbstractFrameModelingVisitor.java
@@ -26,7 +26,7 @@ import edu.umd.cs.findbugs.bcel.generic.NONNULL2Z;
 import edu.umd.cs.findbugs.bcel.generic.NULL2Z;
 
 /**
- * A common base class for frame modeling visitors. This class provides a
+ * <p>A common base class for frame modeling visitors. This class provides a
  * default implementation which copies values between frame slots whenever
  * appropriate. For example, its handler for the ALOAD bytecode will get the
  * value from the referenced local in the frame and push it onto the stack.
@@ -34,7 +34,7 @@ import edu.umd.cs.findbugs.bcel.generic.NULL2Z;
  * values as appropriate, and pushing the "default" value onto the stack for
  * each stack slot produced, where the default value is the one returned by the
  * getDefaultValue() method.
- * <p/>
+ * </p>
  * <p>
  * Subclasses should override the visit methods for any bytecode instructions
  * which require special handling.

--- a/findbugs/src/java/edu/umd/cs/findbugs/ba/BlockOrder.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/ba/BlockOrder.java
@@ -31,7 +31,7 @@ public interface BlockOrder {
     public Iterator<BasicBlock> blockIterator();
 
     /** Return relative order of blocks.
-     * If b1.compareTo(b2) < 0, then b1 should occur before b2 in iteration.
+     * If b1.compareTo(b2) &lt; 0, then b1 should occur before b2 in iteration.
      */
     public int compare(BasicBlock b1, BasicBlock b2);
 }

--- a/findbugs/src/java/edu/umd/cs/findbugs/ba/Frame.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/ba/Frame.java
@@ -35,12 +35,12 @@ import org.apache.bcel.generic.StackConsumer;
 import edu.umd.cs.findbugs.SystemProperties;
 
 /**
- * Generic class for representing a Java stack frame as a dataflow value. A
+ * <p>Generic class for representing a Java stack frame as a dataflow value. A
  * frame consists of "slots", which represent the local variables and values on
  * the Java operand stack. Slots 0 .. <code>getNumLocals() - 1</code> represent
  * the local variables. Slots <code>getNumLocals()</code> ..
  * <code>getNumSlots() - 1</code> represent the Java operand stack.
- * <p/>
+ * </p>
  * <p>
  * Frame is parametized by "ValueType", which is the type of value to be stored
  * in the Frame's slots. This type must form a lattice, according to the
@@ -49,14 +49,14 @@ import edu.umd.cs.findbugs.SystemProperties;
  * all of its slots will contain null. The analysis is responsible for
  * initializing created Frames with default values at the appropriate time.
  * Typically, only initEntryFact() will need to do this.
- * <p/>
+ * </p>
  * <p>
  * A Frame may have the special "TOP" value. Such frames serve as the identity
  * element for the meet operation operation.
- * <p/>
+ * </p>
  * <p>
  * A Frame may have the special "BOTTOM" value. The result of merging any frame
- * with BOTTOM is BOTTOM.
+ * with BOTTOM is BOTTOM.</p>
  *
  * @author David Hovemeyer
  * @see FrameDataflowAnalysis

--- a/findbugs/src/java/edu/umd/cs/findbugs/ba/FrameDataflowAnalysis.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/ba/FrameDataflowAnalysis.java
@@ -132,10 +132,10 @@ ForwardDataflowAnalysis<FrameType> {
     }
 
     /**
-     * Create a modifiable copy of a frame. This is useful for meetInto(), if
+     * <p>Create a modifiable copy of a frame. This is useful for meetInto(), if
      * the frame needs to be modified in a path-sensitive fashion. A typical
      * usage pattern is:
-     * <p/>
+     * </p>
      *
      * <pre>
      * FrameType copy = null;
@@ -149,13 +149,12 @@ ForwardDataflowAnalysis<FrameType> {
      * }
      * if (copy != null)
      *     fact = copy;
-     * <p/>
      * mergeInto(fact, result);
      * </pre>
-     * <p/>
+     * <p>
      * The advantage of using modifyFrame() is that new code can be added before
      * or after other places where the frame is modified, and the code will
-     * remain correct.
+     * remain correct.</p>
      *
      * @param orig
      *            the original frame

--- a/findbugs/src/java/edu/umd/cs/findbugs/ba/Hierarchy.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/ba/Hierarchy.java
@@ -291,23 +291,21 @@ public class Hierarchy {
     }
 
     /**
-     * Find the least upper bound method in the class hierarchy which could be
+     * <p>Find the least upper bound method in the class hierarchy which could be
      * called by the given InvokeInstruction. One reason this method is useful
      * is that it indicates which declared exceptions are thrown by the called
-     * methods.
-     *
-     * <p/>
+     * methods.</p>
      * <ul>
-     * <li>For invokespecial, this is simply an exact lookup.
+     * <li>For invokespecial, this is simply an exact lookup.</li>
      * <li>For invokestatic and invokevirtual, the named class is searched,
      * followed by superclasses up to the root of the object hierarchy
      * (java.lang.Object). Yes, invokestatic really is declared to check
-     * superclasses. See VMSpec, 2nd ed, sec. 5.4.3.3.
+     * superclasses. See VMSpec, 2nd ed, sec. 5.4.3.3.</li>
      * <li>For invokeinterface, the named class is searched, followed by all
      * interfaces transitively declared by the class. (Question: is the order
      * important here? Maybe the VM spec requires that the actual interface
      * desired is given, so the extended lookup will not be required. Should
-     * check.)
+     * check.)</li>
      * </ul>
      *
      * @param inv

--- a/findbugs/src/java/edu/umd/cs/findbugs/ba/Location.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/ba/Location.java
@@ -27,16 +27,16 @@ import org.apache.bcel.generic.InstructionHandle;
 
 
 /**
- * A class representing a location in the CFG for a method. Essentially, it
+ * <p>A class representing a location in the CFG for a method. Essentially, it
  * represents a static instruction, <em>with the important caveat</em> that CFGs
  * have inlined JSR subroutines, meaning that a single InstructionHandle in a
  * CFG may represent several static locations. To this end, a Location is
  * comprised of both an InstructionHandle and the BasicBlock that contains it.
- * <p/>
+ * </p>
  * <p>
  * Location objects may be compared with each other using the equals() method,
  * and may be used as keys in tree and hash maps and sets. Note that
- * <em>it is only valid to compare Locations produced from the same CFG</em>.
+ * <em>it is only valid to compare Locations produced from the same CFG</em>.</p>
  *
  * @author David Hovemeyer
  * @see CFG

--- a/findbugs/src/java/edu/umd/cs/findbugs/ba/SimplePathEnumerator.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/ba/SimplePathEnumerator.java
@@ -26,12 +26,12 @@ import java.util.List;
 import edu.umd.cs.findbugs.SystemProperties;
 
 /**
- * Object to enumerate (some subset of) the simple paths in a CFG. A simple path
+ * <p>Object to enumerate (some subset of) the simple paths in a CFG. A simple path
  * is a path from entry to exit, ignoring backedges and unhandled exceptions.
- * <p/>
+ * </p>
  * <p>
  * FIXME: instead of storing the simple paths, should invoke a callback as each
- * simple path is produced. That would save memory.
+ * simple path is produced. That would save memory.</p>
  *
  * @author David Hovemeyer
  * @see CFG

--- a/findbugs/src/java/edu/umd/cs/findbugs/ba/bcp/Invoke.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/ba/bcp/Invoke.java
@@ -37,39 +37,39 @@ import edu.umd.cs.findbugs.ba.RepositoryLookupFailureCallback;
 import edu.umd.cs.findbugs.ba.vna.ValueNumberFrame;
 
 /**
- * A PatternElement to match a method invocation. Currently, we don't allow
+ * <p>A PatternElement to match a method invocation. Currently, we don't allow
  * variables in this element (for arguments and return value). This would be a
  * good thing to add. We also don't distinguish between invokevirtual,
  * invokeinterface, and invokespecial.
- * <p/>
+ * </p>
  * <p>
  * Invoke objects match by class name, method name, method signature, and
  * <em>mode</em>.
- * <p/>
+ * </p>
  * <p>
  * Names and signatures may be matched in several ways:
  * <ol>
- * <li>By an exact match. This is the default behavior.
+ * <li>By an exact match. This is the default behavior.</li>
  * <li>By a regular expression. If the string provided to the Invoke constructor
  * begins with a "/" character, the rest of the string is treated as a regular
- * expression.
+ * expression.</li>
  * <li>As a subclass match. This only applies to class name matches. If the
  * first character of a class name string is "+", then the rest of the string is
  * treated as the name of a base class. Any subclass or subinterface of the
- * named type will be accepted.
+ * named type will be accepted.</li>
  * </ol>
- * <p/>
+ * </p>
  * <p>
  * The <em>mode</em> specifies what kind of invocations in the Invoke element
  * matches. It is specified as the bitwise combination of the following values:
  * <ol>
- * <li> <code>INSTANCE</code>, which matches ordinary instance method invocations
- * <li> <code>STATIC</code>, which matches static method invocations
- * <li> <code>CONSTRUCTOR</code>, which matches object constructor invocations
+ * <li> <code>INSTANCE</code>, which matches ordinary instance method invocations</li>
+ * <li> <code>STATIC</code>, which matches static method invocations</li>
+ * <li> <code>CONSTRUCTOR</code>, which matches object constructor invocations</li>
  * </ol>
  * The special mode <code>ORDINARY_METHOD</code> is equivalent to
  * <code>INSTANCE|STATIC</code>. The special mode <code>ANY</code> is equivalent
- * to <code>INSTANCE|STATIC|CONSTRUCTOR</code>.
+ * to <code>INSTANCE|STATIC|CONSTRUCTOR</code>.</p>
  *
  * @author David Hovemeyer
  * @see PatternElement

--- a/findbugs/src/java/edu/umd/cs/findbugs/ba/bcp/Invoke.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/ba/bcp/Invoke.java
@@ -47,7 +47,7 @@ import edu.umd.cs.findbugs.ba.vna.ValueNumberFrame;
  * <em>mode</em>.
  * </p>
  * <p>
- * Names and signatures may be matched in several ways:
+ * Names and signatures may be matched in several ways:</p>
  * <ol>
  * <li>By an exact match. This is the default behavior.</li>
  * <li>By a regular expression. If the string provided to the Invoke constructor
@@ -58,16 +58,15 @@ import edu.umd.cs.findbugs.ba.vna.ValueNumberFrame;
  * treated as the name of a base class. Any subclass or subinterface of the
  * named type will be accepted.</li>
  * </ol>
- * </p>
  * <p>
  * The <em>mode</em> specifies what kind of invocations in the Invoke element
- * matches. It is specified as the bitwise combination of the following values:
+ * matches. It is specified as the bitwise combination of the following values:</p>
  * <ol>
  * <li> <code>INSTANCE</code>, which matches ordinary instance method invocations</li>
  * <li> <code>STATIC</code>, which matches static method invocations</li>
  * <li> <code>CONSTRUCTOR</code>, which matches object constructor invocations</li>
  * </ol>
- * The special mode <code>ORDINARY_METHOD</code> is equivalent to
+ * <p>The special mode <code>ORDINARY_METHOD</code> is equivalent to
  * <code>INSTANCE|STATIC</code>. The special mode <code>ANY</code> is equivalent
  * to <code>INSTANCE|STATIC|CONSTRUCTOR</code>.</p>
  *

--- a/findbugs/src/java/edu/umd/cs/findbugs/ba/bcp/MatchAny.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/ba/bcp/MatchAny.java
@@ -28,14 +28,14 @@ import edu.umd.cs.findbugs.ba.Edge;
 import edu.umd.cs.findbugs.ba.vna.ValueNumberFrame;
 
 /**
- * A "meta" PatternElement that matches any of a list of other child
+ * <p>A "meta" PatternElement that matches any of a list of other child
  * PatternElements. An example of how this is useful is that you might want to
  * match invocations of any of a number of different methods. To do this, you
  * can create a MatchAny with some number of Invoke elements as children.
- * <p/>
+ * </p>
  * <p>
  * Note that the minOccur() and maxOccur() counts of the child PatternElements
- * are ignored. A MatchAny element always matches exactly one instruction.
+ * are ignored. A MatchAny element always matches exactly one instruction.</p>
  *
  * @author David Hovemeyer
  * @see PatternElement

--- a/findbugs/src/java/edu/umd/cs/findbugs/ba/bcp/PatternMatcher.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/ba/bcp/PatternMatcher.java
@@ -45,12 +45,12 @@ import edu.umd.cs.findbugs.ba.vna.ValueNumberDataflow;
 import edu.umd.cs.findbugs.ba.vna.ValueNumberFrame;
 
 /**
- * Match a ByteCodePattern against the code of a method, represented by a CFG.
+ * <p>Match a ByteCodePattern against the code of a method, represented by a CFG.
  * Produces some number of ByteCodePatternMatch objects, which indicate how the
  * pattern matched the bytecode instructions in the method.
- * <p/>
+ * </p>
  * <p>
- * This code is a hack and should probably be rewritten.
+ * This code is a hack and should probably be rewritten.</p>
  *
  * @author David Hovemeyer
  * @see ByteCodePattern

--- a/findbugs/src/java/edu/umd/cs/findbugs/ba/type/TypeAnalysis.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/ba/type/TypeAnalysis.java
@@ -68,15 +68,15 @@ import edu.umd.cs.findbugs.ba.vna.ValueNumberDataflow;
 import edu.umd.cs.findbugs.ba.vna.ValueNumberFrame;
 
 /**
- * A forward dataflow analysis to determine the types of all values in the Java
+ * <p>A forward dataflow analysis to determine the types of all values in the Java
  * stack frame at all points in a Java method. The values include local
  * variables and values on the Java operand stack.
- * <p/>
+ * </p>
  * <p>
  * As a side effect, the analysis computes the exception set throwable on each
  * exception edge in the CFG. This information can be used to prune infeasible
  * exception edges, and mark exception edges which propagate only implicit
- * exceptions.
+ * exceptions.</p>
  *
  * @author David Hovemeyer
  * @see Dataflow

--- a/findbugs/src/java/edu/umd/cs/findbugs/ba/vna/AvailableLoad.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/ba/vna/AvailableLoad.java
@@ -22,17 +22,17 @@ package edu.umd.cs.findbugs.ba.vna;
 import edu.umd.cs.findbugs.ba.XField;
 
 /**
- * An AvailableLoad indicates a field and (optionally) object reference for
+ * <p>An AvailableLoad indicates a field and (optionally) object reference for
  * which a value is available. It is used to implement redundant load
  * elimination and forward substitution in ValueNumberAnalysis. The idea is that
  * programmers often reload fields unnecessarily when they "know" that the value
  * will not change. In order to deduce the intended meaning of such code, our
  * analyses need to figure out that such loads return the same value.
- * <p/>
+ * </p>
  * <p>
  * AvailableLoad objects may be used as keys in both hash and tree sets and
  * maps.
- *
+ * </p>
  * @author David Hovemeyer
  * @see ValueNumberAnalysis
  */

--- a/findbugs/src/java/edu/umd/cs/findbugs/ba/vna/ValueNumber.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/ba/vna/ValueNumber.java
@@ -23,15 +23,15 @@ import edu.umd.cs.findbugs.util.MapCache;
 import edu.umd.cs.findbugs.util.Util;
 
 /**
- * A "value number" is a value produced somewhere in a methods. We use value
+ * <p>A "value number" is a value produced somewhere in a methods. We use value
  * numbers as dataflow values in Frames. When two frame slots have the same
  * value number, then the same value is in both of those slots.
- * <p/>
+ * </p>
  * <p>
  * Instances of ValueNumbers produced by the same {@link ValueNumberFactory
  * ValueNumberFactory} are unique, so reference equality may be used to
  * determine whether or not two value numbers are the same. In general,
- * ValueNumbers from different factories cannot be compared.
+ * ValueNumbers from different factories cannot be compared.</p>
  *
  * @author David Hovemeyer
  * @see ValueNumberAnalysis

--- a/findbugs/src/java/edu/umd/cs/findbugs/ba/vna/ValueNumberAnalysis.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/ba/vna/ValueNumberAnalysis.java
@@ -44,12 +44,12 @@ import edu.umd.cs.findbugs.ba.SignatureParser;
 import edu.umd.cs.findbugs.internalAnnotations.DottedClassName;
 
 /**
- * A dataflow analysis to track the production and flow of values in the Java
+ * <p>A dataflow analysis to track the production and flow of values in the Java
  * stack frame. See the {@link ValueNumber ValueNumber} class for an explanation
- * of what the value numbers mean, and when they can be compared.
+ * of what the value numbers mean, and when they can be compared.</p>
  *
  * <p>
- * This class is still experimental.
+ * This class is still experimental.</p>
  *
  * @author David Hovemeyer
  * @see ValueNumber
@@ -388,16 +388,16 @@ public class ValueNumberAnalysis extends FrameDataflowAnalysis<ValueNumber, Valu
      */
 
     /**
-     * Compact the value numbers assigned. This should be done only after the
+     * <p>Compact the value numbers assigned. This should be done only after the
      * dataflow algorithm has executed. This works by modifying the actual
      * ValueNumber objects assigned. After this method is called, the
      * getNumValuesAllocated() method of this object will return a value less
      * than or equal to the value it would have returned before the call to this
      * method.
-     * <p/>
+     * </p>
      * <p>
      * <em>This method should be called at most once</em>.
-     *
+     * </p>
      * @param dataflow
      *            the Dataflow object which executed this analysis (and has all
      *            of the block result values)

--- a/findbugs/src/java/edu/umd/cs/findbugs/ba/vna/ValueNumberAnalysisFeatures.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/ba/vna/ValueNumberAnalysisFeatures.java
@@ -26,18 +26,18 @@ import edu.umd.cs.findbugs.SystemProperties;
  */
 public interface ValueNumberAnalysisFeatures {
     /**
-     * When set, perform redundant load elimination and forward substitution.
+     * <p>When set, perform redundant load elimination and forward substitution.
      * Note that we do <em>not</em> do this in a correctness-preserving way! For
      * example, we don't kill loads when methods are called, even though those
      * methods could change heap values. The intent here is simply to try to
      * handle situations where a field is read multiple times, where the intent
      * of the programmer is clearly that the loaded values will be the same in
      * each case.
-     * <p/>
+     * </p>
      * <p>
      * Eventually, we might do interprocedural analysis that would allow
      * accurate modeling of which fields a called method could modify, which
-     * would allow a more correct implementation.
+     * would allow a more correct implementation.</p>
      */
     public static final boolean REDUNDANT_LOAD_ELIMINATION = !SystemProperties.getBoolean("vna.noRLE");
 

--- a/findbugs/src/java/edu/umd/cs/findbugs/classfile/ICodeBaseEntry.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/classfile/ICodeBaseEntry.java
@@ -66,7 +66,7 @@ public interface ICodeBaseEntry {
      * the class data to be loaded in order to determine the class.
      *
      * @return ClassDescriptor of this entry
-     * @throws ResourceNotFoundException, InvalidClassFileFormatException
+     * @throws ResourceNotFoundException InvalidClassFileFormatException
      *             if the codebase entry does not reference a valid classfile
      * @throws IllegalArgumentException
      *             if the codebase entry's filename is definitely not a

--- a/findbugs/src/java/edu/umd/cs/findbugs/classfile/engine/ClassParser.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/classfile/engine/ClassParser.java
@@ -39,8 +39,7 @@ import edu.umd.cs.findbugs.util.ClassName;
 
 /**
  * Parse a class to extract symbolic information. see <a
- * href=http://java.sun.com
- * /docs/books/vmspec/2nd-edition/html/ClassFile.doc.html">
+ * href="http://java.sun.com/docs/books/vmspec/2nd-edition/html/ClassFile.doc.html">
  * http://java.sun.com/docs/books/vmspec/2nd-edition/html/ClassFile.doc.html
  * </a>
  *

--- a/findbugs/src/java/edu/umd/cs/findbugs/detect/CheckExpectedWarnings.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/detect/CheckExpectedWarnings.java
@@ -69,7 +69,7 @@ import edu.umd.cs.findbugs.classfile.analysis.EnumValue;
  * internal testing of FindBugs (against findbugsTestCases).
  *
  * @author David Hovemeyer
- * @deprecated The annotation based approach is useless for lambdas. Write expectations using {@link com.h3xstream.findbugs.test.matcher.BugInstanceMatcher} matchers
+ * @deprecated The annotation based approach is useless for lambdas. Write expectations using {@code edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher} matchers in test source directory
  */
 @Deprecated
 public class CheckExpectedWarnings implements Detector2, NonReportingDetector {

--- a/findbugs/src/java/edu/umd/cs/findbugs/detect/FindUselessControlFlow.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/detect/FindUselessControlFlow.java
@@ -33,13 +33,13 @@ import edu.umd.cs.findbugs.BytecodeScanningDetector;
 import edu.umd.cs.findbugs.StatelessDetector;
 
 /**
- * <p>A Detector to look for useless control flow. For example,
+ * <p>A Detector to look for useless control flow. For example,</p>
  *
  * <pre>
  * if (argv.length == 1)
  *     ;
  * System.out.println(&quot;Hello, &quot; + argv[0]);
- * </pre></p>
+ * </pre>
  *
  * <p>In this kind of bug, we'll see an ifcmp instruction where the IF target is
  * the same as the fall-through target.

--- a/findbugs/src/java/edu/umd/cs/findbugs/detect/FindUselessControlFlow.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/detect/FindUselessControlFlow.java
@@ -33,21 +33,21 @@ import edu.umd.cs.findbugs.BytecodeScanningDetector;
 import edu.umd.cs.findbugs.StatelessDetector;
 
 /**
- * A Detector to look for useless control flow. For example,
+ * <p>A Detector to look for useless control flow. For example,
  *
  * <pre>
  * if (argv.length == 1)
  *     ;
  * System.out.println(&quot;Hello, &quot; + argv[0]);
- * </pre>
+ * </pre></p>
  *
- * In this kind of bug, we'll see an ifcmp instruction where the IF target is
+ * <p>In this kind of bug, we'll see an ifcmp instruction where the IF target is
  * the same as the fall-through target.
- * <p/>
+ * </p>
  * <p>
  * The idea for this detector came from Richard P. King, and the idea of looking
  * for if instructions with identical branch and fall-through targets is from
- * Mike Fagan.
+ * Mike Fagan.</p>
  *
  * @author David Hovemeyer
  */

--- a/findbugs/src/java/edu/umd/cs/findbugs/detect/IncompatMask.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/detect/IncompatMask.java
@@ -30,7 +30,7 @@ import edu.umd.cs.findbugs.bcel.OpcodeStackDetector;
  * Find comparisons involving values computed with bitwise operations whose
  * outcomes are fixed at compile time.
  *
- * @author Tom Truscott <trt@unx.sas.com>
+ * @author Tom Truscott &lt;trt@unx.sas.com&gt;
  * @author Tagir Valeev
  */
 public class IncompatMask extends OpcodeStackDetector {

--- a/findbugs/src/java/edu/umd/cs/findbugs/detect/Stream.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/detect/Stream.java
@@ -37,17 +37,17 @@ import edu.umd.cs.findbugs.ba.ResourceValue;
 import edu.umd.cs.findbugs.ba.ResourceValueFrame;
 
 /**
- * A Stream object marks the location in the code where a stream is created. It
+ * <p>A Stream object marks the location in the code where a stream is created. It
  * also is responsible for determining some aspects of how the stream state is
  * tracked by the ResourceValueAnalysis, such as when the stream is opened or
  * closed, and whether implicit exception edges are significant.
- * <p/>
+ * </p>
  * <p>
  * TODO: change streamClass and streamBase to ObjectType
- * <p/>
+ * </p>
  * <p>
  * TODO: isStreamOpen() and isStreamClose() should probably be abstract, so we
- * can customize how they work for different kinds of streams
+ * can customize how they work for different kinds of streams</p>
  */
 public class Stream extends ResourceCreationPoint implements Comparable<Stream> {
     private final String streamBase;

--- a/findbugs/src/java/edu/umd/cs/findbugs/visitclass/PreorderVisitor.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/visitclass/PreorderVisitor.java
@@ -82,15 +82,15 @@ import edu.umd.cs.findbugs.internalAnnotations.DottedClassName;
 import edu.umd.cs.findbugs.internalAnnotations.SlashedClassName;
 
 /**
- * Interface to make the use of a visitor pattern programming style possible.
+ * <p>Interface to make the use of a visitor pattern programming style possible.
  * I.e. a class that implements this interface can traverse the contents of a
  * Java class just by calling the `accept' method which all classes have.
- * <p/>
- * Implemented by wish of <A HREF="http://www.inf.fu-berlin.de/~bokowski">Boris
- * Bokowski</A>.
- * <p/>
+ * </p>
+ * <p>Implemented by wish of <A HREF="http://www.inf.fu-berlin.de/~bokowski">Boris
+ * Bokowski</A>.</p>
+ * <p>
  * If don't like it, blame him. If you do like it thank me 8-)
- *
+ * </p>
  * @author <A HREF="http://www.inf.fu-berlin.de/~dahm">M. Dahm</A>
  * @version 970819
  */

--- a/findbugs/src/java/org/apache/bcel/classfile/StackMapTableEntry.java
+++ b/findbugs/src/java/org/apache/bcel/classfile/StackMapTableEntry.java
@@ -322,8 +322,6 @@ public final class StackMapTableEntry implements Node, Cloneable
      * Update the distance (as an offset delta) from this StackMapTable
      * entry to the next.  Note that this might cause the the
      * frame type to change.  Note also that delta may be negative.
-     *
-     * @param int offset delta
      */
     public void updateByteCodeOffset(final int delta) {
         setByteCodeOffset(byte_code_offset + delta);

--- a/gradle/javadoc.gradle
+++ b/gradle/javadoc.gradle
@@ -1,6 +1,5 @@
 tasks.withType(Javadoc).all {
   // Default configuration for all javadoc tasks
-  failOnError false // TODO : There are plenty of errors to fix
   options.with {
      memberLevel = JavadocMemberLevel.PROTECTED
      author = true
@@ -16,5 +15,6 @@ tasks.withType(Javadoc).all {
      splitIndex = true
      use = true
      version = true
+     tags = ["ant.task","noinspection"]
   }
 }


### PR DESCRIPTION
This PR fixes all javadoc errors, and improve `gradle/javadoc.gradle` to mark build with javadoc error as failure.