### PR TITLE
Fix path of class files to analyse in integration test

### DIFF
--- a/findbugs/src/test/java/edu/umd/cs/findbugs/AbstractIntegrationTest.java
+++ b/findbugs/src/test/java/edu/umd/cs/findbugs/AbstractIntegrationTest.java
@@ -28,7 +28,6 @@ import java.io.IOException;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
-import org.junit.Assume;
 
 import edu.umd.cs.findbugs.config.UserPreferences;
 import edu.umd.cs.findbugs.internalAnnotations.SlashedClassName;
@@ -81,8 +80,8 @@ public class AbstractIntegrationTest {
 
     private File getFindbugsTestCasesFile(final String path) {
         final File f = new File(getFindbugsTestCases(), path);
-        Assume.assumeTrue(f.exists());
-        Assume.assumeTrue(f.canRead());
+        assertTrue(f.getAbsolutePath() + " not found", f.exists());
+        assertTrue(f.getAbsolutePath() + " is not readable", f.canRead());
 
         return f;
     }

--- a/findbugs/src/test/java/edu/umd/cs/findbugs/AbstractIntegrationTest.java
+++ b/findbugs/src/test/java/edu/umd/cs/findbugs/AbstractIntegrationTest.java
@@ -121,7 +121,7 @@ public class AbstractIntegrationTest {
 
         for (final String s : analyzeMe) {
             // TODO : Unwire this once we move bug samples to a proper sourceset
-            project.addFile(getFindbugsTestCasesFile("/build/classes/" + s).getPath());
+            project.addFile(getFindbugsTestCasesFile("/build/classes/main/" + s).getPath());
         }
 
         project.addAuxClasspathEntry("lib/junit.jar");

--- a/findbugs/src/test/java/edu/umd/cs/findbugs/AbstractIntegrationTest.java
+++ b/findbugs/src/test/java/edu/umd/cs/findbugs/AbstractIntegrationTest.java
@@ -19,6 +19,7 @@
 
 package edu.umd.cs.findbugs;
 
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.File;
@@ -71,9 +72,9 @@ public class AbstractIntegrationTest {
 
     private File getFindbugsTestCases() {
         final File f = new File(SystemProperties.getProperty("findbugsTestCases.home", "../findbugsTestCases"));
-        Assume.assumeTrue(f.exists());
-        Assume.assumeTrue(f.isDirectory());
-        Assume.assumeTrue(f.canRead());
+        assertTrue("'findbugsTestCases' directory not found", f.exists());
+        assertTrue(f.isDirectory());
+        assertTrue(f.canRead());
 
         return f;
     }

--- a/findbugs/src/test/java/edu/umd/cs/findbugs/DetectorsTest.java
+++ b/findbugs/src/test/java/edu/umd/cs/findbugs/DetectorsTest.java
@@ -98,7 +98,7 @@ public class DetectorsTest {
      */
     @Test
     public void testAllRegressionFilesJavac() throws IOException, InterruptedException {
-        setUpEngine("build/classes/");
+        setUpEngine("build/classes/main/");
 
         engine.execute();
 


### PR DESCRIPTION
Currently gradle generates class files under `findbugsTestCase/build/classes/main` directory, but out test still uses `findbugsTestCase/build/classes`.

To find similar problems asap, I replace `Assume` in `AbstractIntegrationTest` with `Assert`.