### PR TITLE
introduce maven-publish plugin, to publish jar files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 subprojects {
   apply plugin: 'java'
+  apply plugin: 'maven-publish'
   apply from: "$rootDir/gradle/eclipse.gradle"
   apply from: "$rootDir/gradle/idea.gradle"
   apply from: "$rootDir/gradle/test.gradle"

--- a/findbugs/build.gradle
+++ b/findbugs/build.gradle
@@ -255,6 +255,37 @@ task smokeTest {
   }
 }
 
+// https://docs.gradle.org/current/userguide/publishing_maven.html
+publishing {
+  publications {
+    mavenJava(MavenPublication) {
+      from components.java
+      artifactId 'spotbugs'
+
+      artifact sourcesJar {
+        classifier 'sources'
+      }
+
+      artifact javadocJar {
+        classifier 'javadoc'
+      }
+    }
+
+    annotations(MavenPublication) {
+      artifactId 'spotbugs-annotations'
+      artifact annotationsJar
+
+      artifact annotationSourcesJar {
+        classifier 'sources'
+      }
+
+      artifact annotationJavadocJar {
+        classifier 'javadoc'
+      }
+    }
+  }
+}
+
 // TODO : jsr305.jar (really?)
 // TODO : generatemanual (we should decide what to do with the manual)
 // TODO : generatepdfmanual


### PR DESCRIPTION
This change makes it possible to publish `spotbugs.jar` and `spotbugs-annotations.jar`, with sources and javadoc. This would be one of necessary steps to support Maven (#8) and release SNAPSHOT jar files by Travis (#30).

I tried to introduce `maven` plugin first, but it failed to install artifacts because it tries to install two `spotbugs:jar:jar:javadoc`. So I thought `maven-publish` plugin is better option, to make changes simple.

## How I tested

```
$ ./gradlew publishToMavenLocal
$ ls ~/.m2/repository/com/github/spotbugs/
spotbugs             spotbugs-annotations
$ ls ~/.m2/repository/com/github/spotbugs/spotbugs/3.1.0-SNAPSHOT 
maven-metadata-local.xml            spotbugs-3.1.0-SNAPSHOT.jar
spotbugs-3.1.0-SNAPSHOT-javadoc.jar spotbugs-3.1.0-SNAPSHOT.pom
spotbugs-3.1.0-SNAPSHOT-sources.jar
$ ls ~/.m2/repository/com/github/spotbugs/spotbugs-annotations/3.1.0-SNAPSHOT
maven-metadata-local.xml
spotbugs-annotations-3.1.0-SNAPSHOT-javadoc.jar
spotbugs-annotations-3.1.0-SNAPSHOT-sources.jar
spotbugs-annotations-3.1.0-SNAPSHOT.jar
spotbugs-annotations-3.1.0-SNAPSHOT.pom
```