### PR TITLE
add `--add-opens` option to solve InaccessibleObjectException

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ env:
 matrix:
   include:
      env:
-       - JDK_FOR_TEST=oraclejdk9
-       - GRADLE_OPTS='--add-opens java.base/java.lang=ALL-UNNAMED'
+       JDK_FOR_TEST: oraclejdk9
+       GRADLE_OPTS: '--add-opens java.base/java.lang=ALL-UNNAMED'
      addons:
        apt:
          packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ env:
 matrix:
   include:
      env:
-       JDK_FOR_TEST: oraclejdk9
-       GRADLE_OPTS: '--add-opens java.base/java.lang=ALL-UNNAMED'
+       - JDK_FOR_TEST=oraclejdk9
+       - GRADLE_OPTS='--add-opens java.base/java.lang=ALL-UNNAMED'
      addons:
        apt:
          packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,15 @@ dist: trusty
 
 matrix:
   include:
-    - env:
-        - JDK_VERSION=oraclejdk9
-        - JVM_ARGS='--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED -Dsun.reflect.debugModuleAccessChecks=true'
-      addons:
+    - addons:
         apt:
           packages:
             - oracle-java9-installer
-            - oracle-java9-set-default
-    - env:
-        - JDK_VERSION=oraclejdk8
-      addons:
+            - oracle-java8-installer
+            - oracle-java8-set-default
+      env:
+          - JAVA_9_HOME=$(jdk_switcher home oraclejdk9)
+    - addons:
         apt:
           packages:
             - oracle-java8-installer
@@ -27,7 +25,7 @@ install:
   - echo eclipsePlugin.dir=$(pwd)/eclipse/plugins > eclipsePlugin/local.properties
 
 script:
-  - ./gradlew build smoketest -S --no-daemon -Dorg.gradle.java.home=$(jdk_switcher home $JDK_VERSION) -Dorg.gradle.jvmargs="$JVM_ARGS"
+  - ./gradlew build smoketest -S --debug --no-daemon -Dorg.gradle.java.home=$(jdk_switcher home oraclejdk8)
 
 before_cache:
   - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
        apt:
          packages:
            - oracle-java9-installer
-     
+
 install:
   - mkdir -p deps
   - if [[ ! -e deps/eclipse.tar.gz ]]; then wget http://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops/R-3.6.2-201102101200/eclipse-SDK-3.6.2-linux-gtk-x86_64.tar.gz -O deps/eclipse.tar.gz; fi
@@ -27,7 +27,7 @@ install:
 script:
   # Manually switch to JDK9 if needed
   - if [[ $JDK_FOR_TEST == "oraclejdk9" ]]; then remove_dir_from_path $JAVA_HOME/bin; export JAVA_HOME=/usr/lib/jvm/java-9-oracle; export JAVA_HOME=/usr/lib/jvm/java-9-oracle; fi
-  - ./gradlew build smoketest -S
+  - ./gradlew build smoketest -S --no-daemon
 
 before_cache:
   - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
   include:
     - env:
         - JDK_VERSION=oraclejdk9
-        - JVM_ARGS='--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED'
+        - JVM_ARGS='--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED -Dsun.reflect.debugModuleAccessChecks=true'
       addons:
         apt:
           packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ matrix:
        apt:
          packages:
            - oracle-java9-installer
+           - oracle-java9-set-default
 
 install:
   - mkdir -p deps

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,9 @@ env:
 # Java 9 is not currently officially supported, so install it manually
 matrix:
   include:
-     env: JDK_FOR_TEST=oraclejdk9
+     env:
+       - JDK_FOR_TEST=oraclejdk9
+       - GRADLE_OPTS='--add-opens java.base/java.lang=ALL-UNNAMED'
      addons:
        apt:
          packages:
@@ -36,4 +38,3 @@ cache:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
     - deps/
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,33 @@
 language: java
 sudo: false
-jdk: oraclejdk8
+dist: trusty
 
-env:
-  matrix:
-    - JDK_FOR_TEST=oraclejdk8
-#    - JDK_FOR_TEST=oraclejdk9
-
-# Java 9 is not currently officially supported, so install it manually
 matrix:
   include:
-     env:
-       - JDK_FOR_TEST=oraclejdk9
-       - GRADLE_OPTS='--add-opens java.base/java.lang=ALL-UNNAMED'
-     addons:
-       apt:
-         packages:
-           - oracle-java9-installer
-           - oracle-java9-set-default
+    - env:
+        - JDK_VERSION=oraclejdk9
+        - JVM_ARGS='--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED'
+      addons:
+        apt:
+          packages:
+            - oracle-java9-installer
+            - oracle-java9-set-default
+    - env:
+        - JDK_VERSION=oraclejdk8
+      addons:
+        apt:
+          packages:
+            - oracle-java8-installer
+            - oracle-java8-set-default
 
 install:
   - mkdir -p deps
-  - if [[ ! -e deps/eclipse.tar.gz ]]; then wget http://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops/R-3.6.2-201102101200/eclipse-SDK-3.6.2-linux-gtk-x86_64.tar.gz -O deps/eclipse.tar.gz; fi
+  - if [[ ! -e deps/eclipse.tar.gz ]]; then wget http://archive.eclipse.org/eclipse/downloads/drops/R-3.7.2-201202080800/eclipse-SDK-3.7.2-linux-gtk-x86_64.tar.gz -O deps/eclipse.tar.gz; fi
   - tar xzvf deps/eclipse.tar.gz eclipse
   - echo eclipsePlugin.dir=$(pwd)/eclipse/plugins > eclipsePlugin/local.properties
 
 script:
-  # Manually switch to JDK9 if needed
-  - if [[ $JDK_FOR_TEST == "oraclejdk9" ]]; then remove_dir_from_path $JAVA_HOME/bin; export JAVA_HOME=/usr/lib/jvm/java-9-oracle; export JAVA_HOME=/usr/lib/jvm/java-9-oracle; fi
-  - ./gradlew build smoketest -S --no-daemon
+  - ./gradlew build smoketest -S --no-daemon -Dorg.gradle.java.home=$(jdk_switcher home $JDK_VERSION) -Dorg.gradle.jvmargs="$JVM_ARGS"
 
 before_cache:
   - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
 
 install:
   - mkdir -p deps
-  - if [[ ! -e deps/eclipse.tar.gz ]]; then wget http://archive.eclipse.org/eclipse/downloads/drops/R-3.7.2-201202080800/eclipse-SDK-3.7.2-linux-gtk-x86_64.tar.gz -O deps/eclipse.tar.gz; fi
+  - if [[ ! -e deps/eclipse.tar.gz ]]; then wget www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops/R-3.6.2-201102101200/eclipse-SDK-3.6.2-linux-gtk-x86_64.tar.gz -O deps/eclipse.tar.gz; fi
   - tar xzvf deps/eclipse.tar.gz eclipse
   - echo eclipsePlugin.dir=$(pwd)/eclipse/plugins > eclipsePlugin/local.properties
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
 
 install:
   - mkdir -p deps
-  - if [[ ! -e deps/eclipse.tar.gz ]]; then wget www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops/R-3.6.2-201102101200/eclipse-SDK-3.6.2-linux-gtk-x86_64.tar.gz -O deps/eclipse.tar.gz; fi
+  - if [[ ! -e deps/eclipse.tar.gz ]]; then wget http://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops/R-3.6.2-201102101200/eclipse-SDK-3.6.2-linux-gtk-x86_64.tar.gz -O deps/eclipse.tar.gz; fi
   - tar xzvf deps/eclipse.tar.gz eclipse
   - echo eclipsePlugin.dir=$(pwd)/eclipse/plugins > eclipsePlugin/local.properties
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,20 +21,3 @@ wrapper {
   gradleVersion = '3.2.1'
   distributionType = Wrapper.DistributionType.ALL
 }
-
-afterEvaluate {
-  if (System.env.containsKey('JAVA_9_HOME')) {
-    def java9Bin = new File(System.env['JAVA_9_HOME'], 'bin')
-    def java9 = new File(java9Bin, 'java')
-    assert java9.exists() : "Java9 not found at: ${java9}"
-    println "This build will test with Java9 stored at: ${java9}"
-
-    tasks.withType(Test) {
-      executable = java9.toString()
-      jvmArgs += ['-Dsun.reflect.debugModuleAccessChecks=true']
-      jvmArgs += ['--add-opens', 'java.base/java.lang=ALL-UNNAMED']
-      jvmArgs += ['--add-opens', 'java.base/java.util=ALL-UNNAMED']
-      jvmArgs += ['--add-opens', 'java.base/java.io=ALL-UNNAMED']
-    }
-  }
-}

--- a/build.gradle
+++ b/build.gradle
@@ -21,3 +21,20 @@ wrapper {
   gradleVersion = '3.2.1'
   distributionType = Wrapper.DistributionType.ALL
 }
+
+afterEvaluate {
+  if (System.env.containsKey('JAVA_9_HOME')) {
+    def java9Bin = new File(System.env['JAVA_9_HOME'], 'bin')
+    def java9 = new File(java9Bin, 'java')
+    assert java9.exists() : "Java9 not found at: ${java9}"
+    println "This build will test with Java9 stored at: ${java9}"
+
+    tasks.withType(Test) {
+      executable = java9.toString()
+      jvmArgs += ['-Dsun.reflect.debugModuleAccessChecks=true']
+      jvmArgs += ['--add-opens', 'java.base/java.lang=ALL-UNNAMED']
+      jvmArgs += ['--add-opens', 'java.base/java.util=ALL-UNNAMED']
+      jvmArgs += ['--add-opens', 'java.base/java.io=ALL-UNNAMED']
+    }
+  }
+}

--- a/findbugs/build.gradle
+++ b/findbugs/build.gradle
@@ -232,6 +232,21 @@ tasks['assembleDist'].finalizedBy distSrcZip
 test {
   dependsOn ':findbugsTestCases:build'
   maxHeapSize = '1G'
+
+  if (System.env.containsKey('JAVA_9_HOME')) {
+    def java9Bin = new File(System.env['JAVA_9_HOME'], 'bin')
+    def java9 = new File(java9Bin, 'java')
+    assert java9.exists() : "Java9 not found at: ${java9}"
+    println "This build will test with Java9 stored at: ${java9}"
+
+    executable = java9.toString()
+    jvmArgs += [
+      '-Dsun.reflect.debugModuleAccessChecks=true',
+      '--add-opens', 'java.base/java.lang=ALL-UNNAMED',
+      '--add-opens', 'java.base/java.util=ALL-UNNAMED',
+      '--add-opens', 'java.base/java.io=ALL-UNNAMED'
+    ]
+  }
 }
 
 task unzipDist(type:Copy, dependsOn:distZip) {


### PR DESCRIPTION
New Java9 package `oracle-java9-installer=9b149+9b149arm-1~webupd8~0` was released at Jan/4th, and it introduced [a build error](https://github.com/spotbugs/spotbugs/pull/69#issuecomment-271070661) to spotbugs.

This pull-request solves it by adding `--add-opens` option to `GRADLE_OPTS` envvar.