### PR TITLE
Introduce Jacoco to check coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,9 @@ script:
   - if [[ $JDK_FOR_TEST == "oraclejdk9" ]]; then remove_dir_from_path $JAVA_HOME/bin; export JAVA_HOME=/usr/lib/jvm/java-9-oracle; export JAVA_HOME=/usr/lib/jvm/java-9-oracle; fi
   - ./gradlew build smoketest -S
 
+after_success:
+  - if [[ $JDK_FOR_TEST == "oraclejdk8" ]]; then ./gradlew jacocoTestReport coveralls; fi
+
 before_cache:
   - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -rf $HOME/.gradle/caches/*/plugin-resolution/
@@ -36,4 +39,3 @@ cache:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
     - deps/
-

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/spotbugs/spotbugs.svg?branch=master)](https://travis-ci.org/spotbugs/spotbugs)
+[![Coverage Status](https://coveralls.io/repos/github/spotbugs/spotbugs/badge.svg?branch=master)](https://coveralls.io/github/spotbugs/spotbugs?branch=master)
 
 # SpotBugs
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,8 @@
-plugins {
-  id "com.github.kt3k.coveralls" version "2.7.1"
-}
-
 subprojects {
   apply plugin: 'java'
   apply plugin: 'maven-publish'
   apply from: "$rootDir/gradle/eclipse.gradle"
   apply from: "$rootDir/gradle/idea.gradle"
-  apply from: "$rootDir/gradle/jacoco.gradle"
   apply from: "$rootDir/gradle/test.gradle"
 
   group = 'com.github.spotbugs'
@@ -25,9 +20,4 @@ subprojects {
 wrapper {
   gradleVersion = '3.2.1'
   distributionType = Wrapper.DistributionType.ALL
-}
-
-coveralls {
-  sourceDirs = [project(':findbugs')].sourceSets.main.allSource.srcDirs.flatten()
-  jacocoReportPath = "findbugs/build/reports/jacoco/test/jacocoTestReport.xml"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ subprojects {
   apply plugin: 'maven-publish'
   apply from: "$rootDir/gradle/eclipse.gradle"
   apply from: "$rootDir/gradle/idea.gradle"
+  apply from: "$rootDir/gradle/jacoco.gradle"
   apply from: "$rootDir/gradle/test.gradle"
 
   group = 'com.github.spotbugs'

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+  id "com.github.kt3k.coveralls" version "2.7.1"
+}
+
 subprojects {
   apply plugin: 'java'
   apply plugin: 'maven-publish'
@@ -21,4 +25,9 @@ subprojects {
 wrapper {
   gradleVersion = '3.2.1'
   distributionType = Wrapper.DistributionType.ALL
+}
+
+coveralls {
+  sourceDirs = [project(':findbugs')].sourceSets.main.allSource.srcDirs.flatten()
+  jacocoReportPath = "findbugs/build/reports/jacoco/test/jacocoTestReport.xml"
 }

--- a/findbugs/build.gradle
+++ b/findbugs/build.gradle
@@ -1,3 +1,9 @@
+plugins {
+  id "com.github.kt3k.coveralls" version "2.7.1"
+}
+
+apply from: "$rootDir/gradle/jacoco.gradle"
+
 sourceSets {
   main {
     java {
@@ -291,6 +297,10 @@ publishing {
       }
     }
   }
+}
+
+coveralls {
+  jacocoReportPath = "${buildDir}/reports/jacoco/test/jacocoTestReport.xml"
 }
 
 // TODO : jsr305.jar (really?)

--- a/gradle/jacoco.gradle
+++ b/gradle/jacoco.gradle
@@ -1,0 +1,5 @@
+apply plugin: 'jacoco'
+
+jacoco {
+  toolVersion = "0.7.8"
+}

--- a/gradle/jacoco.gradle
+++ b/gradle/jacoco.gradle
@@ -1,5 +1,12 @@
-apply plugin: 'jacoco'
+apply plugin: "jacoco"
 
 jacoco {
   toolVersion = "0.7.8"
+}
+
+jacocoTestReport {
+  reports {
+    xml.enabled = true // coveralls plugin depends on xml format report
+    html.enabled = true
+  }
 }


### PR DESCRIPTION
Introduce jacoco plugin and coveralls plugin, to check test coverage.
To enable coveralls, we need to link this repository to coveralls, but it seems that my account cannot link.

Example: 
* https://coveralls.io/builds/9621402
* https://coveralls.io/github/KengoTODA/spotbugs