### PR TITLE
temporally drop build with java9, it will be back in #101

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,17 +5,7 @@ jdk: oraclejdk8
 env:
   matrix:
     - JDK_FOR_TEST=oraclejdk8
-#    - JDK_FOR_TEST=oraclejdk9
 
-# Java 9 is not currently officially supported, so install it manually
-matrix:
-  include:
-     env: JDK_FOR_TEST=oraclejdk9
-     addons:
-       apt:
-         packages:
-           - oracle-java9-installer
-     
 install:
   - mkdir -p deps
   - if [[ ! -e deps/eclipse.tar.gz ]]; then wget http://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops/R-3.6.2-201102101200/eclipse-SDK-3.6.2-linux-gtk-x86_64.tar.gz -O deps/eclipse.tar.gz; fi
@@ -23,8 +13,6 @@ install:
   - echo eclipsePlugin.dir=$(pwd)/eclipse/plugins > eclipsePlugin/local.properties
 
 script:
-  # Manually switch to JDK9 if needed
-  - if [[ $JDK_FOR_TEST == "oraclejdk9" ]]; then remove_dir_from_path $JAVA_HOME/bin; export JAVA_HOME=/usr/lib/jvm/java-9-oracle; export JAVA_HOME=/usr/lib/jvm/java-9-oracle; fi
   - ./gradlew build smoketest -S
 
 before_cache:
@@ -36,4 +24,3 @@ cache:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
     - deps/
-


### PR DESCRIPTION
It seems that supporting Java9 has taken too long time, so let's disable it temporally to keep making progress.
I will continue working on #101 to enable the build with Java9.