### PR TITLE
[performance improvement] Delete outdated hack for legacy JVM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v0.3](http://
 
 * `OpcodeStack.Item.defineNewSpecialKind(String)` ([#27](https://github.com/spotbugs/spotbugs/pull/27))
 * `Version.RELEASE` ([#125](https://github.com/spotbugs/spotbugs/pull/125))
+* `DescriptorFactory.canonicalizeString(String)` ([#128](https://github.com/spotbugs/spotbugs/pull/128))
 
 ### Removed
 

--- a/findbugs/src/main/java/edu/umd/cs/findbugs/ba/AbstractBlockOrder.java
+++ b/findbugs/src/main/java/edu/umd/cs/findbugs/ba/AbstractBlockOrder.java
@@ -20,7 +20,7 @@
 package edu.umd.cs.findbugs.ba;
 
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 
@@ -37,22 +37,17 @@ public abstract class AbstractBlockOrder implements BlockOrder {
 
     public AbstractBlockOrder(CFG cfg, Comparator<BasicBlock> comparator) {
         this.comparator = comparator;
+
         // Put the blocks in an array
-        int numBlocks = cfg.getNumBasicBlocks(), count = 0;
-        BasicBlock[] blocks = new BasicBlock[numBlocks];
-        for (Iterator<BasicBlock> i = cfg.blockIterator(); i.hasNext();) {
-            blocks[count++] = i.next();
+        int numBlocks = cfg.getNumBasicBlocks();
+        blockList = new ArrayList<BasicBlock>(cfg.getNumBasicBlocks());
+        for (BasicBlock bb : cfg.blocks()) {
+            blockList.add(bb);
         }
-        assert count == numBlocks;
+        assert blockList.size() == numBlocks;
 
         // Sort the blocks according to the comparator
-        Arrays.sort(blocks, comparator);
-
-        // Put the ordered blocks into an array list
-        blockList = new ArrayList<BasicBlock>(numBlocks);
-        for (int i = 0; i < numBlocks; ++i) {
-            blockList.add(blocks[i]);
-        }
+        Collections.sort(blockList, comparator);
     }
 
     @Override

--- a/findbugs/src/main/java/edu/umd/cs/findbugs/ba/Frame.java
+++ b/findbugs/src/main/java/edu/umd/cs/findbugs/ba/Frame.java
@@ -77,7 +77,7 @@ public abstract class Frame<ValueType> {
     /**
      * Array storing the values of local variables and operand stack slots.
      */
-    private final ArrayList<ValueType> slotList;
+    private ArrayList<ValueType> slotList;
 
     /**
      * Flag marking this frame as a special "TOP" value. Such Frames serve as
@@ -605,23 +605,8 @@ public abstract class Frame<ValueType> {
      */
     public void copyFrom(Frame<ValueType> other) {
         lastUpdateTimestamp = other.lastUpdateTimestamp;
-        if (true) {
-            int size = slotList.size();
-            if (size == other.slotList.size()) {
-                for (int i = 0; i < size; i++) {
-                    slotList.set(i, other.slotList.get(i));
-                }
-            } else {
-                slotList.clear();
-                for (ValueType v : other.slotList) {
-                    slotList.add(v);
-                }
-            }
-        } else {
-            slotList.clear();
-            slotList.addAll(other.slotList);
+        slotList = new ArrayList<>(other.slotList);
 
-        }
         /*
          * Andrei, 27.02.2008: "optimized" code below takes ~18% overall FB
          * execution time, code above only 5% int size = slotList.size(); if

--- a/findbugs/src/main/java/edu/umd/cs/findbugs/ba/Frame.java
+++ b/findbugs/src/main/java/edu/umd/cs/findbugs/ba/Frame.java
@@ -606,14 +606,6 @@ public abstract class Frame<ValueType> {
     public void copyFrom(Frame<ValueType> other) {
         lastUpdateTimestamp = other.lastUpdateTimestamp;
         slotList = new ArrayList<>(other.slotList);
-
-        /*
-         * Andrei, 27.02.2008: "optimized" code below takes ~18% overall FB
-         * execution time, code above only 5% int size = slotList.size(); if
-         * (size == other.slotList.size()) { for (int i = 0; i < size; i++)
-         * slotList.set(i, other.slotList.get(i)); } else { slotList.clear();
-         * for (ValueType v : other.slotList) slotList.add(v); }
-         */
         isTop = other.isTop;
         isBottom = other.isBottom;
     }

--- a/findbugs/src/main/java/edu/umd/cs/findbugs/classfile/DescriptorFactory.java
+++ b/findbugs/src/main/java/edu/umd/cs/findbugs/classfile/DescriptorFactory.java
@@ -68,18 +68,15 @@ public class DescriptorFactory {
         this.fieldDescriptorMap = new HashMap<FieldDescriptor, FieldDescriptor>();
     }
 
-    private final MapCache<String, String> stringCache = new MapCache<String, String>(10000);
-
+    /**
+     * This method was designed to canonicalize String to improve performance,
+     * but now GC cost is cheaper than calculation cost in application thread
+     * so removing this old optimization makes SpotBugs 16% faster.
+     * @return given string instance
+     * @deprecated this hack is needless for modern JVM, at least Java8
+     */
+    @Deprecated
     public static String canonicalizeString(@CheckForNull String s) {
-        if (s == null) {
-            return s;
-        }
-        DescriptorFactory df =  instanceThreadLocal.get();
-        String cached = df.stringCache.get(s);
-        if (cached != null) {
-            return cached;
-        }
-        df.stringCache.put(s, s);
         return s;
     }
 

--- a/findbugs/src/test/java/edu/umd/cs/findbugs/ba/FrameTest.java
+++ b/findbugs/src/test/java/edu/umd/cs/findbugs/ba/FrameTest.java
@@ -1,0 +1,22 @@
+package edu.umd.cs.findbugs.ba;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class FrameTest {
+
+    @Test
+    public void testToString() {
+        Frame<String> frame = new Frame<String>(1){
+            @Override
+            public String getValue(int n) {
+                return "value";
+            }
+        };
+        assertThat(frame.toString(), is(equalTo("[value]")));
+    }
+
+}


### PR DESCRIPTION
According to my benchmark, SpotBugs is 6% slower than FindBugs 3.0.1. And some of bottlenecks can be solved easily without adding new dependency nor upgrading library. This pull-request proposes these easy fixes.

## Benchmark script

I use Google Guava as target, because it has no big dependencies but it depends on JSR305 so we can use almost full-set feature of SpotBugs.

```
#!/bin/bash -e
for i in {1..20}; do
  /usr/bin/time java -Xmx2g -Xms2g \
  -jar findbugs/build/distributions/spotbugs-3.1.0-SNAPSHOT/lib/spotbugs.jar \
  -textui -auxclasspath ~/.m2/repository/com/google/code/findbugs/jsr305/3.0.1/jsr305-3.0.1.jar \
  -output /dev/null ~/.m2/repository/com/google/guava/guava/19.0/guava-19.0.jar 2>&1 | \
  grep real | sed 's/ \{1,\}/ /g' | cut -d ' ' -f 2,4,6
done;
```

## Note

* I use this script on OS X, your `time` might not be the same one if you're using different OS.
* I run benchmark 20 times, and use its MEDIAN as performance indicator.
* After applying these optimizations, bottleneck still remains especially in collection handling. I will list the big one as follows, and will consider to introduce Guava, FastUtil or other libraries.
    * edu.umd.cs.findbugs.classfile.DescriptorFactory.getMethodDescriptor(String, String, String, boolean)
        * We creates instance first, and check the existing instance in collection.
        * `HashMap#get(key)` costs much time even though `MethodDescriptor` implements `hashCode()` and `equals()` in acceptable quality.
        * Deleting this cache doesn't improve performance (26.2 sec).
    * edu.umd.cs.findbugs.classfile.impl.AnalysisCache.getClassAnalysis(Class, ClassDescriptor)	
        * `HashMap#get(key)` costs much time even though `ClassDescriptor` implements `hashCode()` and `equals()` in acceptable quality.
    * edu.umd.cs.findbugs.classfile.DescriptorFactory.getClassDescriptor(String)
        * `HashMap#get(key)` costs much time even though we use `String` as key.
    * edu.umd.cs.findbugs.classfile.analysis.ClassInfo.findMethod(String, String, boolean)
        * We use `O(n)` algorithm to search. Better to introduce [Table](https://github.com/google/guava/wiki/NewCollectionTypesExplained#table) or some other collection to search by `O(log(n))` algorithm.
* About detailed report, please check [SpotBugsPerformance_3adfcbf.ods.zip](https://github.com/spotbugs/spotbugs/files/784678/SpotBugsPerformance_3adfcbf.ods.zip)