### PR TITLE
refs #6: support INVOKEDYNAMIC at DismantleBytecode

### DIFF
--- a/findbugs/src/main/java/edu/umd/cs/findbugs/visitclass/DismantleBytecode.java
+++ b/findbugs/src/main/java/edu/umd/cs/findbugs/visitclass/DismantleBytecode.java
@@ -205,6 +205,7 @@ abstract public class DismantleBytecode extends AnnotationVisitor {
         case INVOKESPECIAL:
         case INVOKEVIRTUAL:
         case INVOKESTATIC:
+        case INVOKEDYNAMIC:
             return true;
 
         }
@@ -1169,5 +1170,13 @@ abstract public class DismantleBytecode extends AnnotationVisitor {
             }
         }
         return referencedXClass;
+    }
+
+    /**
+     * This is a setter only for unit test.
+     * @param opcode new opcode value
+     */
+    void setOpcode(int opcode) {
+        this.opcode = opcode;
     }
 }

--- a/findbugs/src/test/java/edu/umd/cs/findbugs/visitclass/DismantleBytecodeTest.java
+++ b/findbugs/src/test/java/edu/umd/cs/findbugs/visitclass/DismantleBytecodeTest.java
@@ -19,7 +19,12 @@
 
 package edu.umd.cs.findbugs.visitclass;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.apache.bcel.Const;
+import org.apache.bcel.Constants;
 
 import junit.framework.TestCase;
 
@@ -27,6 +32,12 @@ import junit.framework.TestCase;
  * @author pugh
  */
 public class DismantleBytecodeTest extends TestCase {
+    public void testIsMethodCall() {
+        DismantleBytecode dismantleBytecode = new DismantleBytecode() {
+        };
+        dismantleBytecode.setOpcode(Constants.INVOKEDYNAMIC);
+        assertThat(dismantleBytecode.isMethodCall(), is(equalTo(true)));
+    }
 
     public void testAreOppositeBranches() {
         assertTrue(DismantleBytecode.areOppositeBranches(Const.IF_ACMPEQ, Const.IF_ACMPNE));


### PR DESCRIPTION
Note that I cannot find any other place which needs to add `INVOKEDYNAMIC`, but I lack the view of whole SpotBugs architecture so we may have more classes to change.