### PR TITLE
Release 3.1.0 rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This is the changelog for SpotBugs. This follows [Keep a Changelog v0.3](http://keepachangelog.com/en/0.3.0/).
 
-## Unreleased
+## 3.1.0-RC1 (2017/Feb/19)
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 [![Build Status](https://travis-ci.org/spotbugs/spotbugs.svg?branch=master)](https://travis-ci.org/spotbugs/spotbugs)
 [![Coverage Status](https://coveralls.io/repos/github/spotbugs/spotbugs/badge.svg?branch=master)](https://coveralls.io/github/spotbugs/spotbugs?branch=master)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.spotbugs/spotbugs/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.github.spotbugs/spotbugs)
 
 
 [SpotBugs](https://spotbugs.github.io/) is the spiritual successor of [FindBugs](https://github.com/findbugsproject/findbugs), carrying on from the point where it left off with support of its community.

--- a/eclipsePlugin/build.gradle
+++ b/eclipsePlugin/build.gradle
@@ -1,6 +1,9 @@
 if (version.endsWith('-SNAPSHOT')) {
   // eclipse doesn't like the `-SNAPSHOT`, so we timestamp uniquely
   version = version - '-SNAPSHOT' + '.' + new Date().format('yyyyMMdd') + '-' + System.currentTimeMillis()
+} else if (version.contains('-RC')) {
+  // eclipse doesn't like the `-RC`, so we timestamp uniquely
+  version = version - '-RC' + '.' + new Date().format('yyyyMMdd') + '-' + System.currentTimeMillis()
 }
 
 sourceSets {

--- a/spotbugs-annotations/README.md
+++ b/spotbugs-annotations/README.md
@@ -1,0 +1,3 @@
+# SpotBugs Annotations
+
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.spotbugs/spotbugs-annotations/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.github.spotbugs/spotbugs-annotations)

--- a/spotbugs-ant/README.md
+++ b/spotbugs-ant/README.md
@@ -1,0 +1,3 @@
+# SpotBugs Ant Task
+
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.spotbugs/spotbugs-ant/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.github.spotbugs/spotbugs-ant)

--- a/test-harness/README.md
+++ b/test-harness/README.md
@@ -1,0 +1,3 @@
+# SpotBugs Test Harness
+
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.spotbugs/test-harness/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.github.spotbugs/test-harness)


### PR DESCRIPTION
Now almost all issues/pull-requests on 3.1.0 milestone are closed, let's release 3.1.0 RC1 to ask community to have a try.

This branch contains several changes to update Gradle, README and CHANGELOG.
However it doesn't contain the commit a935445 which will be tagged as `3.1.0-RC1`. I thought that it is needless in `master`, because we need to switch back version to `3.1.0-SNAPSHOT` again. If we prefer another way, let's go there.

I want to ask @jsotuyod to:

* Review this pull-request
* Close and promote uploaded artifacts named `comgithubspotbugs-1001` at [SonaType Nexus](https://oss.sonatype.org/#stagingRepositories)
* Mention to SonaType members, as [requested at OSSRH-27535](https://issues.sonatype.org/browse/OSSRH-27535?focusedCommentId=389436&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-389436), and
* Ask community to have a try (maybe at that mailing list?), with [a link to migration guide](http://spotbugs.readthedocs.io/en/latest/migration.html).