### PR TITLE
Support plugin development by test harness

### DIFF
--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/Plugin.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/Plugin.java
@@ -637,6 +637,11 @@ public class Plugin {
 
     /**
      * Loads the given plugin and enables it for the given project.
+     * 
+     * @param f
+     *      A non-null jar file of custom plugin.
+     * @param project
+     *      A nullable target project
      */
     public static Plugin loadCustomPlugin(File f, @CheckForNull Project project)
             throws PluginException {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/SortedBugCollection.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/SortedBugCollection.java
@@ -47,6 +47,7 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
@@ -1301,5 +1302,9 @@ public class SortedBugCollection implements BugCollection {
         bugsPopulated = true;
     }
 
+    @Override
+    public String toString() {
+        return bugSet.stream().map(Object::toString).collect(Collectors.joining(",", "[", "]"));
+    }
 }
 

--- a/test-harness/src/main/java/edu/umd/cs/findbugs/test/AnalysisRunner.java
+++ b/test-harness/src/main/java/edu/umd/cs/findbugs/test/AnalysisRunner.java
@@ -2,22 +2,38 @@ package edu.umd.cs.findbugs.test;
 
 import static org.junit.Assert.fail;
 
+import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URISyntaxException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.jar.JarOutputStream;
+import java.util.zip.ZipEntry;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 import edu.umd.cs.findbugs.BugCollectionBugReporter;
 import edu.umd.cs.findbugs.BugRanker;
 import edu.umd.cs.findbugs.DetectorFactoryCollection;
 import edu.umd.cs.findbugs.FindBugs2;
+import edu.umd.cs.findbugs.Plugin;
+import edu.umd.cs.findbugs.PluginException;
 import edu.umd.cs.findbugs.Priorities;
 import edu.umd.cs.findbugs.Project;
 import edu.umd.cs.findbugs.config.UserPreferences;
+import edu.umd.cs.findbugs.plugins.DuplicatePluginIdException;
 
 /**
  * <p>
@@ -31,6 +47,28 @@ import edu.umd.cs.findbugs.config.UserPreferences;
 @ParametersAreNonnullByDefault
 public class AnalysisRunner {
     private final List<Path> auxClasspathEntries = new ArrayList<>();
+
+    /**
+     * SpotBugs stores relation between plugin-id and {@link Plugin} instance in a static field ({@code Plugin.allPlugins}),
+     * so we need to store Plugin information in static field too, to avoid duplicated plugin loading.
+     */
+    @Nullable
+    private static final File PLUGIN_JAR;
+
+    static {
+        File jarFile;
+        try {
+            jarFile = createTempJar();
+            Plugin.loadCustomPlugin(jarFile, null);
+        } catch (DuplicatePluginIdException ignore) {
+            // loading core plugin
+            jarFile = null;
+        } catch (IOException | URISyntaxException | PluginException e) {
+            throw new AssertionError(e);
+        }
+
+        PLUGIN_JAR = jarFile;
+    }
 
     @Nonnull
     public AnalysisRunner addAuxClasspathEntry(Path path) {
@@ -51,6 +89,12 @@ public class AnalysisRunner {
         project.setProjectName(getClass().getSimpleName());
         engine.setProject(project);
 
+        if (PLUGIN_JAR != null) try {
+            String pluginId = Plugin.addCustomPlugin(PLUGIN_JAR.toURI()).getPluginId();
+            project.setPluginStatusTrinary(pluginId, Boolean.TRUE);
+        } catch (PluginException e) {
+            throw new AssertionError("Failed to load plugin", e);
+        }
         final DetectorFactoryCollection detectorFactoryCollection = DetectorFactoryCollection.instance();
         engine.setDetectorFactoryCollection(detectorFactoryCollection);
 
@@ -83,5 +127,40 @@ public class AnalysisRunner {
             throw assertionError;
         }
         return bugReporter;
+    }
+
+    /**
+     * Create a jar file which contains all resource files. This is necessary to
+     * let {@link Plugin#loadCustomPlugin(File, Project)} load custom plugin to
+     * test.
+     * 
+     * @return a {@link File} instance which represent generated jar file
+     * @throws IOException
+     * @throws URISyntaxException
+     */
+    private static File createTempJar() throws IOException, URISyntaxException {
+        ClassLoader cl = AnalysisRunner.class.getClassLoader();
+        Path tempJar = File.createTempFile("SpotBugsAnalysisRunner", ".jar").toPath();
+        try (OutputStream output = Files.newOutputStream(tempJar, StandardOpenOption.WRITE);
+                JarOutputStream jar = new JarOutputStream(output)) {
+            Path resourceRoot = Paths.get(cl.getResource("findbugs.xml").toURI()).getParent();
+
+            byte[] data = new byte[4 * 1024];
+            Files.walkFileTree(resourceRoot, new SimpleFileVisitor<Path>() {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    String name = resourceRoot.relativize(file).toString();
+                    jar.putNextEntry(new ZipEntry(name));
+                    try (InputStream input = Files.newInputStream(file, StandardOpenOption.READ)) {
+                        int len;
+                        while ((len = input.read(data)) > 0) {
+                            jar.write(data, 0, len);
+                        }
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        }
+        return tempJar.toFile();
     }
 }


### PR DESCRIPTION
Current implementation supports SpotBugs core plugin only, to support other plugin developers, we need to load plugin jar file in advance.

Note that SpotBugs manages loaded plugin in static fields, so we need this hack in static initializer

And currently we have no API to create Plugin instance without loading it,
so this code catches `DuplicatePluginIdException` to judge we load core plugin or not.