### PR TITLE
Fix HTML formatting

### DIFF
--- a/spotbugs/etc/messages.xml
+++ b/spotbugs/etc/messages.xml
@@ -93,146 +93,71 @@ This plugin contains all of the standard SpotBugs detectors.
   <BugCategory category="CORRECTNESS">
     <Description>Correctness</Description>
     <Abbreviation>C</Abbreviation>
-    <Details>
-<![CDATA[
-<p>
-    Probable bug - an apparent coding mistake
+    <Details>Probable bug - an apparent coding mistake
             resulting in code that was probably not what the
-            developer intended.
-</p>
-<p>
-             We strive for a low false positive rate.
-</p>
-]]>
-    </Details>
+            developer intended. We strive for a low false positive rate.</Details>
   </BugCategory>
-  
   <BugCategory category="NOISE">
     <Description>Bogus random noise</Description>
     <Abbreviation>N</Abbreviation>
-    <Details>
-<![CDATA[
-<p>
-    Bogus random noise: intended to be useful
+    <Details>Bogus random noise: intended to be useful
     as a control in data mining experiments, not in finding actual bugs in software
-</p>
-]]>
             </Details>
   </BugCategory>
-  
   <BugCategory category="SECURITY">
     <Description>Security</Description>
     <Abbreviation>S</Abbreviation>
-    <Details>
-<![CDATA[
-<p>
-    A use of untrusted input in a way that could create a remotely exploitable security vulnerability.
-</p>
-]]>
+    <Details>A use of untrusted input in a way that could create a remotely exploitable security vulnerability.
     </Details>
   </BugCategory>
-  
   <BugCategory category="BAD_PRACTICE">
     <Description>Bad practice</Description>
     <Abbreviation>B</Abbreviation>
-    <Details>
-<![CDATA[
-<p>
-    Violations of recommended and essential
+    <Details>Violations of recommended and essential
             coding practice. Examples include hash code and equals
             problems, cloneable idiom, dropped exceptions,
             Serializable problems, and misuse of finalize.
-</p>
-<p>
             We strive to make this analysis accurate,
             although some groups may
-            not care about some of the bad practices.
-</p>
-]]>
-            </Details>
+            not care about some of the bad practices.</Details>
   </BugCategory>
-  
   <BugCategory category="STYLE">
     <Description>Dodgy code</Description>
     <Abbreviation>D</Abbreviation>
-    <Details>
-<![CDATA[
-<p>
-    code that is confusing, anomalous, or
+    <Details>code that is confusing, anomalous, or
             written in a way that leads itself to errors.
             Examples include dead local stores, switch fall through,
             unconfirmed casts, and redundant null check of value
             known to be null.
-</p>
-<p>
             More false positives accepted.
-</p>
-<p>
             In previous versions of FindBugs, this category was known as Style.
-</p>
-]]>
 </Details>
   </BugCategory>
-  
   <BugCategory category="PERFORMANCE">
     <Description>Performance</Description>
     <Abbreviation>P</Abbreviation>
-    <Details>
-<![CDATA[
-<p>
-    code that is not necessarily incorrect but may be inefficient.
-</p>
-]]>
-    </Details>
+    <Details>code that is not necessarily incorrect but may be inefficient</Details>
   </BugCategory>
-  
   <BugCategory category="MALICIOUS_CODE">
     <Description>Malicious code vulnerability</Description>
     <Abbreviation>V</Abbreviation>
-    <Details>
-<![CDATA[
-<p>
-    code that is vulnerable to attacks from untrusted code.
-</p>
-]]>
-    </Details>
+    <Details>code that is vulnerable to attacks from untrusted code</Details>
   </BugCategory>
-  
   <BugCategory category="MT_CORRECTNESS">
     <Description>Multithreaded correctness</Description>
     <Abbreviation>M</Abbreviation>
-    <Details>
-<![CDATA[
-<p>
-    code flaws having to do with threads, locks, and volatiles.
-</p>
-]]>
-    </Details>
+    <Details>code flaws having to do with threads, locks, and volatiles</Details>
   </BugCategory>
-  
   <BugCategory category="I18N">
     <Description>Internationalization</Description>
     <Abbreviation>I</Abbreviation>
-    <Details>
-<![CDATA[
-<p>
-    code flaws having to do with internationalization and locale.
-</p>
-]]>
-    </Details>
+    <Details>code flaws having to do with internationalization and locale</Details>
     <!-- DM_CONVERT_CASE is the only core bug pattern in this category -->
   </BugCategory>
-  
   <BugCategory category="EXPERIMENTAL">
     <Description>Experimental</Description>
     <Abbreviation>X</Abbreviation>
-    <Details>
-<![CDATA[
-<p>
-    Experimental and not fully vetted bug patterns.
-</p>
-]]>
-    </Details>
+    <Details>Experimental and not fully vetted bug patterns</Details>
     <!-- DM_CONVERT_CASE is the only core bug pattern in this category -->
   </BugCategory>
   

--- a/spotbugs/etc/messages.xml
+++ b/spotbugs/etc/messages.xml
@@ -3706,10 +3706,11 @@ public class CircularClassInitialization {
   <p> The code synchronizes on interned String.</p>
 <pre><code>
 private static String LOCK = "LOCK";
-
+...
 synchronized(LOCK) {
     ...
 }
+...
 </code></pre>
 <p>Constant Strings are interned and shared across all other classes loaded by the JVM. Thus, this code
 is locking on something that other code might also be locking. This could result in very strange and hard to diagnose
@@ -3727,13 +3728,14 @@ blocking and deadlock behavior. See <a href="http://www.javalobby.org/java/forum
   <p> The code synchronizes on a boxed primitive constant, such as a Boolean.</p>
 <pre><code>
 private static Boolean inited = Boolean.FALSE;
-
+...
 synchronized(inited) { 
     if (!inited) {
         init();
         inited = Boolean.TRUE;
     }
 }
+...
 </code></pre>
 <p>Since there normally exist only two Boolean objects, this code could be synchronizing on the same object as other, unrelated code, leading to unresponsiveness
 and possible deadlock.</p>
@@ -3750,10 +3752,11 @@ and possible deadlock.</p>
 such as an Integer.</p>
 <pre><code>
 private static final Integer fileLock = new Integer(1);
-
+...
 synchronized(fileLock) { 
     .. do something ..
 }
+...
 </code></pre>
 <p>It would be much better, in this code, to redeclare fileLock as</p>
 <pre><code>
@@ -3776,10 +3779,11 @@ throughout the JVM, leading to very confusing behavior and potential deadlock.
   <p> The code synchronizes on a boxed primitive constant, such as an Integer.</p>
 <pre><code>
 private static Integer count = 0;
-
+...
 synchronized(count) { 
     count++;
 }
+...
 </code></pre>
 <p>Since Integer objects can be cached and shared,
 this code could be synchronizing on the same object as other, unrelated code, leading to unresponsiveness
@@ -5538,15 +5542,15 @@ of defensive programming.</p>
 but does not release it on all paths out of the method.  In general, the correct idiom
 for using a JSR-166 lock is:
 </p>
-<pre>
-    Lock l = ...;
-    l.lock();
-    try {
-        // do something
-    } finally {
-        l.unlock();
-    }
-</pre>
+<pre><code>
+Lock l = ...;
+l.lock();
+try {
+    // do something
+} finally {
+    l.unlock();
+}
+</code></pre>
 ]]>
     </Details>
   </BugPattern>

--- a/spotbugs/etc/messages.xml
+++ b/spotbugs/etc/messages.xml
@@ -93,73 +93,149 @@ This plugin contains all of the standard SpotBugs detectors.
   <BugCategory category="CORRECTNESS">
     <Description>Correctness</Description>
     <Abbreviation>C</Abbreviation>
-    <Details>Probable bug - an apparent coding mistake
+    <Details>
+<![CDATA[
+<p>
+    Probable bug - an apparent coding mistake
             resulting in code that was probably not what the
-            developer intended. We strive for a low false positive rate.</Details>
+            developer intended.
+</p>
+<p>
+             We strive for a low false positive rate.
+</p>
+]]>
+    </Details>
   </BugCategory>
+  
   <BugCategory category="NOISE">
     <Description>Bogus random noise</Description>
     <Abbreviation>N</Abbreviation>
-    <Details>Bogus random noise: intended to be useful
+    <Details>
+<![CDATA[
+<p>
+    Bogus random noise: intended to be useful
     as a control in data mining experiments, not in finding actual bugs in software
+</p>
+]]>
             </Details>
   </BugCategory>
+  
   <BugCategory category="SECURITY">
     <Description>Security</Description>
     <Abbreviation>S</Abbreviation>
-    <Details>A use of untrusted input in a way that could create a remotely exploitable security vulnerability.
+    <Details>
+<![CDATA[
+<p>
+    A use of untrusted input in a way that could create a remotely exploitable security vulnerability.
+</p>
+]]>
     </Details>
   </BugCategory>
+  
   <BugCategory category="BAD_PRACTICE">
     <Description>Bad practice</Description>
     <Abbreviation>B</Abbreviation>
-    <Details>Violations of recommended and essential
+    <Details>
+<![CDATA[
+<p>
+    Violations of recommended and essential
             coding practice. Examples include hash code and equals
             problems, cloneable idiom, dropped exceptions,
             Serializable problems, and misuse of finalize.
+</p>
+<p>
             We strive to make this analysis accurate,
             although some groups may
-            not care about some of the bad practices.</Details>
+            not care about some of the bad practices.
+</p>
+]]>
+            </Details>
   </BugCategory>
+  
   <BugCategory category="STYLE">
     <Description>Dodgy code</Description>
     <Abbreviation>D</Abbreviation>
-    <Details>code that is confusing, anomalous, or
+    <Details>
+<![CDATA[
+<p>
+    code that is confusing, anomalous, or
             written in a way that leads itself to errors.
             Examples include dead local stores, switch fall through,
             unconfirmed casts, and redundant null check of value
             known to be null.
+</p>
+<p>
             More false positives accepted.
+</p>
+<p>
             In previous versions of FindBugs, this category was known as Style.
+</p>
+]]>
 </Details>
   </BugCategory>
+  
   <BugCategory category="PERFORMANCE">
     <Description>Performance</Description>
     <Abbreviation>P</Abbreviation>
-    <Details>code that is not necessarily incorrect but may be inefficient</Details>
+    <Details>
+<![CDATA[
+<p>
+    code that is not necessarily incorrect but may be inefficient.
+</p>
+]]>
+    </Details>
   </BugCategory>
+  
   <BugCategory category="MALICIOUS_CODE">
     <Description>Malicious code vulnerability</Description>
     <Abbreviation>V</Abbreviation>
-    <Details>code that is vulnerable to attacks from untrusted code</Details>
+    <Details>
+<![CDATA[
+<p>
+    code that is vulnerable to attacks from untrusted code.
+</p>
+]]>
+    </Details>
   </BugCategory>
+  
   <BugCategory category="MT_CORRECTNESS">
     <Description>Multithreaded correctness</Description>
     <Abbreviation>M</Abbreviation>
-    <Details>code flaws having to do with threads, locks, and volatiles</Details>
+    <Details>
+<![CDATA[
+<p>
+    code flaws having to do with threads, locks, and volatiles.
+</p>
+]]>
+    </Details>
   </BugCategory>
+  
   <BugCategory category="I18N">
     <Description>Internationalization</Description>
     <Abbreviation>I</Abbreviation>
-    <Details>code flaws having to do with internationalization and locale</Details>
+    <Details>
+<![CDATA[
+<p>
+    code flaws having to do with internationalization and locale.
+</p>
+]]>
+    </Details>
     <!-- DM_CONVERT_CASE is the only core bug pattern in this category -->
   </BugCategory>
+  
   <BugCategory category="EXPERIMENTAL">
     <Description>Experimental</Description>
     <Abbreviation>X</Abbreviation>
-    <Details>Experimental and not fully vetted bug patterns</Details>
+    <Details>
+<![CDATA[
+<p>
+    Experimental and not fully vetted bug patterns.
+</p>
+]]>
+    </Details>
     <!-- DM_CONVERT_CASE is the only core bug pattern in this category -->
   </BugCategory>
+  
   <!--
   **********************************************************************
   Detectors
@@ -2200,9 +2276,10 @@ should be written to the JarFile between the calls to
 <p>Array of covariant type is assigned to a field. This is confusing and may lead to ArrayStoreException at runtime
 if the reference of some other type will be stored in this array later like in the following code:
 </p>
-<p><code>Number[] arr = new Integer[10];
+<pre><code>
+Number[] arr = new Integer[10];
 arr[0] = 1.0;
-</code></p>
+</code></pre>
 <p>Consider changing the type of created array or the field type.</p>   	
 ]]>
     </Details>
@@ -2215,9 +2292,10 @@ arr[0] = 1.0;
 <p>Array of covariant type is assigned to a local variable. This is confusing and may lead to ArrayStoreException at runtime
 if the reference of some other type will be stored in this array later like in the following code:
 </p>
-<p><code>Number[] arr = new Integer[10];
+<pre><code>
+Number[] arr = new Integer[10];
 arr[0] = 1.0;
-</code></p>
+</code></pre>
 <p>Consider changing the type of created array or the local variable type.</p>   	
 ]]>
     </Details>
@@ -2342,8 +2420,7 @@ will need to be changed in order to compile it in later versions of Java.</p>
 ]]>
     </Details>
   </BugPattern>
-  <BugPattern type="DP_DO_INSIDE_DO_PRIVILEDGED">
-    <!-- misspelled for backward compatibility -->
+  <BugPattern type="DP_DO_INSIDE_DO_PRIVILEDGED"> <!-- misspelled for backward compatibility -->
     <ShortDescription>Method invoked that should be only be invoked inside a doPrivileged block</ShortDescription>
     <LongDescription>Invocation of {2}, which should be invoked from within a doPrivileged block, in {1}</LongDescription>
     <Details>
@@ -2879,14 +2956,15 @@ on objects referenced by X, because they may already be getting finalized in a s
 the equals method). For example, the Foo class might have an equals method
 that looks like:
 </p>
-<pre>
+<pre><code>
 public boolean equals(Object o) {
-  if (o instanceof Foo)
-    return name.equals(((Foo)o).name);
-  else if (o instanceof String)
-    return name.equals(o);
-  else return false;
-</pre>
+    if (o instanceof Foo)
+        return name.equals(((Foo)o).name);
+    else if (o instanceof String)
+        return name.equals(o);
+    else return false;
+}
+</code></pre>
 
 <p>This is considered bad practice, as it makes it very hard to implement an equals method that
 is symmetric and transitive. Without those properties, very unexpected behaviors are possible.
@@ -3049,9 +3127,11 @@ Plus, it means that the equals method is not symmetric.
 that equals is not reflexive, one of the requirements of the equals method.</p>
 <p>The likely intended semantics are object identity: that an object is equal to itself. This is the behavior inherited from class <code>Object</code>. If you need to override an equals inherited from a different
 superclass, you can use:</p>
-<pre>
-public boolean equals(Object o) { return this == o; }
-</pre>
+<pre><code>
+public boolean equals(Object o) {
+    return this == o;
+}
+</code></pre>
 ]]>
     </Details>
   </BugPattern>
@@ -3191,10 +3271,12 @@ fix this problem of highest importance.
   than simple reference equality.)</p>
 <p>If you don't think instances of this class will ever be inserted into a HashMap/HashTable,
 the recommended <code>hashCode</code> implementation to use is:</p>
-<pre>public int hashCode() {
-  assert false : "hashCode not designed";
-  return 42; // any arbitrary constant will do
-  }</pre>
+<pre><code>
+public int hashCode() {
+    assert false : "hashCode not designed";
+    return 42; // any arbitrary constant will do
+}
+</code></pre>
 ]]>
     </Details>
   </BugPattern>
@@ -3246,10 +3328,12 @@ is "Note: this class has a natural ordering that is inconsistent with equals."
 
 <p>If you don't think instances of this class will ever be inserted into a HashMap/HashTable,
 the recommended <code>hashCode</code> implementation to use is:</p>
-<pre>public int hashCode() {
-  assert false : "hashCode not designed";
-  return 42; // any arbitrary constant will do
-  }</pre>
+<pre><code>
+public int hashCode() {
+    assert false : "hashCode not designed";
+    return 42; // any arbitrary constant will do
+}
+</code></pre>
 ]]>
     </Details>
   </BugPattern>
@@ -3553,8 +3637,7 @@ This not necessarily a bug, but is worth examining
 ]]>
     </Details>
   </BugPattern>
-  <BugPattern type="TLW_TWO_LOCK_NOTIFY" deprecated="true">
-    <!-- never generated -->
+  <BugPattern type="TLW_TWO_LOCK_NOTIFY" deprecated="true"> <!-- never generated -->
     <ShortDescription>Notify with two locks held</ShortDescription>
     <LongDescription>notify() or notifyAll*() with two locks held in {1}</LongDescription>
     <Details>
@@ -3602,22 +3685,28 @@ This not necessarily a bug, but is worth examining
   <p> This method is invoked in the constructor of the superclass. At this point,
     the fields of the class have not yet initialized.</p>
 <p>To make this more concrete, consider the following classes:</p>
-<pre>abstract class A {
-  int hashCode;
-  abstract Object getValue();
-  A() {
-    hashCode = getValue().hashCode();
+<pre><code>
+abstract class A {
+    int hashCode;
+    abstract Object getValue();
+    
+    A() {
+        hashCode = getValue().hashCode();
     }
-  }
+}
+
 class B extends A {
-  Object value;
-  B(Object v) {
-    this.value = v;
+    Object value;
+
+    B(Object v) {
+        this.value = v;
     }
-  Object getValue() {
-    return value;
-  }
-  }</pre>
+
+    Object getValue() {
+        return value;
+    }
+}
+</code></pre>
 <p>When a <code>B</code> is constructed,
 the constructor for the <code>A</code> class is invoked
 <em>before</em> the constructor for <code>B</code> sets <code>value</code>.
@@ -3659,17 +3748,15 @@ an uninitialized value is read for <code>value</code>.
   <p> During the initialization of a class, the class makes an active use of a subclass.
 That subclass will not yet be initialized at the time of this use.
 For example, in the following code, <code>foo</code> will be null.</p>
-
-<pre>
+<pre><code>
 public class CircularClassInitialization {
     static class InnerClassSingleton extends CircularClassInitialization {
         static InnerClassSingleton singleton = new InnerClassSingleton();
     }
-
+    
     static CircularClassInitialization foo = InnerClassSingleton.singleton;
 }
-</pre>
-
+</code></pre>
 ]]>
     </Details>
   </BugPattern>
@@ -3692,12 +3779,13 @@ public class CircularClassInitialization {
     <Details>
 <![CDATA[
   <p> The code synchronizes on interned String.</p>
-<pre>
+<pre><code>
 private static String LOCK = "LOCK";
-...
-  synchronized(LOCK) { ...}
-...
-</pre>
+
+synchronized(LOCK) {
+    ...
+}
+</code></pre>
 <p>Constant Strings are interned and shared across all other classes loaded by the JVM. Thus, this code
 is locking on something that other code might also be locking. This could result in very strange and hard to diagnose
 blocking and deadlock behavior. See <a href="http://www.javalobby.org/java/forums/t96352.html">http://www.javalobby.org/java/forums/t96352.html</a> and <a href="http://jira.codehaus.org/browse/JETTY-352">http://jira.codehaus.org/browse/JETTY-352</a>.
@@ -3712,17 +3800,16 @@ blocking and deadlock behavior. See <a href="http://www.javalobby.org/java/forum
     <Details>
       <![CDATA[
   <p> The code synchronizes on a boxed primitive constant, such as a Boolean.</p>
-<pre>
+<pre><code>
 private static Boolean inited = Boolean.FALSE;
-...
-  synchronized(inited) {
+
+synchronized(inited) { 
     if (!inited) {
-       init();
-       inited = Boolean.TRUE;
-       }
-     }
-...
-</pre>
+        init();
+        inited = Boolean.TRUE;
+    }
+}
+</code></pre>
 <p>Since there normally exist only two Boolean objects, this code could be synchronizing on the same object as other, unrelated code, leading to unresponsiveness
 and possible deadlock.</p>
 <p>See CERT <a href="https://www.securecoding.cert.org/confluence/display/java/CON08-J.+Do+not+synchronize+on+objects+that+may+be+reused">CON08-J. Do not synchronize on objects that may be reused</a> for more information.</p>
@@ -3736,18 +3823,17 @@ and possible deadlock.</p>
       <![CDATA[
   <p> The code synchronizes on an apparently unshared boxed primitive,
 such as an Integer.</p>
-<pre>
+<pre><code>
 private static final Integer fileLock = new Integer(1);
-...
-  synchronized(fileLock) {
-     .. do something ..
-     }
-...
-</pre>
+
+synchronized(fileLock) { 
+    .. do something ..
+}
+</code></pre>
 <p>It would be much better, in this code, to redeclare fileLock as</p>
-<pre>
+<pre><code>
 private static final Object fileLock = new Object();
-</pre>
+</code></pre>
 <p>
 The existing code might be OK, but it is confusing and a
 future refactoring, such as the "Remove Boxing" refactoring in IntelliJ,
@@ -3763,14 +3849,13 @@ throughout the JVM, leading to very confusing behavior and potential deadlock.
     <Details>
       <![CDATA[
   <p> The code synchronizes on a boxed primitive constant, such as an Integer.</p>
-<pre>
+<pre><code>
 private static Integer count = 0;
-...
-  synchronized(count) {
-     count++;
-     }
-...
-</pre>
+
+synchronized(count) { 
+    count++;
+}
+</code></pre>
 <p>Since Integer objects can be cached and shared,
 this code could be synchronizing on the same object as other, unrelated code, leading to unresponsiveness
 and possible deadlock.</p>
@@ -3784,9 +3869,10 @@ and possible deadlock.</p>
     <Details>
 <![CDATA[
   <p> The code contains an empty synchronized block:</p>
-<pre>
-synchronized() {}
-</pre>
+<pre><code>
+synchronized() {
+}
+</code></pre>
 <p>Empty synchronized blocks are far more subtle and hard to use correctly
 than most people recognize, and empty synchronized blocks
 are almost never a better solution
@@ -3833,7 +3919,7 @@ gets a lock on the referenced object, not on the field. This may not
 provide the mutual exclusion you need, and other threads might
 be obtaining locks on the referenced objects (for other purposes). An example
 of this pattern would be:</p>
-<pre>
+<pre><code>
 private Long myNtfSeqNbrCounter = new Long(0);
 private Long getNotificationSequenceNumber() {
      Long result = null;
@@ -3842,8 +3928,8 @@ private Long getNotificationSequenceNumber() {
          myNtfSeqNbrCounter = new Long(result.longValue());
      }
      return result;
- }
-</pre>
+}
+</code></pre>
 ]]>
     </Details>
   </BugPattern>
@@ -4136,21 +4222,19 @@ You should try hard to eliminate one of them, unless you are forced to have both
 <![CDATA[
   <p> The method in the subclass doesn't override a similar method in a superclass because the type of a parameter doesn't exactly match
 the type of the corresponding parameter in the superclass. For example, if you have:</p>
-
-<blockquote>
-<pre>
+<pre><code>
 import alpha.Foo;
+
 public class A {
-  public int f(Foo x) { return 17; }
+    public int f(Foo x) { return 17; }
 }
 ----
 import beta.Foo;
-public class B extends A {
-  public int f(Foo x) { return 42; }
-}
-</pre>
-</blockquote>
 
+public class B extends A {
+    public int f(Foo x) { return 42; }
+}
+</code></pre>
 <p>The <code>f(Foo)</code> method defined in class <code>B</code> doesn't
 override the
 <code>f(Foo)</code> method defined in class <code>A</code>, because the argument
@@ -4166,22 +4250,20 @@ types are <code>Foo</code>'s from different packages.
 <![CDATA[
   <p> The method in the subclass doesn't override a similar method in a superclass because the type of a parameter doesn't exactly match
 the type of the corresponding parameter in the superclass. For example, if you have:</p>
-
-<blockquote>
-<pre>
+<pre><code>
 import alpha.Foo;
+
 public class A {
-  public int f(Foo x) { return 17; }
+    public int f(Foo x) { return 17; }
 }
 ----
 import beta.Foo;
-public class B extends A {
-  public int f(Foo x) { return 42; }
-  public int f(alpha.Foo x) { return 27; }
-}
-</pre>
-</blockquote>
 
+public class B extends A {
+    public int f(Foo x) { return 42; }
+    public int f(alpha.Foo x) { return 27; }
+}
+</code></pre>
 <p>The <code>f(Foo)</code> method defined in class <code>B</code> doesn't
 override the
 <code>f(Foo)</code> method defined in class <code>A</code>, because the argument
@@ -4885,8 +4967,10 @@ Please check it: probably there's a mistake in its code or its body can be fully
 </p>
 <p>We are trying to reduce the false positives as much as possible, but in some cases this warning might be wrong.
 Common false-positive cases include:</p>
-<p>- The method is intended to trigger loading of some class which may have a side effect.</p>
-<p>- The method is intended to implicitly throw some obscure exception.</p>
+<ul>
+<li>The method is intended to trigger loading of some class which may have a side effect.</li>
+<li>The method is intended to implicitly throw some obscure exception.</li>
+</ul>
 ]]>
     </Details>
   </BugPattern>
@@ -5046,22 +5130,18 @@ to instruct FindBugs that ignoring the return value of this method is acceptable
 cause of this warning is to invoke a method on an immutable object,
 thinking that it updates the object. For example, in the following code
 fragment,</p>
-<blockquote>
-<pre>
+<pre><code>
 String dateString = getHeaderField(name);
 dateString.trim();
-</pre>
-</blockquote>
+</code></pre>
 <p>the programmer seems to be thinking that the trim() method will update
 the String referenced by dateString. But since Strings are immutable, the trim()
 function returns a new String value, which is being ignored here. The code
 should be corrected to: </p>
-<blockquote>
-<pre>
+<pre><code>
 String dateString = getHeaderField(name);
 dateString = dateString.trim();
-</pre>
-</blockquote>
+</code></pre>
 ]]>
     </Details>
   </BugPattern>
@@ -5102,19 +5182,17 @@ will return other values.
 <![CDATA[
    <p> This code creates an exception (or error) object, but doesn't do anything with it. For example,
 something like </p>
-<blockquote>
-<pre>
-if (x &lt; 0)
-  new IllegalArgumentException("x must be nonnegative");
-</pre>
-</blockquote>
+<pre><code>
+if (x &lt; 0) {
+    new IllegalArgumentException("x must be nonnegative");
+}
+</code></pre>
 <p>It was probably the intent of the programmer to throw the created exception:</p>
-<blockquote>
-<pre>
-if (x &lt; 0)
-  throw new IllegalArgumentException("x must be nonnegative");
-</pre>
-</blockquote>
+<pre><code>
+if (x &lt; 0) {
+    throw new IllegalArgumentException("x must be nonnegative");
+}
+</code></pre>
 ]]>
     </Details>
   </BugPattern>
@@ -5427,11 +5505,11 @@ control flow continues onto the same place regardless of whether or not
 the branch is taken. For example,
 this is caused by having an empty statement
 block for an <code>if</code> statement:</p>
-<pre>
-    if (argv.length == 0) {
+<pre><code>
+if (argv.length == 0) {
     // TODO: handle this case
-    }
-</pre>
+}
+</code></pre>
 ]]>
     </Details>
   </BugPattern>
@@ -5445,10 +5523,10 @@ flow follows to the same or following line regardless of whether or not
 the branch is taken.
 Often, this is caused by inadvertently using an empty statement as the
 body of an <code>if</code> statement, e.g.:</p>
-<pre>
-    if (argv.length == 1);
-        System.out.println("Hello, " + argv[0]);
-</pre>
+<pre><code>
+if (argv.length == 1);
+    System.out.println("Hello, " + argv[0]);
+</code></pre>
 ]]>
     </Details>
   </BugPattern>
@@ -5506,8 +5584,7 @@ known to be null.</p>
 ]]>
     </Details>
   </BugPattern>
-  <BugPattern type="RCN_REDUNDANT_CHECKED_NULL_COMPARISON" deprecated="true">
-    <!-- deprecated in favor of two separate RCN_ patterns -->
+  <BugPattern type="RCN_REDUNDANT_CHECKED_NULL_COMPARISON" deprecated="true"> <!-- deprecated in favor of two separate RCN_ patterns -->
     <ShortDescription>Redundant comparison to null of previously checked value</ShortDescription>
     <LongDescription>Redundant comparison to null of previously checked {2} in {1}</LongDescription>
     <Details>
@@ -5557,15 +5634,15 @@ for using a JSR-166 lock is:
 but does not release it on all exception paths out of the method.  In general, the correct idiom
 for using a JSR-166 lock is:
 </p>
-<pre>
-    Lock l = ...;
-    l.lock();
-    try {
-        // do something
-    } finally {
-        l.unlock();
-    }
-</pre>
+<pre><code>
+Lock l = ...;
+l.lock();
+try {
+    // do something
+} finally {
+    l.unlock();
+}
+</code></pre>
 ]]>
     </Details>
   </BugPattern>
@@ -5724,12 +5801,12 @@ an <code>IllegalMonitorStateException</code> being thrown.</p>
 <p> This method contains a self assignment of a local variable, and there
 is a field with an identical name.
 assignment appears to have been ; e.g.</p>
-<pre>
-  int foo;
-  public void setFoo(int foo) {
-    foo = foo;
-  }
-</pre>
+<pre><code>
+    int foo;
+    public void setFoo(int foo) {
+        foo = foo;
+    }
+</code></pre>
 <p>The assignment is useless. Did you mean to assign to the field instead?</p>
 ]]>
     </Details>
@@ -5740,12 +5817,12 @@ assignment appears to have been ; e.g.</p>
     <Details>
 <![CDATA[
 <p> This method contains a self assignment of a local variable; e.g.</p>
-<pre>
-  public void foo() {
+<pre><code>
+public void foo() {
     int x = 3;
     x = x;
-  }
-</pre>
+}
+</code></pre>
 <p>
 Such assignments are useless, and may indicate a logic error or typo.
 </p>
@@ -5759,12 +5836,12 @@ Such assignments are useless, and may indicate a logic error or typo.
 <![CDATA[
 <p> This method contains a self assignment of a field; e.g.
 </p>
-<pre>
-  int x;
-  public void foo() {
+<pre><code>
+int x;
+public void foo() {
     x = x;
-  }
-</pre>
+}
+</code></pre>
 <p>Such assignments are useless, and may indicate a logic error or typo.</p>
 ]]>
     </Details>
@@ -5776,12 +5853,12 @@ Such assignments are useless, and may indicate a logic error or typo.
 <![CDATA[
 <p> This method contains a double assignment of a field; e.g.
 </p>
-<pre>
-  int x,y;
-  public void foo() {
+<pre><code>
+int x,y;
+public void foo() {
     x = x = 17;
-  }
-</pre>
+}
+</code></pre>
 <p>Assigning to a field twice is useless, and may indicate a logic error or typo.</p>
 ]]>
     </Details>
@@ -5793,12 +5870,12 @@ Such assignments are useless, and may indicate a logic error or typo.
 <![CDATA[
 <p> This method contains a double assignment of a local variable; e.g.
 </p>
-<pre>
-  public void foo() {
+<pre><code>
+public void foo() {
     int x,y;
     x = x = 17;
-  }
-</pre>
+}
+</code></pre>
 <p>Assigning the same value to a variable twice is useless, and may indicate a logic error or typo.</p>
 ]]>
     </Details>
@@ -6049,19 +6126,19 @@ to get <code>0xffffffff</code>, and thus give the value
 </p>
 
 <p>In particular, the following code for packing a byte array into an int is badly wrong: </p>
-<pre>
+<pre><code>
 int result = 0;
-for(int i = 0; i &lt; 4; i++)
-  result = ((result &lt;&lt; 8) | b[i]);
-</pre>
-
+for(int i = 0; i &lt; 4; i++) {
+    result = ((result &lt;&lt; 8) | b[i]);
+}
+</code></pre>
 <p>The following idiom will work instead: </p>
-<pre>
+<pre><code>
 int result = 0;
-for(int i = 0; i &lt; 4; i++)
-  result = ((result &lt;&lt; 8) | (b[i] &amp; 0xff));
-</pre>
-
+for(int i = 0; i &lt; 4; i++) {
+    result = ((result &lt;&lt; 8) | (b[i] &amp; 0xff));
+}
+</code></pre>
 ]]>
     </Details>
   </BugPattern>
@@ -6081,19 +6158,17 @@ to get <code>0xffffffff</code>, and thus give the value
 </p>
 
 <p>In particular, the following code for packing a byte array into an int is badly wrong: </p>
-<pre>
+<pre><code>
 int result = 0;
-for(int i = 0; i &lt; 4; i++)
-  result = ((result &lt;&lt; 8) + b[i]);
-</pre>
-
+for(int i = 0; i &lt; 4; i++) 
+    result = ((result &lt;&lt; 8) + b[i]);
+</code></pre>
 <p>The following idiom will work instead: </p>
-<pre>
+<pre><code>
 int result = 0;
-for(int i = 0; i &lt; 4; i++)
-  result = ((result &lt;&lt; 8) + (b[i] &amp; 0xff));
-</pre>
-
+for(int i = 0; i &lt; 4; i++) 
+    result = ((result &lt;&lt; 8) + (b[i] &amp; 0xff));
+</code></pre>
 ]]>
     </Details>
   </BugPattern>
@@ -6169,8 +6244,7 @@ which is parsed like <code>((e &amp; A) | B) == C</code> while <code>(e &amp; (A
 ]]>
     </Details>
   </BugPattern>
-  <BugPattern type="LI_LAZY_INIT_INSTANCE" deprecated="true">
-    <!-- never generated? -->
+  <BugPattern type="LI_LAZY_INIT_INSTANCE" deprecated="true"> <!-- never generated? -->
     <ShortDescription>Incorrect lazy initialization of instance field</ShortDescription>
     <LongDescription>Incorrect lazy initialization of instance field {2} in {1}</LongDescription>
     <Details>
@@ -6344,20 +6418,20 @@ In each iteration, the String is converted to a StringBuffer/StringBuilder,
 a StringBuffer (or StringBuilder in Java 1.5) explicitly.</p>
 
 <p> For example:</p>
-<pre>
-  // This is bad
-  String s = "";
-  for (int i = 0; i &lt; field.length; ++i) {
+<pre><code>
+// This is bad
+String s = "";
+for (int i = 0; i &lt; field.length; ++i) {
     s = s + field[i];
-  }
+}
 
-  // This is better
-  StringBuffer buf = new StringBuffer();
-  for (int i = 0; i &lt; field.length; ++i) {
+// This is better
+StringBuffer buf = new StringBuffer();
+for (int i = 0; i &lt; field.length; ++i) {
     buf.append(field[i]);
-  }
-  String s = buf.toString();
-</pre>
+}
+String s = buf.toString();
+</code></pre>
 ]]>
     </Details>
   </BugPattern>
@@ -6493,9 +6567,15 @@ super.tearDown(), but doesn't.</p>
 <![CDATA[
 <p> Class is a JUnit TestCase and defines a suite() method.
 However, the suite method needs to be declared as either</p>
-<pre>public static junit.framework.Test suite()</pre>
+<pre><code>
+public static junit.framework.Test suite()
+</code></pre>
+<p>
 or
-<pre>public static junit.framework.TestSuite suite()</pre>
+</p>
+<pre><code>
+public static junit.framework.TestSuite suite()
+</code></pre>
 ]]>
     </Details>
   </BugPattern>
@@ -6519,8 +6599,7 @@ get called when the event occurs.</p>
 ]]>
     </Details>
   </BugPattern>
-  <BugPattern type="BRSA_BAD_RESULTSET_ACCESS" deprecated="true">
-    <!-- deprecated in favor of SQL_BAD_RESULTSET_ACCESS -->
+  <BugPattern type="BRSA_BAD_RESULTSET_ACCESS" deprecated="true"> <!-- deprecated in favor of SQL_BAD_RESULTSET_ACCESS -->
     <ShortDescription>Method attempts to access a result set field with index 0</ShortDescription>
     <LongDescription>{1} attempts to access a result set field with index 0</LongDescription>
     <Details>
@@ -6809,14 +6888,15 @@ does not need to be created, just access the static methods directly using the c
   </p>
   <p>A better approach is to either explicitly catch the specific exceptions that are thrown,
   or to explicitly catch RuntimeException exception, rethrow it, and then catch all non-Runtime Exceptions, as shown below:</p>
-  <pre>
-  try {
+<pre><code>
+try {
     ...
-  } catch (RuntimeException e) {
+} catch (RuntimeException e) {
     throw e;
-  } catch (Exception e) {
+} catch (Exception e) {
     ... deal with all non-runtime exceptions ...
-  }</pre>
+}
+</code></pre>
   ]]>
      </Details>
   </BugPattern>
@@ -7025,21 +7105,23 @@ just use the constant. Methods detected are:
 <p>
 This code performs integer multiply and then converts the result to a long,
 as in:</p>
-<pre>
-    long convertDaysToMilliseconds(int days) { return 1000*3600*24*days; }
-</pre>
+<pre><code>
+long convertDaysToMilliseconds(int days) { return 1000*3600*24*days; } 
+</code></pre>
 <p>
 If the multiplication is done using long arithmetic, you can avoid
 the possibility that the result will overflow. For example, you
 could fix the above code to:</p>
-<pre>
-    long convertDaysToMilliseconds(int days) { return 1000L*3600*24*days; }
-</pre>
+<pre><code>
+long convertDaysToMilliseconds(int days) { return 1000L*3600*24*days; } 
+</code></pre>
+<p>
 or
-<pre>
-    static final long MILLISECONDS_PER_DAY = 24L*3600*1000;
-    long convertDaysToMilliseconds(int days) { return days * MILLISECONDS_PER_DAY; }
-</pre>
+</p>
+<pre><code>
+static final long MILLISECONDS_PER_DAY = 24L*3600*1000;
+long convertDaysToMilliseconds(int days) { return days * MILLISECONDS_PER_DAY; } 
+</code></pre>
 ]]>
     </Details>
   </BugPattern>
@@ -7055,22 +7137,21 @@ An absolute time value is the number
 of milliseconds since the standard base time known as "the epoch", namely January 1, 1970, 00:00:00 GMT.
 For example, the following method, intended to convert seconds since the epoch into a Date, is badly
 broken:</p>
-<pre>
+<pre><code>
 Date getDate(int seconds) { return new Date(seconds * 1000); }
-</pre>
+</code></pre>
 <p>The multiplication is done using 32-bit arithmetic, and then converted to a 64-bit value.
 When a 32-bit value is converted to 64-bits and used to express an absolute time
 value, only dates in December 1969 and January 1970 can be represented.</p>
 
 <p>Correct implementations for the above method are:</p>
-
-<pre>
+<pre><code>
 // Fails for dates after 2037
 Date getDate(int seconds) { return new Date(seconds * 1000L); }
 
 // better, works for all dates
 Date getDate(long seconds) { return new Date(seconds * 1000); }
-</pre>
+</code></pre>
 ]]>
     </Details>
   </BugPattern>
@@ -7128,17 +7209,15 @@ was cast to double suggests that this precision should have been retained.
 What was probably meant was to cast one or both of the operands to
 double <em>before</em> performing the division.  Here is an example:
 </p>
-<blockquote>
-<pre>
+<pre><code>
 int x = 2;
 int y = 5;
 // Wrong: yields result 0.0
-double value1 =  x / y;
+double value1 = x / y;
 
 // Right: yields result 0.4
-double value2 =  x / (double) y;
-</pre>
-</blockquote>
+double value2 = x / (double) y;
+</code></pre>
 ]]>
     </Details>
   </BugPattern>
@@ -7417,11 +7496,11 @@ downcast it to a subtype will always fail by throwing a ClassCastException.
 <p>
 This code is casting the result of calling <code>toArray()</code> on a collection
 to a type more specific than <code>Object[]</code>, as in:</p>
-<pre>
+<pre><code>
 String[] getAsArray(Collection&lt;String&gt; c) {
-  return (String[]) c.toArray();
-  }
-</pre>
+    return (String[]) c.toArray();
+}
+</code></pre>
 <p>This will usually fail by throwing a ClassCastException. The <code>toArray()</code>
 of almost all collections return an <code>Object[]</code>. They can't really do anything else,
 since the Collection object has no reference to the declared generic type of the collection.
@@ -7450,8 +7529,7 @@ an indication of some misunderstanding or some other logic error.
 ]]>
     </Details>
   </BugPattern>
-  <BugPattern type="BC_NULL_INSTANCEOF" deprecated="true">
-    <!-- deprecated in favor of NP_NULL_INSTANCEOF -->
+  <BugPattern type="BC_NULL_INSTANCEOF" deprecated="true"> <!-- deprecated in favor of NP_NULL_INSTANCEOF -->
     <ShortDescription>A known null value is checked to see if it is an instance of a type</ShortDescription>
     <LongDescription>A known null value is checked to see if it is an instance of {2} in {1}</LongDescription>
     <Details>
@@ -7543,11 +7621,13 @@ collection class.
 A String function is being invoked and "." or "|" is being passed
 to a parameter that takes a regular expression as an argument. Is this what you intended?
 For example
-<li>s.replaceAll(".", "/") will return a String in which <em>every</em> character has been replaced by a '/' character
-<li>s.split(".") <em>always</em> returns a zero length array of String
-<li>"ab|cd".replaceAll("|", "/") will return "/a/b/|/c/d/"
-<li>"ab|cd".split("|") will return array with six (!) elements: [, a, b, |, c, d]
 </p>
+<ul>
+<li>s.replaceAll(".", "/") will return a String in which <em>every</em> character has been replaced by a '/' character</li>
+<li>s.split(".") <em>always</em> returns a zero length array of String</li>
+<li>"ab|cd".replaceAll("|", "/") will return "/a/b/|/c/d/"</li>
+<li>"ab|cd".split("|") will return array with six (!) elements: [, a, b, |, c, d]</li>
+</ul>
 ]]>
     </Details>
   </BugPattern>
@@ -8106,13 +8186,11 @@ and <a href="http://bugs.java.com/bugdatabase/view_bug.do?bug_id=6178997">JDK Bu
         the return statement requires a @NonNegative value,
         but receives one that is marked as @Negative.
         </p>
-        <blockquote>
-<pre>
+<pre><code>
 public boolean example(@Negative Integer value1, @NonNegative Integer value2) {
     return value1.equals(value2);
 }
-</pre>
-        </blockquote>
+</code></pre>
       ]]>
     </Details>
   </BugPattern>
@@ -8141,13 +8219,11 @@ public boolean example(@Negative Integer value1, @NonNegative Integer value2) {
         the return statement requires a @NonNegative value,
         but receives one that is marked as @Negative.
         </p>
-        <blockquote>
-<pre>
+<pre><code>
 public @NonNegative Integer example(@Negative Integer value) {
     return value;
 }
-</pre>
-        </blockquote>
+</code></pre>
       ]]>
     </Details>
   </BugPattern>
@@ -8281,26 +8357,28 @@ public @NonNegative Integer example(@Negative Integer value) {
      This instance method synchronizes on <code>this.getClass()</code>. If this class is subclassed,
      subclasses will synchronize on the class object for the subclass, which isn't likely what was intended.
      For example, consider this code from java.awt.Label:</p>
-     <pre>
-     private static final String base = "label";
-     private static int nameCounter = 0;
-     String constructComponentName() {
-        synchronized (getClass()) {
-            return base + nameCounter++;
-        }
-     }
-     </pre>
+<pre><code>
+private static final String base = "label";
+private static int nameCounter = 0;
+
+String constructComponentName() {
+    synchronized (getClass()) {
+        return base + nameCounter++;
+    }
+}
+</code></pre>
      <p>Subclasses of <code>Label</code> won't synchronize on the same subclass, giving rise to a datarace.
      Instead, this code should be synchronizing on <code>Label.class</code></p>
-      <pre>
-     private static final String base = "label";
-     private static int nameCounter = 0;
-     String constructComponentName() {
-        synchronized (Label.class) {
-            return base + nameCounter++;
-        }
-     }
-     </pre>
+<pre><code>
+private static final String base = "label";
+private static int nameCounter = 0;
+
+String constructComponentName() {
+    synchronized (Label.class) {
+        return base + nameCounter++;
+    }
+}
+</code></pre>
       <p>Bug pattern contributed by Jason Mehrens</p>
       ]]>
     </Details>
@@ -8464,23 +8542,24 @@ public @NonNegative Integer example(@Negative Integer value) {
   that memory, which means that the logger configuration is lost. For example,
 consider:
 </p>
-
-<pre>public static void initLogging() throws Exception {
- Logger logger = Logger.getLogger("edu.umd.cs");
- logger.addHandler(new FileHandler()); // call to change logger configuration
- logger.setUseParentHandlers(false); // another call to change logger configuration
-}</pre>
-
+<pre><code>
+public static void initLogging() throws Exception {
+    Logger logger = Logger.getLogger("edu.umd.cs");
+    logger.addHandler(new FileHandler()); // call to change logger configuration
+    logger.setUseParentHandlers(false); // another call to change logger configuration
+}
+</code></pre>
 <p>The logger reference is lost at the end of the method (it doesn't
 escape the method), so if you have a garbage collection cycle just
 after the call to initLogging, the logger configuration is lost
 (because Logger only keeps weak references).</p>
-
-<pre>public static void main(String[] args) throws Exception {
- initLogging(); // adds a file handler to the logger
- System.gc(); // logger configuration lost
- Logger.getLogger("edu.umd.cs").info("Some message"); // this isn't logged to the file as expected
-}</pre>
+<pre><code>
+public static void main(String[] args) throws Exception {
+    initLogging(); // adds a file handler to the logger
+    System.gc(); // logger configuration lost
+    Logger.getLogger("edu.umd.cs").info("Some message"); // this isn't logged to the file as expected
+}
+</code></pre>
 <p><em>Ulf Ochsenfahrt and Eric Fellheimer</em></p>
           ]]>
       </Details>

--- a/spotbugs/etc/messages_fr.xml
+++ b/spotbugs/etc/messages_fr.xml
@@ -1394,12 +1394,12 @@ La classe est annotée avec <code>net.jcip.annotations.Immutable</code>, et la r
 <![CDATA[
 <p>Cette classe définit une méthode <code>hashCode()</code> mais hérite la méthode <code>equals()</code> de <code>java.lang.Object</code> (qui définit l'égalité par comparaison des références des objets). Bien que cela satisfasse certainement le contrat indiquant que les objets égaux doivent avoir des codes de hachage égaux, ce n'est certainement pas ce qui était voulu lors de la surcharge de la méthode <code>hashCode()</code> (Surcharger <code>hashCode()</code> implique que l'identité des objets soit basée sur des critères plus compliqués qu'une simple égalités des références.)</p>
 <p>Si vous ne pensez pas que des instances de cette classe soient un jour insérées dans des <code>HashMap</code>/<code>HashTable</code>, l'implémentation recommendée de <code>hashCode</code> est :</p>
-<p><pre>
+<pre><code>
 public int hashCode() {
   assert false : "hashCode not designed";
   return 42; // any arbitrary constant will do 
   }
-</pre></p>
+</code></pre>
 ]]>
   </Details>
  </BugPattern>
@@ -1419,12 +1419,12 @@ public int hashCode() {
 <![CDATA[
 <p>Cette classe surcharge <code>equals(Object)</code>, pas <code>hashCode()</code>, et hérite de l'implémentation de <code>hashCode()</code> issue de <code>java.lang.Object</code> (qui renvoie le code de hachage d'identité, une valeur arbitraire assignée à l'objet par la JVM). C'est pourquoi la classe a des chances de violer le contrat impliquant que des objets égaux doivent avoir des codes de hachage identiques.</p>
 <p>Si vous ne pensez pas que des instances de cette classe soient un jour insérés dans des<code>HashMap</code>/<code>Hashtable</code>, l'implémentation recommendée est du type :</p>
-<p><pre>
+<pre><code>
 public int hashCode() {
   assert false : "hashCode not designed";
   return 42; // any arbitrary constant will do 
 }
-</pre></p>
+</code></pre>
 ]]>
   </Details>
  </BugPattern>
@@ -1634,14 +1634,14 @@ public int hashCode() {
   <Details>
 <![CDATA[
 <p>Durant l'intialisation, une classe utilise activement l'une de ses sous-classes. Cette sous-classe ne sera pas encore initialisée lors de la première utilisation. Par exemple, dans le code suivant, <code>foo</code> sera à <code>null</code>.</p>
-<p><code><pre>
+<pre><code>
 public class CircularClassInitialization {
     static class InnerClassSingleton extends CircularClassInitialization {
         static InnerClassSingleton singleton = new InnerClassSingleton();
     }
     static CircularClassInitialization foo = InnerClassSingleton.singleton;
 }
-</pre></code></p>
+</code></pre>
 ]]>
   </Details>
  </BugPattern>
@@ -1660,9 +1660,9 @@ public class CircularClassInitialization {
   <Details>
 <![CDATA[
 <p>Présence d'un bloc synchronisé vide:</p>
-<pre>
+<pre><code>
 synchronized() {}
-</pre>
+</code></pre>
 <p>L'utilisation de blocs synchronisés vides est bien plus subtile et dure à réaliser correctement que bien des gens ne le reconnaissent, et de plus ne correspond que rarement à la meilleure des solutions.</p>
 ]]>
   </Details>
@@ -2203,19 +2203,15 @@ Si c'est bien le cas, retirez la déclaration d'une valeur de retour.</p>
   <Details>
 <![CDATA[
 <p>La valeur renvoyée par cette méthode devrait-être vérifiée. Une cause habituelle de cette alarme est d'invoquer une méthode sur un objet constant en pensant que cela modifiera l'objet. Par exemple :</p>
-<blockquote>
-<pre>
+<pre><code>
 String dateString = getHeaderField(name);
 dateString.trim();
-</pre>
-</blockquote>
+</code></pre>
 <p>Le programmeur semble croire que la méthode <code>trim()</code> mettra à jour l'objet <code>String</code> référencé par <code>dateString</code>. Mais, les objets <code>String</code> étant constants, la fonction renvoi une nouvelle valeur qui est ici ignorée. Le code devrait être corrigé en :</p>
-<blockquote>
-<pre>
+<pre><code>
 String dateString = getHeaderField(name);
 dateString = dateString.trim();
-</pre>
-</blockquote>
+</code></pre>
 ]]>
   </Details>
  </BugPattern>
@@ -2373,10 +2369,10 @@ dateString = dateString.trim();
   <Details>
 <![CDATA[
 <p>Cette méthode contient une instruction de contrôle du flux inutile. Ceci est souvent provoqué par inadvertance, en utilisant un paragraphe vide comme corps d'une condition. Exemple :</p>
-<pre>
+<pre><code>
 if (argv.length == 1);
     System.out.println("Hello, " + argv[0]);
-</pre>
+</code></pre>
 ]]>
   </Details>
  </BugPattern>
@@ -2445,7 +2441,7 @@ if (argv.length == 1);
   <Details>
 <![CDATA[
 <p>Cette méthode acquière un verrou JSR-166 (<code>java.util.concurrent</code>), mais ne le libère pas dans tous les chemins d'exécution. En général, l'idiome correct pour utiliser un verrou JSR-166 est :</p>
-<pre>
+<pre><code>
 Lock l = ...;
 l.lock();
 try {
@@ -2453,7 +2449,7 @@ try {
 } finally {
     l.unlock();
 }
-</pre>
+</code></pre>
 ]]>
   </Details>
  </BugPattern>
@@ -2463,7 +2459,7 @@ try {
   <Details>
 <![CDATA[
 <p>Cette méthode acquière un verrou JSR-166 (<code>java.util.concurrent</code>), mais ne le libère pas dans tous les chemins d'exception. En général, l'idiome correct pour utiliser un verrou JSR-166 est :</p>
-<pre>
+<pre><code>
 Lock l = ...;
 l.lock();
 try {
@@ -2471,7 +2467,7 @@ try {
 } finally {
     l.unlock();
 }
-</pre>
+</code></pre>
 ]]>
   </Details>
  </BugPattern>
@@ -2544,12 +2540,12 @@ try {
   <Details>
 <![CDATA[
 <p>Cette méthode contient une auto-alimentation d'une variable locale, par exemple :</p>
-<pre>
+<pre><code>
 public vida foo() {
   int x = 3;
   x = x;
 }
-</pre>
+</code></pre>
 <p>De telles affectations sont inutiles et peuvent indiquer une faute de frappe ou une erreur de logique.</p>
 ]]>
   </Details>
@@ -2560,12 +2556,12 @@ public vida foo() {
   <Details>
 <![CDATA[
 <p>Cette méthode contient un champ s'auto-alimentant; par exemple :</p>
-<pre>
+<pre><code>
 int x;
 public void foo() {
   x = x;
 }
-</pre>
+</code></pre>
 <p>De telles affectations sont inutiles et peuvent indiquer une faute de frappe ou une erreur logique.</p>
 ]]>
   </Details>
@@ -2715,7 +2711,7 @@ public void foo() {
 <p>Cette méthode semble construire une <ocde>String</code> en utilisant une concaténation en boucle. A chaque itération, l'objet <code>String</code> est converti en <code>StringBuffer</code>/<code>StringBuilder</code>, complété, puis de nouveau converti en <code>String</code>. Ceci a un coût exponentiel en fonction du nombre d'itérations, puisque la chaîne est recopiée à chaque itération.</p>
 <p>De meilleurs performances peuvent être obtenues en utilisant explicitement <code>StringBuffer</code> (ou <code>StringBuilder</code> en Java 5).</p>
 <p>Par exemple :</p>
-<pre>
+<pre><code>
 // C'est mal !
 String s = "";
 for (int i = 0; i &lt; field.length; ++i) {
@@ -2728,7 +2724,7 @@ for (int i = 0; i &lt; field.length; ++i) {
   buf.append(field[i]);
 }
 String s = buf.toString();
-</pre>
+</code></pre>
 ]]>
   </Details>
  </BugPattern>
@@ -3045,10 +3041,11 @@ String s = buf.toString();
   <Details>
 <![CDATA[
 <p>Ce code effectue des multiplications entières et transtype le résultat en <code>long</code>, comme dans :
-<code>long convertDaysToMilliseconds(int days) { return 1000*3600*24*days; }</code>. Si la multiplication était réalisée en utilisant l'arithmétique <code>long</code>, vous pourriez éviter le risque de débordement de capacité du calcul. Vous pouvez par exemple corriger le code précédent par : <code>long convertDaysToMilliseconds(int days) { return 1000L*3600*24*days; }</code> ou <code><pre>
+<code>long convertDaysToMilliseconds(int days) { return 1000*3600*24*days; }</code>. Si la multiplication était réalisée en utilisant l'arithmétique <code>long</code>, vous pourriez éviter le risque de débordement de capacité du calcul. Vous pouvez par exemple corriger le code précédent par : <code>long convertDaysToMilliseconds(int days) { return 1000L*3600*24*days; }</code> ou</p>
+<pre><code>
 static final long MILLISECONDS_PER_DAY = 24L*3600*1000;
 long convertDaysToMilliseconds(int days) { return days * MILLISECONDS_PER_DAY; } 
-</pre></code></p>
+</code></pre>
 ]]>
   </Details>
  </BugPattern>
@@ -3076,8 +3073,7 @@ long convertDaysToMilliseconds(int days) { return days * MILLISECONDS_PER_DAY; }
   <Details>
 <![CDATA[
 <p>Ce code transtype le résultat d'une division entière en un nombre flottant à double précision. Effectuer une division sur des nombres entiers n'est pas précis. Le fait que le résultat soit transtypé en <code>double</code> suggère que cette précision était voulue dès le départ. Peut être l'un ou l'autre des opérandes, ou les deux opérandes, auraient du être transtypé avant d'effectuer la division. Voici un exemple :</p>
-<blockquote>
-<pre>
+<pre><code>
 int x = 2;
 int y = 5;
 // Faux: renvoi 0.0
@@ -3085,8 +3081,7 @@ double value1 =  x / y;
 
 // Juste: renvoi 0.4
 double value2 =  x / (double) y;
-</pre>
-</blockquote>
+</code></pre>
 ]]>
   </Details>
  </BugPattern>

--- a/spotbugs/etc/messages_ja.xml
+++ b/spotbugs/etc/messages_ja.xml
@@ -4204,10 +4204,11 @@ public class CircularClassInitialization {
 </p>
 <pre><code>
 private static String LOCK = "LOCK";
-
+...
 synchronized(LOCK) {
     ...
 }
+...
 </code></pre>
 <p>
 文字列定数は正準化され，Java 仮想マシンによってロードされたすべてのクラス全体で共有されます。
@@ -4232,13 +4233,14 @@ CERT <a href="https://www.securecoding.cert.org/confluence/display/java/CON08-J.
 </p>
 <pre><code>
 private static Boolean inited = Boolean.FALSE;
-
+...
 synchronized(inited) { 
     if (!inited) {
         init();
         inited = Boolean.TRUE;
     }
 }
+...
 </code></pre>
 <p>
 一般には2つの <code>Boolean</code> オブジェクトだけが存在しています。
@@ -4261,10 +4263,11 @@ CERT <a href="https://www.securecoding.cert.org/confluence/display/java/CON08-J.
 </p>
 <pre><code>
 private static final Integer fileLock = new Integer(1);
-
+...
 synchronized(fileLock) { 
     .. do something ..
 }
+...
 </code></pre>
 <p>
 このコードは fileLock を次のように宣言するとより良くなります。
@@ -4290,10 +4293,11 @@ private static final Object fileLock = new Object();
 </p>
 <pre><code>
 private static Integer count = 0;
-
+...
 synchronized(count) { 
     count++;
 }
+...
 </code></pre>
 <p>
 <code>Integer</code> オブジェクトはキャッシュして共有できます。

--- a/spotbugs/etc/messages_ja.xml
+++ b/spotbugs/etc/messages_ja.xml
@@ -99,135 +99,70 @@
   <BugCategory category="CORRECTNESS">
     <Description>正確性</Description>
     <Abbreviation>C</Abbreviation>
-    <Details>
-<![CDATA[
-<p>
-バグの可能性 - おそらく，開発者が意図していなかったコードになっている明らかなコーディングミスです。
-</p>
-<p>
+    <Details>バグの可能性 - おそらく，開発者が意図していなかったコードになっている明らかなコーディングミスです。
 我々は低い誤検出率のために努力します。
-</p>
-]]>  
     </Details>
   </BugCategory>
 
   <BugCategory category="NOISE">
     <Description>偽のランダムノイズ</Description>
     <Abbreviation>N</Abbreviation>
-    <Details>
-<![CDATA[
-<p>
-偽のランダムノイズ: ソフトウェアで実際のバグを発見するのではなく，データマイニング実験のコントロールとして役に立つことを意図しています。
-</p>
-]]>
-    </Details>
+    <Details>偽のランダムノイズ: ソフトウェアで実際のバグを発見するのではなく，データマイニング実験のコントロールとして役に立つことを意図しています。</Details>
   </BugCategory>
 
   <BugCategory category="SECURITY">
     <Description>セキュリティ</Description>
     <Abbreviation>S</Abbreviation>
-    <Details>
-<![CDATA[
-<p>
-リモートから悪用可能なセキュリティ脆弱性を引き起こすかもしれない信頼できない入力を使用しています。
-</p>
-]]>
-    </Details>
+    <Details>リモートから悪用可能なセキュリティ脆弱性を引き起こすかもしれない信頼できない入力を使用しています。 </Details>
   </BugCategory>
 
   <BugCategory category="BAD_PRACTICE">
     <Description>バッドプラクティス</Description>
     <Abbreviation>B</Abbreviation>
-    <Details>
-<![CDATA[
-<p>
-推奨または必須のコーディングプラクティスへの違反です。たとえば， <code>hashCode</code> と <code>equals</code> の問題， <code>Cloneable</code> イディオム，捨てられた例外， <code>Serializable</code> の問題， <code>finalize</code> の誤用などです。
-</p>
-<p>
-いくつかのグループはバッドプラクティスを気にしないかもしれないが，我々は正確な解析をしようと努力します。
-</p>
-]]>
+    <Details>推奨または必須のコーディングプラクティスへの違反です。たとえば，hashCode と equals の問題，Cloneable イディオム，捨てられた例外，Serializable の問題，finalize の誤用などです。
+いくつかのグループはバッドプラクティスを気にしないかもしれないが，我々はこの解析が正確になるよう努力しています。
     </Details>
   </BugCategory>
 
   <BugCategory category="STYLE">
     <Description>危ないコード</Description>
     <Abbreviation>D</Abbreviation>
-    <Details>
-<![CDATA[
-<p>
-紛らわしいコード，異常なコード，またはエラーを引き起こす方法で書かれたコードです。
-たとえば，ローカル変数への無効な代入， <code>switch</code> 文のフォールスルー，未確認のキャスト， <code>null</code> とわかっている値の冗長な <code>null</code> チェックなどです。
-</p>
-<p>
- より多くの誤検出を受け入れました。
-</p>
-<p>
+    <Details>紛らわしいコード，異常なコード，またはエラーを引き起こす方法で書かれたコードです。
+たとえば，ローカル変数への無効な代入，switch 文のフォールスルー，未確認のキャスト，null とわかっている値の冗長な null チェックなどです。
+より多くの誤検出を受け入れました。
 FindBugs の以前のバージョンでは，このカテゴリは Style として知られていました。
-</p>
-]]>
     </Details>
   </BugCategory>
 
   <BugCategory category="PERFORMANCE">
     <Description>性能</Description>
     <Abbreviation>P</Abbreviation>
-    <Details>
-<![CDATA[
-<p>
-必ずしも間違っているというわけではないが，効率が悪いかもしれないコードです。
-</p>
-]]>
-    </Details>
+    <Details>必ずしも間違っているというわけではないが，効率が悪いかもしれないコードです。 </Details>
   </BugCategory>
 
   <BugCategory category="MALICIOUS_CODE">
     <Description>悪意のあるコード脆弱性</Description>
     <Abbreviation>V</Abbreviation>
-    <Details>
-<![CDATA[
-<p>
-信頼できないコードからの攻撃に対して脆弱なコードです。
-</p>
-]]>
-    </Details>
+    <Details>信頼できないコードからの攻撃に対して脆弱なコードです。</Details>
   </BugCategory>
 
   <BugCategory category="MT_CORRECTNESS">
     <Description>マルチスレッドの正確性</Description>
     <Abbreviation>M</Abbreviation>
-    <Details>
-<![CDATA[
-<p>
-スレッド，ロック， <code>volatile</code> に関係があるコードの欠陥です。
-</p>
-]]>
-    </Details>
+    <Details>スレッド，ロック，volatile に関係があるコードの欠陥です。 </Details>
   </BugCategory>
 
   <BugCategory category="I18N">
     <Description>国際化</Description>
     <Abbreviation>I</Abbreviation>
-    <Details>
-<![CDATA[
-<p>
-国際化とロケールに関係があるコードの欠陥です。
-</p>
-]]>
-    </Details>
+    <Details>国際化とロケールに関係があるコードの欠陥です。 </Details>
     <!-- DM_CONVERT_CASE is the only core bug pattern in this category -->
   </BugCategory>
 
   <BugCategory category="EXPERIMENTAL">
     <Description>実験用</Description>
     <Abbreviation>X</Abbreviation>
-    <Details>
-<![CDATA[
-<p>
-実験用で完全に精査されていないバグパターンです。
-</p>
-]]>
-    </Details>
+    <Details>実験用で完全に精査されていないバグパターンです。 </Details>
     <!-- DM_CONVERT_CASE is the only core bug pattern in this category -->
   </BugCategory>
 


### PR DESCRIPTION
Fix HTML formatting even in messages.xml and messages_fr.xml.

- Modify source code block(&lt;blockquote&gt; -&gt; &lt;code&gt;).
- Change to the bulleted list(&lt;ul&gt;&lt;/ul&gt;).
- Change Datails of the BugCategory into the HTML format.