### PR TITLE
stop JDK9 build temporally to stabilize build result

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ env:
 #    - JDK_FOR_TEST=oraclejdk9
 
 # Java 9 is not currently officially supported, so install it manually
-matrix:
-  include:
-     env: JDK_FOR_TEST=oraclejdk9
+#matrix:
+#  include:
+#     env: JDK_FOR_TEST=oraclejdk9
 
 before_install:
   - mkdir -p deps


### PR DESCRIPTION
Currently JDK9 build in `master` branch (and others) are broken, because we cannot download JDK from oracle.com. It says that it's under maintenance.

I'm not sure when the maintenance for oracle.com will be finished, so I'll propose this as workaround.