### PR TITLE
Fix eclipse update site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 This is the changelog for SpotBugs. This follows [Keep a Changelog v0.3](http://keepachangelog.com/en/0.3.0/).
 
-## 3.1.0-RC2 (2017/??/??)
+## Unreleased (2017/??/??)
+
+### Fixed
+
+* Fix wrong version in Eclipse Plugin ([#173](https://github.com/spotbugs/spotbugs/pull/173))
+
+## 3.1.0-RC2 (2017/May/16)
 
 ### Added
 

--- a/eclipsePlugin/build.gradle
+++ b/eclipsePlugin/build.gradle
@@ -5,7 +5,7 @@ if (version.endsWith('-SNAPSHOT')) {
   version = version - '-SNAPSHOT' + '.' + new Date().format('yyyyMMdd') + '-' + System.currentTimeMillis()
 } else if (version.contains('-RC')) {
   // eclipse doesn't like the `-RC`, so we timestamp uniquely
-  version = version - '-RC' + '.' + new Date().format('yyyyMMdd') + '-' + System.currentTimeMillis()
+  version = version.substring(0, version.lastIndexOf('-RC')) + '.' + new Date().format('yyyyMMdd') + '-' + System.currentTimeMillis()
 }
 
 sourceSets {

--- a/eclipsePlugin/plugin_feature-candidate.xml
+++ b/eclipsePlugin/plugin_feature-candidate.xml
@@ -7,7 +7,7 @@
       plugin="@PLUGIN_ID@">
 
    <description url="https://spotbugs.github.io/">
-      This feature is a wrapper for the FindBugs plugin for installation via the Eclipse Update Manager.
+      This feature is a wrapper for the SpotBugs plugin for installation via the Eclipse Update Manager.
    </description>
 
    <copyright>


### PR DESCRIPTION
This changes fix problem in Eclipse Update site reported at https://github.com/spotbugs/spotbugs.github.io/pull/14

### site.xml generated in this branch

```xml
<?xml version="1.0" encoding="UTF-8"?>
<site>

   <description url="https://spotbugs.github.io/eclipse">
      This is the Eclipse update site for SpotBugs features.
   </description>

   <feature url="features/com.github.spotbugs.plugin.eclipse_3.1.0.20170517-1494985961678.jar"
            id="com.github.spotbugs.plugin.eclipse"
            version="3.1.0.20170517-1494985961678">
      <category name="SpotBugs"/>
   </feature>

   <category-def name="SpotBugs" label="SpotBugs">
      <description>
         This is the Eclipse category for SpotBugs features.
      </description>
   </category-def>

</site>
```