### PR TITLE
No more JSR305, use SpotBugs internal annotation instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ## Unreleased
 
+### Changed
+
+* SpotBugs annotation is recommended instead of JSR305 annotation ([#130](https://github.com/spotbugs/spotbugs/pull/130))
+
 ### Fixed
 
 * Wrong Class-Path in MANIFEST.MF ([#407](https://github.com/spotbugs/spotbugs/pull/407))

--- a/spotbugs-annotations/build-template.properties
+++ b/spotbugs-annotations/build-template.properties
@@ -1,6 +1,0 @@
-src.excludes=META-INF/MANIFEST-TEMPLATE.MF
-bin.includes=META-INF/
-jars.compile.order=spotbugs-annotations.jar
-src.includes=META-INF/
-output.spotbugs-annotations.jar=bin_eclipse/
-bin.excludes=META-INF/MANIFEST-TEMPLATE.MF

--- a/spotbugs-annotations/build-template.properties
+++ b/spotbugs-annotations/build-template.properties
@@ -1,0 +1,6 @@
+src.excludes=META-INF/MANIFEST-TEMPLATE.MF
+bin.includes=META-INF/
+jars.compile.order=spotbugs-annotations.jar
+src.includes=META-INF/
+output.spotbugs-annotations.jar=bin_eclipse/
+bin.excludes=META-INF/MANIFEST-TEMPLATE.MF

--- a/spotbugs-annotations/build.gradle
+++ b/spotbugs-annotations/build.gradle
@@ -7,7 +7,7 @@ apply from: "$rootDir/gradle/javadoc.gradle"
 apply from: "$rootDir/gradle/maven.gradle"
 
 dependencies {
-  compile 'com.google.code.findbugs:jsr305:3.0.1'
+  compile 'com.google.code.findbugs:jsr305:3.0.2'
 }
 
 def manifestSpec = manifest {

--- a/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/CheckForNull.java
+++ b/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/CheckForNull.java
@@ -33,15 +33,12 @@ import javax.annotation.meta.When;
  *
  * When this annotation is applied to a method it applies to the method return
  * value.
- *
- * @deprecated - use {@link javax.annotation.CheckForNull} instead.
  **/
 @Documented
 @Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE })
 @Retention(RetentionPolicy.CLASS)
 @javax.annotation.Nonnull(when = When.MAYBE)
 @TypeQualifierNickname
-@Deprecated
 public @interface CheckForNull {
 
 }

--- a/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/CheckReturnValue.java
+++ b/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/CheckReturnValue.java
@@ -29,13 +29,10 @@ import java.lang.annotation.Target;
  * be checked when invoking the method.
  *
  * The checker treats this annotation as inherited by overriding methods.
- *
- * @deprecated - use {@link javax.annotation.CheckReturnValue} instead.
  */
 @Documented
 @Target({ ElementType.METHOD, ElementType.CONSTRUCTOR })
 @Retention(RetentionPolicy.CLASS)
-@Deprecated
 public @interface CheckReturnValue {
 
     @Deprecated

--- a/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/Confidence.java
+++ b/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/Confidence.java
@@ -19,8 +19,6 @@
 
 package edu.umd.cs.findbugs.annotations;
 
-import javax.annotation.Nonnull;
-
 /**
  * Describes the confidence with which FindBugs reports a bug instance.
  */
@@ -33,7 +31,7 @@ public enum Confidence {
     private final int confidenceValue;
 
     /** Given a numeric confidence value, report the corresponding confidence enum value */
-    @Nonnull
+    @NonNull
     static public Confidence getConfidence(int prio) {
         for(Confidence c : values()) {
             if (prio <= c.confidenceValue) {

--- a/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/DefaultAnnotation.java
+++ b/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/DefaultAnnotation.java
@@ -41,28 +41,12 @@ import javax.annotation.meta.TypeQualifierDefault;
  * package, and then use @Nullable only on those parameters, methods or fields
  * that you want to allow to be null.
  *
- * @deprecated -  Use the JSR305 annotations instead.
- * For example, you can use {@link javax.annotation.ParametersAreNonnullByDefault} instead
- * of @DefaultAnnotation(NonNull.class) so that method parameters are nonnull by default in the annotated
- * element. You can also use {@link javax.annotation.meta.TypeQualifierDefault}
- * in general to define your own annotation that specifies a default type qualifier. For example,
- * <br><pre><code>
- * {@link Nonnegative}
- * {@link TypeQualifierDefault}({@link ElementType#PARAMETER})
- * public @interface ParametersAreNonnegativeByDefault {}
- * </code></pre>
- *
- * <br>The JSR305 {@link javax.annotation.CheckReturnValue}
- * annotation can be applied to a type or package, and it will act as a default for all methods
- * in that class or package unless otherwise overridden.
- *
  * @author William Pugh
  */
 
 @Documented
 @Target({ ElementType.TYPE, ElementType.PACKAGE })
 @Retention(RetentionPolicy.CLASS)
-@Deprecated
 public @interface DefaultAnnotation {
     Class<? extends Annotation>[] value();
 

--- a/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/DefaultAnnotationForFields.java
+++ b/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/DefaultAnnotationForFields.java
@@ -43,7 +43,6 @@ import java.lang.annotation.Target;
 @Documented
 @Target({ ElementType.TYPE, ElementType.PACKAGE })
 @Retention(RetentionPolicy.CLASS)
-@Deprecated
 public @interface DefaultAnnotationForFields {
     Class<? extends Annotation>[] value();
 

--- a/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/DefaultAnnotationForMethods.java
+++ b/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/DefaultAnnotationForMethods.java
@@ -43,7 +43,6 @@ import java.lang.annotation.Target;
 @Documented
 @Target({ ElementType.TYPE, ElementType.PACKAGE })
 @Retention(RetentionPolicy.CLASS)
-@Deprecated
 public @interface DefaultAnnotationForMethods {
     Class<? extends Annotation>[] value();
 

--- a/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/DefaultAnnotationForParameters.java
+++ b/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/DefaultAnnotationForParameters.java
@@ -37,20 +37,12 @@ import java.lang.annotation.Target;
  * package, and then use @Nullable only on those parameters, methods or fields
  * that you want to allow to be null.
  *
- * @deprecated -  use the JSR305 annotations instead,
- * For example, you can use {@link javax.annotation.ParametersAreNonnullByDefault} instead
- * of @DefaultAnnotation(NonNull.class), and {@link javax.annotation.meta.TypeQualifierDefault}
- * in general to define a type qualifier default. The JSR305 {@link javax.annotation.CheckReturnValue}
- * annotation can be applied to a type or package, and it will act as a default for all methods
- * in that class or package unless otherwise overridden.
- *
  * @author William Pugh
  */
 
 @Documented
 @Target({ ElementType.TYPE, ElementType.PACKAGE })
 @Retention(RetentionPolicy.CLASS)
-@Deprecated
 public @interface DefaultAnnotationForParameters {
     Class<? extends Annotation>[] value();
 

--- a/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/NonNull.java
+++ b/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/NonNull.java
@@ -32,15 +32,12 @@ import javax.annotation.meta.When;
  *
  * Annotated Fields must only not be null after construction has completed.
  * Annotated methods must have non-null return values.
- *
- * @deprecated - use {@link javax.annotation.Nonnull} instead.
  **/
 @Documented
 @Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE })
 @Retention(RetentionPolicy.CLASS)
 @javax.annotation.Nonnull(when = When.ALWAYS)
 @TypeQualifierNickname
-@Deprecated
 public @interface NonNull {
 
 }

--- a/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/Nullable.java
+++ b/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/Nullable.java
@@ -36,15 +36,12 @@ import javax.annotation.meta.When;
  *
  * When this annotation is applied to a method it applies to the method return
  * value.
- *
- * @deprecated - use {@link javax.annotation.Nullable} instead.
  **/
 @Documented
 @Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE })
 @Retention(RetentionPolicy.CLASS)
 @javax.annotation.Nonnull(when = When.UNKNOWN)
 @TypeQualifierNickname
-@Deprecated
 public @interface Nullable {
 
 }

--- a/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/OverrideMustInvoke.java
+++ b/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/OverrideMustInvoke.java
@@ -35,11 +35,8 @@ import java.lang.annotation.Target;
  * overriding method.
  *
  * @see edu.umd.cs.findbugs.annotations.When
- *
- * @deprecated - Use {@link javax.annotation.OverridingMethodsMustInvokeSuper} instead
  **/
 @Documented
-@Deprecated
 @Target({ ElementType.METHOD })
 @Retention(RetentionPolicy.CLASS)
 public @interface OverrideMustInvoke {

--- a/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/ReturnValuesAreNonnullByDefault.java
+++ b/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/ReturnValuesAreNonnullByDefault.java
@@ -37,7 +37,7 @@ import javax.annotation.meta.TypeQualifierDefault;
  * annotation of the corresponding parameter in the superclass applies)
  * <li>there is a default annotation applied to a more tightly nested element.
  * </ul>
- *
+ * @deprecated This annotation depends on JSR-305 which is already deprecated. Use {@link DefaultAnnotationForMethods} instead.
  */
 @Documented
 @Nonnull

--- a/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/ReturnValuesAreNonnullByDefault.java
+++ b/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/ReturnValuesAreNonnullByDefault.java
@@ -37,12 +37,10 @@ import javax.annotation.meta.TypeQualifierDefault;
  * annotation of the corresponding parameter in the superclass applies)
  * <li>there is a default annotation applied to a more tightly nested element.
  * </ul>
- * @deprecated This annotation depends on JSR-305 which is already deprecated. Use {@link DefaultAnnotationForMethods} instead.
  */
 @Documented
 @Nonnull
 @TypeQualifierDefault(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
-@Deprecated
 public @interface ReturnValuesAreNonnullByDefault {
 }

--- a/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/UnknownNullness.java
+++ b/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/UnknownNullness.java
@@ -36,7 +36,6 @@ import javax.annotation.meta.When;
 @Retention(RetentionPolicy.CLASS)
 @javax.annotation.Nonnull(when = When.UNKNOWN)
 @TypeQualifierNickname
-@Deprecated
 public @interface UnknownNullness {
 
 }

--- a/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/package-info.java
+++ b/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/package-info.java
@@ -1,18 +1,6 @@
 /**
  * Annotations for FindBugs (mostly deprecated except for {@link edu.umd.cs.findbugs.annotations.SuppressFBWarnings}).
  *
- * This annotations are mostly deprecated and replaced by JSR 305 annotations
- * defined in javax.annotation. The annotations still actively supported are:
- * <ul>
- * <li> {@link edu.umd.cs.findbugs.annotations.SuppressFBWarnings} for suppressing FindBugs warnings
- * <li> Annotations about expected/unexpected warnings in FindBugs regression tests
- * <ul>
- * <li>  {@link edu.umd.cs.findbugs.annotations.ExpectWarning} Warnings expected to be generated
- *  <li>  {@link edu.umd.cs.findbugs.annotations.NoWarning} Warnings that should not  be generated
- *  <li>  {@link edu.umd.cs.findbugs.annotations.DesireWarning} Warnings we wish to generated
- *  <li>  {@link edu.umd.cs.findbugs.annotations.DesireNoWarning} Warnings we wish to not generate generated
- *  </ul></ul>
- *
  *  There are another set of annotations used by an experimental detector for unclosed resources:
  *  <ul>
  *  <li>{@link edu.umd.cs.findbugs.annotations.CleanupObligation}
@@ -22,4 +10,3 @@
 
  */
 package edu.umd.cs.findbugs.annotations;
-

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -295,7 +295,6 @@ uploadArchives {
 ext.moduleName = 'com.github.spotbugs.spotbugs'
 apply from: "$rootDir/gradle/jigsaw.gradle"
 
-// TODO : jsr305.jar (really?)
 // TODO : generatemanual (we should decide what to do with the manual)
 // TODO : generatepdfmanual
 // TODO : bugdesc


### PR DESCRIPTION
This PR will close #130 and cancel deprecation on SpotBugs annotations.
Let's have discussion about we should cancel this deprecation or not.

I think we don't need to recommend jsr305 in current situation, but this change will affect public interface so I'm marking this PR for SpotBugs 4.0.0 release. Please do not merge this PR for now.