### PR TITLE
When AnalysisRunner has findbugs.xml in jar, don't create temp jar

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindUnsatisfiedObligationTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindUnsatisfiedObligationTest.java
@@ -6,12 +6,10 @@ import static org.junit.Assert.assertThat;
 
 import java.nio.file.Paths;
 
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
 import edu.umd.cs.findbugs.BugCollection;
-import edu.umd.cs.findbugs.annotations.DischargesObligation;
 import edu.umd.cs.findbugs.test.SpotBugsRule;
 
 public class FindUnsatisfiedObligationTest {
@@ -23,7 +21,6 @@ public class FindUnsatisfiedObligationTest {
      *      issue</a>
      */
     @Test
-    @Ignore
     public void testIssue60() {
         BugCollection bugCollection = spotbugs.performAnalysis(Paths.get("../spotbugsTestCases/build/classes/main/Issue60.class"));
         assertThat(bugCollection, is(emptyIterable()));

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/integration/FindNullDerefIntegrationTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/integration/FindNullDerefIntegrationTest.java
@@ -24,7 +24,6 @@ import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
@@ -34,7 +33,6 @@ import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 public class FindNullDerefIntegrationTest extends AbstractIntegrationTest {
 
     @Test
-    @Ignore
     public void testNullFromReturnOnLambda() {
         performAnalysis("Elvis.class");
 
@@ -53,7 +51,6 @@ public class FindNullDerefIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Test
-    @Ignore
     public void testLambdaIssue20() throws IOException, InterruptedException {
         performAnalysis("lambdas/Issue20.class");
 


### PR DESCRIPTION
When AnalysisRunner is using spotbugs.jar, then there's no need to create temp jar for resources

fix #156 