### PR TITLE
Report coverage not only from spotbugs subproject but also other subprojects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ script:
   - ./gradlew build smoketest -S
 
 after_success:
-  - if [[ $JDK_FOR_TEST == "oraclejdk8" ]]; then ./gradlew jacocoTestReport coveralls; fi
+  - if [[ $JDK_FOR_TEST == "oraclejdk8" ]]; then ./gradlew coveralls; fi
 
 before_cache:
   - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,15 @@
+plugins {
+  id "com.github.kt3k.coveralls" version "2.7.1"
+}
+apply plugin: 'java'
+apply from: "$rootDir/gradle/jacoco.gradle"
+
 subprojects {
   apply plugin: 'java'
   apply from: "$rootDir/gradle/eclipse.gradle"
   apply from: "$rootDir/gradle/idea.gradle"
   apply from: "$rootDir/gradle/test.gradle"
+  apply from: "$rootDir/gradle/jacoco.gradle"
 
   group = 'com.github.spotbugs'
   version = '3.1.0-SNAPSHOT'
@@ -16,7 +23,36 @@ subprojects {
   }
 }
 
+repositories {
+  jcenter()
+}
+
 wrapper {
   gradleVersion = '3.2.1'
   distributionType = Wrapper.DistributionType.ALL
+}
+
+// https://discuss.gradle.org/t/merge-jacoco-coverage-reports-for-multiproject-setups/12100/6
+task jacocoRootReport(type: JacocoReport) {
+  description = 'Merge all coverage reports before submit to coveralls'
+
+  executionData fileTree(project.rootDir.absolutePath).include("**/build/jacoco/*.exec")
+  sourceDirectories = files(subprojects.sourceSets.main.allSource.srcDirs)
+  classDirectories = files(subprojects.sourceSets.main.output)
+
+  reports {
+    xml.enabled = true
+  }
+}
+
+coveralls {
+  jacocoReportPath = "${buildDir}/reports/jacoco/jacocoRootReport/jacocoRootReport.xml"
+}
+
+tasks.coveralls {
+  dependsOn jacocoRootReport
+  doFirst {
+    // set lazily to relect subproject specific config in each build.groovy
+    coveralls.sourceDirs = subprojects.sourceSets.main.allSource.srcDirs.flatten()
+  }
 }

--- a/eclipsePlugin-junit/build.gradle
+++ b/eclipsePlugin-junit/build.gradle
@@ -5,3 +5,8 @@ dependencies {
   testCompile 'junit:junit:4.12'
   testCompile 'org.mockito:mockito-core:2.7.22'
 }
+
+jacocoTestReport {
+  additionalSourceDirs = files(project(':eclipsePlugin').sourceSets.main.java.srcDirs)
+  additionalClassDirs = files(project(':eclipsePlugin').sourceSets.main.output.classesDir)
+}

--- a/spotbugs-tests/build.gradle
+++ b/spotbugs-tests/build.gradle
@@ -1,9 +1,4 @@
-plugins {
-  id "com.github.kt3k.coveralls" version "2.7.1"
-}
-
 apply from: "$rootDir/gradle/checkstyle.gradle"
-apply from: "$rootDir/gradle/jacoco.gradle"
 
 dependencies {
   compile 'org.ow2.asm:asm-debug-all:6.0_ALPHA'
@@ -38,8 +33,4 @@ artifacts {
 jacocoTestReport {
   additionalSourceDirs = files(project(':spotbugs').sourceSets.main.java.srcDirs)
   additionalClassDirs = files(project(':spotbugs').sourceSets.main.output.classesDir)
-}
-
-coveralls {
-  sourceDirs = new ArrayList(project(':spotbugs').sourceSets.main.java.srcDirs)
 }


### PR DESCRIPTION
Currently we analyze spotbugs subproject only. After we apply this change, we can check coverage even in other subprojects such as gradlePlugin and eclipsePlugin-junit.