### PR TITLE
Account for OS-dependent Eclipse directory layout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
 install:
   - if [[ ! -e deps/eclipse.tar.gz ]]; then wget http://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops/R-3.6.2-201102101200/eclipse-SDK-3.6.2-linux-gtk-x86_64.tar.gz -O deps/eclipse.tar.gz; fi
   - tar xzvf deps/eclipse.tar.gz eclipse
-  - echo eclipsePlugin.dir=$(pwd)/eclipse/plugins > eclipsePlugin/local.properties
+  - echo eclipseRoot.dir=$(pwd)/eclipse > eclipsePlugin/local.properties
 
 script:
   # Manually switch to JDK9 if needed

--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ SpotBugs is built using [Gradle](https://gradle.org). The recommended way to obt
 
 To see a list of build options, run `gradle tasks` (or `gradlew tasks`). The `build` task will perform a full build and test.
 
-To build the FindBugs plugin for Eclipse, you'll need to create the file `eclipsePlugin/local.properties`, containing a property `eclipsePlugin.dir` that points to an Eclipse installation's plugin directory (see `.travis.yml` for an example), then run the build.
+To build the FindBugs plugin for Eclipse, you'll need to create the file `eclipsePlugin/local.properties`, containing a property `eclipseRoot.dir` that points to an Eclipse installation's root directory (see `.travis.yml` for an example), then run the build.

--- a/eclipsePlugin/build.gradle
+++ b/eclipsePlugin/build.gradle
@@ -34,6 +34,16 @@ def eclipsePluginId = 'com.github.spotbugs.plugin.eclipse'
 def localProps = new Properties()
 localProps.load(new FileInputStream("$projectDir/local.properties"))
 
+def eclipseRootDir = new File(localProps.getProperty('eclipseRoot.dir'))
+// Eclipse 4.5+ uses a different directory layout under macOS. Try to detect this first.
+def eclipseExecutable = new File(eclipseRootDir, "Contents/MacOS/eclipse")
+def eclipsePluginsDir = new File(eclipseRootDir, "Contents/Eclipse/plugins")
+if (!eclipseExecutable.exists()) {
+   // Fall back to non-macOS directory layout.
+   eclipseExecutable = new File(eclipseRootDir, "eclipse")
+   eclipsePluginsDir = new File(eclipseRootDir, "plugins")
+}
+
 // TODO : convert these to external dependencies
 def requiredLibs = fileTree(dir:'lib', include:[
   'jsr305.jar',
@@ -46,7 +56,7 @@ def requiredLibs = fileTree(dir:'lib', include:[
 dependencies {
   includedLibs requiredLibs
 
-  compile fileTree(dir:localProps.getProperty('eclipsePlugin.dir'), include:'**/*.jar',
+  compile fileTree(dir:eclipsePluginsDir, include:'**/*.jar',
     exclude:['**/datanucleus-enhancer*.jar', 'edu.umd.cs.findbugs.**/*.jar', 'com.github.spotbugs.**/*.jar'])
 
   includedLibs project(':spotbugs-annotations')
@@ -198,7 +208,7 @@ task siteDailyXml(type:Copy) {
 task generateP2Metadata(type:Exec) {
   inputs.file 'local.properties'
   dependsOn pluginJar, featureJar, siteXml
-  commandLine "${localProps.getProperty('eclipsePlugin.dir')}/../eclipse", '-nosplash',
+  commandLine "${eclipseExecutable}", '-nosplash',
     '-application', 'org.eclipse.equinox.p2.publisher.UpdateSitePublisher',
     '-metadataRepository', "file:${buildDir}/site/eclipse", // TODO : May not work on Windows
     '-artifactRepository', "file:${buildDir}/site/eclipse", // TODO : May not work on Windows
@@ -208,7 +218,7 @@ task generateP2Metadata(type:Exec) {
 task generateCandidateP2Metadata(type:Exec) {
   inputs.file 'local.properties'
   dependsOn pluginCandidateJar, featureCandidateJar, siteCandidateXml
-  commandLine "${localProps.getProperty('eclipsePlugin.dir')}/../eclipse", '-nosplash',
+  commandLine "${eclipseExecutable}", '-nosplash',
     '-application', 'org.eclipse.equinox.p2.publisher.UpdateSitePublisher',
     '-metadataRepository', "file:${buildDir}/site/eclipse-candidate", // TODO : May not work on Windows
     '-artifactRepository', "file:${buildDir}/site/eclipse-candidate", // TODO : May not work on Windows
@@ -218,7 +228,7 @@ task generateCandidateP2Metadata(type:Exec) {
 task generateP2MetadataDaily(type:Exec) {
   inputs.file 'local.properties'
   dependsOn pluginDailyJar, featureDailyJar, siteDailyXml
-  commandLine "${localProps.getProperty('eclipsePlugin.dir')}/../eclipse", '-nosplash',
+  commandLine "${eclipseExecutable}", '-nosplash',
     '-application', 'org.eclipse.equinox.p2.publisher.UpdateSitePublisher',
     '-metadataRepository', "file:${buildDir}/site/eclipse-daily", // TODO : May not work on Windows
     '-artifactRepository', "file:${buildDir}/site/eclipse-daily", // TODO : May not work on Windows

--- a/eclipsePlugin/doc/building_findbugsplugin.txt
+++ b/eclipsePlugin/doc/building_findbugsplugin.txt
@@ -51,7 +51,7 @@ Setup target platform/findbugs libraries
 cd /home/%username%/git/findbugs/findbugs
 ant
 cd ../eclipsePlugin
-echo eclipsePlugin.dir=/home/user/bin/Eclipse36 > local.properties
+echo eclipseRoot.dir=/home/user/bin/Eclipse36 > local.properties
 ant
 10) In Eclipse, refresh all projects (hit F5 in Explorer view) => now all errors should disappear.
 

--- a/spotbugs/build.xml
+++ b/spotbugs/build.xml
@@ -7,7 +7,7 @@
 <project name="findbugs" default="build">
 
     <!--
-            The local.properties properties file contains the location of eclipsePlugin.dir
+            The local.properties properties file contains the location of eclipseRoot.dir
 
             This value is likely to be different for each checkout of the plugin,
             so the local.properties file is not managed by cvs


### PR DESCRIPTION
This replaces the `eclipsePlugin.dir` property in `eclipsePlugin/local.properties` with `eclipseRoot.dir` and automatically computes the OS-dependent `eclipseExecutable` and `eclipsePluginsDir` properties from it.

This change fixes spotbugs/spotbugs#203.