### PR TITLE
Support import of eclipsePlugin(-junit) with Eclipse Buildship

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 def eclipseFile = "eclipsePlugin/local.properties"
-if (new File(eclipseFile).exists()) {
+if (new File(rootDir, eclipseFile).exists()) {
   include ':eclipsePlugin', ':eclipsePlugin-junit', ':spotbugsTestCases', ':spotbugs', ':spotbugs-tests', ':gradlePlugin', ':test-harness', ':spotbugs-annotations', ':spotbugs-ant', 'gradlePlugin'
 } else {
   logger.lifecycle('Eclipse plugin configuration (' + eclipseFile + ') was not found. Skipping Eclipse plugin...')


### PR DESCRIPTION
This fix ensures that the path to `eclipsePlugin/local.properties` is taken to be relative to the root project, both on the command line and by Eclipse Buildship's project import.

This change fixes spotbugs/spotbugs#206.