### PR TITLE
Earlier/LaterSubtypes supports only built-in supertypes (#215)

### DIFF
--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/PluginLoader.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/PluginLoader.java
@@ -1268,7 +1268,7 @@ public class PluginLoader {
         }
     }
 
-    private static DetectorFactorySelector getConstraintSelector(Element constraintElement, Plugin plugin,
+    private DetectorFactorySelector getConstraintSelector(Element constraintElement, Plugin plugin,
             String singleDetectorElementName/*
              * , String
              * detectorCategoryElementName
@@ -1305,7 +1305,7 @@ public class PluginLoader {
             String superName = node.valueOf("@super");
             if (!"".equals(superName)) {
                 try {
-                    Class<?> superClass = Class.forName(superName);
+                    Class<?> superClass = Class.forName(superName, true, classLoader);
                     return new ByInterfaceDetectorFactorySelector(spanPlugins ? null : plugin, superClass);
                 } catch (ClassNotFoundException e) {
                     throw new PluginException("Unknown class " + superName + " in constraint selector node");


### PR DESCRIPTION
This lets the `PluginLoader` load the supertype with the plugin's class loader, not the class loader that loaded the SpotBugs core.