### PR TITLE
[docs] Add links & how-to implement SpotBugs plugin

### DIFF
--- a/docs/implement-plugin.rst
+++ b/docs/implement-plugin.rst
@@ -1,0 +1,76 @@
+Implement SpotBugs plugin
+=========================
+
+Create Maven project
+--------------------
+
+Use `spotbugs-archetype <https://github.com/spotbugs/spotbugs-archetype>`_ to create Maven project.
+Then Maven archetype plugin will ask you to decide plugin's groupId, artifactId, package and initial version.
+
+.. code-block:: bash
+
+  $ mvn archetype:generate \
+        -DarchetypeArtifactId=spotbugs-archetype \
+        -DarchetypeGroupId=com.github.spotbugs \
+        -DarchetypeVersion=0.1.0
+
+Write java codes to represent bug to find
+-----------------------------------------
+
+In generated project, you can find a file named as `BadCase.java <https://github.com/spotbugs/spotbugs-archetype/blob/spotbugs-archetype-0.1.0/src/main/resources/archetype-resources/src/test/java/BadCase.java>`_.
+Update this file to represent the target bug to find.
+
+If you have multiple patterns to represent, add more classes into ``src/test/java`` directory.
+
+
+Write test case to ensure your detector can find bug
+----------------------------------------------------
+
+In generated project, you can find another file named as `MyDetectorTest.java <https://github.com/spotbugs/spotbugs-archetype/blob/spotbugs-archetype-0.1.0/src/main/resources/archetype-resources/src/test/java/MyDetectorTest.java>`_.
+The ``spotbugs.performAnalysis(Path)`` in this test runs SpotBugs with your plugin, and return all found bugs (here 1st argument of this method is a path of class file compiled from ``BadCase.java``).
+
+You can use `BugInstanceMatcher <https://github.com/spotbugs/spotbugs/blob/master/test-harness/src/main/java/edu/umd/cs/findbugs/test/matcher/BugInstanceMatcher.java>`_ to verify that your plugin can find bug as expected.
+
+Currently this test should fail, because we've not updated detector itself yet.
+
+
+Write java codes to avoid false-positive
+----------------------------------------
+
+To avoid false-positive, it is good to ensure that in which case detector should NOT find bug.
+
+Update `GoodCase.java <https://github.com/spotbugs/spotbugs-archetype/blob/spotbugs-archetype-0.1.0/src/main/resources/archetype-resources/src/test/java/GoodCase.java>`_ in your project, and represent such cases.
+After that, add a test method into ``MyDetectorTest.java`` which verify that no bug found from this ``GoodCase`` class.
+
+If you have multiple patterns to represent, add more classes into ``src/test/java`` directory.
+
+
+Update detector to pass all unit tests
+--------------------------------------
+
+Now you have tests to ensure that your detector can work as expected.
+
+.. note::
+
+  TBU
+
+
+Which super class you should choose
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+`AnnotationDetector <https://javadoc.io/page/com.github.spotbugs/spotbugs/latest/edu/umd/cs/findbugs/bcel/AnnotationDetector.html>`_
+  Base detector which analyzes annotations on classes, fields, methods, and method parameters.
+
+`BytecodeScanningDetector <https://javadoc.io/page/com.github.spotbugs/spotbugs/latest/edu/umd/cs/findbugs/BytecodeScanningDetector.html>`_
+  Base detector which analyzes java bytecode in class files.
+
+`OpcodeStackDetector <https://javadoc.io/page/com.github.spotbugs/spotbugs/latest/edu/umd/cs/findbugs/bcel/OpcodeStackDetector.html>`_
+  Sub class of ``BytecodeScanningDetector``, which can scan the bytecode of a method and use an `operand stack <https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-2.html#jvms-2.6.2>`_.
+
+
+Update findbugs.xml and messages.xml
+------------------------------------
+
+.. note::
+
+  TBU

--- a/docs/implement-plugin.rst
+++ b/docs/implement-plugin.rst
@@ -68,9 +68,77 @@ Which super class you should choose
   Sub class of ``BytecodeScanningDetector``, which can scan the bytecode of a method and use an `operand stack <https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-2.html#jvms-2.6.2>`_.
 
 
-Update findbugs.xml and messages.xml
-------------------------------------
+Update findbugs.xml
+-------------------
 
-.. note::
+SpotBugs reads ``findbugs.xml`` in each plugin to find detectors and bugs.
+So when you add new detector, you need to add new ``<Detector>`` element like below:
 
-  TBU
+.. code-block:: xml
+
+  <Detector class="com.github.plugin.MyDetector" reports="MY_BUG" speed="fast" />
+
+It is also necessary to add ``<BugPattern>``, to describe type and category of your bug pattern.
+
+.. code-block:: xml
+
+  <BugPattern type="MY_BUG" category="CORRECTNESS" />
+
+You can find ``findbugs.xml`` in ``src/main/resources`` directory of generated Maven project.
+
+
+
+Update messages.xml
+-------------------
+
+SpotBugs reads ``messages.xml`` in each plugin to construct human readable message to report detected bug.
+It also supports reading localized messages from ``messages_ja.xml``, ``messages_fr.xml`` and so on.
+
+You can find ``messages.xml`` in ``src/main/resources`` directory of generated Maven project.
+
+Update message of Detector
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In ``<Detector>`` element, you can add detector's description message. Note that it should be plain text, HTML is not supported.
+
+.. code-block:: xml
+
+  <Detector class="com.github.plugin.MyDetector">
+    <Details>
+      Original detector to detect MY_BUG bug pattern.
+    </Details>
+  </Detector>
+
+Update message of Bug Pattern
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In ``<BugPattern>`` element, you can add bug pattern's description message.
+There are three kinds of messages:
+
+ShortDescription
+  Short description for bug pattern. Useful to tell its intent and character for users.
+  It should be plain text, HTML is not supported.
+
+LongDescription
+  Longer description for bug pattern.
+  You can use placeholder like ``{0}`` (0-indexed), then added data into `BugInstance <https://javadoc.io/page/com.github.spotbugs/spotbugs/latest/edu/umd/cs/findbugs/BugInstance.html>`_ will be inserted at there.
+  So this ``LongDescription`` is useful to tell detailed information about detected bug.
+
+  It should be plain text, HTML is not supported.
+
+Details
+  Detailed description for bug pattern. It should be HTML format, so this is useful to tell detailed specs/examples with table, list and code snippets.
+
+.. code-block:: xml
+
+  <BugPattern type="MY_BUG">
+    <ShortDescription>Explain bug pattern shortly.</ShortDescription>
+    <LongDescription>
+      Explain existing problem in code, and how developer should improve their implementation.
+    </LongDescription>
+    <Details>
+      <![CDATA[
+        <p>Explain existing problem in code, and how developer should improve their implementation.</p>
+      ]]>
+    </Details>
+  </BugPattern>

--- a/docs/implement-plugin.rst
+++ b/docs/implement-plugin.rst
@@ -14,8 +14,8 @@ Then Maven archetype plugin will ask you to decide plugin's groupId, artifactId,
         -DarchetypeGroupId=com.github.spotbugs \
         -DarchetypeVersion=0.1.0
 
-Write java codes to represent bug to find
------------------------------------------
+Write java code to represent bug to find
+----------------------------------------
 
 In generated project, you can find a file named as `BadCase.java <https://github.com/spotbugs/spotbugs-archetype/blob/spotbugs-archetype-0.1.0/src/main/resources/archetype-resources/src/test/java/BadCase.java>`_.
 Update this file to represent the target bug to find.
@@ -34,8 +34,8 @@ You can use `BugInstanceMatcher <https://github.com/spotbugs/spotbugs/blob/maste
 Currently this test should fail, because we've not updated detector itself yet.
 
 
-Write java codes to avoid false-positive
-----------------------------------------
+Write java code to avoid false-positive
+---------------------------------------
 
 To avoid false-positive, it is good to ensure that in which case detector should NOT find bug.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,5 +32,6 @@ Contents
    filter
    analysisprops
    faq
+   links
    bugDescriptions
    migration

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,6 +30,7 @@ Contents
    ant
    filter
    analysisprops
+   implement-plugin
    faq
    links
    bugDescriptions

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,7 +14,6 @@ The name FindBugs and the FindBugs logo are trademarked by the University of Mar
 Indices and tables
 ==================
 
-* :ref:`genindex`
 * :ref:`search`
 
 Contents

--- a/docs/links.rst
+++ b/docs/links.rst
@@ -1,0 +1,40 @@
+SpotBugs Links
+==============
+
+This page contains links to related projects, including tools that are similar to SpotBugs.
+
+SpotBugs Plugins
+----------------
+
+`fb-contrib <http://fb-contrib.sourceforge.net/>`_
+  A FindBugs/SpotBugs plugin for doing static code analysis on java byte code.
+
+`Find Security Bugs <http://find-sec-bugs.github.io/>`_
+  A FindBugs/SpotBugs plugin for security audits of Java web applications.
+
+`findbugs-slf4j <https://github.com/KengoTODA/findbugs-slf4j>`_
+  A FindBugs/SpotBugs plugin to verify usage of `SLF4J <https://www.slf4j.org/>`_.
+
+Similar/Related Tools
+---------------------
+
+`FindBugs-IDEA <https://plugins.jetbrains.com/plugin/3847-findbugs-idea>`_
+  The FindBugs plugin for `IntelliJ IDEA <https://www.jetbrains.com/idea/>`_.
+
+`sonar-findbugs <https://github.com/SonarQubeCommunity/sonar-findbugs>`_
+  A `SonarQube <https://www.sonarqube.org/>`_ plugin which provides rules based on SpotBugs and its major plugins.
+
+`Checkstyle <http://checkstyle.sourceforge.net/>`_
+  A style checker for Java.
+
+`PMD <https://pmd.github.io/>`_
+  An extensible cross-language static code analyzer.
+
+`huntbugs <https://github.com/amaembo/huntbugs>`_
+  New Java bytecode static analyzer tool based on `Procyon Compiler Tools <https://bitbucket.org/mstrobel/procyon/overview>`_ aimed to supersede the FindBugs.
+
+`Google Error Prone <http://errorprone.info/>`_
+  A static analysis tool for Java that catches common programming mistakes at compile-time.
+
+`Checker Framework <https://checkerframework.org/>`_
+  A pluggable type-checking for Java.

--- a/docs/locale/ja/LC_MESSAGES/implement-plugin.po
+++ b/docs/locale/ja/LC_MESSAGES/implement-plugin.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: spotbugs 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-07-02 06:33+0000\n"
+"POT-Creation-Date: 2017-07-02 06:48+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -34,7 +34,7 @@ msgid ""
 msgstr ""
 
 #: ../../implement-plugin.rst:18
-msgid "Write java codes to represent bug to find"
+msgid "Write java code to represent bug to find"
 msgstr ""
 
 #: ../../implement-plugin.rst:20
@@ -82,7 +82,7 @@ msgid ""
 msgstr ""
 
 #: ../../implement-plugin.rst:38
-msgid "Write java codes to avoid false-positive"
+msgid "Write java code to avoid false-positive"
 msgstr ""
 
 #: ../../implement-plugin.rst:40
@@ -254,5 +254,11 @@ msgstr ""
 #~ msgstr ""
 
 #~ msgid "Update findbugs.xml and messages.xml"
+#~ msgstr ""
+
+#~ msgid "Write java codes to represent bug to find"
+#~ msgstr ""
+
+#~ msgid "Write java codes to avoid false-positive"
 #~ msgstr ""
 

--- a/docs/locale/ja/LC_MESSAGES/implement-plugin.po
+++ b/docs/locale/ja/LC_MESSAGES/implement-plugin.po
@@ -1,0 +1,173 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2016-2017, spotbugs community
+# This file is distributed under the same license as the spotbugs package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: spotbugs 3.1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-06-28 19:04+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 1.3\n"
+
+#: ../../implement-plugin.rst:2
+msgid "Implement SpotBugs plugin"
+msgstr ""
+
+#: ../../implement-plugin.rst:5
+msgid "Create Maven project"
+msgstr ""
+
+#: ../../implement-plugin.rst:7
+msgid ""
+"Use `spotbugs-archetype <https://github.com/spotbugs/spotbugs-"
+"archetype>`_ to create Maven project. Then Maven archetype plugin will "
+"ask you to decide plugin's groupId, artifactId, package and initial "
+"version."
+msgstr ""
+
+#: ../../implement-plugin.rst:18
+msgid "Write java codes to represent bug to find"
+msgstr ""
+
+#: ../../implement-plugin.rst:20
+msgid ""
+"In generated project, you can find a file named as `BadCase.java "
+"<https://github.com/spotbugs/spotbugs-archetype/blob/spotbugs-"
+"archetype-0.1.0/src/main/resources/archetype-"
+"resources/src/test/java/BadCase.java>`_. Update this file to represent "
+"the target bug to find."
+msgstr ""
+
+#: ../../implement-plugin.rst:23 ../../implement-plugin.rst:45
+msgid ""
+"If you have multiple patterns to represent, add more classes into "
+"``src/test/java`` directory."
+msgstr ""
+
+#: ../../implement-plugin.rst:27
+msgid "Write test case to ensure your detector can find bug"
+msgstr ""
+
+#: ../../implement-plugin.rst:29
+msgid ""
+"In generated project, you can find another file named as "
+"`MyDetectorTest.java <https://github.com/spotbugs/spotbugs-archetype/blob"
+"/spotbugs-archetype-0.1.0/src/main/resources/archetype-"
+"resources/src/test/java/MyDetectorTest.java>`_. The "
+"``spotbugs.performAnalysis(Path)`` in this test runs SpotBugs with your "
+"plugin, and return all found bugs (here 1st argument of this method is a "
+"path of class file compiled from ``BadCase.java``)."
+msgstr ""
+
+#: ../../implement-plugin.rst:32
+msgid ""
+"You can use `BugInstanceMatcher "
+"<https://github.com/spotbugs/spotbugs/blob/master/test-"
+"harness/src/main/java/edu/umd/cs/findbugs/test/matcher/BugInstanceMatcher.java>`_"
+" to verify that your plugin can find bug as expected."
+msgstr ""
+
+#: ../../implement-plugin.rst:34
+msgid ""
+"Currently this test should fail, because we've not updated detector "
+"itself yet."
+msgstr ""
+
+#: ../../implement-plugin.rst:38
+msgid "Write java codes to avoid false-positive"
+msgstr ""
+
+#: ../../implement-plugin.rst:40
+msgid ""
+"To avoid false-positive, it is good to ensure that in which case detector"
+" should NOT find bug."
+msgstr ""
+
+#: ../../implement-plugin.rst:42
+msgid ""
+"Update `GoodCase.java <https://github.com/spotbugs/spotbugs-"
+"archetype/blob/spotbugs-archetype-0.1.0/src/main/resources/archetype-"
+"resources/src/test/java/GoodCase.java>`_ in your project, and represent "
+"such cases. After that, add a test method into ``MyDetectorTest.java`` "
+"which verify that no bug found from this ``GoodCase`` class."
+msgstr ""
+
+#: ../../implement-plugin.rst:49
+msgid "Update detector to pass all unit tests"
+msgstr ""
+
+#: ../../implement-plugin.rst:51
+msgid "Now you have tests to ensure that your detector can work as expected."
+msgstr ""
+
+#: ../../implement-plugin.rst:55 ../../implement-plugin.rst:76
+msgid "TBU"
+msgstr ""
+
+#: ../../implement-plugin.rst:59
+msgid "Which super class you should choose"
+msgstr ""
+
+#: ../../implement-plugin.rst:62
+msgid ""
+"`AnnotationDetector "
+"<https://javadoc.io/page/com.github.spotbugs/spotbugs/latest/edu/umd/cs/findbugs/bcel/AnnotationDetector.html>`_"
+msgstr ""
+
+#: ../../implement-plugin.rst:62
+msgid ""
+"Base detector which analyzes annotations on classes, fields, methods, and"
+" method parameters."
+msgstr ""
+
+#: ../../implement-plugin.rst:65
+msgid ""
+"`BytecodeScanningDetector "
+"<https://javadoc.io/page/com.github.spotbugs/spotbugs/latest/edu/umd/cs/findbugs/BytecodeScanningDetector.html>`_"
+msgstr ""
+
+#: ../../implement-plugin.rst:65
+msgid "Base detector which analyzes java bytecode in class files."
+msgstr ""
+
+#: ../../implement-plugin.rst:69
+msgid ""
+"`OpcodeStackDetector "
+"<https://javadoc.io/page/com.github.spotbugs/spotbugs/latest/edu/umd/cs/findbugs/bcel/OpcodeStackDetector.html>`_"
+msgstr ""
+
+#: ../../implement-plugin.rst:68
+msgid ""
+"Sub class of ``BytecodeScanningDetector``, which can scan the bytecode of"
+" a method and use an `operand stack "
+"<https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-2.html#jvms-2.6.2>`_."
+msgstr ""
+
+#: ../../implement-plugin.rst:72
+msgid "Update findbugs.xml and messages.xml"
+msgstr ""
+
+#~ msgid ""
+#~ msgstr ""
+
+#~ msgid ""
+#~ "In generated project, you can find "
+#~ "another file named as `MyDetectorTest.java "
+#~ "<https://github.com/spotbugs/spotbugs-archetype/blob"
+#~ "/spotbugs-archetype-0.1.0/src/main/resources/archetype-"
+#~ "resources/src/test/java/MyDetectorTest.java>`_. The "
+#~ "``spotbugs.performAnalysis(Path)`` in this test "
+#~ "runs SpotBugs with your plugin, and "
+#~ "return all found bugs (here 1st "
+#~ "argument is a path of class file"
+#~ " compiled from ``BadCase.java``)."
+#~ msgstr ""
+

--- a/docs/locale/ja/LC_MESSAGES/implement-plugin.po
+++ b/docs/locale/ja/LC_MESSAGES/implement-plugin.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: spotbugs 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-06-28 19:04+0000\n"
+"POT-Creation-Date: 2017-07-02 06:33+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -108,7 +108,7 @@ msgstr ""
 msgid "Now you have tests to ensure that your detector can work as expected."
 msgstr ""
 
-#: ../../implement-plugin.rst:55 ../../implement-plugin.rst:76
+#: ../../implement-plugin.rst:55
 msgid "TBU"
 msgstr ""
 
@@ -152,22 +152,107 @@ msgid ""
 msgstr ""
 
 #: ../../implement-plugin.rst:72
-msgid "Update findbugs.xml and messages.xml"
+msgid "Update findbugs.xml"
+msgstr ""
+
+#: ../../implement-plugin.rst:74
+msgid ""
+"SpotBugs reads ``findbugs.xml`` in each plugin to find detectors and "
+"bugs. So when you add new detector, you need to add new ``<Detector>`` "
+"element like below:"
+msgstr ""
+
+#: ../../implement-plugin.rst:81
+msgid ""
+"It is also necessary to add ``<BugPattern>``, to describe type and "
+"category of your bug pattern."
+msgstr ""
+
+#: ../../implement-plugin.rst:87
+msgid ""
+"You can find ``findbugs.xml`` in ``src/main/resources`` directory of "
+"generated Maven project."
+msgstr ""
+
+#: ../../implement-plugin.rst:92
+msgid "Update messages.xml"
+msgstr ""
+
+#: ../../implement-plugin.rst:94
+msgid ""
+"SpotBugs reads ``messages.xml`` in each plugin to construct human "
+"readable message to report detected bug. It also supports reading "
+"localized messages from ``messages_ja.xml``, ``messages_fr.xml`` and so "
+"on."
+msgstr ""
+
+#: ../../implement-plugin.rst:97
+msgid ""
+"You can find ``messages.xml`` in ``src/main/resources`` directory of "
+"generated Maven project."
+msgstr ""
+
+#: ../../implement-plugin.rst:100
+msgid "Update message of Detector"
+msgstr ""
+
+#: ../../implement-plugin.rst:102
+msgid ""
+"In ``<Detector>`` element, you can add detector's description message. "
+"Note that it should be plain text, HTML is not supported."
+msgstr ""
+
+#: ../../implement-plugin.rst:113
+msgid "Update message of Bug Pattern"
+msgstr ""
+
+#: ../../implement-plugin.rst:115
+msgid ""
+"In ``<BugPattern>`` element, you can add bug pattern's description "
+"message. There are three kinds of messages:"
+msgstr ""
+
+#: ../../implement-plugin.rst:120
+msgid "ShortDescription"
+msgstr ""
+
+#: ../../implement-plugin.rst:119
+msgid ""
+"Short description for bug pattern. Useful to tell its intent and "
+"character for users. It should be plain text, HTML is not supported."
+msgstr ""
+
+#: ../../implement-plugin.rst:127
+msgid "LongDescription"
+msgstr ""
+
+#: ../../implement-plugin.rst:123
+msgid ""
+"Longer description for bug pattern. You can use placeholder like ``{0}`` "
+"(0-indexed), then added data into `BugInstance "
+"<https://javadoc.io/page/com.github.spotbugs/spotbugs/latest/edu/umd/cs/findbugs/BugInstance.html>`_"
+" will be inserted at there. So this ``LongDescription`` is useful to tell"
+" detailed information about detected bug."
+msgstr ""
+
+#: ../../implement-plugin.rst:127
+msgid "It should be plain text, HTML is not supported."
+msgstr ""
+
+#: ../../implement-plugin.rst:130
+msgid "Details"
+msgstr ""
+
+#: ../../implement-plugin.rst:130
+msgid ""
+"Detailed description for bug pattern. It should be HTML format, so this "
+"is useful to tell detailed specs/examples with table, list and code "
+"snippets."
 msgstr ""
 
 #~ msgid ""
 #~ msgstr ""
 
-#~ msgid ""
-#~ "In generated project, you can find "
-#~ "another file named as `MyDetectorTest.java "
-#~ "<https://github.com/spotbugs/spotbugs-archetype/blob"
-#~ "/spotbugs-archetype-0.1.0/src/main/resources/archetype-"
-#~ "resources/src/test/java/MyDetectorTest.java>`_. The "
-#~ "``spotbugs.performAnalysis(Path)`` in this test "
-#~ "runs SpotBugs with your plugin, and "
-#~ "return all found bugs (here 1st "
-#~ "argument is a path of class file"
-#~ " compiled from ``BadCase.java``)."
+#~ msgid "Update findbugs.xml and messages.xml"
 #~ msgstr ""
 

--- a/docs/locale/ja/LC_MESSAGES/index.po
+++ b/docs/locale/ja/LC_MESSAGES/index.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: spotbugs 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-28 22:04+0000\n"
+"POT-Creation-Date: 2017-06-28 18:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,11 +17,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 1.3\n"
 
-#: ../../source/index.rst:7
+#: ../../index.rst:7
 msgid "SpotBugs manual"
 msgstr ""
 
-#: ../../source/index.rst:9
+#: ../../index.rst:9
 msgid ""
 "This manual is licensed under the Creative Commons Attribution-"
 "NonCommercial-ShareAlike License. To view a copy of this license, visit "
@@ -29,25 +29,24 @@ msgid ""
 "Creative Commons, 559 Nathan Abbott Way, Stanford, California 94305, USA."
 msgstr ""
 
-#: ../../source/index.rst:12
+#: ../../index.rst:12
 msgid ""
 "The name FindBugs and the FindBugs logo are trademarked by the University"
 " of Maryland."
 msgstr ""
 
-#: ../../source/index.rst:15
+#: ../../index.rst:15
 msgid "Indices and tables"
 msgstr ""
 
-#: ../../source/index.rst:17
-msgid ":ref:`genindex`"
-msgstr ""
-
-#: ../../source/index.rst:18
+#: ../../index.rst:17
 msgid ":ref:`search`"
 msgstr ""
 
-#: ../../source/index.rst:21
+#: ../../index.rst:20
 msgid "Contents"
 msgstr ""
+
+#~ msgid ":ref:`genindex`"
+#~ msgstr ""
 

--- a/docs/locale/ja/LC_MESSAGES/links.po
+++ b/docs/locale/ja/LC_MESSAGES/links.po
@@ -1,0 +1,154 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2016-2017, spotbugs community
+# This file is distributed under the same license as the spotbugs package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: spotbugs 3.1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-06-28 18:09+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 1.3\n"
+
+#: ../../links.rst:2
+msgid "SpotBugs Links"
+msgstr ""
+
+#: ../../links.rst:4
+msgid ""
+"This page contains links to related projects, including tools that are "
+"similar to SpotBugs."
+msgstr ""
+
+#: ../../links.rst:7
+msgid "SpotBugs Plugins"
+msgstr ""
+
+#: ../../links.rst:10
+msgid "`fb-contrib <http://fb-contrib.sourceforge.net/>`_"
+msgstr ""
+
+#: ../../links.rst:10
+msgid ""
+"A FindBugs/SpotBugs plugin for doing static code analysis on java byte "
+"code."
+msgstr ""
+
+#: ../../links.rst:13
+msgid "`Find Security Bugs <http://find-sec-bugs.github.io/>`_"
+msgstr ""
+
+#: ../../links.rst:13
+msgid "A FindBugs/SpotBugs plugin for security audits of Java web applications."
+msgstr ""
+
+#: ../../links.rst:16
+msgid "`findbugs-slf4j <https://github.com/KengoTODA/findbugs-slf4j>`_"
+msgstr ""
+
+#: ../../links.rst:16
+msgid ""
+"A FindBugs/SpotBugs plugin to verify usage of `SLF4J "
+"<https://www.slf4j.org/>`_."
+msgstr ""
+
+#: ../../links.rst:19
+msgid "Similar/Related Tools"
+msgstr ""
+
+#: ../../links.rst:22
+msgid "`FindBugs-IDEA <https://plugins.jetbrains.com/plugin/3847-findbugs-idea>`_"
+msgstr ""
+
+#: ../../links.rst:22
+msgid ""
+"The FindBugs plugin for `IntelliJ IDEA "
+"<https://www.jetbrains.com/idea/>`_."
+msgstr ""
+
+#: ../../links.rst:25
+msgid "`sonar-findbugs <https://github.com/SonarQubeCommunity/sonar-findbugs>`_"
+msgstr ""
+
+#: ../../links.rst:25
+msgid ""
+"A `SonarQube <https://www.sonarqube.org/>`_ plugin which provides rules "
+"based on SpotBugs and its major plugins."
+msgstr ""
+
+#: ../../links.rst:28
+msgid "`Checkstyle <http://checkstyle.sourceforge.net/>`_"
+msgstr ""
+
+#: ../../links.rst:28
+msgid "A style checker for Java."
+msgstr ""
+
+#: ../../links.rst:31
+msgid "`PMD <https://pmd.github.io/>`_"
+msgstr ""
+
+#: ../../links.rst:31
+msgid "An extensible cross-language static code analyzer."
+msgstr ""
+
+#: ../../links.rst:34
+msgid "`huntbugs <https://github.com/amaembo/huntbugs>`_"
+msgstr ""
+
+#: ../../links.rst:34
+msgid ""
+"New Java bytecode static analyzer tool based on `Procyon Compiler Tools "
+"<https://bitbucket.org/mstrobel/procyon/overview>`_ aimed to supersede "
+"the FindBugs."
+msgstr ""
+
+#: ../../links.rst:37
+msgid "`Google Error Prone <http://errorprone.info/>`_"
+msgstr ""
+
+#: ../../links.rst:37
+msgid ""
+"A static analysis tool for Java that catches common programming mistakes "
+"at compile-time."
+msgstr ""
+
+#: ../../links.rst:39
+msgid "`Checker Framework <https://checkerframework.org/>`_"
+msgstr ""
+
+#: ../../links.rst:40
+msgid "A pluggable type-checking for Java."
+msgstr ""
+
+#~ msgid "`huntbugs <https://github.com/amaembo/huntbugs>`_`"
+#~ msgstr ""
+
+#~ msgid "Similar Tools"
+#~ msgstr ""
+
+#~ msgid "A FindBugs/SpotBugs plugin to verify usage of SLF4J."
+#~ msgstr ""
+
+#~ msgid "The FindBugs plugin for IntelliJ IDEA."
+#~ msgstr ""
+
+#~ msgid ""
+#~ "A SonarQube plugin which provides rules"
+#~ " based on SpotBugs and its major "
+#~ "plugins."
+#~ msgstr ""
+
+#~ msgid "`SonarQube <https://www.sonarqube.org/>`_"
+#~ msgstr ""
+
+#~ msgid "The leading product for continuous code quality."
+#~ msgstr ""
+


### PR DESCRIPTION
This PR will add two pages into manual. You can check their preview by following URLs:

* [SpotBugs Links](http://spotbugs-in-kengo-toda.readthedocs.io/en/latest/links.html)
* [Implement Plugin](http://spotbugs-in-kengo-toda.readthedocs.io/en/latest/implement-plugin.html)

Links page is almost same with [FindBugs Links](http://findbugs.sourceforge.net/links.html), but its content is updated to follow current situation.
Implement Plugin page is newly added. Please feel free to give feedback, especially about **TBU** part.