### PR TITLE
Allow upgrades of both FindBugs and SpotBugs features (#209)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v0.3](http://
 
 ### Added
 
+* The Eclipse SpotBugs plugin is eligible as an update for FindBugs 3.0.2 and earlier ([#209](https://github.com/spotbugs/spotbugs/issues/209))
 * `<EarlierSubtypes>` and `<LaterSubtypes>` can now refer to supertypes from custom plug-ins ([#215](https://github.com/spotbugs/spotbugs/issues/215))
 
 ## 3.1.0-RC3 (2017/Jun/10)

--- a/eclipsePlugin/build.gradle
+++ b/eclipsePlugin/build.gradle
@@ -242,6 +242,10 @@ task featureJar(type:Zip) {
     filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
     rename { 'feature.xml' }
   }
+  from('feature_p2.inf') {
+    filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
+    rename { 'p2.inf' }
+  }
   destinationDir = file("${buildDir}/site/eclipse/features/")
 }
 
@@ -252,6 +256,10 @@ task featureCandidateJar(type:Zip) {
     filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
     rename { 'feature.xml' }
   }
+  from('feature_p2.inf') {
+    filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
+    rename { 'p2.inf' }
+  }
   destinationDir = file("${buildDir}/site/eclipse-candidate/features/")
 }
 
@@ -261,6 +269,10 @@ task featureDailyJar(type:Zip) {
   from('plugin_feature-daily.xml') {
     filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
     rename { 'feature.xml' }
+  }
+  from('feature_p2.inf') {
+    filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
+    rename { 'p2.inf' }
   }
   destinationDir = file("${buildDir}/site/eclipse-daily/features/")
 }

--- a/eclipsePlugin/feature_p2.inf
+++ b/eclipsePlugin/feature_p2.inf
@@ -1,0 +1,7 @@
+# Consider this feature to be an update of both earlier versions of SpotBugs
+# and all versions of FindBugs up to 3.0.2, the last release prior to the fork.
+update.matchExp = providedCapabilities.exists(iu | iu.namespace == 'org.eclipse.equinox.p2.iu' && \
+ ((iu.name == '@FEATURE_ID@.feature.group' && iu.version ~= range('[0, $version$)')) || \
+  (iu.name == 'edu.umd.cs.findbugs.plugin.eclipse.feature.group' && iu.version ~= range('[0, 3.0.3)'))))
+update.severity = 0
+update.description = Update FindBugs to SpotBugs.


### PR DESCRIPTION
As noted in #209, this works for both updates from FindBugs and older versions of SpotBugs. The only thing we *may* want to discuss is which maximum version of FindBugs SpotBugs should be considered an update for.

In the pull request, I choose 3.0.2, which is as of this writing the latest version of FindBugs. If FindBugs evolves in a different direction, then we won’t overwrite it, but the present state of affairs is IMHO completely superseded by SpotBugs. Makes sense?