### PR TITLE
Call fbwrap in convenience scripts (#221)

### DIFF
--- a/spotbugs/src/scripts/experimental/backdateHistoryUsingSource
+++ b/spotbugs/src/scripts/experimental/backdateHistoryUsingSource
@@ -1,11 +1,3 @@
 #! /bin/sh
 
-@GET_FBHOME@
-
-@SET_DEFAULT_JAVA@
-
-fb_mainclass=edu.umd.cs.findbugs.workflow.BackdateHistoryUsingSource
-
-@WRAP_JAVA@
-
-# vim:ts=3
+"$(dirname $0)/../fbwrap" edu.umd.cs.findbugs.workflow.BackdateHistoryUsingSource

--- a/spotbugs/src/scripts/experimental/churn
+++ b/spotbugs/src/scripts/experimental/churn
@@ -1,11 +1,3 @@
 #! /bin/sh
 
-@GET_FBHOME@
-
-@SET_DEFAULT_JAVA@
-
-fb_mainclass=edu.umd.cs.findbugs.workflow.Churn
-
-@WRAP_JAVA@
-
-# vim:ts=3
+"$(dirname $0)/../fbwrap" edu.umd.cs.findbugs.workflow.Churn

--- a/spotbugs/src/scripts/experimental/obfuscate
+++ b/spotbugs/src/scripts/experimental/obfuscate
@@ -1,11 +1,3 @@
 #! /bin/sh
 
-@GET_FBHOME@
-
-@SET_DEFAULT_JAVA@
-
-fb_mainclass=edu.umd.cs.findbugs.workflow.ObfuscateBugs
-
-@WRAP_JAVA@
-
-# vim:ts=3
+"$(dirname $0)/../fbwrap" edu.umd.cs.findbugs.workflow.ObfuscateBugs

--- a/spotbugs/src/scripts/experimental/treemapVisualization
+++ b/spotbugs/src/scripts/experimental/treemapVisualization
@@ -1,11 +1,3 @@
 #! /bin/sh
 
-@GET_FBHOME@
-
-@SET_DEFAULT_JAVA@
-
-fb_mainclass=edu.umd.cs.findbugs.workflow.TreemapVisualization
-
-@WRAP_JAVA@
-
-# vim:ts=3
+"$(dirname $0)/../fbwrap" edu.umd.cs.findbugs.workflow.TreemapVisualization

--- a/spotbugs/src/scripts/standard/addMessages
+++ b/spotbugs/src/scripts/standard/addMessages
@@ -1,9 +1,3 @@
 #! /bin/sh
 
-@GET_FBHOME@
-
-@SET_DEFAULT_JAVA@
-
-fb_mainclass=edu.umd.cs.findbugs.AddMessages
-
-@WRAP_JAVA@
+"$(dirname $0)/fbwrap" edu.umd.cs.findbugs.AddMessages

--- a/spotbugs/src/scripts/standard/computeBugHistory
+++ b/spotbugs/src/scripts/standard/computeBugHistory
@@ -3,12 +3,4 @@
 # Merge a historical bug collection and a bug collection, producing an updated
 # historical bug collection
 
-@GET_FBHOME@
-
-@SET_DEFAULT_JAVA@
-
-fb_mainclass=edu.umd.cs.findbugs.workflow.Update
-
-@WRAP_JAVA@
-
-# vim:ts=3
+"$(dirname $0)/fbwrap" edu.umd.cs.findbugs.workflow.Update

--- a/spotbugs/src/scripts/standard/convertXmlToText
+++ b/spotbugs/src/scripts/standard/convertXmlToText
@@ -1,9 +1,3 @@
 #! /bin/sh
 
-@GET_FBHOME@
-
-@SET_DEFAULT_JAVA@
-
-fb_mainclass=edu.umd.cs.findbugs.PrintingBugReporter
-
-@WRAP_JAVA@
+"$(dirname $0)/fbwrap" edu.umd.cs.findbugs.PrintingBugReporter

--- a/spotbugs/src/scripts/standard/copyBuggySource
+++ b/spotbugs/src/scripts/standard/copyBuggySource
@@ -1,11 +1,3 @@
 #! /bin/sh
 
-@GET_FBHOME@
-
-@SET_DEFAULT_JAVA@
-
-fb_mainclass=edu.umd.cs.findbugs.workflow.CopyBuggySource
-
-@WRAP_JAVA@
-
-# vim:ts=3
+"$(dirname $0)/fbwrap" edu.umd.cs.findbugs.workflow.CopyBuggySource

--- a/spotbugs/src/scripts/standard/defectDensity
+++ b/spotbugs/src/scripts/standard/defectDensity
@@ -2,12 +2,4 @@
 
 # Generate a defect density table from a bug collection
 
-@GET_FBHOME@
-
-@SET_DEFAULT_JAVA@
-
-fb_mainclass=edu.umd.cs.findbugs.workflow.DefectDensity
-
-@WRAP_JAVA@
-
-# vim:ts=3
+"$(dirname $0)/fbwrap" edu.umd.cs.findbugs.workflow.DefectDensity

--- a/spotbugs/src/scripts/standard/filterBugs
+++ b/spotbugs/src/scripts/standard/filterBugs
@@ -3,12 +3,4 @@
 # General purpose utility for filtering/transforming
 # bug collection and/or historical bug collections
 
-@GET_FBHOME@
-
-@SET_DEFAULT_JAVA@
-
-fb_mainclass=edu.umd.cs.findbugs.workflow.Filter
-
-@WRAP_JAVA@
-
-# vim:ts=3
+"$(dirname $0)/fbwrap" edu.umd.cs.findbugs.workflow.Filter

--- a/spotbugs/src/scripts/standard/findbugs-msv
+++ b/spotbugs/src/scripts/standard/findbugs-msv
@@ -1,12 +1,3 @@
 #! /bin/sh
 
-
-@GET_FBHOME@
-
-@SET_DEFAULT_JAVA@
-
-fb_mainclass=edu.umd.cs.findbugs.workflow.MergeSummarizeAndView
-
-@WRAP_JAVA@
-
-# vim:ts=3
+"$(dirname $0)/fbwrap" edu.umd.cs.findbugs.workflow.MergeSummarizeAndView

--- a/spotbugs/src/scripts/standard/listBugDatabaseInfo
+++ b/spotbugs/src/scripts/standard/listBugDatabaseInfo
@@ -1,11 +1,3 @@
 #! /bin/sh
 
-@GET_FBHOME@
-
-@SET_DEFAULT_JAVA@
-
-fb_mainclass=edu.umd.cs.findbugs.workflow.ListBugDatabaseInfo
-
-@WRAP_JAVA@
-
-# vim:ts=3
+"$(dirname $0)/fbwrap" edu.umd.cs.findbugs.workflow.ListBugDatabaseInfo

--- a/spotbugs/src/scripts/standard/mineBugHistory
+++ b/spotbugs/src/scripts/standard/mineBugHistory
@@ -1,9 +1,3 @@
 #! /bin/sh
 
-@GET_FBHOME@
-
-@SET_DEFAULT_JAVA@
-
-fb_mainclass=edu.umd.cs.findbugs.workflow.MineBugHistory
-
-@WRAP_JAVA@
+"$(dirname $0)/fbwrap" edu.umd.cs.findbugs.workflow.MineBugHistory

--- a/spotbugs/src/scripts/standard/printAppVersion
+++ b/spotbugs/src/scripts/standard/printAppVersion
@@ -1,11 +1,3 @@
 #! /bin/sh
 
-@GET_FBHOME@
-
-@SET_DEFAULT_JAVA@
-
-fb_mainclass=edu.umd.cs.findbugs.workflow.PrintAppVersion
-
-@WRAP_JAVA@
-
-# vim:ts=3
+"$(dirname $0)/fbwrap" edu.umd.cs.findbugs.workflow.PrintAppVersion

--- a/spotbugs/src/scripts/standard/printClass
+++ b/spotbugs/src/scripts/standard/printClass
@@ -1,9 +1,3 @@
 #! /bin/sh
 
-@GET_FBHOME@
-
-@SET_DEFAULT_JAVA@
-
-fb_mainclass=edu.umd.cs.findbugs.visitclass.PrintClass
-
-@WRAP_JAVA@
+"$(dirname $0)/fbwrap" edu.umd.cs.findbugs.visitclass.PrintClass

--- a/spotbugs/src/scripts/standard/rejarForAnalysis
+++ b/spotbugs/src/scripts/standard/rejarForAnalysis
@@ -1,11 +1,3 @@
 #! /bin/sh
 
-@GET_FBHOME@
-
-@SET_DEFAULT_JAVA@
-
-fb_mainclass=edu.umd.cs.findbugs.workflow.RejarClassesForAnalysis
-
-@WRAP_JAVA@
-
-# vim:ts=3
+"$(dirname $0)/fbwrap" edu.umd.cs.findbugs.workflow.RejarClassesForAnalysis

--- a/spotbugs/src/scripts/standard/setBugDatabaseInfo
+++ b/spotbugs/src/scripts/standard/setBugDatabaseInfo
@@ -1,11 +1,3 @@
 #! /bin/sh
 
-@GET_FBHOME@
-
-@SET_DEFAULT_JAVA@
-
-fb_mainclass=edu.umd.cs.findbugs.workflow.SetBugDatabaseInfo
-
-@WRAP_JAVA@
-
-# vim:ts=3
+"$(dirname $0)/fbwrap" edu.umd.cs.findbugs.workflow.SetBugDatabaseInfo

--- a/spotbugs/src/scripts/standard/unionBugs
+++ b/spotbugs/src/scripts/standard/unionBugs
@@ -5,12 +5,4 @@
 # Create the union of two results files, preserving
 # annotations in both files in the result.
 
-@GET_FBHOME@
-
-@SET_DEFAULT_JAVA@
-
-fb_mainclass=edu.umd.cs.findbugs.workflow.UnionResults
-
-@WRAP_JAVA@
-
-# vim:ts=3
+"$(dirname $0)/fbwrap" edu.umd.cs.findbugs.workflow.UnionResults

--- a/spotbugs/src/scripts/standard/xpathFind
+++ b/spotbugs/src/scripts/standard/xpathFind
@@ -1,11 +1,3 @@
 #! /bin/sh
 
-@GET_FBHOME@
-
-@SET_DEFAULT_JAVA@
-
-fb_mainclass=edu.umd.cs.findbugs.xml.XPathFind
-
-@WRAP_JAVA@
-
-# vim:ts=3
+"$(dirname $0)/fbwrap" edu.umd.cs.findbugs.xml.XPathFind


### PR DESCRIPTION
This is a first step to consolidate the different scripts.

If nothing else, it safes a bit of space in the distribution scripts (`spotbugs-3.1.0-SNAPSHOT.zip` shrinks by about 14 KB), as the convenience scripts simply call `fbwrap` rather than duplicating lots of code.