### PR TITLE
Update building_spotbugs_plugin.txt

### DIFF
--- a/eclipsePlugin/doc/building_spotbugs_plugin.txt
+++ b/eclipsePlugin/doc/building_spotbugs_plugin.txt
@@ -9,7 +9,7 @@ Install Eclipse
 ================
 1) Download and install Eclipse 4.6.+ (minimum supported version).
 2) Download and install EGit plugin for Git.
-    Chose [Help | Software Updates... | Available Software | Add Site...] and use
+    Choose [Help | Software Updates... | Available Software | Add Site...] and use
     http://download.eclipse.org/egit/updates as update site url. Select both checkboxes
     [Eclipse Git Team Provider] and [JGit]
 3) Uncheck "Task focused interface" child element of "Eclipse Git Team Provider".
@@ -31,8 +31,8 @@ Setup target platform/spotbugs libraries
     the official http://archive.eclipse.org/eclipse/downloads/ page.
 7) cd ~/git/spotbugs/eclipsePlugin
 echo eclipseRoot.dir=/home/user/bin/Eclipse46 > local.properties
-## on windows something like:
-# echo eclipseRoot.dir=C:/work/eclipse-SDK-4.6/eclipse > local.properties
+## on Windows use this syntax instead (notice the escaped backslashes):
+## echo eclipseRoot.dir=C:\\work\\eclipse-SDK-4.6\\eclipse > local.properties
 cd ..
 ./gradlew eclipse
 
@@ -41,9 +41,10 @@ Import the projects
 8) Choose [File | Import General | Existing Projects into Workspace | Next]. The Import project import wizard opens.
 9) In the wizard, proceed as follows:
    a) Choose [Select root directory].
-   b) Enter ~/git/spotbugs. Click [Browse]
-   c) Click [Finish].
-   g) Now "spotbugs" project will be compiled by Eclipse and should not have any errors,
+   b) Enter ~/git/spotbugs. Click [Browse]. Make sure the checkbox "Search for nested projects" is selected.
+   c) Select all projects except the top level "spotbugs" project
+   d) Click [Finish].
+   e) Now "spotbugs" project will be compiled by Eclipse and should not have any errors,
    the rest could have classpath errors due wrong target platform.
 10) Set the right target platform in Eclipse. Go to
     [Window | Preferences | Plugin Development | Target Platform]


### PR DESCRIPTION
* Windows uses double backslashes in properties files
* Since the new smart import wizard it is important to not try to import the root level project, since there would be a name clash between the root spotbugs project and the spotbugs\spotbugs project.

I managed to setup my workspace with these changed instructions.