### PR TITLE
Remove calls to no-op canonicalizeString methods

### DIFF
--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/OpcodeStack.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/OpcodeStack.java
@@ -630,7 +630,7 @@ public class OpcodeStack implements Constants2 {
 
         public Item(Item it, String signature) {
             this(it);
-            this.signature = DescriptorFactory.canonicalizeString(signature);
+            this.signature = signature;
             if (constValue instanceof Number) {
                 Number constantNumericValue = (Number) constValue;
                 if ("B".equals(signature)) {
@@ -662,7 +662,7 @@ public class OpcodeStack implements Constants2 {
         }
 
         public Item(String signature, FieldAnnotation f) {
-            this.signature = DescriptorFactory.canonicalizeString(signature);
+            this.signature = signature;
             setSpecialKindFromSignature();
             if (f != null) {
                 source = XFactory.createXField(f);
@@ -671,7 +671,7 @@ public class OpcodeStack implements Constants2 {
         }
 
         public Item(String signature, FieldAnnotation f, int fieldLoadedFromRegister) {
-            this.signature = DescriptorFactory.canonicalizeString(signature);
+            this.signature = signature;
             if (f != null) {
                 source = XFactory.createXField(f);
             }
@@ -717,7 +717,7 @@ public class OpcodeStack implements Constants2 {
         }
 
         public Item(String signature, Object constantValue) {
-            this.signature = DescriptorFactory.canonicalizeString(signature);
+            this.signature = signature;
             setSpecialKindFromSignature();
             constValue = constantValue;
             if (constantValue instanceof Integer) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/PackageMemberAnnotation.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/PackageMemberAnnotation.java
@@ -76,7 +76,7 @@ public abstract class PackageMemberAnnotation extends BugAnnotationWithSourceLin
             assert false : "classname " + className + " should be dotted";
         className = className.replace('/', '.');
         }
-        this.className = DescriptorFactory.canonicalizeString(className);
+        this.className = className;
         this.sourceFileName = sourceFileName;
         if (description != null) {
             description = description.intern();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/AbstractClassMember.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/AbstractClassMember.java
@@ -61,9 +61,9 @@ public abstract class AbstractClassMember implements ClassMember {
         // else if (signature.indexOf('/') >= 0) {
         //     slashCountSignature++;
         // }
-        this.className = DescriptorFactory.canonicalizeString(className);
-        this.name = DescriptorFactory.canonicalizeString(name);
-        this.signature = DescriptorFactory.canonicalizeString(signature);
+        this.className = className;
+        this.name = name;
+        this.signature = signature;
         this.accessFlags = accessFlags;
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/XFactory.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/XFactory.java
@@ -232,8 +232,12 @@ public class XFactory {
         return m.isResolved();
     }
 
+    /**
+     * @see DescriptorFactory#canonicalizeString(String)
+     */
+    @Deprecated
     public static String canonicalizeString(String s) {
-        return DescriptorFactory.canonicalizeString(s);
+        return s;
     }
 
     /**

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/generic/GenericObjectType.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/generic/GenericObjectType.java
@@ -190,8 +190,8 @@ public class GenericObjectType extends ObjectType {
      *            the type variable e.g. <code>T</code>
      */
     GenericObjectType(@Nonnull String wildcard, @CheckForNull ReferenceType extension) {
-        super(DescriptorFactory.canonicalizeString(Type.OBJECT.getClassName()));
-        this.variable = DescriptorFactory.canonicalizeString(wildcard);
+        super(Type.OBJECT.getClassName());
+        this.variable = wildcard;
         this.extension = extension;
         parameters = null;
     }
@@ -206,7 +206,7 @@ public class GenericObjectType extends ObjectType {
      *            the parameters of this class, must be at least 1 parameter
      */
     GenericObjectType(@DottedClassName String class_name, List<? extends ReferenceType> parameters) {
-        super(DescriptorFactory.canonicalizeString(class_name));
+        super(class_name);
         variable = null;
         extension = null;
         if (parameters == null || parameters.size() == 0) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/interproc/FieldPropertyDatabase.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/interproc/FieldPropertyDatabase.java
@@ -51,9 +51,9 @@ public abstract class FieldPropertyDatabase<Property> extends PropertyDatabase<F
             throw new PropertyDatabaseFormatException("Invalid field tuple: " + s);
         }
 
-        String className = XFactory.canonicalizeString(tuple[0]);
-        String fieldName = XFactory.canonicalizeString(tuple[1]);
-        String signature = XFactory.canonicalizeString(tuple[2]);
+        String className = tuple[0];
+        String fieldName = tuple[1];
+        String signature = tuple[2];
         int accessFlags;
         try {
             accessFlags = Integer.parseInt(tuple[3]);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/interproc/MethodPropertyDatabase.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/interproc/MethodPropertyDatabase.java
@@ -50,9 +50,9 @@ public abstract class MethodPropertyDatabase<Property> extends PropertyDatabase<
             // XFactory.createMethodDescriptor(XFactory.canonicalizeString(tuple[0]),
             // XFactory.canonicalizeString( tuple[1]),
             // XFactory.canonicalizeString(tuple[2]), accessFlags);
-            String className = XFactory.canonicalizeString(tuple[0]);
-            String methodName = XFactory.canonicalizeString(tuple[1]);
-            String methodSig = XFactory.canonicalizeString(tuple[2]);
+            String className = tuple[0];
+            String methodName = tuple[1];
+            String methodSig = tuple[2];
             return DescriptorFactory.instance().getMethodDescriptor(ClassName.toSlashedClassName(className), methodName,
                     methodSig, (accessFlags & Const.ACC_STATIC) != 0);
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/DescriptorFactory.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/DescriptorFactory.java
@@ -118,7 +118,7 @@ public class DescriptorFactory {
     public @Nonnull
     ClassDescriptor getClassDescriptor(@SlashedClassName String className) {
         assert className.indexOf('.') == -1;
-        className = canonicalizeString(className);
+        className = className;
         ClassDescriptor classDescriptor = classDescriptorMap.get(className);
         if (classDescriptor == null) {
             classDescriptor = new ClassDescriptor(className);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/FieldOrMethodDescriptor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/FieldOrMethodDescriptor.java
@@ -44,9 +44,9 @@ public abstract class FieldOrMethodDescriptor implements FieldOrMethodName {
     public FieldOrMethodDescriptor(@SlashedClassName String slashedClassName, String name, String signature, boolean isStatic) {
         assert slashedClassName.indexOf('.') == -1 : "class name not in VM format: " + slashedClassName;
 
-        this.slashedClassName = DescriptorFactory.canonicalizeString(slashedClassName);
-        this.name = DescriptorFactory.canonicalizeString(name);
-        this.signature = DescriptorFactory.canonicalizeString(signature);
+        this.slashedClassName = slashedClassName;
+        this.name = name;
+        this.signature = signature;
         this.isStatic = isStatic;
         this.nameSigHashCode = getNameSigHashCode(this.name, this.signature);
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/analysis/MethodInfo.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/analysis/MethodInfo.java
@@ -291,12 +291,7 @@ public class MethodInfo extends MethodDescriptor implements XMethod {
         super(className, methodName, methodSignature, (accessFlags & Const.ACC_STATIC) != 0);
         this.accessFlags = accessFlags;
         this.exceptions = exceptions;
-        if (exceptions != null) {
-            for (int i = 0; i < exceptions.length; i++) {
-                exceptions[i] = DescriptorFactory.canonicalizeString(exceptions[i]);
-            }
-        }
-        this.methodSourceSignature = DescriptorFactory.canonicalizeString(methodSourceSignature);
+        this.methodSourceSignature = methodSourceSignature;
         this.methodAnnotations = Util.immutableMap(methodAnnotations);
         this.methodParameterAnnotations = Util.immutableMap(methodParameterAnnotations);
         if (isUnconditionalThrower) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/ClassName.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/ClassName.java
@@ -115,7 +115,7 @@ public abstract class ClassName {
     @SuppressFBWarnings("TQ_EXPLICIT_UNKNOWN_SOURCE_VALUE_REACHES_ALWAYS_SINK")
     public static String toSlashedClassName(@SlashedClassName(when = When.UNKNOWN) String className) {
         if (className.indexOf('.') >= 0) {
-            return DescriptorFactory.canonicalizeString(className.replace('.', '/'));
+            return className.replace('.', '/');
         }
         return className;
     }
@@ -132,7 +132,7 @@ public abstract class ClassName {
     @SuppressFBWarnings("TQ_EXPLICIT_UNKNOWN_SOURCE_VALUE_REACHES_NEVER_SINK")
     public static String toDottedClassName(@SlashedClassName(when = When.UNKNOWN) String className) {
         if (className.indexOf('/') >= 0) {
-            return DescriptorFactory.canonicalizeString(className.replace('/', '.'));
+            return className.replace('/', '.');
         }
         return className;
     }


### PR DESCRIPTION
These methods have been deprecated and turned into no-ops with #128. This change removes the calls (but not the methods themselves, so not to break API) to reduce the number of distracting warnings (12 warnings less).

@KengoTODA As you implemented the performance improvement in #128 that turned these methods to no-ops, would you care to review this change please?