### PR TITLE
This implements part 1 of the changes described in #262

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v0.3](http://
 
 * `jdepend:jdepend:2.9.1` is no longer a compile-scoped dependency but only test-scoped. ([#242](https://github.com/spotbugs/spotbugs/issues/242))
 
+### Deprecated
+
+* In future versions of SpotBugs, classes currently implementing the deprecated `org.apache.bcel.Constants` interface may no longer do so.
+  Subclasses should either implement this interface themselves or, preferably, use the constants defined in the (non-deprecated) `org.apache.bcel.Const` class instead.
+  ([#262](https://github.com/spotbugs/spotbugs/issues/262))
+
 ## 3.1.0-RC3 (2017/Jun/10)
 
 ### Added

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/MethodAnnotation.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/MethodAnnotation.java
@@ -283,11 +283,11 @@ public class MethodAnnotation extends PackageMemberAnnotation {
 
 
     public String getJavaSourceMethodName() {
-        if ("<clinit>".equals(methodName)) {
+        if (Const.STATIC_INITIALIZER_NAME.equals(methodName)) {
             return "<static initializer for " + getSimpleClassName() + ">";
         }
 
-        if ("<init>".equals(methodName)) {
+        if (Const.CONSTRUCTOR_NAME.equals(methodName)) {
             return getSimpleClassName();
         }
         return methodName;
@@ -332,7 +332,7 @@ public class MethodAnnotation extends PackageMemberAnnotation {
         if ("".equals(key)) {
             return UGLY_METHODS ? getUglyMethod() : getFullMethod(primaryClass);
         } else if ("givenClass".equals(key)) {
-            if ("<init>".equals(methodName)) {
+            if (Const.CONSTRUCTOR_NAME.equals(methodName)) {
                 return "new " + shorten(primaryClass.getPackageName(), className) + getSignatureInClass(primaryClass);
             }
             if (className.equals(primaryClass.getClassName())) {
@@ -437,7 +437,7 @@ public class MethodAnnotation extends PackageMemberAnnotation {
      */
     public String getFullMethod(ClassAnnotation primaryClass) {
         if (fullMethod == null) {
-            if ("<init>".equals(methodName)) {
+            if (Const.CONSTRUCTOR_NAME.equals(methodName)) {
                 fullMethod = "new " + stripJavaLang(className) + getSignatureInClass(primaryClass);
             } else {
                 fullMethod = stripJavaLang(className) + "." + getNameInClass(primaryClass);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/OpcodeStack.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/OpcodeStack.java
@@ -38,6 +38,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.meta.TypeQualifier;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.Repository;
 import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.CodeException;
@@ -1300,7 +1301,7 @@ public class OpcodeStack implements Constants2 {
                 return;
             }
 
-            if (seen == GOTO) {
+            if (seen == Const.GOTO) {
                 int nextPC = dbc.getPC() + 3;
                 if (nextPC <= dbc.getMaxPC()) {
 
@@ -1309,11 +1310,11 @@ public class OpcodeStack implements Constants2 {
                     try {
                         int nextOpcode = dbc.getCodeByte(dbc.getPC() + 3);
 
-                        if ((prevOpcode1 == ICONST_0 || prevOpcode1 == ICONST_1)
-                                && (prevOpcode2 == IFNULL || prevOpcode2 == IFNONNULL)
-                                && (nextOpcode == ICONST_0 || nextOpcode == ICONST_1) && prevOpcode1 != nextOpcode) {
-                            oneMeansNull = prevOpcode1 == ICONST_0;
-                            if (prevOpcode2 != IFNULL) {
+                        if ((prevOpcode1 == Const.ICONST_0 || prevOpcode1 == Const.ICONST_1)
+                                && (prevOpcode2 == Const.IFNULL || prevOpcode2 == Const.IFNONNULL)
+                                && (nextOpcode == Const.ICONST_0 || nextOpcode == Const.ICONST_1) && prevOpcode1 != nextOpcode) {
+                            oneMeansNull = prevOpcode1 == Const.ICONST_0;
+                            if (prevOpcode2 != Const.IFNULL) {
                                 oneMeansNull = !oneMeansNull;
                             }
                             zeroOneComing = nextPC + 1;
@@ -1328,17 +1329,17 @@ public class OpcodeStack implements Constants2 {
             }
 
             switch (seen) {
-            case ICONST_1:
+            case Const.ICONST_1:
                 convertJumpToOneZeroState = 1;
                 break;
-            case GOTO:
+            case Const.GOTO:
                 if (convertJumpToOneZeroState == 1 && dbc.getBranchOffset() == 4) {
                     convertJumpToOneZeroState = 2;
                 } else {
                     convertJumpToOneZeroState = 0;
                 }
                 break;
-            case ICONST_0:
+            case Const.ICONST_0:
                 if (convertJumpToOneZeroState == 2) {
                     convertJumpToOneZeroState = 3;
                 } else {
@@ -1350,17 +1351,17 @@ public class OpcodeStack implements Constants2 {
 
             }
             switch (seen) {
-            case ICONST_0:
+            case Const.ICONST_0:
                 convertJumpToZeroOneState = 1;
                 break;
-            case GOTO:
+            case Const.GOTO:
                 if (convertJumpToZeroOneState == 1 && dbc.getBranchOffset() == 4) {
                     convertJumpToZeroOneState = 2;
                 } else {
                     convertJumpToZeroOneState = 0;
                 }
                 break;
-            case ICONST_1:
+            case Const.ICONST_1:
                 if (convertJumpToZeroOneState == 2) {
                     convertJumpToZeroOneState = 3;
                 } else {
@@ -1372,62 +1373,62 @@ public class OpcodeStack implements Constants2 {
             }
 
             switch (seen) {
-            case ALOAD:
+            case Const.ALOAD:
                 pushByLocalObjectLoad(dbc, dbc.getRegisterOperand());
                 break;
 
-            case ALOAD_0:
-            case ALOAD_1:
-            case ALOAD_2:
-            case ALOAD_3:
-                pushByLocalObjectLoad(dbc, seen - ALOAD_0);
+            case Const.ALOAD_0:
+            case Const.ALOAD_1:
+            case Const.ALOAD_2:
+            case Const.ALOAD_3:
+                pushByLocalObjectLoad(dbc, seen - Const.ALOAD_0);
                 break;
 
-            case DLOAD:
+            case Const.DLOAD:
                 pushByLocalLoad("D", dbc.getRegisterOperand());
                 break;
 
-            case DLOAD_0:
-            case DLOAD_1:
-            case DLOAD_2:
-            case DLOAD_3:
-                pushByLocalLoad("D", seen - DLOAD_0);
+            case Const.DLOAD_0:
+            case Const.DLOAD_1:
+            case Const.DLOAD_2:
+            case Const.DLOAD_3:
+                pushByLocalLoad("D", seen - Const.DLOAD_0);
                 break;
 
-            case FLOAD:
+            case Const.FLOAD:
                 pushByLocalLoad("F", dbc.getRegisterOperand());
                 break;
 
-            case FLOAD_0:
-            case FLOAD_1:
-            case FLOAD_2:
-            case FLOAD_3:
-                pushByLocalLoad("F", seen - FLOAD_0);
+            case Const.FLOAD_0:
+            case Const.FLOAD_1:
+            case Const.FLOAD_2:
+            case Const.FLOAD_3:
+                pushByLocalLoad("F", seen - Const.FLOAD_0);
                 break;
 
-            case ILOAD:
+            case Const.ILOAD:
                 pushByLocalLoad("I", dbc.getRegisterOperand());
                 break;
 
-            case ILOAD_0:
-            case ILOAD_1:
-            case ILOAD_2:
-            case ILOAD_3:
-                pushByLocalLoad("I", seen - ILOAD_0);
+            case Const.ILOAD_0:
+            case Const.ILOAD_1:
+            case Const.ILOAD_2:
+            case Const.ILOAD_3:
+                pushByLocalLoad("I", seen - Const.ILOAD_0);
                 break;
 
-            case LLOAD:
+            case Const.LLOAD:
                 pushByLocalLoad("J", dbc.getRegisterOperand());
                 break;
 
-            case LLOAD_0:
-            case LLOAD_1:
-            case LLOAD_2:
-            case LLOAD_3:
-                pushByLocalLoad("J", seen - LLOAD_0);
+            case Const.LLOAD_0:
+            case Const.LLOAD_1:
+            case Const.LLOAD_2:
+            case Const.LLOAD_3:
+                pushByLocalLoad("J", seen - Const.LLOAD_0);
                 break;
 
-            case GETSTATIC: {
+            case Const.GETSTATIC: {
                 FieldSummary fieldSummary = AnalysisContext.currentAnalysisContext().getFieldSummary();
                 XField fieldOperand = dbc.getXFieldOperand();
 
@@ -1451,20 +1452,20 @@ public class OpcodeStack implements Constants2 {
                 break;
             }
 
-            case LDC:
-            case LDC_W:
-            case LDC2_W:
+            case Const.LDC:
+            case Const.LDC_W:
+            case Const.LDC2_W:
                 cons = dbc.getConstantRefOperand();
                 pushByConstant(dbc, cons);
                 break;
 
-            case INSTANCEOF:
+            case Const.INSTANCEOF:
                 pop();
                 push(new Item("I"));
                 break;
 
-            case IFNONNULL:
-            case IFNULL:
+            case Const.IFNONNULL:
+            case Const.IFNULL:
                 // {
                 // Item topItem = pop();
                 // if (seen == IFNONNULL && topItem.isNull())
@@ -1475,12 +1476,12 @@ public class OpcodeStack implements Constants2 {
                 // break;
                 // }
 
-            case IFEQ:
-            case IFNE:
-            case IFLT:
-            case IFLE:
-            case IFGT:
-            case IFGE:
+            case Const.IFEQ:
+            case Const.IFNE:
+            case Const.IFLT:
+            case Const.IFLE:
+            case Const.IFGT:
+            case Const.IFGE:
 
                 seenTransferOfControl = true;
                 {
@@ -1488,13 +1489,13 @@ public class OpcodeStack implements Constants2 {
 
                     // System.out.printf("%4d %10s %s%n",
                     // dbc.getPC(),OPCODE_NAMES[seen], topItem);
-                    if (seen == IFLT || seen == IFLE) {
+                    if (seen == Const.IFLT || seen == Const.IFLE) {
                         registerTestedFoundToBeNonnegative = topItem.registerNumber;
                     }
                     // if we see a test comparing a special negative value with
                     // 0,
                     // reset all other such values on the opcode stack
-                    if (topItem.valueCouldBeNegative() && (seen == IFLT || seen == IFLE || seen == IFGT || seen == IFGE)) {
+                    if (topItem.valueCouldBeNegative() && (seen == Const.IFLT || seen == Const.IFLE || seen == Const.IFGT || seen == Const.IFGE)) {
                         int specialKind = topItem.getSpecialKind();
                         for (Item item : stack) {
                             if (item != null && item.getSpecialKind() == specialKind) {
@@ -1512,9 +1513,9 @@ public class OpcodeStack implements Constants2 {
                 addJumpValue(dbc.getPC(), dbc.getBranchTarget());
 
                 break;
-            case LOOKUPSWITCH:
+            case Const.LOOKUPSWITCH:
 
-            case TABLESWITCH:
+            case Const.TABLESWITCH:
                 seenTransferOfControl = true;
                 setReachOnlyByBranch(true);
                 pop();
@@ -1525,40 +1526,40 @@ public class OpcodeStack implements Constants2 {
                 }
 
                 break;
-            case ARETURN:
-            case DRETURN:
-            case FRETURN:
+            case Const.ARETURN:
+            case Const.DRETURN:
+            case Const.FRETURN:
 
-            case IRETURN:
-            case LRETURN:
+            case Const.IRETURN:
+            case Const.LRETURN:
 
                 seenTransferOfControl = true;
                 setReachOnlyByBranch(true);
                 pop();
                 break;
-            case MONITORENTER:
-            case MONITOREXIT:
-            case POP:
+            case Const.MONITORENTER:
+            case Const.MONITOREXIT:
+            case Const.POP:
                 pop();
                 break;
 
-            case PUTSTATIC:
+            case Const.PUTSTATIC:
                 pop();
                 eraseKnowledgeOf(dbc.getXFieldOperand());
                 break;
-            case PUTFIELD:
+            case Const.PUTFIELD:
                 pop(2);
                 eraseKnowledgeOf(dbc.getXFieldOperand());
                 break;
 
-            case IF_ACMPEQ:
-            case IF_ACMPNE:
-            case IF_ICMPEQ:
-            case IF_ICMPNE:
-            case IF_ICMPLT:
-            case IF_ICMPLE:
-            case IF_ICMPGT:
-            case IF_ICMPGE:
+            case Const.IF_ACMPEQ:
+            case Const.IF_ACMPNE:
+            case Const.IF_ICMPEQ:
+            case Const.IF_ICMPNE:
+            case Const.IF_ICMPLT:
+            case Const.IF_ICMPLE:
+            case Const.IF_ICMPGT:
+            case Const.IF_ICMPGE:
 
             {
                 seenTransferOfControl = true;
@@ -1569,37 +1570,37 @@ public class OpcodeStack implements Constants2 {
                 Object rConstant = right.getConstant();
                 boolean takeJump = false;
                 boolean handled = false;
-                if (seen == IF_ACMPNE || seen == IF_ACMPEQ) {
+                if (seen == Const.IF_ACMPNE || seen == Const.IF_ACMPEQ) {
                     if (lConstant != null && rConstant != null && !lConstant.equals(rConstant) || lConstant != null
                             && right.isNull() || rConstant != null && left.isNull()) {
                         handled = true;
-                        takeJump = seen == IF_ACMPNE;
+                        takeJump = seen == Const.IF_ACMPNE;
                     }
                 } else if (lConstant instanceof Integer && rConstant instanceof Integer) {
                     int lC = ((Integer) lConstant).intValue();
                     int rC = ((Integer) rConstant).intValue();
                     switch (seen) {
-                    case IF_ICMPEQ:
+                    case Const.IF_ICMPEQ:
                         takeJump = lC == rC;
                         handled = true;
                         break;
-                    case IF_ICMPNE:
+                    case Const.IF_ICMPNE:
                         takeJump = lC != rC;
                         handled = true;
                         break;
-                    case IF_ICMPGE:
+                    case Const.IF_ICMPGE:
                         takeJump = lC >= rC;
                         handled = true;
                         break;
-                    case IF_ICMPGT:
+                    case Const.IF_ICMPGT:
                         takeJump = lC > rC;
                         handled = true;
                         break;
-                    case IF_ICMPLE:
+                    case Const.IF_ICMPLE:
                         takeJump = lC <= rC;
                         handled = true;
                         break;
-                    case IF_ICMPLT:
+                    case Const.IF_ICMPLT:
                         takeJump = lC < rC;
                         handled = true;
                         break;
@@ -1636,7 +1637,7 @@ public class OpcodeStack implements Constants2 {
                 break;
             }
 
-            case POP2:
+            case Const.POP2:
                 it = pop();
                 if (it.getSize() == 1) {
                     pop();
@@ -1644,53 +1645,53 @@ public class OpcodeStack implements Constants2 {
                 break;
 
 
-            case IALOAD:
-            case SALOAD:
+            case Const.IALOAD:
+            case Const.SALOAD:
                 pop(2);
                 push(new Item("I"));
                 break;
 
-            case DUP:
+            case Const.DUP:
                 handleDup();
                 break;
 
-            case DUP2:
+            case Const.DUP2:
                 handleDup2();
                 break;
 
-            case DUP_X1:
+            case Const.DUP_X1:
                 handleDupX1();
                 break;
 
-            case DUP_X2:
+            case Const.DUP_X2:
 
                 handleDupX2();
                 break;
 
-            case DUP2_X1:
+            case Const.DUP2_X1:
                 handleDup2X1();
                 break;
 
-            case DUP2_X2:
+            case Const.DUP2_X2:
                 handleDup2X2();
                 break;
 
-            case IINC:
+            case Const.IINC:
                 register = dbc.getRegisterOperand();
                 it = getLVValue(register);
                 it2 = new Item("I", dbc.getIntConstant());
-                pushByIntMath(dbc, IADD, it2, it);
+                pushByIntMath(dbc, Const.IADD, it2, it);
                 pushByLocalStore(register);
                 break;
 
-            case ATHROW:
+            case Const.ATHROW:
                 pop();
                 seenTransferOfControl = true;
                 setReachOnlyByBranch(true);
                 setTop(true);
                 break;
 
-            case CHECKCAST: {
+            case Const.CHECKCAST: {
                 String castTo = dbc.getClassConstantOperand();
 
                 if (castTo.charAt(0) != '[') {
@@ -1705,16 +1706,16 @@ public class OpcodeStack implements Constants2 {
                 break;
 
             }
-            case NOP:
+            case Const.NOP:
                 break;
-            case RET:
-            case RETURN:
+            case Const.RET:
+            case Const.RETURN:
                 seenTransferOfControl = true;
                 setReachOnlyByBranch(true);
                 break;
 
-            case GOTO:
-            case GOTO_W:
+            case Const.GOTO:
+            case Const.GOTO_W:
                 seenTransferOfControl = true;
                 setReachOnlyByBranch(true);
                 addJumpValue(dbc.getPC(), dbc.getBranchTarget());
@@ -1723,84 +1724,84 @@ public class OpcodeStack implements Constants2 {
 
                 break;
 
-            case SWAP:
+            case Const.SWAP:
                 handleSwap();
                 break;
 
-            case ICONST_M1:
-            case ICONST_0:
-            case ICONST_1:
-            case ICONST_2:
-            case ICONST_3:
-            case ICONST_4:
-            case ICONST_5:
-                push(new Item("I", (seen - ICONST_0)));
+            case Const.ICONST_M1:
+            case Const.ICONST_0:
+            case Const.ICONST_1:
+            case Const.ICONST_2:
+            case Const.ICONST_3:
+            case Const.ICONST_4:
+            case Const.ICONST_5:
+                push(new Item("I", (seen - Const.ICONST_0)));
                 break;
 
-            case LCONST_0:
-            case LCONST_1:
-                push(new Item("J", Long.valueOf(seen - LCONST_0)));
+            case Const.LCONST_0:
+            case Const.LCONST_1:
+                push(new Item("J", Long.valueOf(seen - Const.LCONST_0)));
                 break;
 
-            case DCONST_0:
-            case DCONST_1:
-                push(new Item("D", Double.valueOf(seen - DCONST_0)));
+            case Const.DCONST_0:
+            case Const.DCONST_1:
+                push(new Item("D", Double.valueOf(seen - Const.DCONST_0)));
                 break;
 
-            case FCONST_0:
-            case FCONST_1:
-            case FCONST_2:
-                push(new Item("F", Float.valueOf(seen - FCONST_0)));
+            case Const.FCONST_0:
+            case Const.FCONST_1:
+            case Const.FCONST_2:
+                push(new Item("F", Float.valueOf(seen - Const.FCONST_0)));
                 break;
 
-            case ACONST_NULL:
+            case Const.ACONST_NULL:
                 push(new Item());
                 break;
 
-            case ASTORE:
-            case DSTORE:
-            case FSTORE:
-            case ISTORE:
-            case LSTORE:
+            case Const.ASTORE:
+            case Const.DSTORE:
+            case Const.FSTORE:
+            case Const.ISTORE:
+            case Const.LSTORE:
                 pushByLocalStore(dbc.getRegisterOperand());
                 break;
 
-            case ASTORE_0:
-            case ASTORE_1:
-            case ASTORE_2:
-            case ASTORE_3:
-                pushByLocalStore(seen - ASTORE_0);
+            case Const.ASTORE_0:
+            case Const.ASTORE_1:
+            case Const.ASTORE_2:
+            case Const.ASTORE_3:
+                pushByLocalStore(seen - Const.ASTORE_0);
                 break;
 
-            case DSTORE_0:
-            case DSTORE_1:
-            case DSTORE_2:
-            case DSTORE_3:
-                pushByLocalStore(seen - DSTORE_0);
+            case Const.DSTORE_0:
+            case Const.DSTORE_1:
+            case Const.DSTORE_2:
+            case Const.DSTORE_3:
+                pushByLocalStore(seen - Const.DSTORE_0);
                 break;
 
-            case FSTORE_0:
-            case FSTORE_1:
-            case FSTORE_2:
-            case FSTORE_3:
-                pushByLocalStore(seen - FSTORE_0);
+            case Const.FSTORE_0:
+            case Const.FSTORE_1:
+            case Const.FSTORE_2:
+            case Const.FSTORE_3:
+                pushByLocalStore(seen - Const.FSTORE_0);
                 break;
 
-            case ISTORE_0:
-            case ISTORE_1:
-            case ISTORE_2:
-            case ISTORE_3:
-                pushByLocalStore(seen - ISTORE_0);
+            case Const.ISTORE_0:
+            case Const.ISTORE_1:
+            case Const.ISTORE_2:
+            case Const.ISTORE_3:
+                pushByLocalStore(seen - Const.ISTORE_0);
                 break;
 
-            case LSTORE_0:
-            case LSTORE_1:
-            case LSTORE_2:
-            case LSTORE_3:
-                pushByLocalStore(seen - LSTORE_0);
+            case Const.LSTORE_0:
+            case Const.LSTORE_1:
+            case Const.LSTORE_2:
+            case Const.LSTORE_3:
+                pushByLocalStore(seen - Const.LSTORE_0);
                 break;
 
-            case GETFIELD: {
+            case Const.GETFIELD: {
                 FieldSummary fieldSummary = AnalysisContext.currentAnalysisContext().getFieldSummary();
                 XField fieldOperand = dbc.getXFieldOperand();
                 if (fieldOperand != null && fieldSummary.isComplete() && !fieldOperand.isPublic()) {
@@ -1823,7 +1824,7 @@ public class OpcodeStack implements Constants2 {
             }
             break;
 
-            case ARRAYLENGTH: {
+            case Const.ARRAYLENGTH: {
                 Item array = pop();
                 Item newItem = new Item("I", array.getConstant());
                 newItem.setSpecialKind(Item.NON_NEGATIVE);
@@ -1831,68 +1832,68 @@ public class OpcodeStack implements Constants2 {
             }
             break;
 
-            case BALOAD: {
+            case Const.BALOAD: {
                 pop(2);
                 Item newItem = new Item("I");
                 newItem.setSpecialKind(Item.SIGNED_BYTE);
                 push(newItem);
                 break;
             }
-            case CALOAD: {
+            case Const.CALOAD: {
                 pop(2);
                 Item newItem = new Item("I");
                 newItem.setSpecialKind(Item.NON_NEGATIVE);
                 push(newItem);
                 break;
             }
-            case DALOAD:
+            case Const.DALOAD:
                 pop(2);
                 push(new Item("D"));
                 break;
 
-            case FALOAD:
+            case Const.FALOAD:
                 pop(2);
                 push(new Item("F"));
                 break;
 
-            case LALOAD:
+            case Const.LALOAD:
                 pop(2);
                 push(new Item("J"));
                 break;
 
-            case AASTORE:
-            case BASTORE:
-            case CASTORE:
-            case DASTORE:
-            case FASTORE:
-            case IASTORE:
-            case LASTORE:
-            case SASTORE:
+            case Const.AASTORE:
+            case Const.BASTORE:
+            case Const.CASTORE:
+            case Const.DASTORE:
+            case Const.FASTORE:
+            case Const.IASTORE:
+            case Const.LASTORE:
+            case Const.SASTORE:
                 pop(3);
                 break;
 
-            case BIPUSH:
-            case SIPUSH:
+            case Const.BIPUSH:
+            case Const.SIPUSH:
                 push(new Item("I", Integer.valueOf(dbc.getIntConstant())));
                 break;
 
-            case IADD:
-            case ISUB:
-            case IMUL:
-            case IDIV:
-            case IAND:
-            case IOR:
-            case IXOR:
-            case ISHL:
-            case ISHR:
-            case IREM:
-            case IUSHR:
+            case Const.IADD:
+            case Const.ISUB:
+            case Const.IMUL:
+            case Const.IDIV:
+            case Const.IAND:
+            case Const.IOR:
+            case Const.IXOR:
+            case Const.ISHL:
+            case Const.ISHR:
+            case Const.IREM:
+            case Const.IUSHR:
                 it = pop();
                 it2 = pop();
                 pushByIntMath(dbc, seen, it2, it);
                 break;
 
-            case INEG:
+            case Const.INEG:
                 it = pop();
                 if (it.getConstant() instanceof Integer) {
                     push(new Item("I", Integer.valueOf(-constantToInt(it))));
@@ -1901,7 +1902,7 @@ public class OpcodeStack implements Constants2 {
                 }
                 break;
 
-            case LNEG:
+            case Const.LNEG:
                 it = pop();
                 if (it.getConstant() instanceof Long) {
                     push(new Item("J", Long.valueOf(-constantToLong(it))));
@@ -1909,7 +1910,7 @@ public class OpcodeStack implements Constants2 {
                     push(new Item("J"));
                 }
                 break;
-            case FNEG:
+            case Const.FNEG:
                 it = pop();
                 if (it.getConstant() instanceof Float) {
                     push(new Item("F", Float.valueOf(-constantToFloat(it))));
@@ -1917,7 +1918,7 @@ public class OpcodeStack implements Constants2 {
                     push(new Item("F"));
                 }
                 break;
-            case DNEG:
+            case Const.DNEG:
                 it = pop();
                 if (it.getConstant() instanceof Double) {
                     push(new Item("D", Double.valueOf(-constantToDouble(it))));
@@ -1926,58 +1927,58 @@ public class OpcodeStack implements Constants2 {
                 }
                 break;
 
-            case LADD:
-            case LSUB:
-            case LMUL:
-            case LDIV:
-            case LAND:
-            case LOR:
-            case LXOR:
-            case LSHL:
-            case LSHR:
-            case LREM:
-            case LUSHR:
+            case Const.LADD:
+            case Const.LSUB:
+            case Const.LMUL:
+            case Const.LDIV:
+            case Const.LAND:
+            case Const.LOR:
+            case Const.LXOR:
+            case Const.LSHL:
+            case Const.LSHR:
+            case Const.LREM:
+            case Const.LUSHR:
 
                 it = pop();
                 it2 = pop();
                 pushByLongMath(seen, it2, it);
                 break;
 
-            case LCMP:
+            case Const.LCMP:
                 handleLcmp();
                 break;
 
-            case FCMPG:
-            case FCMPL:
+            case Const.FCMPG:
+            case Const.FCMPL:
                 handleFcmp(seen);
                 break;
 
-            case DCMPG:
-            case DCMPL:
+            case Const.DCMPG:
+            case Const.DCMPL:
                 handleDcmp(seen);
                 break;
 
-            case FADD:
-            case FSUB:
-            case FMUL:
-            case FDIV:
-            case FREM:
+            case Const.FADD:
+            case Const.FSUB:
+            case Const.FMUL:
+            case Const.FDIV:
+            case Const.FREM:
                 it = pop();
                 it2 = pop();
                 pushByFloatMath(seen, it, it2);
                 break;
 
-            case DADD:
-            case DSUB:
-            case DMUL:
-            case DDIV:
-            case DREM:
+            case Const.DADD:
+            case Const.DSUB:
+            case Const.DMUL:
+            case Const.DDIV:
+            case Const.DREM:
                 it = pop();
                 it2 = pop();
                 pushByDoubleMath(seen, it, it2);
                 break;
 
-            case I2B: {
+            case Const.I2B: {
                 it = pop();
                 Item newValue = new Item(it, "B");
                 newValue.setCouldBeNegative();
@@ -1988,7 +1989,7 @@ public class OpcodeStack implements Constants2 {
 
 
 
-            case I2C: {
+            case Const.I2C: {
                 it = pop();
                 Item newValue = new Item(it, "C");
 
@@ -1996,15 +1997,15 @@ public class OpcodeStack implements Constants2 {
             }
             break;
 
-            case I2L:
-            case D2L:
-            case F2L: {
+            case Const.I2L:
+            case Const.D2L:
+            case Const.F2L: {
                 it = pop();
                 Item newValue = new Item(it, "J");
 
                 int specialKind = it.getSpecialKind();
 
-                if (specialKind != Item.SIGNED_BYTE && seen == I2L) {
+                if (specialKind != Item.SIGNED_BYTE && seen == Const.I2L) {
                     newValue.setSpecialKind(Item.RESULT_OF_I2L);
                 }
 
@@ -2012,7 +2013,7 @@ public class OpcodeStack implements Constants2 {
             }
             break;
 
-            case I2S:
+            case Const.I2S:
             {
                 Item item1 = pop();
                 Item newValue = new Item(item1, "S");
@@ -2021,9 +2022,9 @@ public class OpcodeStack implements Constants2 {
             }
             break;
 
-            case L2I:
-            case D2I:
-            case F2I:
+            case Const.L2I:
+            case Const.D2I:
+            case Const.F2I:
                 it = pop();
                 int oldSpecialKind = it.getSpecialKind();
                 it = new Item(it, "I");
@@ -2035,9 +2036,9 @@ public class OpcodeStack implements Constants2 {
 
                 break;
 
-            case L2F:
-            case D2F:
-            case I2F:
+            case Const.L2F:
+            case Const.D2F:
+            case Const.I2F:
                 it = pop();
                 if (it.getConstant() != null) {
                     push(new Item("F", Float.valueOf(constantToFloat(it))));
@@ -2046,9 +2047,9 @@ public class OpcodeStack implements Constants2 {
                 }
                 break;
 
-            case F2D:
-            case I2D:
-            case L2D:
+            case Const.F2D:
+            case Const.I2D:
+            case Const.L2D:
                 it = pop();
                 if (it.getConstant() != null) {
                     push(new Item("D", Double.valueOf(constantToDouble(it))));
@@ -2057,14 +2058,14 @@ public class OpcodeStack implements Constants2 {
                 }
                 break;
 
-            case NEW: {
+            case Const.NEW: {
                 Item item = new Item("L" + dbc.getClassConstantOperand() + ";", (Object) null);
                 item.setSpecialKind(Item.NEWLY_ALLOCATED);
                 push(item);
             }
             break;
 
-            case NEWARRAY: {
+            case Const.NEWARRAY: {
                 Item length = pop();
                 signature = "[" + BasicType.getType((byte) dbc.getIntConstant()).getSignature();
                 Item item = new Item(signature, length.getConstant());
@@ -2079,7 +2080,7 @@ public class OpcodeStack implements Constants2 {
             // "internal form"), or array classes (encoded as signatures
             // beginning with "[").
 
-            case ANEWARRAY: {
+            case Const.ANEWARRAY: {
                 Item length = pop();
                 signature = dbc.getClassConstantOperand();
                 if (signature.charAt(0) == '[') {
@@ -2094,7 +2095,7 @@ public class OpcodeStack implements Constants2 {
                 break;
             }
 
-            case MULTIANEWARRAY:
+            case Const.MULTIANEWARRAY:
                 int dims = dbc.getIntConstant();
                 for (int i = 0; i < dims; i++) {
                     pop();
@@ -2105,7 +2106,7 @@ public class OpcodeStack implements Constants2 {
                 getStackItem(0).setSpecialKind(Item.NEWLY_ALLOCATED);
                 break;
 
-            case AALOAD: {
+            case Const.AALOAD: {
                 pop();
                 it = pop();
                 String arraySig = it.getSignature();
@@ -2117,7 +2118,7 @@ public class OpcodeStack implements Constants2 {
             }
             break;
 
-            case JSR:
+            case Const.JSR:
                 seenTransferOfControl = true;
                 setReachOnlyByBranch(false);
                 push(new Item("")); // push return address on stack
@@ -2134,17 +2135,17 @@ public class OpcodeStack implements Constants2 {
                 setTop(false);
                 break;
 
-            case INVOKEINTERFACE:
-            case INVOKESPECIAL:
-            case INVOKESTATIC:
-            case INVOKEVIRTUAL:
+            case Const.INVOKEINTERFACE:
+            case Const.INVOKESPECIAL:
+            case Const.INVOKESTATIC:
+            case Const.INVOKEVIRTUAL:
                 processMethodCall(dbc, seen);
                 break;
-            case INVOKEDYNAMIC:
+            case Const.INVOKEDYNAMIC:
                 processInvokeDynamic(dbc);
                 break;
             default:
-                throw new UnsupportedOperationException("OpCode " + seen + ":" + OPCODE_NAMES[seen] + " not supported ");
+                throw new UnsupportedOperationException("OpCode " + seen + ":" + Const.getOpcodeName(seen) + " not supported ");
             }
         }
 
@@ -2156,7 +2157,7 @@ public class OpcodeStack implements Constants2 {
             // or the stack will resync with the code. But hopefully not false
             // positives
 
-            String msg = "Error processing opcode " + OPCODE_NAMES[seen] + " @ " + dbc.getPC() + " in "
+            String msg = "Error processing opcode " + Const.getOpcodeName(seen) + " @ " + dbc.getPC() + " in "
                     + dbc.getFullyQualifiedMethodName();
             AnalysisContext.logError(msg, e);
             if (DEBUG) {
@@ -2166,7 +2167,7 @@ public class OpcodeStack implements Constants2 {
             setTop(true);
         } finally {
             if (DEBUG) {
-                System.out.printf("%4d: %14s %s%n", dbc.getPC(), OPCODE_NAMES[seen] ,  this);
+                System.out.printf("%4d: %14s %s%n", dbc.getPC(), Const.getOpcodeName(seen) ,  this);
             }
         }
     }
@@ -2237,7 +2238,7 @@ public class OpcodeStack implements Constants2 {
             double d = constantToDouble(it);
             double d2 = constantToDouble(it2);
             if (Double.isNaN(d) || Double.isNaN(d2)) {
-                if (opcode == DCMPG) {
+                if (opcode == Const.DCMPG) {
                     push(new Item("I", Integer.valueOf(1)));
                 } else {
                     push(new Item("I", Integer.valueOf(-1)));
@@ -2262,7 +2263,7 @@ public class OpcodeStack implements Constants2 {
             float f = constantToFloat(it);
             float f2 = constantToFloat(it2);
             if (Float.isNaN(f) || Float.isNaN(f2)) {
-                if (opcode == FCMPG) {
+                if (opcode == Const.FCMPG) {
                     push(new Item("I", Integer.valueOf(1)));
                 } else {
                     push(new Item("I", Integer.valueOf(-1)));
@@ -2484,7 +2485,7 @@ public class OpcodeStack implements Constants2 {
             return;
         }
 
-        int firstArgument = seen == INVOKESTATIC ? 0 : 1;
+        int firstArgument = seen == Const.INVOKESTATIC ? 0 : 1;
         for (int i = firstArgument; i < firstArgument + numberArguments; i++) {
             if (i >= getStackDepth()) {
                 break;
@@ -2496,7 +2497,7 @@ public class OpcodeStack implements Constants2 {
             }
         }
         boolean initializingServletWriter = false;
-        if (seen == INVOKESPECIAL && "<init>".equals(methodName) && clsName.startsWith("java/io") && clsName.endsWith("Writer")
+        if (seen == Const.INVOKESPECIAL && "<init>".equals(methodName) && clsName.startsWith("java/io") && clsName.endsWith("Writer")
                 && numberArguments > 0) {
             Item firstArg = getStackItem(numberArguments-1);
             if (firstArg.isServletWriter()) {
@@ -2550,7 +2551,7 @@ public class OpcodeStack implements Constants2 {
                     sawUnknownAppend = true;
                 }
             }
-        } else if (seen == INVOKESPECIAL && "java/io/FileOutputStream".equals(clsName) && "<init>".equals(methodName)
+        } else if (seen == Const.INVOKESPECIAL && "java/io/FileOutputStream".equals(clsName) && "<init>".equals(methodName)
                 && ("(Ljava/io/File;Z)V".equals(signature) || "(Ljava/lang/String;Z)V".equals(signature)) && stack.size() > 3) {
             OpcodeStack.Item item = getStackItem(0);
             Object value = item.getConstant();
@@ -2564,7 +2565,7 @@ public class OpcodeStack implements Constants2 {
                 }
                 return;
             }
-        } else if (seen == INVOKESPECIAL && "java/io/BufferedOutputStream".equals(clsName) && "<init>".equals(methodName)
+        } else if (seen == Const.INVOKESPECIAL && "java/io/BufferedOutputStream".equals(clsName) && "<init>".equals(methodName)
                 && "(Ljava/io/OutputStream;)V".equals(signature)) {
 
             if (getStackItem(0).getSpecialKind() == Item.FILE_OPENED_IN_APPEND_MODE
@@ -2577,7 +2578,7 @@ public class OpcodeStack implements Constants2 {
                 newTop.setPC(dbc.getPC());
                 return;
             }
-        } else if (seen == INVOKEINTERFACE && "getParameter".equals(methodName)
+        } else if (seen == Const.INVOKEINTERFACE && "getParameter".equals(methodName)
                 && "javax/servlet/http/HttpServletRequest".equals(clsName) || "javax/servlet/http/ServletRequest".equals(clsName)) {
             Item requestParameter = pop();
             pop();
@@ -2593,7 +2594,7 @@ public class OpcodeStack implements Constants2 {
             result.setPC(dbc.getPC());
             push(result);
             return;
-        } else if (seen == INVOKEINTERFACE && "getQueryString".equals(methodName)
+        } else if (seen == Const.INVOKEINTERFACE && "getQueryString".equals(methodName)
                 && "javax/servlet/http/HttpServletRequest".equals(clsName) || "javax/servlet/http/ServletRequest".equals(clsName)) {
             pop();
             Item result = new Item("Ljava/lang/String;");
@@ -2602,7 +2603,7 @@ public class OpcodeStack implements Constants2 {
             result.setPC(dbc.getPC());
             push(result);
             return;
-        } else if (seen == INVOKEINTERFACE && "getHeader".equals(methodName)
+        } else if (seen == Const.INVOKEINTERFACE && "getHeader".equals(methodName)
                 && "javax/servlet/http/HttpServletRequest".equals(clsName) || "javax/servlet/http/ServletRequest".equals(clsName)) {
             /* Item requestParameter = */pop();
             pop();
@@ -2612,12 +2613,12 @@ public class OpcodeStack implements Constants2 {
             result.setPC(dbc.getPC());
             push(result);
             return;
-        } else if (seen == INVOKESTATIC && "asList".equals(methodName) && "java/util/Arrays".equals(clsName)) {
+        } else if (seen == Const.INVOKESTATIC && "asList".equals(methodName) && "java/util/Arrays".equals(clsName)) {
             /* Item requestParameter = */pop();
             Item result = new Item(JAVA_UTIL_ARRAYS_ARRAY_LIST);
             push(result);
             return;
-        } else if (seen == INVOKESTATIC && "(Ljava/util/List;)Ljava/util/List;".equals(signature)
+        } else if (seen == Const.INVOKESTATIC && "(Ljava/util/List;)Ljava/util/List;".equals(signature)
                 && "java/util/Collections".equals(clsName)) {
             Item requestParameter = pop();
             if (JAVA_UTIL_ARRAYS_ARRAY_LIST.equals(requestParameter.getSignature())) {
@@ -2628,7 +2629,7 @@ public class OpcodeStack implements Constants2 {
             push(requestParameter); // fall back to standard logic
         }
 
-        pushByInvoke(dbc, seen != INVOKESTATIC);
+        pushByInvoke(dbc, seen != Const.INVOKESTATIC);
 
         if (sbItem != null && sbItem.isNewlyAllocated()) {
             this.getStackItem(0).setSpecialKind(Item.NEWLY_ALLOCATED);
@@ -2705,7 +2706,7 @@ public class OpcodeStack implements Constants2 {
                 i.setSpecialKind(Item.MATH_ABS);
             }
             push(i);
-        } else if (seen == INVOKEVIRTUAL && "hashCode".equals(methodName) && "()I".equals(signature) || seen == INVOKESTATIC
+        } else if (seen == Const.INVOKEVIRTUAL && "hashCode".equals(methodName) && "()I".equals(signature) || seen == Const.INVOKESTATIC
                 && "java/lang/System".equals(clsName) && "identityHashCode".equals(methodName)
                 && "(Ljava/lang/Object;)I".equals(signature)) {
             Item i = new Item(pop());
@@ -2879,7 +2880,7 @@ public class OpcodeStack implements Constants2 {
                 stack.precomputation(this);
 
                 if (DEBUG1) {
-                    System.out.printf("%4d %-15s %s%n", getPC(), OPCODE_NAMES[seen], stack);
+                    System.out.printf("%4d %-15s %s%n", getPC(), Const.getOpcodeName(seen), stack);
                 }
                 try {
                     stack.sawOpcode(this, seen);
@@ -3229,68 +3230,68 @@ public class OpcodeStack implements Constants2 {
         try {
             if (DEBUG) {
                 System.out.println("pushByIntMath " + dbc.getFullyQualifiedMethodName() + " @ " + dbc.getPC() + " : " + lhs
-                        + OPCODE_NAMES[seen] + rhs);
+                        + Const.getOpcodeName(seen) + rhs);
             }
 
             if (rhs.getConstant() != null && lhs.getConstant() != null) {
                 int lhsValue = constantToInt(lhs);
                 int rhsValue = constantToInt(rhs);
-                if ((seen == IDIV || seen == IREM) && rhsValue == 0) {
+                if ((seen == Const.IDIV || seen == Const.IREM) && rhsValue == 0) {
                     push(newValue);
                     return;
                 }
                 switch (seen) {
 
-                case IADD:
+                case Const.IADD:
                     newValue = new Item("I", lhsValue + rhsValue);
                     break;
-                case ISUB:
+                case Const.ISUB:
                     newValue = new Item("I", lhsValue - rhsValue);
                     break;
-                case IMUL:
+                case Const.IMUL:
                     newValue = new Item("I", lhsValue * rhsValue);
                     break;
-                case IDIV:
+                case Const.IDIV:
                     newValue = new Item("I", lhsValue / rhsValue);
                     break;
-                case IREM:
+                case Const.IREM:
                     newValue = new Item("I", lhsValue % rhsValue);
                     break;
-                case IAND:
+                case Const.IAND:
                     newValue = new Item("I", lhsValue & rhsValue);
                     if ((rhsValue & 0xff) == 0 && rhsValue != 0 || (lhsValue & 0xff) == 0 && lhsValue != 0) {
                         newValue.setSpecialKind(Item.LOW_8_BITS_CLEAR);
                     }
 
                     break;
-                case IOR:
+                case Const.IOR:
                     newValue = new Item("I", lhsValue | rhsValue);
                     break;
-                case IXOR:
+                case Const.IXOR:
                     newValue = new Item("I", lhsValue ^ rhsValue);
                     break;
-                case ISHL:
+                case Const.ISHL:
                     newValue = new Item("I", lhsValue << rhsValue);
                     if (rhsValue >= 8) {
                         newValue.setSpecialKind(Item.LOW_8_BITS_CLEAR);
                     }
 
                     break;
-                case ISHR:
+                case Const.ISHR:
                     newValue = new Item("I", lhsValue >> rhsValue);
 
                     break;
-                case IUSHR:
+                case Const.IUSHR:
                     newValue = new Item("I", lhsValue >>> rhsValue);
 
                 }
 
-            } else if ((seen == ISHL || seen == ISHR || seen == IUSHR)) {
+            } else if ((seen == Const.ISHL || seen == Const.ISHR || seen == Const.IUSHR)) {
                 if (rhs.getConstant() != null) {
                     int constant = constantToInt(rhs);
                     if ((constant & 0x1f) == 0) {
                         newValue = new Item(lhs);
-                    } else if (seen == ISHL && (constant & 0x1f) >= 8) {
+                    } else if (seen == Const.ISHL && (constant & 0x1f) >= 8) {
                         newValue.setSpecialKind(Item.LOW_8_BITS_CLEAR);
                     }
                 } else if (lhs.getConstant() != null) {
@@ -3299,7 +3300,7 @@ public class OpcodeStack implements Constants2 {
                         newValue = new Item("I", 0);
                     }
                 }
-            } else if (lhs.getConstant() != null && seen == IAND) {
+            } else if (lhs.getConstant() != null && seen == Const.IAND) {
                 int value = constantToInt(lhs);
                 if (value == 0) {
                     newValue = new Item("I", 0);
@@ -3308,7 +3309,7 @@ public class OpcodeStack implements Constants2 {
                 } else if (value >= 0) {
                     newValue.setSpecialKind(Item.NON_NEGATIVE);
                 }
-            } else if (rhs.getConstant() != null && seen == IAND) {
+            } else if (rhs.getConstant() != null && seen == Const.IAND) {
                 int value = constantToInt(rhs);
                 if (value == 0) {
                     newValue = new Item("I", 0);
@@ -3317,44 +3318,44 @@ public class OpcodeStack implements Constants2 {
                 } else if (value >= 0) {
                     newValue.setSpecialKind(Item.NON_NEGATIVE);
                 }
-            } else if (seen == IAND && lhs.getSpecialKind() == Item.ZERO_MEANS_NULL) {
+            } else if (seen == Const.IAND && lhs.getSpecialKind() == Item.ZERO_MEANS_NULL) {
                 newValue.setSpecialKind(Item.ZERO_MEANS_NULL);
                 newValue.setPC(lhs.getPC());
-            } else if (seen == IAND && rhs.getSpecialKind() == Item.ZERO_MEANS_NULL) {
+            } else if (seen == Const.IAND && rhs.getSpecialKind() == Item.ZERO_MEANS_NULL) {
                 newValue.setSpecialKind(Item.ZERO_MEANS_NULL);
                 newValue.setPC(rhs.getPC());
-            } else if (seen == IOR && lhs.getSpecialKind() == Item.NONZERO_MEANS_NULL) {
+            } else if (seen == Const.IOR && lhs.getSpecialKind() == Item.NONZERO_MEANS_NULL) {
                 newValue.setSpecialKind(Item.NONZERO_MEANS_NULL);
                 newValue.setPC(lhs.getPC());
-            } else if (seen == IOR && rhs.getSpecialKind() == Item.NONZERO_MEANS_NULL) {
+            } else if (seen == Const.IOR && rhs.getSpecialKind() == Item.NONZERO_MEANS_NULL) {
                 newValue.setSpecialKind(Item.NONZERO_MEANS_NULL);
                 newValue.setPC(rhs.getPC());
             }
         } catch (ArithmeticException e) {
             assert true; // ignore it
         } catch (RuntimeException e) {
-            String msg = "Error processing2 " + lhs + OPCODE_NAMES[seen] + rhs + " @ " + dbc.getPC() + " in "
+            String msg = "Error processing2 " + lhs + Const.getOpcodeName(seen) + rhs + " @ " + dbc.getPC() + " in "
                     + dbc.getFullyQualifiedMethodName();
             AnalysisContext.logError(msg, e);
 
         }
         if (lhs.getSpecialKind() == Item.INTEGER_SUM && rhs.getConstant() != null) {
             int rhsValue = constantToInt(rhs);
-            if (seen == IDIV && rhsValue == 2 || seen == ISHR && rhsValue == 1) {
+            if (seen == Const.IDIV && rhsValue == 2 || seen == Const.ISHR && rhsValue == 1) {
                 newValue.setSpecialKind(Item.AVERAGE_COMPUTED_USING_DIVISION);
             }
         }
-        if (seen == IADD && newValue.getSpecialKind() == Item.NOT_SPECIAL && lhs.getConstant() == null
+        if (seen == Const.IADD && newValue.getSpecialKind() == Item.NOT_SPECIAL && lhs.getConstant() == null
                 && rhs.getConstant() == null) {
             newValue.setSpecialKind(Item.INTEGER_SUM);
         }
-        if (seen == IREM && lhs.getSpecialKind() == Item.HASHCODE_INT) {
+        if (seen == Const.IREM && lhs.getSpecialKind() == Item.HASHCODE_INT) {
             newValue.setSpecialKind(Item.HASHCODE_INT_REMAINDER);
         }
-        if (seen == IREM && lhs.getSpecialKind() == Item.RANDOM_INT) {
+        if (seen == Const.IREM && lhs.getSpecialKind() == Item.RANDOM_INT) {
             newValue.setSpecialKind(Item.RANDOM_INT_REMAINDER);
         }
-        if (seen == IREM && lhs.checkForIntegerMinValue()) {
+        if (seen == Const.IREM && lhs.checkForIntegerMinValue()) {
             if (rhs.getConstant() != null) {
                 int rhsValue = constantToInt(rhs);
                 if (!Util.isPowerOfTwo(rhsValue)) {
@@ -3378,43 +3379,43 @@ public class OpcodeStack implements Constants2 {
             if ((rhs.getConstant() != null) && lhs.getConstant() != null) {
 
                 long lhsValue = constantToLong(lhs);
-                if (seen == LSHL) {
+                if (seen == Const.LSHL) {
                     newValue = new Item("J", Long.valueOf(lhsValue << constantToInt(rhs)));
                     if (constantToInt(rhs) >= 8) {
                         newValue.setSpecialKind(Item.LOW_8_BITS_CLEAR);
                     }
-                } else if (seen == LSHR) {
+                } else if (seen == Const.LSHR) {
                     newValue = new Item("J", Long.valueOf(lhsValue >> constantToInt(rhs)));
-                } else if (seen == LUSHR) {
+                } else if (seen == Const.LUSHR) {
                     newValue = new Item("J", Long.valueOf(lhsValue >>> constantToInt(rhs)));
                 } else {
                     long rhsValue = constantToLong(rhs);
-                    if (seen == LADD) {
+                    if (seen == Const.LADD) {
                         newValue = new Item("J", Long.valueOf(lhsValue + rhsValue));
-                    } else if (seen == LSUB) {
+                    } else if (seen == Const.LSUB) {
                         newValue = new Item("J", Long.valueOf(lhsValue - rhsValue));
-                    } else if (seen == LMUL) {
+                    } else if (seen == Const.LMUL) {
                         newValue = new Item("J", Long.valueOf(lhsValue * rhsValue));
-                    } else if (seen == LDIV) {
+                    } else if (seen == Const.LDIV) {
                         newValue = new Item("J", Long.valueOf(lhsValue / rhsValue));
-                    } else if (seen == LAND) {
+                    } else if (seen == Const.LAND) {
                         newValue = new Item("J", Long.valueOf(lhsValue & rhsValue));
                         if ((rhsValue & 0xff) == 0 && rhsValue != 0 || (lhsValue & 0xff) == 0 && lhsValue != 0) {
                             newValue.setSpecialKind(Item.LOW_8_BITS_CLEAR);
                         }
-                    } else if (seen == LOR) {
+                    } else if (seen == Const.LOR) {
                         newValue = new Item("J", Long.valueOf(lhsValue | rhsValue));
-                    } else if (seen == LXOR) {
+                    } else if (seen == Const.LXOR) {
                         newValue = new Item("J", Long.valueOf(lhsValue ^ rhsValue));
-                    } else if (seen == LREM) {
+                    } else if (seen == Const.LREM) {
                         newValue = new Item("J", Long.valueOf(lhsValue % rhsValue));
                     }
                 }
-            } else if (rhs.getConstant() != null && seen == LSHL && constantToInt(rhs) >= 8) {
+            } else if (rhs.getConstant() != null && seen == Const.LSHL && constantToInt(rhs) >= 8) {
                 newValue.setSpecialKind(Item.LOW_8_BITS_CLEAR);
-            } else if (lhs.getConstant() != null && seen == LAND && (constantToLong(lhs) & 0xff) == 0) {
+            } else if (lhs.getConstant() != null && seen == Const.LAND && (constantToLong(lhs) & 0xff) == 0) {
                 newValue.setSpecialKind(Item.LOW_8_BITS_CLEAR);
-            } else if (rhs.getConstant() != null && seen == LAND && (constantToLong(rhs) & 0xff) == 0) {
+            } else if (rhs.getConstant() != null && seen == Const.LAND && (constantToLong(rhs) & 0xff) == 0) {
                 newValue.setSpecialKind(Item.LOW_8_BITS_CLEAR);
             }
         } catch (RuntimeException e) {
@@ -3427,22 +3428,22 @@ public class OpcodeStack implements Constants2 {
         Item result;
         @SpecialKind int specialKind = Item.FLOAT_MATH;
         if ((it.getConstant() instanceof Float) && it2.getConstant() instanceof Float) {
-            if (seen == FADD) {
+            if (seen == Const.FADD) {
                 result = new Item("F", Float.valueOf(constantToFloat(it2) + constantToFloat(it)));
-            } else if (seen == FSUB) {
+            } else if (seen == Const.FSUB) {
                 result = new Item("F", Float.valueOf(constantToFloat(it2) - constantToFloat(it)));
-            } else if (seen == FMUL) {
+            } else if (seen == Const.FMUL) {
                 result = new Item("F", Float.valueOf(constantToFloat(it2) * constantToFloat(it)));
-            } else if (seen == FDIV) {
+            } else if (seen == Const.FDIV) {
                 result = new Item("F", Float.valueOf(constantToFloat(it2) / constantToFloat(it)));
-            } else if (seen == FREM) {
+            } else if (seen == Const.FREM) {
                 result = new Item("F", Float.valueOf(constantToFloat(it2) % constantToFloat(it)));
             } else {
                 result = new Item("F");
             }
         } else {
             result = new Item("F");
-            if (seen == DDIV) {
+            if (seen == Const.DDIV) {
                 specialKind = Item.NASTY_FLOAT_MATH;
             }
         }
@@ -3454,15 +3455,15 @@ public class OpcodeStack implements Constants2 {
         Item result;
         @SpecialKind int specialKind = Item.FLOAT_MATH;
         if ((it.getConstant() instanceof Double) && it2.getConstant() instanceof Double) {
-            if (seen == DADD) {
+            if (seen == Const.DADD) {
                 result = new Item("D", Double.valueOf(constantToDouble(it2) + constantToDouble(it)));
-            } else if (seen == DSUB) {
+            } else if (seen == Const.DSUB) {
                 result = new Item("D", Double.valueOf(constantToDouble(it2) - constantToDouble(it)));
-            } else if (seen == DMUL) {
+            } else if (seen == Const.DMUL) {
                 result = new Item("D", Double.valueOf(constantToDouble(it2) * constantToDouble(it)));
-            } else if (seen == DDIV) {
+            } else if (seen == Const.DDIV) {
                 result = new Item("D", Double.valueOf(constantToDouble(it2) / constantToDouble(it)));
-            } else if (seen == DREM) {
+            } else if (seen == Const.DREM) {
                 result = new Item("D", Double.valueOf(constantToDouble(it2) % constantToDouble(it)));
             }
             else {
@@ -3470,7 +3471,7 @@ public class OpcodeStack implements Constants2 {
             }
         } else {
             result = new Item("D");
-            if (seen == DDIV) {
+            if (seen == Const.DDIV) {
                 specialKind = Item.NASTY_FLOAT_MATH;
             }
         }
@@ -3501,9 +3502,9 @@ public class OpcodeStack implements Constants2 {
     public Item getItemMethodInvokedOn(DismantleBytecode dbc) {
         int opcode = dbc.getOpcode();
         switch (opcode) {
-        case INVOKEVIRTUAL:
-        case INVOKEINTERFACE:
-        case INVOKESPECIAL:
+        case Const.INVOKEVIRTUAL:
+        case Const.INVOKEINTERFACE:
+        case Const.INVOKESPECIAL:
             String signature = dbc.getSigConstantOperand();
             int stackOffset = PreorderVisitor.getNumberArguments(signature);
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/OpcodeStack.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/OpcodeStack.java
@@ -2497,7 +2497,7 @@ public class OpcodeStack implements Constants2 {
             }
         }
         boolean initializingServletWriter = false;
-        if (seen == Const.INVOKESPECIAL && "<init>".equals(methodName) && clsName.startsWith("java/io") && clsName.endsWith("Writer")
+        if (seen == Const.INVOKESPECIAL && Const.CONSTRUCTOR_NAME.equals(methodName) && clsName.startsWith("java/io") && clsName.endsWith("Writer")
                 && numberArguments > 0) {
             Item firstArg = getStackItem(numberArguments-1);
             if (firstArg.isServletWriter()) {
@@ -2513,7 +2513,7 @@ public class OpcodeStack implements Constants2 {
         // TODO: stack merging for trinaries kills the constant.. would be nice
         // to maintain.
         if ("java/lang/StringBuffer".equals(clsName) || "java/lang/StringBuilder".equals(clsName)) {
-            if ("<init>".equals(methodName)) {
+            if (Const.CONSTRUCTOR_NAME.equals(methodName)) {
                 if ("(Ljava/lang/String;)V".equals(signature)) {
                     Item i = getStackItem(0);
                     appenderValue = (String) i.getConstant();
@@ -2551,7 +2551,7 @@ public class OpcodeStack implements Constants2 {
                     sawUnknownAppend = true;
                 }
             }
-        } else if (seen == Const.INVOKESPECIAL && "java/io/FileOutputStream".equals(clsName) && "<init>".equals(methodName)
+        } else if (seen == Const.INVOKESPECIAL && "java/io/FileOutputStream".equals(clsName) && Const.CONSTRUCTOR_NAME.equals(methodName)
                 && ("(Ljava/io/File;Z)V".equals(signature) || "(Ljava/lang/String;Z)V".equals(signature)) && stack.size() > 3) {
             OpcodeStack.Item item = getStackItem(0);
             Object value = item.getConstant();
@@ -2565,7 +2565,7 @@ public class OpcodeStack implements Constants2 {
                 }
                 return;
             }
-        } else if (seen == Const.INVOKESPECIAL && "java/io/BufferedOutputStream".equals(clsName) && "<init>".equals(methodName)
+        } else if (seen == Const.INVOKESPECIAL && "java/io/BufferedOutputStream".equals(clsName) && Const.CONSTRUCTOR_NAME.equals(methodName)
                 && "(Ljava/io/OutputStream;)V".equals(signature)) {
 
             if (getStackItem(0).getSpecialKind() == Item.FILE_OPENED_IN_APPEND_MODE
@@ -3481,7 +3481,7 @@ public class OpcodeStack implements Constants2 {
 
     private void pushByInvoke(DismantleBytecode dbc, boolean popThis) {
         String signature = dbc.getSigConstantOperand();
-        if ("<init>".equals(dbc.getNameConstantOperand()) && signature.endsWith(")V") && popThis) {
+        if (Const.CONSTRUCTOR_NAME.equals(dbc.getNameConstantOperand()) && signature.endsWith(")V") && popThis) {
             pop(PreorderVisitor.getNumberArguments(signature));
             Item constructed = pop();
             if (getStackDepth() > 0) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/AnnotationDatabase.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/AnnotationDatabase.java
@@ -28,6 +28,7 @@ import java.util.TreeSet;
 
 import javax.annotation.CheckForNull;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.Repository;
 import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.classfile.Method;
@@ -172,7 +173,7 @@ public class AnnotationDatabase<AnnotationEnum extends AnnotationEnumeration<Ann
                     isSyntheticMethod = m.isSynthetic();
                     className = m.getClassName();
                     kind = Target.PARAMETER;
-                    if ("<init>".equals(m.getName())) {
+                    if (Const.CONSTRUCTOR_NAME.equals(m.getName())) {
                         int i = className.lastIndexOf('$');
                         if (i + 1 < className.length() && Character.isDigit(className.charAt(i + 1))) {
                             isParameterToInitMethodofAnonymousInnerClass = true;
@@ -182,7 +183,7 @@ public class AnnotationDatabase<AnnotationEnum extends AnnotationEnumeration<Ann
                     throw new IllegalStateException("impossible");
                 }
 
-                if (!m.isStatic() && !"<init>".equals(m.getName())) {
+                if (!m.isStatic() && !Const.CONSTRUCTOR_NAME.equals(m.getName())) {
                     JavaClass c = Repository.lookupClass(className);
                     // get inherited annotation
                     TreeSet<AnnotationEnum> inheritedAnnotations = new TreeSet<AnnotationEnum>();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/AssertionMethods.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/AssertionMethods.java
@@ -24,6 +24,7 @@ import java.util.BitSet;
 import java.util.List;
 import java.util.StringTokenizer;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.Constants;
 import org.apache.bcel.classfile.ClassFormatException;
 import org.apache.bcel.classfile.Constant;
@@ -117,10 +118,10 @@ public class AssertionMethods implements Constants {
                 if (c instanceof ConstantMethodref) {
                     ConstantMethodref cmr = (ConstantMethodref) c;
                     ConstantNameAndType cnat = (ConstantNameAndType) cp.getConstant(cmr.getNameAndTypeIndex(),
-                            CONSTANT_NameAndType);
-                    String methodName = ((ConstantUtf8) cp.getConstant(cnat.getNameIndex(), CONSTANT_Utf8)).getBytes();
-                    String className = cp.getConstantString(cmr.getClassIndex(), CONSTANT_Class).replace('/', '.');
-                    String methodSig = ((ConstantUtf8) cp.getConstant(cnat.getSignatureIndex(), CONSTANT_Utf8)).getBytes();
+                            Const.CONSTANT_NameAndType);
+                    String methodName = ((ConstantUtf8) cp.getConstant(cnat.getNameIndex(), Const.CONSTANT_Utf8)).getBytes();
+                    String className = cp.getConstantString(cmr.getClassIndex(), Const.CONSTANT_Class).replace('/', '.');
+                    String methodSig = ((ConstantUtf8) cp.getConstant(cnat.getSignatureIndex(), Const.CONSTANT_Utf8)).getBytes();
 
                     String classNameLC = className.toLowerCase();
                     String methodNameLC = methodName.toLowerCase();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/BytecodeScanner.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/BytecodeScanner.java
@@ -19,6 +19,8 @@
 
 package edu.umd.cs.findbugs.ba;
 
+import org.apache.bcel.Const;
+
 import edu.umd.cs.findbugs.SystemProperties;
 
 /**
@@ -95,181 +97,181 @@ public class BytecodeScanner implements org.apache.bcel.Constants {
             callback.handleInstruction(opcode, index);
 
             if (DEBUG) {
-                System.out.println(index + ": " + OPCODE_NAMES[opcode]);
+                System.out.println(index + ": " + Const.getOpcodeName(opcode));
             }
 
             switch (opcode) {
 
             // Single byte instructions.
-            case NOP:
-            case ACONST_NULL:
-            case ICONST_M1:
-            case ICONST_0:
-            case ICONST_1:
-            case ICONST_2:
-            case ICONST_3:
-            case ICONST_4:
-            case ICONST_5:
-            case LCONST_0:
-            case LCONST_1:
-            case FCONST_0:
-            case FCONST_1:
-            case FCONST_2:
-            case DCONST_0:
-            case DCONST_1:
-            case ILOAD_0:
-            case ILOAD_1:
-            case ILOAD_2:
-            case ILOAD_3:
-            case LLOAD_0:
-            case LLOAD_1:
-            case LLOAD_2:
-            case LLOAD_3:
-            case FLOAD_0:
-            case FLOAD_1:
-            case FLOAD_2:
-            case FLOAD_3:
-            case DLOAD_0:
-            case DLOAD_1:
-            case DLOAD_2:
-            case DLOAD_3:
-            case ALOAD_0:
-            case ALOAD_1:
-            case ALOAD_2:
-            case ALOAD_3:
-            case IALOAD:
-            case LALOAD:
-            case FALOAD:
-            case DALOAD:
-            case AALOAD:
-            case BALOAD:
-            case CALOAD:
-            case SALOAD:
-            case ISTORE_0:
-            case ISTORE_1:
-            case ISTORE_2:
-            case ISTORE_3:
-            case LSTORE_0:
-            case LSTORE_1:
-            case LSTORE_2:
-            case LSTORE_3:
-            case FSTORE_0:
-            case FSTORE_1:
-            case FSTORE_2:
-            case FSTORE_3:
-            case DSTORE_0:
-            case DSTORE_1:
-            case DSTORE_2:
-            case DSTORE_3:
-            case ASTORE_0:
-            case ASTORE_1:
-            case ASTORE_2:
-            case ASTORE_3:
-            case IASTORE:
-            case LASTORE:
-            case FASTORE:
-            case DASTORE:
-            case AASTORE:
-            case BASTORE:
-            case CASTORE:
-            case SASTORE:
-            case POP:
-            case POP2:
-            case DUP:
-            case DUP_X1:
-            case DUP_X2:
-            case DUP2:
-            case DUP2_X1:
-            case DUP2_X2:
-            case SWAP:
-            case IADD:
-            case LADD:
-            case FADD:
-            case DADD:
-            case ISUB:
-            case LSUB:
-            case FSUB:
-            case DSUB:
-            case IMUL:
-            case LMUL:
-            case FMUL:
-            case DMUL:
-            case IDIV:
-            case LDIV:
-            case FDIV:
-            case DDIV:
-            case IREM:
-            case LREM:
-            case FREM:
-            case DREM:
-            case INEG:
-            case LNEG:
-            case FNEG:
-            case DNEG:
-            case ISHL:
-            case LSHL:
-            case ISHR:
-            case LSHR:
-            case IUSHR:
-            case LUSHR:
-            case IAND:
-            case LAND:
-            case IOR:
-            case LOR:
-            case IXOR:
-            case LXOR:
-            case I2L:
-            case I2F:
-            case I2D:
-            case L2I:
-            case L2F:
-            case L2D:
-            case F2I:
-            case F2L:
-            case F2D:
-            case D2I:
-            case D2L:
-            case D2F:
-            case I2B:
-            case I2C:
-            case I2S:
-            case LCMP:
-            case FCMPL:
-            case FCMPG:
-            case DCMPL:
-            case DCMPG:
-            case IRETURN:
-            case LRETURN:
-            case FRETURN:
-            case DRETURN:
-            case ARETURN:
-            case RETURN:
-            case ARRAYLENGTH:
-            case ATHROW:
-            case MONITORENTER:
-            case MONITOREXIT:
+            case Const.NOP:
+            case Const.ACONST_NULL:
+            case Const.ICONST_M1:
+            case Const.ICONST_0:
+            case Const.ICONST_1:
+            case Const.ICONST_2:
+            case Const.ICONST_3:
+            case Const.ICONST_4:
+            case Const.ICONST_5:
+            case Const.LCONST_0:
+            case Const.LCONST_1:
+            case Const.FCONST_0:
+            case Const.FCONST_1:
+            case Const.FCONST_2:
+            case Const.DCONST_0:
+            case Const.DCONST_1:
+            case Const.ILOAD_0:
+            case Const.ILOAD_1:
+            case Const.ILOAD_2:
+            case Const.ILOAD_3:
+            case Const.LLOAD_0:
+            case Const.LLOAD_1:
+            case Const.LLOAD_2:
+            case Const.LLOAD_3:
+            case Const.FLOAD_0:
+            case Const.FLOAD_1:
+            case Const.FLOAD_2:
+            case Const.FLOAD_3:
+            case Const.DLOAD_0:
+            case Const.DLOAD_1:
+            case Const.DLOAD_2:
+            case Const.DLOAD_3:
+            case Const.ALOAD_0:
+            case Const.ALOAD_1:
+            case Const.ALOAD_2:
+            case Const.ALOAD_3:
+            case Const.IALOAD:
+            case Const.LALOAD:
+            case Const.FALOAD:
+            case Const.DALOAD:
+            case Const.AALOAD:
+            case Const.BALOAD:
+            case Const.CALOAD:
+            case Const.SALOAD:
+            case Const.ISTORE_0:
+            case Const.ISTORE_1:
+            case Const.ISTORE_2:
+            case Const.ISTORE_3:
+            case Const.LSTORE_0:
+            case Const.LSTORE_1:
+            case Const.LSTORE_2:
+            case Const.LSTORE_3:
+            case Const.FSTORE_0:
+            case Const.FSTORE_1:
+            case Const.FSTORE_2:
+            case Const.FSTORE_3:
+            case Const.DSTORE_0:
+            case Const.DSTORE_1:
+            case Const.DSTORE_2:
+            case Const.DSTORE_3:
+            case Const.ASTORE_0:
+            case Const.ASTORE_1:
+            case Const.ASTORE_2:
+            case Const.ASTORE_3:
+            case Const.IASTORE:
+            case Const.LASTORE:
+            case Const.FASTORE:
+            case Const.DASTORE:
+            case Const.AASTORE:
+            case Const.BASTORE:
+            case Const.CASTORE:
+            case Const.SASTORE:
+            case Const.POP:
+            case Const.POP2:
+            case Const.DUP:
+            case Const.DUP_X1:
+            case Const.DUP_X2:
+            case Const.DUP2:
+            case Const.DUP2_X1:
+            case Const.DUP2_X2:
+            case Const.SWAP:
+            case Const.IADD:
+            case Const.LADD:
+            case Const.FADD:
+            case Const.DADD:
+            case Const.ISUB:
+            case Const.LSUB:
+            case Const.FSUB:
+            case Const.DSUB:
+            case Const.IMUL:
+            case Const.LMUL:
+            case Const.FMUL:
+            case Const.DMUL:
+            case Const.IDIV:
+            case Const.LDIV:
+            case Const.FDIV:
+            case Const.DDIV:
+            case Const.IREM:
+            case Const.LREM:
+            case Const.FREM:
+            case Const.DREM:
+            case Const.INEG:
+            case Const.LNEG:
+            case Const.FNEG:
+            case Const.DNEG:
+            case Const.ISHL:
+            case Const.LSHL:
+            case Const.ISHR:
+            case Const.LSHR:
+            case Const.IUSHR:
+            case Const.LUSHR:
+            case Const.IAND:
+            case Const.LAND:
+            case Const.IOR:
+            case Const.LOR:
+            case Const.IXOR:
+            case Const.LXOR:
+            case Const.I2L:
+            case Const.I2F:
+            case Const.I2D:
+            case Const.L2I:
+            case Const.L2F:
+            case Const.L2D:
+            case Const.F2I:
+            case Const.F2L:
+            case Const.F2D:
+            case Const.D2I:
+            case Const.D2L:
+            case Const.D2F:
+            case Const.I2B:
+            case Const.I2C:
+            case Const.I2S:
+            case Const.LCMP:
+            case Const.FCMPL:
+            case Const.FCMPG:
+            case Const.DCMPL:
+            case Const.DCMPG:
+            case Const.IRETURN:
+            case Const.LRETURN:
+            case Const.FRETURN:
+            case Const.DRETURN:
+            case Const.ARETURN:
+            case Const.RETURN:
+            case Const.ARRAYLENGTH:
+            case Const.ATHROW:
+            case Const.MONITORENTER:
+            case Const.MONITOREXIT:
                 ++index;
                 break;
 
                 // Two byte instructions.
-            case BIPUSH:
-            case LDC:
-            case NEWARRAY:
+            case Const.BIPUSH:
+            case Const.LDC:
+            case Const.NEWARRAY:
                 index += 2;
                 break;
 
                 // Instructions that can be used with the WIDE prefix.
-            case ILOAD:
-            case LLOAD:
-            case FLOAD:
-            case DLOAD:
-            case ALOAD:
-            case ISTORE:
-            case LSTORE:
-            case FSTORE:
-            case DSTORE:
-            case ASTORE:
-            case RET:
+            case Const.ILOAD:
+            case Const.LLOAD:
+            case Const.FLOAD:
+            case Const.DLOAD:
+            case Const.ALOAD:
+            case Const.ISTORE:
+            case Const.LSTORE:
+            case Const.FSTORE:
+            case Const.DSTORE:
+            case Const.ASTORE:
+            case Const.RET:
                 if (wide) {
                     // Skip opcode and two immediate bytes.
                     index += 3;
@@ -280,8 +282,8 @@ public class BytecodeScanner implements org.apache.bcel.Constants {
                 }
                 break;
 
-                // IINC is a special case for WIDE handling
-            case IINC:
+                // IINC is a special case Const.for WIDE handling
+            case Const.IINC:
                 if (wide) {
                     // Skip opcode, two byte index, and two byte immediate
                     // value.
@@ -294,56 +296,56 @@ public class BytecodeScanner implements org.apache.bcel.Constants {
                 break;
 
                 // Three byte instructions.
-            case SIPUSH:
-            case LDC_W:
-            case LDC2_W:
-            case IFEQ:
-            case IFNE:
-            case IFLT:
-            case IFGE:
-            case IFGT:
-            case IFLE:
-            case IF_ICMPEQ:
-            case IF_ICMPNE:
-            case IF_ICMPLT:
-            case IF_ICMPGE:
-            case IF_ICMPGT:
-            case IF_ICMPLE:
-            case IF_ACMPEQ:
-            case IF_ACMPNE:
-            case GOTO:
-            case JSR:
-            case GETSTATIC:
-            case PUTSTATIC:
-            case GETFIELD:
-            case PUTFIELD:
-            case INVOKEVIRTUAL:
-            case INVOKESPECIAL:
-            case INVOKESTATIC:
-            case NEW:
-            case ANEWARRAY:
-            case CHECKCAST:
-            case INSTANCEOF:
-            case IFNULL:
-            case IFNONNULL:
+            case Const.SIPUSH:
+            case Const.LDC_W:
+            case Const.LDC2_W:
+            case Const.IFEQ:
+            case Const.IFNE:
+            case Const.IFLT:
+            case Const.IFGE:
+            case Const.IFGT:
+            case Const.IFLE:
+            case Const.IF_ICMPEQ:
+            case Const.IF_ICMPNE:
+            case Const.IF_ICMPLT:
+            case Const.IF_ICMPGE:
+            case Const.IF_ICMPGT:
+            case Const.IF_ICMPLE:
+            case Const.IF_ACMPEQ:
+            case Const.IF_ACMPNE:
+            case Const.GOTO:
+            case Const.JSR:
+            case Const.GETSTATIC:
+            case Const.PUTSTATIC:
+            case Const.GETFIELD:
+            case Const.PUTFIELD:
+            case Const.INVOKEVIRTUAL:
+            case Const.INVOKESPECIAL:
+            case Const.INVOKESTATIC:
+            case Const.NEW:
+            case Const.ANEWARRAY:
+            case Const.CHECKCAST:
+            case Const.INSTANCEOF:
+            case Const.IFNULL:
+            case Const.IFNONNULL:
                 index += 3;
                 break;
 
                 // Four byte instructions.
-            case MULTIANEWARRAY:
+            case Const.MULTIANEWARRAY:
                 index += 4;
                 break;
 
                 // Five byte instructions.
-            case INVOKEINTERFACE:
-            case INVOKEDYNAMIC:
-            case GOTO_W:
-            case JSR_W:
+            case Const.INVOKEINTERFACE:
+            case Const.INVOKEDYNAMIC:
+            case Const.GOTO_W:
+            case Const.JSR_W:
                 index += 5;
                 break;
 
                 // TABLESWITCH - variable length.
-            case TABLESWITCH: {
+            case Const.TABLESWITCH: {
                 // Skip padding.
                 int offset = index + 1; // skip the opcode
                 offset += PAD[offset & 3];
@@ -365,7 +367,7 @@ public class BytecodeScanner implements org.apache.bcel.Constants {
             break;
 
             // LOOKUPSWITCH - variable length.
-            case LOOKUPSWITCH: {
+            case Const.LOOKUPSWITCH: {
                 // Skip padding.
                 int offset = index + 1; // skip the opcode
                 offset += PAD[offset & 3];
@@ -385,7 +387,7 @@ public class BytecodeScanner implements org.apache.bcel.Constants {
             break;
 
             // Wide prefix.
-            case WIDE:
+            case Const.WIDE:
                 wide = true;
                 ++index;
                 break;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/CheckReturnAnnotationDatabase.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/CheckReturnAnnotationDatabase.java
@@ -24,6 +24,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadPoolExecutor;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.Repository;
 import org.apache.bcel.classfile.JavaClass;
 
@@ -137,11 +138,11 @@ public class CheckReturnAnnotationDatabase extends AnnotationDatabase<CheckRetur
                 CheckReturnValueAnnotation.CHECK_RETURN_VALUE_LOW);
         addMethodAnnotation("java.lang.String", "intern", "()Ljava/lang/String;", false,
                 CheckReturnValueAnnotation.CHECK_RETURN_VALUE_MEDIUM);
-        addMethodAnnotation("java.lang.String", "<init>", "([BLjava/lang/String;)V", false,
+        addMethodAnnotation("java.lang.String", Const.CONSTRUCTOR_NAME, "([BLjava/lang/String;)V", false,
                 CheckReturnValueAnnotation.CHECK_RETURN_VALUE_IGNORE);
-        addMethodAnnotation("java.lang.String", "<init>", "(Ljava/lang/String;)V", false,
+        addMethodAnnotation("java.lang.String", Const.CONSTRUCTOR_NAME, "(Ljava/lang/String;)V", false,
                 CheckReturnValueAnnotation.CHECK_RETURN_VALUE_LOW);
-        addMethodAnnotation("java.lang.String", "<init>", "()V", false, CheckReturnValueAnnotation.CHECK_RETURN_VALUE_LOW);
+        addMethodAnnotation("java.lang.String", Const.CONSTRUCTOR_NAME, "()V", false, CheckReturnValueAnnotation.CHECK_RETURN_VALUE_LOW);
         addDefaultMethodAnnotation("java.math.BigDecimal", CheckReturnValueAnnotation.CHECK_RETURN_VALUE_HIGH);
         addMethodAnnotation("java.math.BigDecimal", "inflate", "()Ljava/math/BigInteger;", false,
                 CheckReturnValueAnnotation.CHECK_RETURN_VALUE_IGNORE);
@@ -158,7 +159,7 @@ public class CheckReturnAnnotationDatabase extends AnnotationDatabase<CheckRetur
                 CheckReturnValueAnnotation.CHECK_RETURN_VALUE_IGNORE);
         addMethodAnnotation("java.math.BigDecimal", "byteValueExact", "()B", false,
                 CheckReturnValueAnnotation.CHECK_RETURN_VALUE_IGNORE);
-        addMethodAnnotation("java.math.BigDecimal", "<init>", "(Ljava/lang/String;)V", false,
+        addMethodAnnotation("java.math.BigDecimal", Const.CONSTRUCTOR_NAME, "(Ljava/lang/String;)V", false,
                 CheckReturnValueAnnotation.CHECK_RETURN_VALUE_IGNORE);
         addMethodAnnotation("java.math.BigDecimal", "intValue", "()I", false,
                 CheckReturnValueAnnotation.CHECK_RETURN_VALUE_IGNORE);
@@ -170,7 +171,7 @@ public class CheckReturnAnnotationDatabase extends AnnotationDatabase<CheckRetur
                 CheckReturnValueAnnotation.CHECK_RETURN_VALUE_IGNORE);
         addMethodAnnotation("java.math.BigInteger", "subN", "([I[II)I", true,
                 CheckReturnValueAnnotation.CHECK_RETURN_VALUE_IGNORE);
-        addMethodAnnotation("java.math.BigInteger", "<init>", "(Ljava/lang/String;)V", false,
+        addMethodAnnotation("java.math.BigInteger", Const.CONSTRUCTOR_NAME, "(Ljava/lang/String;)V", false,
                 CheckReturnValueAnnotation.CHECK_RETURN_VALUE_IGNORE);
         addDefaultMethodAnnotation("java.sql.Connection", CheckReturnValueAnnotation.CHECK_RETURN_VALUE_MEDIUM);
         addDefaultMethodAnnotation("java.net.InetAddress", CheckReturnValueAnnotation.CHECK_RETURN_VALUE_MEDIUM);
@@ -232,7 +233,7 @@ public class CheckReturnAnnotationDatabase extends AnnotationDatabase<CheckRetur
         XMethod m = (XMethod) o;
         if (m.getName().startsWith("access$")) {
             return null;
-        } else if ("<init>".equals(m.getName())) {
+        } else if (Const.CONSTRUCTOR_NAME.equals(m.getName())) {
             try {
                 if (throwableClass != null && Repository.instanceOf(m.getClassName(), throwableClass)) {
                     return CheckReturnValueAnnotation.CHECK_RETURN_VALUE_VERY_HIGH;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/OpcodeStackScanner.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/OpcodeStackScanner.java
@@ -19,6 +19,7 @@
 
 package edu.umd.cs.findbugs.ba;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.classfile.Method;
 
@@ -92,7 +93,7 @@ public class OpcodeStackScanner {
         @Override
         public void afterOpcode(int seen) {
             if(DEBUG) {
-                System.out.printf("%3d: %8s %s%n", getPC(), OPCODE_NAMES[seen], getStack());
+                System.out.printf("%3d: %8s %s%n", getPC(), Const.getOpcodeName(seen), getStack());
             }
             if (getPC() == targetPC) {
                 throw new EarlyExitException(stack);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/PutfieldScanner.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/PutfieldScanner.java
@@ -22,6 +22,7 @@ package edu.umd.cs.findbugs.ba;
 import java.util.Map;
 import java.util.TreeMap;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.classfile.Method;
 
@@ -59,7 +60,7 @@ public class PutfieldScanner {
 
         @Override
         public void sawOpcode(int seen) {
-            if (seen != PUTFIELD) {
+            if (seen != Const.PUTFIELD) {
                 return;
             }
             XField xFieldOperand = getXFieldOperand();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/UnresolvedXMethod.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/UnresolvedXMethod.java
@@ -61,7 +61,7 @@ class UnresolvedXMethod extends AbstractMethod {
 
     @Override
     public ElementType getElementType() {
-        if ("<init>".equals(getName())) {
+        if (Const.CONSTRUCTOR_NAME.equals(getName())) {
             return ElementType.CONSTRUCTOR;
         }
         return ElementType.METHOD;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/XFactory.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/XFactory.java
@@ -134,7 +134,7 @@ public class XFactory {
     }
 
     public boolean isCalled(XMethod m) {
-        if ("<clinit>".equals(m.getName())) {
+        if (Const.STATIC_INITIALIZER_NAME.equals(m.getName())) {
             return true;
         }
         return calledMethods.contains(m);
@@ -167,7 +167,7 @@ public class XFactory {
         if (isCalled(m)) {
             return true;
         }
-        if (m.isStatic() || m.isPrivate() || "<init>".equals(m.getName())) {
+        if (m.isStatic() || m.isPrivate() || Const.CONSTRUCTOR_NAME.equals(m.getName())) {
             return false;
         }
         try {
@@ -406,7 +406,7 @@ public class XFactory {
                      * obligation. If strict checking is performed, // weak
                      * entries are ignored.
                      */
-                    if ("<init>".equals(methodName) || methodName.startsWith("access$") || xmethod.isStatic()
+                    if (Const.CONSTRUCTOR_NAME.equals(methodName) || methodName.startsWith("access$") || xmethod.isStatic()
                             || methodName.toLowerCase().indexOf("close") >= 0
                             || xmethod.getSignature().toLowerCase().indexOf("Closeable") >= 0) {
                         ObligationPolicyDatabaseEntry entry = database.addParameterDeletesObligationDatabaseEntry(xmethod,

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/bcp/FieldAccess.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/bcp/FieldAccess.java
@@ -19,6 +19,7 @@
 
 package edu.umd.cs.findbugs.ba.bcp;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.generic.ConstantPoolGen;
 import org.apache.bcel.generic.FieldInstruction;
 import org.apache.bcel.generic.Type;
@@ -93,7 +94,7 @@ public abstract class FieldAccess extends SingleInstruction implements org.apach
     protected static boolean isLongOrDouble(FieldInstruction fieldIns, ConstantPoolGen cpg) {
         Type type = fieldIns.getFieldType(cpg);
         int code = type.getType();
-        return code == T_LONG || code == T_DOUBLE;
+        return code == Const.T_LONG || code == Const.T_DOUBLE;
     }
 
     /**

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/bcp/Invoke.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/bcp/Invoke.java
@@ -201,7 +201,7 @@ public class Invoke extends PatternElement {
 
         String methodName = inv.getMethodName(cpg);
         boolean isStatic = inv.getOpcode() == Const.INVOKESTATIC;
-        boolean isCtor = "<init>".equals(methodName);
+        boolean isCtor = Const.CONSTRUCTOR_NAME.equals(methodName);
 
         int actualMode = 0;
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/type/ExceptionObjectType.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/type/ExceptionObjectType.java
@@ -19,6 +19,7 @@
 
 package edu.umd.cs.findbugs.ba.type;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.Constants;
 import org.apache.bcel.generic.ObjectType;
 import org.apache.bcel.generic.Type;
@@ -59,7 +60,7 @@ public class ExceptionObjectType extends ObjectType implements Constants, Extend
      */
     public static Type fromExceptionSet(ExceptionSet exceptionSet) throws ClassNotFoundException {
         Type commonSupertype = exceptionSet.getCommonSupertype();
-        if (commonSupertype.getType() != T_OBJECT) {
+        if (commonSupertype.getType() != Const.T_OBJECT) {
             return commonSupertype;
         }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/type/StandardTypeMerger.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/type/StandardTypeMerger.java
@@ -22,6 +22,7 @@ package edu.umd.cs.findbugs.ba.type;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.Constants;
 import org.apache.bcel.generic.ObjectType;
 import org.apache.bcel.generic.ReferenceType;
@@ -119,7 +120,7 @@ public class StandardTypeMerger implements TypeMerger, Constants, ExtendedTypes 
      * defined new object types with different type codes.
      */
     protected boolean isReferenceType(byte type) {
-        return type == T_OBJECT || type == T_ARRAY || type == T_NULL || type == T_EXCEPTION;
+        return type == Const.T_OBJECT || type == Const.T_ARRAY || type == T_NULL || type == T_EXCEPTION;
     }
 
     /**
@@ -127,7 +128,7 @@ public class StandardTypeMerger implements TypeMerger, Constants, ExtendedTypes 
      * should override with any new object types.
      */
     protected boolean isObjectType(byte type) {
-        return type == T_OBJECT || type == T_EXCEPTION;
+        return type == Const.T_OBJECT || type == T_EXCEPTION;
     }
 
     /**
@@ -137,7 +138,7 @@ public class StandardTypeMerger implements TypeMerger, Constants, ExtendedTypes 
      * have defined new integer types with different type codes.
      */
     protected boolean isIntegerType(byte type) {
-        return type == T_INT || type == T_BYTE || type == T_BOOLEAN || type == T_CHAR || type == T_SHORT;
+        return type == Const.T_INT || type == Const.T_BYTE || type == Const.T_BOOLEAN || type == Const.T_CHAR || type == Const.T_SHORT;
     }
 
     private static void updateExceptionSet(ExceptionSet exceptionSet, ObjectType type) {
@@ -172,10 +173,10 @@ public class StandardTypeMerger implements TypeMerger, Constants, ExtendedTypes 
             if (isObjectType(aType) && isObjectType(bType)
                     && ((aType == T_EXCEPTION || isThrowable(aRef))  && (bType == T_EXCEPTION ||   isThrowable(bRef)))) {
                 ExceptionSet union = exceptionSetFactory.createExceptionSet();
-                if (aType == T_OBJECT && "Ljava/lang/Throwable;".equals(aRef.getSignature())) {
+                if (aType == Const.T_OBJECT && "Ljava/lang/Throwable;".equals(aRef.getSignature())) {
                     return aRef;
                 }
-                if (bType == T_OBJECT && "Ljava/lang/Throwable;".equals(bRef.getSignature())) {
+                if (bType == Const.T_OBJECT && "Ljava/lang/Throwable;".equals(bRef.getSignature())) {
                     return bRef;
                 }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/type/TypeFrameModelingVisitor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/type/TypeFrameModelingVisitor.java
@@ -238,14 +238,14 @@ public class TypeFrameModelingVisitor extends AbstractFrameModelingVisitor<Type,
      * method ensures that we push two types for each double or long value.
      */
     protected void pushValue(Type type) {
-        if (type.getType() == T_VOID) {
+        if (type.getType() == Const.T_VOID) {
             throw new IllegalArgumentException("Can't push void");
         }
         TypeFrame frame = getFrame();
-        if (type.getType() == T_LONG) {
+        if (type.getType() == Const.T_LONG) {
             frame.pushValue(Type.LONG);
             frame.pushValue(TypeFrame.getLongExtraType());
-        } else if (type.getType() == T_DOUBLE) {
+        } else if (type.getType() == Const.T_DOUBLE) {
             frame.pushValue(Type.DOUBLE);
             frame.pushValue(TypeFrame.getDoubleExtraType());
         } else {
@@ -259,7 +259,7 @@ public class TypeFrameModelingVisitor extends AbstractFrameModelingVisitor<Type,
     protected void pushReturnType(InvokeInstruction ins) {
         ConstantPoolGen cpg = getCPG();
         Type type = ins.getType(cpg);
-        if (type.getType() != T_VOID) {
+        if (type.getType() != Const.T_VOID) {
             pushValue(type);
         }
     }
@@ -682,7 +682,7 @@ public class TypeFrameModelingVisitor extends AbstractFrameModelingVisitor<Type,
                         try {
                             Type t = GenericUtilities.getType(rv);
                             if (t != null) {
-                                assert t.getType() != T_VOID;
+                                assert t.getType() != Const.T_VOID;
                                 result = merge(result, t);
                                 foundSomething = true;
                             }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/analysis/MethodInfo.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/analysis/MethodInfo.java
@@ -621,7 +621,7 @@ public class MethodInfo extends MethodDescriptor implements XMethod {
 
     @Override
     public ElementType getElementType() {
-        if ("<init>".equals(getName())) {
+        if (Const.CONSTRUCTOR_NAME.equals(getName())) {
             return ElementType.CONSTRUCTOR;
         }
         return ElementType.METHOD;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/bcel/MethodGenFactory.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/bcel/MethodGenFactory.java
@@ -18,6 +18,7 @@
  */
 package edu.umd.cs.findbugs.classfile.engine.bcel;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.classfile.Method;
 import org.apache.bcel.generic.ConstantPoolGen;
@@ -74,13 +75,13 @@ public class MethodGenFactory extends AnalysisFactory<MethodGen> {
             String methodName = method.getName();
             int codeLength = method.getCode().getCode().length;
             String superclassName = jclass.getSuperclassName();
-            if (codeLength > 6000 && "<clinit>".equals(methodName) && "java.lang.Enum".equals(superclassName)) {
+            if (codeLength > 6000 && Const.STATIC_INITIALIZER_NAME.equals(methodName) && "java.lang.Enum".equals(superclassName)) {
                 analysisContext.getLookupFailureCallback().reportSkippedAnalysis(
                         new JavaClassAndMethod(jclass, method).toMethodDescriptor());
                 return null;
             }
             if (analysisContext.getBoolProperty(AnalysisFeatures.SKIP_HUGE_METHODS)) {
-                if (codeLength > 6000 || ("<clinit>".equals(methodName) || "getContents".equals(methodName)) && codeLength > 2000) {
+                if (codeLength > 6000 || (Const.STATIC_INITIALIZER_NAME.equals(methodName) || "getContents".equals(methodName)) && codeLength > 2000) {
                     analysisContext.getLookupFailureCallback().reportSkippedAnalysis(
                             new JavaClassAndMethod(jclass, method).toMethodDescriptor());
                     return null;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/AppendingToAnObjectOutputStream.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/AppendingToAnObjectOutputStream.java
@@ -68,7 +68,7 @@ public class AppendingToAnObjectOutputStream extends OpcodeStackDetector {
         String calledMethodName = getNameConstantOperand();
         String calledMethodSig = getSigConstantOperand();
         if (!sawOpenInAppendMode) {
-            if ("java/io/ObjectOutputStream".equals(calledClassName) && "<init>".equals(calledMethodName)
+            if ("java/io/ObjectOutputStream".equals(calledClassName) && Const.CONSTRUCTOR_NAME.equals(calledMethodName)
                     && "(Ljava/io/OutputStream;)V".equals(calledMethodSig)
                     && stack.getStackItem(0).getSpecialKind() == OpcodeStack.Item.FILE_OPENED_IN_APPEND_MODE) {
                 bugReporter.reportBug(new BugInstance(this, "IO_APPENDING_TO_OBJECT_OUTPUT_STREAM", Priorities.HIGH_PRIORITY)
@@ -76,18 +76,18 @@ public class AppendingToAnObjectOutputStream extends OpcodeStackDetector {
             }
             return;
         }
-        if ("java/io/FileOutputStream".equals(calledClassName) && "<init>".equals(calledMethodName)
+        if ("java/io/FileOutputStream".equals(calledClassName) && Const.CONSTRUCTOR_NAME.equals(calledMethodName)
                 && ("(Ljava/io/File;Z)V".equals(calledMethodSig) || "(Ljava/lang/String;Z)V".equals(calledMethodSig))) {
             OpcodeStack.Item item = stack.getStackItem(0);
             Object value = item.getConstant();
             sawOpenInAppendMode = value instanceof Integer && ((Integer) value).intValue() == 1;
         } else if (!sawOpenInAppendMode) {
             return;
-        } else if ("java/io/BufferedOutputStream".equals(calledClassName) && "<init>".equals(calledMethodName)
+        } else if ("java/io/BufferedOutputStream".equals(calledClassName) && Const.CONSTRUCTOR_NAME.equals(calledMethodName)
                 && "(Ljava/io/OutputStream;)V".equals(calledMethodSig)) {
             // do nothing
 
-        } else if ("java/io/ObjectOutputStream".equals(calledClassName) && "<init>".equals(calledMethodName)
+        } else if ("java/io/ObjectOutputStream".equals(calledClassName) && Const.CONSTRUCTOR_NAME.equals(calledMethodName)
                 && "(Ljava/io/OutputStream;)V".equals(calledMethodSig)) {
             bugReporter.reportBug(new BugInstance(this, "IO_APPENDING_TO_OBJECT_OUTPUT_STREAM", Priorities.HIGH_PRIORITY)
             .addClassAndMethod(this).addSourceLine(this));

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/AppendingToAnObjectOutputStream.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/AppendingToAnObjectOutputStream.java
@@ -21,6 +21,7 @@ package edu.umd.cs.findbugs.detect;
 
 import java.util.Collections;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Method;
 
 import edu.umd.cs.findbugs.BugInstance;
@@ -59,7 +60,7 @@ public class AppendingToAnObjectOutputStream extends OpcodeStackDetector {
      */
     @Override
     public void sawOpcode(int seen) {
-        if (seen != INVOKESPECIAL) {
+        if (seen != Const.INVOKESPECIAL) {
             sawOpenInAppendMode = false;
             return;
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/AtomicityProblem.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/AtomicityProblem.java
@@ -21,6 +21,7 @@ package edu.umd.cs.findbugs.detect;
 
 import java.util.Collections;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 
 import edu.umd.cs.findbugs.BugInstance;
@@ -77,11 +78,11 @@ public class AtomicityProblem extends OpcodeStackDetector {
     @Override
     public void sawOpcode(int seen) {
         if (DEBUG) {
-            System.out.println(getPC() + " " + OPCODE_NAMES[seen]);
+            System.out.println(getPC() + " " + Const.getOpcodeName(seen));
         }
         switch (seen) {
-        case IFNE:
-        case IFEQ: {
+        case Const.IFNE:
+        case Const.IFEQ: {
             OpcodeStack.Item top = stack.getStackItem(0);
             if (DEBUG) {
                 System.out.println("Stack top: " + top);
@@ -90,16 +91,16 @@ public class AtomicityProblem extends OpcodeStackDetector {
             if (m != null && "java.util.concurrent.ConcurrentHashMap".equals(m.getClassName())
                     && "containsKey".equals(m.getName())) {
                 lastQuestionableCheckTarget = getBranchTarget();
-                if (seen == IFEQ) {
+                if (seen == Const.IFEQ) {
                     priority = LOW_PRIORITY;
-                } else if (seen == IFNE) {
+                } else if (seen == Const.IFNE) {
                     priority = NORMAL_PRIORITY;
                 }
             }
             break;
         }
-        case IFNULL:
-        case IFNONNULL: {
+        case Const.IFNULL:
+        case Const.IFNONNULL: {
             OpcodeStack.Item top = stack.getStackItem(0);
             if (DEBUG) {
                 System.out.println("Stack top: " + top);
@@ -110,16 +111,16 @@ public class AtomicityProblem extends OpcodeStackDetector {
             }
             if (m != null && "java.util.concurrent.ConcurrentHashMap".equals(m.getClassName()) && "get".equals(m.getName())) {
                 lastQuestionableCheckTarget = getBranchTarget();
-                if (seen == IFNULL) {
+                if (seen == Const.IFNULL) {
                     priority = LOW_PRIORITY;
-                } else if (seen == IFNONNULL) {
+                } else if (seen == Const.IFNONNULL) {
                     priority = NORMAL_PRIORITY;
                 }
             }
             break;
         }
-        case INVOKEVIRTUAL:
-        case INVOKEINTERFACE: {
+        case Const.INVOKEVIRTUAL:
+        case Const.INVOKEINTERFACE: {
             if ("java.util.concurrent.ConcurrentHashMap".equals(getDottedClassConstantOperand())) {
                 String methodName = getNameConstantOperand();
                 XClass xClass = getXClassOperand();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BadAppletConstructor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BadAppletConstructor.java
@@ -67,7 +67,7 @@ public class BadAppletConstructor extends BytecodeScanningDetector {
 
     @Override
     public void visit(Method obj) {
-        inConstructor = "<init>".equals(obj.getName());
+        inConstructor = Const.CONSTRUCTOR_NAME.equals(obj.getName());
     }
 
     @Override

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BadAppletConstructor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BadAppletConstructor.java
@@ -20,6 +20,7 @@
 
 package edu.umd.cs.findbugs.detect;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.Repository;
 import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.JavaClass;
@@ -78,7 +79,7 @@ public class BadAppletConstructor extends BytecodeScanningDetector {
 
     @Override
     public void sawOpcode(int seen) {
-        if (seen == INVOKEVIRTUAL) {
+        if (seen == Const.INVOKEVIRTUAL) {
             String method = getNameConstantOperand();
             String signature = getSigConstantOperand();
             if ((("getDocumentBase".equals(method) || "getCodeBase".equals(method)) && "()Ljava/net/URL;".equals(signature))

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BadResultSetAccess.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BadResultSetAccess.java
@@ -24,6 +24,8 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.apache.bcel.Const;
+
 import edu.umd.cs.findbugs.BugInstance;
 import edu.umd.cs.findbugs.BugReporter;
 import edu.umd.cs.findbugs.OpcodeStack;
@@ -81,7 +83,7 @@ public class BadResultSetAccess extends OpcodeStackDetector {
     @Override
     public void sawOpcode(int seen) {
 
-        if (seen == INVOKEINTERFACE) {
+        if (seen == Const.INVOKEINTERFACE) {
             String methodName = getNameConstantOperand();
             String clsConstant = getClassConstantOperand();
             if (("java/sql/ResultSet".equals(clsConstant) && ((methodName.startsWith("get") && dbFieldTypesSet

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BadSyntaxForRegularExpression.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BadSyntaxForRegularExpression.java
@@ -22,6 +22,8 @@ package edu.umd.cs.findbugs.detect;
 
 import java.util.regex.Pattern;
 
+import org.apache.bcel.Const;
+
 import edu.umd.cs.findbugs.BugInstance;
 import edu.umd.cs.findbugs.BugReporter;
 import edu.umd.cs.findbugs.OpcodeStack;
@@ -128,28 +130,28 @@ public class BadSyntaxForRegularExpression extends OpcodeStackDetector {
 
     @Override
     public void sawOpcode(int seen) {
-        if (seen == INVOKESTATIC && "java/util/regex/Pattern".equals(getClassConstantOperand())
+        if (seen == Const.INVOKESTATIC && "java/util/regex/Pattern".equals(getClassConstantOperand())
                 && "compile".equals(getNameConstantOperand()) && getSigConstantOperand().startsWith("(Ljava/lang/String;I)")) {
             sawRegExPattern(1, getIntValue(0, 0));
-        } else if (seen == INVOKESTATIC && "java/util/regex/Pattern".equals(getClassConstantOperand())
+        } else if (seen == Const.INVOKESTATIC && "java/util/regex/Pattern".equals(getClassConstantOperand())
                 && "compile".equals(getNameConstantOperand()) && getSigConstantOperand().startsWith("(Ljava/lang/String;)")) {
             sawRegExPattern(0);
-        } else if (seen == INVOKESTATIC && "java/util/regex/Pattern".equals(getClassConstantOperand())
+        } else if (seen == Const.INVOKESTATIC && "java/util/regex/Pattern".equals(getClassConstantOperand())
                 && "matches".equals(getNameConstantOperand())) {
             sawRegExPattern(1);
-        } else if (seen == INVOKEVIRTUAL && "java/lang/String".equals(getClassConstantOperand())
+        } else if (seen == Const.INVOKEVIRTUAL && "java/lang/String".equals(getClassConstantOperand())
                 && "replaceAll".equals(getNameConstantOperand())) {
             sawRegExPattern(1);
             singleDotPatternWouldBeSilly(1, true);
-        } else if (seen == INVOKEVIRTUAL && "java/lang/String".equals(getClassConstantOperand())
+        } else if (seen == Const.INVOKEVIRTUAL && "java/lang/String".equals(getClassConstantOperand())
                 && "replaceFirst".equals(getNameConstantOperand())) {
             sawRegExPattern(1);
             singleDotPatternWouldBeSilly(1, false);
-        } else if (seen == INVOKEVIRTUAL && "java/lang/String".equals(getClassConstantOperand())
+        } else if (seen == Const.INVOKEVIRTUAL && "java/lang/String".equals(getClassConstantOperand())
                 && "matches".equals(getNameConstantOperand())) {
             sawRegExPattern(0);
             singleDotPatternWouldBeSilly(0, false);
-        } else if (seen == INVOKEVIRTUAL && "java/lang/String".equals(getClassConstantOperand())
+        } else if (seen == Const.INVOKEVIRTUAL && "java/lang/String".equals(getClassConstantOperand())
                 && "split".equals(getNameConstantOperand())) {
             sawRegExPattern(0);
             singleDotPatternWouldBeSilly(0, false);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BadUseOfReturnValue.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BadUseOfReturnValue.java
@@ -19,6 +19,7 @@
 
 package edu.umd.cs.findbugs.detect;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 
 import edu.umd.cs.findbugs.BugAccumulator;
@@ -48,24 +49,24 @@ public class BadUseOfReturnValue extends BytecodeScanningDetector {
 
     @Override
     public void sawOpcode(int seen) {
-        if (seen == INVOKEVIRTUAL && "indexOf".equals(getNameConstantOperand())
+        if (seen == Const.INVOKEVIRTUAL && "indexOf".equals(getNameConstantOperand())
                 && "java/lang/String".equals(getClassConstantOperand())
                 && "(Ljava/lang/String;)I".equals(getSigConstantOperand())) {
             stringIndexOfOnTOS = true;
         } else if (stringIndexOfOnTOS) {
-            if (seen == IFLE || seen == IFGT) {
+            if (seen == Const.IFLE || seen == Const.IFGT) {
                 bugAccumulator.accumulateBug(
                         new BugInstance(this, "RV_CHECK_FOR_POSITIVE_INDEXOF", LOW_PRIORITY).addClassAndMethod(this), this);
             }
             stringIndexOfOnTOS = false;
         }
 
-        if (seen == INVOKEVIRTUAL && "readLine".equals(getNameConstantOperand())
+        if (seen == Const.INVOKEVIRTUAL && "readLine".equals(getNameConstantOperand())
                 && "()Ljava/lang/String;".equals(getSigConstantOperand()) && getClassConstantOperand().startsWith("java/io")
                 && !"java/io/LineNumberReader".equals(getClassConstantOperand())) {
             readLineOnTOS = true;
         } else if (readLineOnTOS) {
-            if (seen == IFNULL || seen == IFNONNULL) {
+            if (seen == Const.IFNULL || seen == Const.IFNONNULL) {
                 bugAccumulator.accumulateBug(
                         new BugInstance(this, "RV_DONT_JUST_NULL_CHECK_READLINE", NORMAL_PRIORITY).addClassAndMethod(this), this);
             }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BadlyOverriddenAdapter.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BadlyOverriddenAdapter.java
@@ -23,6 +23,7 @@ package edu.umd.cs.findbugs.detect;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.classfile.Method;
 
@@ -85,7 +86,7 @@ public class BadlyOverriddenAdapter extends BytecodeScanningDetector {
         if (isAdapter) {
             String methodName = obj.getName();
             String signature = methodMap.get(methodName);
-            if (!"<init>".equals(methodName) && signature != null) {
+            if (!Const.CONSTRUCTOR_NAME.equals(methodName) && signature != null) {
                 if (!signature.equals(obj.getSignature())) {
                     if (!badOverrideMap.keySet().contains(methodName)) {
                         badOverrideMap.put(methodName, new BugInstance(this, "BOA_BADLY_OVERRIDDEN_ADAPTER", NORMAL_PRIORITY)

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BuildStringPassthruGraph.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BuildStringPassthruGraph.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.Method;
 import org.apache.bcel.generic.Type;
@@ -276,10 +277,10 @@ public class BuildStringPassthruGraph extends OpcodeStackDetector implements Non
             }
         }
         switch (seen) {
-        case INVOKESPECIAL:
-        case INVOKESTATIC:
-        case INVOKEINTERFACE:
-        case INVOKEVIRTUAL:
+        case Const.INVOKESPECIAL:
+        case Const.INVOKESTATIC:
+        case Const.INVOKEINTERFACE:
+        case Const.INVOKEVIRTUAL:
             MethodDescriptor md = getMethodDescriptorOperand();
             int callArgs = getNumberArguments(md.getSignature());
             for (int i = 0; i < callArgs; i++) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BuildStringPassthruGraph.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BuildStringPassthruGraph.java
@@ -108,27 +108,27 @@ public class BuildStringPassthruGraph extends OpcodeStackDetector implements Non
 
     public static class StringPassthruDatabase {
         private static final List<MethodDescriptor> FILENAME_STRING_METHODS = Arrays.asList(
-                new MethodDescriptor("java/io/File", "<init>", "(Ljava/lang/String;)V"),
-                new MethodDescriptor("java/io/File", "<init>", "(Ljava/lang/String;Ljava/lang/String;)V"),
-                new MethodDescriptor("java/io/RandomAccessFile", "<init>", "(Ljava/lang/String;Ljava/lang/String;)V"),
+                new MethodDescriptor("java/io/File", Const.CONSTRUCTOR_NAME, "(Ljava/lang/String;)V"),
+                new MethodDescriptor("java/io/File", Const.CONSTRUCTOR_NAME, "(Ljava/lang/String;Ljava/lang/String;)V"),
+                new MethodDescriptor("java/io/RandomAccessFile", Const.CONSTRUCTOR_NAME, "(Ljava/lang/String;Ljava/lang/String;)V"),
                 new MethodDescriptor("java/nio/file/Paths", "get", "(Ljava/lang/String;[Ljava/lang/String;)Ljava/nio/file/Path;", true),
-                new MethodDescriptor("java/io/FileReader", "<init>", "(Ljava/lang/String;)V"),
-                new MethodDescriptor("java/io/FileWriter", "<init>", "(Ljava/lang/String;)V"),
-                new MethodDescriptor("java/io/FileWriter", "<init>", "(Ljava/lang/String;Z)V"),
-                new MethodDescriptor("java/io/FileInputStream", "<init>", "(Ljava/lang/String;)V"),
-                new MethodDescriptor("java/io/FileOutputStream", "<init>", "(Ljava/lang/String;)V"),
-                new MethodDescriptor("java/io/FileOutputStream", "<init>", "(Ljava/lang/String;Z)V"),
-                new MethodDescriptor("java/util/Formatter", "<init>", "(Ljava/lang/String;)V"),
-                new MethodDescriptor("java/util/Formatter", "<init>", "(Ljava/lang/String;Ljava/lang/String;)V"),
-                new MethodDescriptor("java/util/Formatter", "<init>", "(Ljava/lang/String;Ljava/lang/String;Ljava/util/Locale;)V"),
-                new MethodDescriptor("java/util/jar/JarFile", "<init>", "(Ljava/lang/String;)V"),
-                new MethodDescriptor("java/util/jar/JarFile", "<init>", "(Ljava/lang/String;Z)V"),
-                new MethodDescriptor("java/util/zip/ZipFile", "<init>", "(Ljava/lang/String;)V"),
-                new MethodDescriptor("java/util/zip/ZipFile", "<init>", "(Ljava/lang/String;Ljava/nio/charset/Charset;)V"),
-                new MethodDescriptor("java/io/PrintStream", "<init>", "(Ljava/lang/String;)V"),
-                new MethodDescriptor("java/io/PrintStream", "<init>", "(Ljava/lang/String;Ljava/lang/String;)V"),
-                new MethodDescriptor("java/io/PrintWriter", "<init>", "(Ljava/lang/String;)V"),
-                new MethodDescriptor("java/io/PrintWriter", "<init>", "(Ljava/lang/String;Ljava/lang/String;)V")
+                new MethodDescriptor("java/io/FileReader", Const.CONSTRUCTOR_NAME, "(Ljava/lang/String;)V"),
+                new MethodDescriptor("java/io/FileWriter", Const.CONSTRUCTOR_NAME, "(Ljava/lang/String;)V"),
+                new MethodDescriptor("java/io/FileWriter", Const.CONSTRUCTOR_NAME, "(Ljava/lang/String;Z)V"),
+                new MethodDescriptor("java/io/FileInputStream", Const.CONSTRUCTOR_NAME, "(Ljava/lang/String;)V"),
+                new MethodDescriptor("java/io/FileOutputStream", Const.CONSTRUCTOR_NAME, "(Ljava/lang/String;)V"),
+                new MethodDescriptor("java/io/FileOutputStream", Const.CONSTRUCTOR_NAME, "(Ljava/lang/String;Z)V"),
+                new MethodDescriptor("java/util/Formatter", Const.CONSTRUCTOR_NAME, "(Ljava/lang/String;)V"),
+                new MethodDescriptor("java/util/Formatter", Const.CONSTRUCTOR_NAME, "(Ljava/lang/String;Ljava/lang/String;)V"),
+                new MethodDescriptor("java/util/Formatter", Const.CONSTRUCTOR_NAME, "(Ljava/lang/String;Ljava/lang/String;Ljava/util/Locale;)V"),
+                new MethodDescriptor("java/util/jar/JarFile", Const.CONSTRUCTOR_NAME, "(Ljava/lang/String;)V"),
+                new MethodDescriptor("java/util/jar/JarFile", Const.CONSTRUCTOR_NAME, "(Ljava/lang/String;Z)V"),
+                new MethodDescriptor("java/util/zip/ZipFile", Const.CONSTRUCTOR_NAME, "(Ljava/lang/String;)V"),
+                new MethodDescriptor("java/util/zip/ZipFile", Const.CONSTRUCTOR_NAME, "(Ljava/lang/String;Ljava/nio/charset/Charset;)V"),
+                new MethodDescriptor("java/io/PrintStream", Const.CONSTRUCTOR_NAME, "(Ljava/lang/String;)V"),
+                new MethodDescriptor("java/io/PrintStream", Const.CONSTRUCTOR_NAME, "(Ljava/lang/String;Ljava/lang/String;)V"),
+                new MethodDescriptor("java/io/PrintWriter", Const.CONSTRUCTOR_NAME, "(Ljava/lang/String;)V"),
+                new MethodDescriptor("java/io/PrintWriter", Const.CONSTRUCTOR_NAME, "(Ljava/lang/String;Ljava/lang/String;)V")
                 );
 
         private final Map<MethodParameter, Set<MethodParameter>> graph = new HashMap<>();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BuildUnconditionalParamDerefDatabase.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BuildUnconditionalParamDerefDatabase.java
@@ -170,7 +170,7 @@ public abstract class BuildUnconditionalParamDerefDatabase implements Detector {
                         if (typeQualifierAnnotation.when != When.UNKNOWN) {
                             priority--;
                         }
-                        if (xmethod.isStatic() || xmethod.isFinal() || xmethod.isPrivate() || "<init>".equals(xmethod.getName())
+                        if (xmethod.isStatic() || xmethod.isFinal() || xmethod.isPrivate() || Const.CONSTRUCTOR_NAME.equals(xmethod.getName())
                                 || jclass.isFinal()) {
                             priority--;
                         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/CalledMethods.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/CalledMethods.java
@@ -21,6 +21,8 @@ package edu.umd.cs.findbugs.detect;
 
 import java.util.HashSet;
 
+import org.apache.bcel.Const;
+
 import edu.umd.cs.findbugs.BugReporter;
 import edu.umd.cs.findbugs.BytecodeScanningDetector;
 import edu.umd.cs.findbugs.NonReportingDetector;
@@ -49,7 +51,7 @@ public class CalledMethods extends BytecodeScanningDetector implements NonReport
     @Override
     public void sawOpcode(int seen) {
 
-        if ((seen == PUTFIELD || seen == PUTSTATIC)) {
+        if ((seen == Const.PUTFIELD || seen == Const.PUTSTATIC)) {
             XField f = getXFieldOperand();
             if (f != null) {
                 if (f.isFinal() || !f.isProtected() && !f.isPublic()) {
@@ -62,20 +64,20 @@ public class CalledMethods extends BytecodeScanningDetector implements NonReport
             }
 
         }
-        emptyArrayOnTOS = (seen == ANEWARRAY || seen == NEWARRAY || seen == MULTIANEWARRAY && getIntConstant() == 1)
-                && getPrevOpcode(1) == ICONST_0;
+        emptyArrayOnTOS = (seen == Const.ANEWARRAY || seen == Const.NEWARRAY || seen == Const.MULTIANEWARRAY && getIntConstant() == 1)
+                && getPrevOpcode(1) == Const.ICONST_0;
 
-        if (seen == GETSTATIC || seen == GETFIELD) {
+        if (seen == Const.GETSTATIC || seen == Const.GETFIELD) {
             XField f = getXFieldOperand();
             if (emptyArray.contains(f) && !nonEmptyArray.contains(f) && f.isFinal()) {
                 emptyArrayOnTOS = true;
             }
         }
         switch (seen) {
-        case INVOKEVIRTUAL:
-        case INVOKESPECIAL:
-        case INVOKESTATIC:
-        case INVOKEINTERFACE:
+        case Const.INVOKEVIRTUAL:
+        case Const.INVOKESPECIAL:
+        case Const.INVOKESTATIC:
+        case Const.INVOKEINTERFACE:
             ClassDescriptor c = getClassDescriptorOperand();
             Subtypes2 subtypes2 = AnalysisContext.currentAnalysisContext().getSubtypes2();
             if (subtypes2.isApplicationClass(c)) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/CbeckMustOverrideSuperAnnotation.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/CbeckMustOverrideSuperAnnotation.java
@@ -21,6 +21,7 @@ package edu.umd.cs.findbugs.detect;
 
 import javax.annotation.OverridingMethodsMustInvokeSuper;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 
 import edu.umd.cs.findbugs.BugInstance;
@@ -80,7 +81,7 @@ public class CbeckMustOverrideSuperAnnotation extends OpcodeStackDetector {
      */
     @Override
     public void sawOpcode(int seen) {
-        if (seen != INVOKESPECIAL) {
+        if (seen != Const.INVOKESPECIAL) {
             return;
         }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/CloneIdiom.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/CloneIdiom.java
@@ -21,6 +21,7 @@ package edu.umd.cs.findbugs.detect;
 
 import java.util.Set;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.ConstantNameAndType;
 import org.apache.bcel.classfile.JavaClass;
@@ -86,7 +87,7 @@ public class CloneIdiom extends DismantleBytecode implements Detector, Stateless
 
     @Override
     public void sawOpcode(int seen) {
-        if (seen == INVOKESPECIAL && "clone".equals(getNameConstantOperand()) && getSigConstantOperand().startsWith("()")) {
+        if (seen == Const.INVOKESPECIAL && "clone".equals(getNameConstantOperand()) && getSigConstantOperand().startsWith("()")) {
             /*
              * System.out.println("Saw call to " + nameConstant + ":" +
              * sigConstant + " in " + betterMethodName);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ConfusionBetweenInheritedAndOuterMethod.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ConfusionBetweenInheritedAndOuterMethod.java
@@ -19,6 +19,7 @@
 
 package edu.umd.cs.findbugs.detect;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.Field;
 import org.apache.bcel.classfile.JavaClass;
@@ -92,7 +93,7 @@ public class ConfusionBetweenInheritedAndOuterMethod extends OpcodeStackDetector
             }
             iteratorBug = null;
         }
-        if (seen != INVOKEVIRTUAL) {
+        if (seen != Const.INVOKEVIRTUAL) {
             return;
         }
         if (!getClassName().equals(getClassConstantOperand())) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/CovariantArrayAssignment.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/CovariantArrayAssignment.java
@@ -19,6 +19,7 @@
 
 package edu.umd.cs.findbugs.detect;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.LocalVariable;
 import org.apache.bcel.classfile.LocalVariableTable;
@@ -89,7 +90,7 @@ public class CovariantArrayAssignment extends OpcodeStackDetector {
 
     @Override
     public void sawOpcode(int seen) {
-        if ((isRegisterStore() && !isRegisterLoad()) || seen == PUTFIELD || seen == PUTSTATIC || seen == ARETURN) {
+        if ((isRegisterStore() && !isRegisterLoad()) || seen == Const.PUTFIELD || seen == Const.PUTSTATIC || seen == Const.ARETURN) {
             Item valueItem = getStack().getStackItem(0);
             if(!valueItem.isNull() && valueItem.isNewlyAllocated() && valueItem.getSignature().startsWith("[L")
                     && !((Integer)0).equals(valueItem.getConstant())) {
@@ -98,7 +99,7 @@ public class CovariantArrayAssignment extends OpcodeStackDetector {
                 int priority = LOW_PRIORITY;
                 String pattern = null;
                 FieldDescriptor field = null;
-                if(seen == PUTFIELD || seen == PUTSTATIC) {
+                if(seen == Const.PUTFIELD || seen == Const.PUTSTATIC) {
                     arraySignature = getSigConstantOperand();
                     pattern = "CAA_COVARIANT_ARRAY_FIELD";
                     field = getFieldDescriptorOperand();
@@ -111,7 +112,7 @@ public class CovariantArrayAssignment extends OpcodeStackDetector {
                             }
                         }
                     }
-                } else if(seen == ARETURN) {
+                } else if(seen == Const.ARETURN) {
                     if(getXMethod().bridgeFrom() == null) {
                         pattern = "CAA_COVARIANT_ARRAY_RETURN";
                         arraySignature = new SignatureParser(getMethodSig()).getReturnTypeSignature();
@@ -148,7 +149,7 @@ public class CovariantArrayAssignment extends OpcodeStackDetector {
             }
         }
 
-        if (seen == AASTORE) {
+        if (seen == Const.AASTORE) {
             Item valueItem = getStack().getStackItem(0);
             if(!valueItem.isNull()) {
                 Item arrayItem = getStack().getStackItem(2);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/CrossSiteScripting.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/CrossSiteScripting.java
@@ -120,7 +120,7 @@ public class CrossSiteScripting extends OpcodeStackDetector {
             String calledMethodName = getNameConstantOperand();
             String calledMethodSig = getSigConstantOperand();
 
-            if ("javax/servlet/http/Cookie".equals(calledClassName) && "<init>".equals(calledMethodName)
+            if ("javax/servlet/http/Cookie".equals(calledClassName) && Const.CONSTRUCTOR_NAME.equals(calledMethodName)
                     && "(Ljava/lang/String;Ljava/lang/String;)V".equals(calledMethodSig)) {
                 OpcodeStack.Item value = stack.getStackItem(0);
                 OpcodeStack.Item name = stack.getStackItem(1);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/CrossSiteScripting.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/CrossSiteScripting.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 
 import edu.umd.cs.findbugs.BugAccumulator;
@@ -99,7 +100,7 @@ public class CrossSiteScripting extends OpcodeStackDetector {
 
         OpcodeStack.Item oldTop = top;
         top = null;
-        if (seen == INVOKESPECIAL || seen == INVOKESTATIC || seen == INVOKEINTERFACE || seen == INVOKEVIRTUAL) {
+        if (seen == Const.INVOKESPECIAL || seen == Const.INVOKESTATIC || seen == Const.INVOKEINTERFACE || seen == Const.INVOKEVIRTUAL) {
             int[] params = allFileNameStringMethods.get(getMethodDescriptorOperand());
             if(params != null) {
                 int numArgs = getNumberArguments(getSigConstantOperand());
@@ -114,7 +115,7 @@ public class CrossSiteScripting extends OpcodeStackDetector {
                 }
             }
         }
-        if (seen == INVOKESPECIAL) {
+        if (seen == Const.INVOKESPECIAL) {
             String calledClassName = getClassConstantOperand();
             String calledMethodName = getNameConstantOperand();
             String calledMethodSig = getSigConstantOperand();
@@ -131,7 +132,7 @@ public class CrossSiteScripting extends OpcodeStackDetector {
 
             }
 
-        } else if (seen == INVOKEINTERFACE) {
+        } else if (seen == Const.INVOKEINTERFACE) {
             String calledClassName = getClassConstantOperand();
             String calledMethodName = getNameConstantOperand();
             String calledMethodSig = getSigConstantOperand();
@@ -178,7 +179,7 @@ public class CrossSiteScripting extends OpcodeStackDetector {
                 }
             }
 
-        } else if (seen == INVOKEVIRTUAL && !isPlainText) {
+        } else if (seen == Const.INVOKEVIRTUAL && !isPlainText) {
             String calledClassName = getClassConstantOperand();
             String calledMethodName = getNameConstantOperand();
             String calledMethodSig = getSigConstantOperand();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DefaultEncodingDetector.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DefaultEncodingDetector.java
@@ -85,57 +85,57 @@ public class DefaultEncodingDetector extends OpcodeStackDetector {
         @Override
         public void loadAuxiliaryAnnotations() {
             addMethodAnnotation("java.lang.String", "getBytes", "()[B", false, DefaultEncodingAnnotation.DEFAULT_ENCODING);
-            addMethodAnnotation("java.lang.String", "<init>", "([B)V", false, DefaultEncodingAnnotation.DEFAULT_ENCODING);
-            addMethodAnnotation("java.lang.String", "<init>", "([BII)V", false, DefaultEncodingAnnotation.DEFAULT_ENCODING);
+            addMethodAnnotation("java.lang.String", Const.CONSTRUCTOR_NAME, "([B)V", false, DefaultEncodingAnnotation.DEFAULT_ENCODING);
+            addMethodAnnotation("java.lang.String", Const.CONSTRUCTOR_NAME, "([BII)V", false, DefaultEncodingAnnotation.DEFAULT_ENCODING);
             addMethodAnnotation("java.io.ByteArrayOutputStream", "toString", "()Ljava/lang/String;", false,
                     DefaultEncodingAnnotation.DEFAULT_ENCODING);
-            addMethodAnnotation("java.io.FileReader", "<init>", "(Ljava/lang/String;)V", false,
+            addMethodAnnotation("java.io.FileReader", Const.CONSTRUCTOR_NAME, "(Ljava/lang/String;)V", false,
                     DefaultEncodingAnnotation.DEFAULT_ENCODING);
-            addMethodAnnotation("java.io.FileReader", "<init>", "(Ljava/io/File;)V", false,
+            addMethodAnnotation("java.io.FileReader", Const.CONSTRUCTOR_NAME, "(Ljava/io/File;)V", false,
                     DefaultEncodingAnnotation.DEFAULT_ENCODING);
-            addMethodAnnotation("java.io.FileReader", "<init>", "(Ljava/io/FileDescriptor;)V", false,
+            addMethodAnnotation("java.io.FileReader", Const.CONSTRUCTOR_NAME, "(Ljava/io/FileDescriptor;)V", false,
                     DefaultEncodingAnnotation.DEFAULT_ENCODING);
-            addMethodAnnotation("java.io.FileWriter", "<init>", "(Ljava/lang/String;)V", false,
+            addMethodAnnotation("java.io.FileWriter", Const.CONSTRUCTOR_NAME, "(Ljava/lang/String;)V", false,
                     DefaultEncodingAnnotation.DEFAULT_ENCODING);
-            addMethodAnnotation("java.io.FileWriter", "<init>", "(Ljava/lang/String;Z)V", false,
+            addMethodAnnotation("java.io.FileWriter", Const.CONSTRUCTOR_NAME, "(Ljava/lang/String;Z)V", false,
                     DefaultEncodingAnnotation.DEFAULT_ENCODING);
-            addMethodAnnotation("java.io.FileWriter", "<init>", "(Ljava/io/File;)V", false,
+            addMethodAnnotation("java.io.FileWriter", Const.CONSTRUCTOR_NAME, "(Ljava/io/File;)V", false,
                     DefaultEncodingAnnotation.DEFAULT_ENCODING);
-            addMethodAnnotation("java.io.FileWriter", "<init>", "(Ljava/io/File;Z)V", false,
+            addMethodAnnotation("java.io.FileWriter", Const.CONSTRUCTOR_NAME, "(Ljava/io/File;Z)V", false,
                     DefaultEncodingAnnotation.DEFAULT_ENCODING);
-            addMethodAnnotation("java.io.FileWriter", "<init>", "(Ljava/io/FileDescriptor;)V", false,
+            addMethodAnnotation("java.io.FileWriter", Const.CONSTRUCTOR_NAME, "(Ljava/io/FileDescriptor;)V", false,
                     DefaultEncodingAnnotation.DEFAULT_ENCODING);
-            addMethodAnnotation("java.io.InputStreamReader", "<init>", "(Ljava/io/InputStream;)V", false,
+            addMethodAnnotation("java.io.InputStreamReader", Const.CONSTRUCTOR_NAME, "(Ljava/io/InputStream;)V", false,
                     DefaultEncodingAnnotation.DEFAULT_ENCODING);
-            addMethodAnnotation("java.io.OutputStreamWriter", "<init>", "(Ljava/io/OutputStream;)V", false,
+            addMethodAnnotation("java.io.OutputStreamWriter", Const.CONSTRUCTOR_NAME, "(Ljava/io/OutputStream;)V", false,
                     DefaultEncodingAnnotation.DEFAULT_ENCODING);
-            addMethodAnnotation("java.io.PrintStream", "<init>", "(Ljava/io/File;)V", false,
+            addMethodAnnotation("java.io.PrintStream", Const.CONSTRUCTOR_NAME, "(Ljava/io/File;)V", false,
                     DefaultEncodingAnnotation.DEFAULT_ENCODING);
-            addMethodAnnotation("java.io.PrintStream", "<init>", "(Ljava/io/OutputStream;)V", false,
+            addMethodAnnotation("java.io.PrintStream", Const.CONSTRUCTOR_NAME, "(Ljava/io/OutputStream;)V", false,
                     DefaultEncodingAnnotation.DEFAULT_ENCODING);
-            addMethodAnnotation("java.io.PrintStream", "<init>", "(Ljava/io/OutputStream;Z)V", false,
+            addMethodAnnotation("java.io.PrintStream", Const.CONSTRUCTOR_NAME, "(Ljava/io/OutputStream;Z)V", false,
                     DefaultEncodingAnnotation.DEFAULT_ENCODING);
-            addMethodAnnotation("java.io.PrintStream", "<init>", "(Ljava/lang/String;)V", false,
+            addMethodAnnotation("java.io.PrintStream", Const.CONSTRUCTOR_NAME, "(Ljava/lang/String;)V", false,
                     DefaultEncodingAnnotation.DEFAULT_ENCODING);
-            addMethodAnnotation("java.io.PrintWriter", "<init>", "(Ljava/io/File;)V", false,
+            addMethodAnnotation("java.io.PrintWriter", Const.CONSTRUCTOR_NAME, "(Ljava/io/File;)V", false,
                     DefaultEncodingAnnotation.DEFAULT_ENCODING);
-            addMethodAnnotation("java.io.PrintWriter", "<init>", "(Ljava/io/OutputStream;)V", false,
+            addMethodAnnotation("java.io.PrintWriter", Const.CONSTRUCTOR_NAME, "(Ljava/io/OutputStream;)V", false,
                     DefaultEncodingAnnotation.DEFAULT_ENCODING);
-            addMethodAnnotation("java.io.PrintWriter", "<init>", "(Ljava/io/OutputStream;Z)V", false,
+            addMethodAnnotation("java.io.PrintWriter", Const.CONSTRUCTOR_NAME, "(Ljava/io/OutputStream;Z)V", false,
                     DefaultEncodingAnnotation.DEFAULT_ENCODING);
-            addMethodAnnotation("java.io.PrintWriter", "<init>", "(Ljava/lang/String;)V", false,
+            addMethodAnnotation("java.io.PrintWriter", Const.CONSTRUCTOR_NAME, "(Ljava/lang/String;)V", false,
                     DefaultEncodingAnnotation.DEFAULT_ENCODING);
-            addMethodAnnotation("java.util.Scanner", "<init>", "(Ljava/io/File;)V", false,
+            addMethodAnnotation("java.util.Scanner", Const.CONSTRUCTOR_NAME, "(Ljava/io/File;)V", false,
                     DefaultEncodingAnnotation.DEFAULT_ENCODING);
-            addMethodAnnotation("java.util.Scanner", "<init>", "(Ljava/io/InputStream;)V", false,
+            addMethodAnnotation("java.util.Scanner", Const.CONSTRUCTOR_NAME, "(Ljava/io/InputStream;)V", false,
                     DefaultEncodingAnnotation.DEFAULT_ENCODING);
-            addMethodAnnotation("java.util.Scanner", "<init>", "(Ljava/nio/channels/ReadableByteChannel;)V", false,
+            addMethodAnnotation("java.util.Scanner", Const.CONSTRUCTOR_NAME, "(Ljava/nio/channels/ReadableByteChannel;)V", false,
                     DefaultEncodingAnnotation.DEFAULT_ENCODING);
-            addMethodAnnotation("java.util.Formatter", "<init>", "(Ljava/lang/String;)V", false,
+            addMethodAnnotation("java.util.Formatter", Const.CONSTRUCTOR_NAME, "(Ljava/lang/String;)V", false,
                     DefaultEncodingAnnotation.DEFAULT_ENCODING);
-            addMethodAnnotation("java.util.Formatter", "<init>", "(Ljava/io/File;)V", false,
+            addMethodAnnotation("java.util.Formatter", Const.CONSTRUCTOR_NAME, "(Ljava/io/File;)V", false,
                     DefaultEncodingAnnotation.DEFAULT_ENCODING);
-            addMethodAnnotation("java.util.Formatter", "<init>", "(Ljava/io/OutputStream;)V", false,
+            addMethodAnnotation("java.util.Formatter", Const.CONSTRUCTOR_NAME, "(Ljava/io/OutputStream;)V", false,
                     DefaultEncodingAnnotation.DEFAULT_ENCODING);
         }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DefaultEncodingDetector.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DefaultEncodingDetector.java
@@ -3,6 +3,7 @@ package edu.umd.cs.findbugs.detect;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.JavaClass;
 
@@ -165,9 +166,9 @@ public class DefaultEncodingDetector extends OpcodeStackDetector {
     @Override
     public void sawOpcode(int seen) {
         switch (seen) {
-        case INVOKEVIRTUAL:
-        case INVOKESPECIAL:
-        case INVOKESTATIC:
+        case Const.INVOKEVIRTUAL:
+        case Const.INVOKESPECIAL:
+        case Const.INVOKESTATIC:
             XMethod callSeen = XFactory.createXMethod(MethodAnnotation.fromCalledMethod(this));
             DefaultEncodingAnnotation annotation = defaultEncodingAnnotationDatabase.getDirectAnnotation(callSeen);
             if (annotation != null) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DoInsideDoPrivileged.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DoInsideDoPrivileged.java
@@ -19,6 +19,7 @@
 
 package edu.umd.cs.findbugs.detect;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.JavaClass;
 
@@ -65,7 +66,7 @@ public class DoInsideDoPrivileged extends BytecodeScanningDetector {
 
     @Override
     public void sawOpcode(int seen) {
-        if (seen == INVOKEVIRTUAL && "setAccessible".equals(getNameConstantOperand())) {
+        if (seen == Const.INVOKEVIRTUAL && "setAccessible".equals(getNameConstantOperand())) {
             @DottedClassName
             String className = getDottedClassConstantOperand();
             if ("java.lang.reflect.Field".equals(className) || "java.lang.reflect.Method".equals(className)) {
@@ -75,7 +76,7 @@ public class DoInsideDoPrivileged extends BytecodeScanningDetector {
             }
 
         }
-        if (seen == NEW) {
+        if (seen == Const.NEW) {
             @DottedClassName
             String classOfConstructedClass = getDottedClassConstantOperand();
             if (Subtypes2.instanceOf(classOfConstructedClass, "java.lang.ClassLoader")

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DontUseEnum.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DontUseEnum.java
@@ -19,6 +19,7 @@
 
 package edu.umd.cs.findbugs.detect;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Field;
 import org.apache.bcel.classfile.FieldOrMethod;
 import org.apache.bcel.classfile.LocalVariable;
@@ -48,7 +49,7 @@ public class DontUseEnum extends PreorderDetector {
     }
 
     private boolean isVisible(FieldOrMethod obj) {
-        return (obj.getAccessFlags() & ACC_PUBLIC) != 0 || (obj.getAccessFlags() & ACC_PROTECTED) != 0;
+        return (obj.getAccessFlags() & Const.ACC_PUBLIC) != 0 || (obj.getAccessFlags() & Const.ACC_PROTECTED) != 0;
     }
 
     private boolean isReservedName(String name) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DumbMethods.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DumbMethods.java
@@ -90,7 +90,7 @@ public class DumbMethods extends OpcodeStackDetector {
 
         @Override
         public void sawOpcode(int seen) {
-            if(seen == INVOKESTATIC && getClassConstantOperand().equals("java/lang/Math") && (getMethodDescriptorOperand().getName().equals("max")
+            if(seen == Const.INVOKESTATIC && getClassConstantOperand().equals("java/lang/Math") && (getMethodDescriptorOperand().getName().equals("max")
                     || getMethodDescriptorOperand().getName().equals("min"))) {
                 Object const1 = stack.getStackItem(0).getConstant();
                 Object const2 = stack.getStackItem(1).getConstant();
@@ -130,7 +130,7 @@ public class DumbMethods extends OpcodeStackDetector {
 
         @Override
         public void sawOpcode(int seen) {
-            if (seen == INVOKESTATIC && ("com/google/common/base/Preconditions".equals(getClassConstantOperand())
+            if (seen == Const.INVOKESTATIC && ("com/google/common/base/Preconditions".equals(getClassConstantOperand())
                     && "checkNotNull".equals(getNameConstantOperand())
                     || "com/google/common/base/Strings".equals(getClassConstantOperand())
                     && ("nullToEmpty".equals(getNameConstantOperand()) ||
@@ -165,7 +165,7 @@ public class DumbMethods extends OpcodeStackDetector {
                 }
             }
 
-            if (seen == INVOKESTATIC && ("junit/framework/Assert".equals(getClassConstantOperand()) || "org/junit/Assert".equals(getClassConstantOperand()))
+            if (seen == Const.INVOKESTATIC && ("junit/framework/Assert".equals(getClassConstantOperand()) || "org/junit/Assert".equals(getClassConstantOperand()))
                     && "assertNotNull".equals(getNameConstantOperand())) {
 
                 OpcodeStack.Item item = stack.getStackItem(0);
@@ -199,7 +199,7 @@ public class DumbMethods extends OpcodeStackDetector {
     private class FutilePoolSizeSubDetector extends SubDetector {
         @Override
         public void sawOpcode(int seen) {
-            if (seen == INVOKEVIRTUAL && "java/util/concurrent/ScheduledThreadPoolExecutor".equals(getClassConstantOperand())
+            if (seen == Const.INVOKEVIRTUAL && "java/util/concurrent/ScheduledThreadPoolExecutor".equals(getClassConstantOperand())
                     && "setMaximumPoolSize".equals(getNameConstantOperand())) {
                 accumulator.accumulateBug(new BugInstance(DumbMethods.this,
                         "DMI_FUTILE_ATTEMPT_TO_CHANGE_MAXPOOL_SIZE_OF_SCHEDULED_THREAD_POOL_EXECUTOR", HIGH_PRIORITY)
@@ -270,30 +270,30 @@ public class DumbMethods extends OpcodeStackDetector {
         public void sawOpcode(int seen) {
             // System.out.printf("%4d %s%n", getPC(), OPCODE_NAMES[seen]);
             switch(seen) {
-            case IALOAD:
-            case AALOAD:
-            case SALOAD:
-            case CALOAD:
-            case BALOAD:
-            case LALOAD:
-            case DALOAD:
-            case FALOAD: {
+            case Const.IALOAD:
+            case Const.AALOAD:
+            case Const.SALOAD:
+            case Const.CALOAD:
+            case Const.BALOAD:
+            case Const.LALOAD:
+            case Const.DALOAD:
+            case Const.FALOAD: {
                 checkRange(stack.getStackItem(0), 0, stack.getStackItem(1), "RANGE_ARRAY_INDEX");
                 break;
             }
-            case IASTORE:
-            case AASTORE:
-            case SASTORE:
-            case CASTORE:
-            case BASTORE:
-            case LASTORE:
-            case DASTORE:
-            case FASTORE: {
+            case Const.IASTORE:
+            case Const.AASTORE:
+            case Const.SASTORE:
+            case Const.CASTORE:
+            case Const.BASTORE:
+            case Const.LASTORE:
+            case Const.DASTORE:
+            case Const.FASTORE: {
 
                 checkRange(stack.getStackItem(1), 0,  stack.getStackItem(2), "RANGE_ARRAY_INDEX");
                 break;
             }
-            case INVOKESTATIC: {
+            case Const.INVOKESTATIC: {
                 MethodDescriptor m = getMethodDescriptorOperand();
                 if(m.getSlashedClassName().equals("java/lang/System") && m.getName().equals("arraycopy")) {
                     // void arraycopy(Object src, int srcPos, Object dest, int destPos, int length)
@@ -329,8 +329,8 @@ public class DumbMethods extends OpcodeStackDetector {
                 }
                 break;
             }
-            case INVOKEVIRTUAL:
-            case INVOKESPECIAL: {
+            case Const.INVOKEVIRTUAL:
+            case Const.INVOKESPECIAL: {
                 MethodDescriptor m = getMethodDescriptorOperand();
                 if(m.getSlashedClassName().equals("java/lang/String")) {
                     if((m.getName().equals("charAt") || m.getName().equals("codePointAt")) && m.getSignature().startsWith("(I)")) {
@@ -378,10 +378,10 @@ public class DumbMethods extends OpcodeStackDetector {
     private class UrlCollectionSubDetector extends SubDetector {
         @Override
         public void sawOpcode(int seen) {
-            if ((seen == INVOKEVIRTUAL && "java/util/HashMap".equals(getClassConstantOperand()) && "get".equals(getNameConstantOperand()))
-                    || (seen == INVOKEINTERFACE && "java/util/Map".equals(getClassConstantOperand()) && "get".equals(getNameConstantOperand()))
-                    || (seen == INVOKEVIRTUAL && "java/util/HashSet".equals(getClassConstantOperand()) && "contains".equals(getNameConstantOperand()))
-                    || (seen == INVOKEINTERFACE && "java/util/Set".equals(getClassConstantOperand()) && "contains".equals(getNameConstantOperand()))) {
+            if ((seen == Const.INVOKEVIRTUAL && "java/util/HashMap".equals(getClassConstantOperand()) && "get".equals(getNameConstantOperand()))
+                    || (seen == Const.INVOKEINTERFACE && "java/util/Map".equals(getClassConstantOperand()) && "get".equals(getNameConstantOperand()))
+                    || (seen == Const.INVOKEVIRTUAL && "java/util/HashSet".equals(getClassConstantOperand()) && "contains".equals(getNameConstantOperand()))
+                    || (seen == Const.INVOKEINTERFACE && "java/util/Set".equals(getClassConstantOperand()) && "contains".equals(getNameConstantOperand()))) {
                 OpcodeStack.Item top = stack.getStackItem(0);
                 if ("Ljava/net/URL;".equals(top.getSignature())) {
                     accumulator.accumulateBug(new BugInstance(DumbMethods.this, "DMI_COLLECTION_OF_URLS", HIGH_PRIORITY)
@@ -395,7 +395,7 @@ public class DumbMethods extends OpcodeStackDetector {
         @Override
         public void sawOpcode(int seen) {
             boolean foundVacuousComparison = false;
-            if (seen == IF_ICMPGT || seen == IF_ICMPLE) {
+            if (seen == Const.IF_ICMPGT || seen == Const.IF_ICMPLE) {
                 OpcodeStack.Item rhs = stack.getStackItem(0);
                 Object rhsConstant = rhs.getConstant();
                 if (rhsConstant instanceof Integer && ((Integer) rhsConstant).intValue() == Integer.MAX_VALUE) {
@@ -408,7 +408,7 @@ public class DumbMethods extends OpcodeStackDetector {
                 }
 
             }
-            if (seen == IF_ICMPLT || seen == IF_ICMPGE) {
+            if (seen == Const.IF_ICMPLT || seen == Const.IF_ICMPGE) {
                 OpcodeStack.Item rhs = stack.getStackItem(0);
                 Object rhsConstant = rhs.getConstant();
                 if (rhsConstant instanceof Integer && ((Integer) rhsConstant).intValue() == Integer.MIN_VALUE) {
@@ -445,26 +445,26 @@ public class DumbMethods extends OpcodeStackDetector {
         @Override
         public void sawOpcode(int seen) {
             if (isEqualsObject && !reportedBadCastInEquals) {
-                if (seen == INVOKEVIRTUAL && "isInstance".equals(getNameConstantOperand())
+                if (seen == Const.INVOKEVIRTUAL && "isInstance".equals(getNameConstantOperand())
                         && "java/lang/Class".equals(getClassConstantOperand())) {
                     OpcodeStack.Item item = stack.getStackItem(0);
                     if (item.getRegisterNumber() == 1) {
                         sawInstanceofCheck = true;
                     }
-                } else if (seen == INSTANCEOF || seen == INVOKEVIRTUAL && "getClass".equals(getNameConstantOperand())
+                } else if (seen == Const.INSTANCEOF || seen == Const.INVOKEVIRTUAL && "getClass".equals(getNameConstantOperand())
                         && "()Ljava/lang/Class;".equals(getSigConstantOperand())) {
                     OpcodeStack.Item item = stack.getStackItem(0);
                     if (item.getRegisterNumber() == 1) {
                         sawInstanceofCheck = true;
                     }
-                } else if (seen == INVOKESPECIAL && "equals".equals(getNameConstantOperand())
+                } else if (seen == Const.INVOKESPECIAL && "equals".equals(getNameConstantOperand())
                         && "(Ljava/lang/Object;)Z".equals(getSigConstantOperand())) {
                     OpcodeStack.Item item0 = stack.getStackItem(0);
                     OpcodeStack.Item item1 = stack.getStackItem(1);
                     if (item1.getRegisterNumber() + item0.getRegisterNumber() == 1) {
                         sawInstanceofCheck = true;
                     }
-                } else if (seen == CHECKCAST && !sawInstanceofCheck) {
+                } else if (seen == Const.CHECKCAST && !sawInstanceofCheck) {
                     OpcodeStack.Item item = stack.getStackItem(0);
                     if (item.getRegisterNumber() == 1) {
                         if (getSizeOfSurroundingTryBlock(getPC()) == Integer.MAX_VALUE) {
@@ -491,14 +491,14 @@ public class DumbMethods extends OpcodeStackDetector {
 
         @Override
         public void sawOpcode(int seen) {
-            if (seen == INVOKEVIRTUAL && "java/util/Random".equals(getClassConstantOperand())
+            if (seen == Const.INVOKEVIRTUAL && "java/util/Random".equals(getClassConstantOperand())
                     && (freshRandomOnTos || freshRandomOneBelowTos)) {
                 accumulator.accumulateBug(new BugInstance(DumbMethods.this, "DMI_RANDOM_USED_ONLY_ONCE", HIGH_PRIORITY)
                         .addClassAndMethod(DumbMethods.this).addCalledMethod(DumbMethods.this), DumbMethods.this);
 
             }
             freshRandomOneBelowTos = freshRandomOnTos && isRegisterLoad();
-            freshRandomOnTos = seen == INVOKESPECIAL && "java/util/Random".equals(getClassConstantOperand())
+            freshRandomOnTos = seen == Const.INVOKESPECIAL && "java/util/Random".equals(getClassConstantOperand())
                     && "<init>".equals(getNameConstantOperand());
         }
     }
@@ -704,7 +704,7 @@ public class DumbMethods extends OpcodeStackDetector {
                     }
                     if (primitiveType != null
                             && (previousMethodCall.equals(rvo) || signature.equals(primitiveType))
-                            && (getThisClass().getMajor() >= Const.MAJOR_1_7 || getThisClass().getMajor() >= MAJOR_1_4
+                            && (getThisClass().getMajor() >= Const.MAJOR_1_7 || getThisClass().getMajor() >= Const.MAJOR_1_4
                             && (primitiveType.equals("D") || primitiveType.equals("F")))) {
                         MethodDescriptor shouldCall = new MethodDescriptor(called.getClassDescriptor().getClassName(), "compare",
                                 "(" + primitiveType + primitiveType + ")I", true);
@@ -722,7 +722,7 @@ public class DumbMethods extends OpcodeStackDetector {
         }
 
 
-        if (seen == LDC || seen == LDC_W || seen == LDC2_W) {
+        if (seen == Const.LDC || seen == Const.LDC_W || seen == Const.LDC2_W) {
             Constant c = getConstantRefOperand();
             if (testingEnabled && (c instanceof ConstantInteger && ((ConstantInteger) c).getBytes() == MICROS_PER_DAY_OVERFLOWED_AS_INT
                     || c instanceof ConstantLong && ((ConstantLong) c).getBytes() == MICROS_PER_DAY_OVERFLOWED_AS_INT)) {
@@ -741,7 +741,7 @@ public class DumbMethods extends OpcodeStackDetector {
         }
 
 
-        if (seen == LCMP) {
+        if (seen == Const.LCMP) {
             OpcodeStack.Item left = stack.getStackItem(1);
             OpcodeStack.Item right = stack.getStackItem(0);
             checkForCompatibleLongComparison(left, right);
@@ -750,12 +750,12 @@ public class DumbMethods extends OpcodeStackDetector {
 
         if (stack.getStackDepth() >= 2) {
             switch (seen) {
-            case IF_ICMPEQ:
-            case IF_ICMPNE:
-            case IF_ICMPLE:
-            case IF_ICMPGE:
-            case IF_ICMPLT:
-            case IF_ICMPGT:
+            case Const.IF_ICMPEQ:
+            case Const.IF_ICMPNE:
+            case Const.IF_ICMPLE:
+            case Const.IF_ICMPGE:
+            case Const.IF_ICMPLT:
+            case Const.IF_ICMPGT:
                 OpcodeStack.Item item0 = stack.getStackItem(0);
                 OpcodeStack.Item item1 = stack.getStackItem(1);
                 if (item0.getConstant() instanceof Integer) {
@@ -786,7 +786,7 @@ public class DumbMethods extends OpcodeStackDetector {
 
         // System.out.printf("%4d %10s: %s\n", getPC(), OPCODE_NAMES[seen],
         // stack);
-        if (seen == IFLT && stack.getStackDepth() > 0 && stack.getStackItem(0).getSpecialKind() == OpcodeStack.Item.SIGNED_BYTE) {
+        if (seen == Const.IFLT && stack.getStackDepth() > 0 && stack.getStackItem(0).getSpecialKind() == OpcodeStack.Item.SIGNED_BYTE) {
             sawCheckForNonNegativeSignedByte = getPC();
         }
 
@@ -794,7 +794,7 @@ public class DumbMethods extends OpcodeStackDetector {
             if (opcodesSincePendingAbsoluteValueBug == 0) {
                 opcodesSincePendingAbsoluteValueBug++;
             } else {
-                if (seen == IREM) {
+                if (seen == Const.IREM) {
                     OpcodeStack.Item top = stack.getStackItem(0);
                     Object constantValue = top.getConstant();
                     if (constantValue instanceof Number && Util.isPowerOfTwo(((Number) constantValue).intValue())) {
@@ -817,16 +817,16 @@ public class DumbMethods extends OpcodeStackDetector {
             }
         }
 
-        if (seen == INVOKESTATIC
+        if (seen == Const.INVOKESTATIC
                 && "org/easymock/EasyMock".equals(getClassConstantOperand())
                 && ("replay".equals(getNameConstantOperand()) || "verify".equals(getNameConstantOperand()) || getNameConstantOperand()
                         .startsWith("reset")) && "([Ljava/lang/Object;)V".equals(getSigConstantOperand())
-                && getPrevOpcode(1) == ANEWARRAY && getPrevOpcode(2) == ICONST_0) {
+                && getPrevOpcode(1) == Const.ANEWARRAY && getPrevOpcode(2) == Const.ICONST_0) {
             accumulator.accumulateBug(new BugInstance(this, "DMI_VACUOUS_CALL_TO_EASYMOCK_METHOD", NORMAL_PRIORITY)
                     .addClassAndMethod(this).addCalledMethod(this), this);
         }
 
-        if ((seen == INVOKESTATIC || seen == INVOKEVIRTUAL || seen == INVOKESPECIAL || seen == INVOKEINTERFACE)
+        if ((seen == Const.INVOKESTATIC || seen == Const.INVOKEVIRTUAL || seen == Const.INVOKESPECIAL || seen == Const.INVOKEINTERFACE)
                 && getSigConstantOperand().indexOf("Ljava/lang/Runnable;") >= 0) {
             SignatureParser parser = new SignatureParser(getSigConstantOperand());
             int count = 0;
@@ -844,7 +844,7 @@ public class DumbMethods extends OpcodeStackDetector {
 
         }
 
-        if (prevOpcode == I2L && seen == INVOKESTATIC && "java/lang/Double".equals(getClassConstantOperand())
+        if (prevOpcode == Const.I2L && seen == Const.INVOKESTATIC && "java/lang/Double".equals(getClassConstantOperand())
                 && "longBitsToDouble".equals(getNameConstantOperand())) {
             accumulator.accumulateBug(new BugInstance(this, "DMI_LONG_BITS_TO_DOUBLE_INVOKED_ON_INT", HIGH_PRIORITY)
                     .addClassAndMethod(this).addCalledMethod(this), this);
@@ -871,7 +871,7 @@ public class DumbMethods extends OpcodeStackDetector {
             subDetector.sawOpcode(seen);
         }
 
-        if (!sawLoadOfMinValue && seen == INVOKESTATIC &&
+        if (!sawLoadOfMinValue && seen == Const.INVOKESTATIC &&
                 ClassName.isMathClass(getClassConstantOperand()) && "abs".equals(getNameConstantOperand())
                 ) {
             OpcodeStack.Item item0 = stack.getStackItem(0);
@@ -912,7 +912,7 @@ public class DumbMethods extends OpcodeStackDetector {
                 }
 
             }
-            if (seen == IREM) {
+            if (seen == Const.IREM) {
                 OpcodeStack.Item item0 = stack.getStackItem(0);
                 Object constant0 = item0.getConstant();
                 if (constant0 instanceof Integer && ((Integer) constant0).intValue() == 1) {
@@ -922,7 +922,7 @@ public class DumbMethods extends OpcodeStackDetector {
 
             }
 
-            if (stack.getStackDepth() >= 1 && (seen == LOOKUPSWITCH || seen == TABLESWITCH)) {
+            if (stack.getStackDepth() >= 1 && (seen == Const.LOOKUPSWITCH || seen == Const.TABLESWITCH)) {
                 OpcodeStack.Item item0 = stack.getStackItem(0);
                 if (item0.getSpecialKind() == OpcodeStack.Item.SIGNED_BYTE) {
                     int[] switchLabels = getSwitchLabels();
@@ -942,12 +942,12 @@ public class DumbMethods extends OpcodeStackDetector {
             // the -128...127 range
             if (stack.getStackDepth() >= 2) {
                 switch (seen) {
-                case IF_ICMPEQ:
-                case IF_ICMPNE:
-                case IF_ICMPLT:
-                case IF_ICMPLE:
-                case IF_ICMPGE:
-                case IF_ICMPGT:
+                case Const.IF_ICMPEQ:
+                case Const.IF_ICMPNE:
+                case Const.IF_ICMPLT:
+                case Const.IF_ICMPLE:
+                case Const.IF_ICMPGE:
+                case Const.IF_ICMPGT:
                     OpcodeStack.Item item0 = stack.getStackItem(0);
                     OpcodeStack.Item item1 = stack.getStackItem(1);
                     int seen2 = seen;
@@ -956,17 +956,17 @@ public class DumbMethods extends OpcodeStackDetector {
                         item0 = item1;
                         item1 = tmp;
                         switch (seen) {
-                        case IF_ICMPLT:
-                            seen2 = IF_ICMPGT;
+                        case Const.IF_ICMPLT:
+                            seen2 = Const.IF_ICMPGT;
                             break;
-                        case IF_ICMPGE:
-                            seen2 = IF_ICMPLE;
+                        case Const.IF_ICMPGE:
+                            seen2 = Const.IF_ICMPLE;
                             break;
-                        case IF_ICMPGT:
-                            seen2 = IF_ICMPLT;
+                        case Const.IF_ICMPGT:
+                            seen2 = Const.IF_ICMPLT;
                             break;
-                        case IF_ICMPLE:
-                            seen2 = IF_ICMPGE;
+                        case Const.IF_ICMPLE:
+                            seen2 = Const.IF_ICMPGE;
                             break;
                         default:
                             break;
@@ -975,37 +975,37 @@ public class DumbMethods extends OpcodeStackDetector {
                     Object constant1 = item1.getConstant();
                     if (item0.getSpecialKind() == OpcodeStack.Item.SIGNED_BYTE && constant1 instanceof Number) {
                         int v1 = ((Number) constant1).intValue();
-                        if (v1 <= -129 || v1 >= 128 || v1 == 127 && !(seen2 == IF_ICMPEQ || seen2 == IF_ICMPNE
+                        if (v1 <= -129 || v1 >= 128 || v1 == 127 && !(seen2 == Const.IF_ICMPEQ || seen2 == Const.IF_ICMPNE
 
                                 )) {
                             int priority = HIGH_PRIORITY;
                             if (v1 == 127) {
                                 switch (seen2) {
-                                case IF_ICMPGT: // 127 > x
+                                case Const.IF_ICMPGT: // 127 > x
                                     priority = LOW_PRIORITY;
                                     break;
-                                case IF_ICMPGE: // 127 >= x : always true
+                                case Const.IF_ICMPGE: // 127 >= x : always true
                                     priority = NORMAL_PRIORITY;
                                     break;
-                                case IF_ICMPLT: // 127 < x : never true
+                                case Const.IF_ICMPLT: // 127 < x : never true
                                     priority = NORMAL_PRIORITY;
                                     break;
-                                case IF_ICMPLE: // 127 <= x
+                                case Const.IF_ICMPLE: // 127 <= x
                                     priority = LOW_PRIORITY;
                                     break;
                                 }
                             } else if (v1 == 128) {
                                 switch (seen2) {
-                                case IF_ICMPGT: // 128 > x; always true
+                                case Const.IF_ICMPGT: // 128 > x; always true
                                     priority = NORMAL_PRIORITY;
                                     break;
-                                case IF_ICMPGE: // 128 >= x
+                                case Const.IF_ICMPGE: // 128 >= x
                                     priority = HIGH_PRIORITY;
                                     break;
-                                case IF_ICMPLT: // 128 < x
+                                case Const.IF_ICMPLT: // 128 < x
                                     priority = HIGH_PRIORITY;
                                     break;
-                                case IF_ICMPLE: // 128 <= x; never true
+                                case Const.IF_ICMPLE: // 128 <= x; never true
                                     priority = NORMAL_PRIORITY;
                                     break;
                                 }
@@ -1034,45 +1034,45 @@ public class DumbMethods extends OpcodeStackDetector {
             }
 
             switch (seen) {
-            case IFGE:
-            case IFLT:
+            case Const.IFGE:
+            case Const.IFLT:
                 if(stack.getStackDepth() > 0 && stack.getStackItem(0).getSpecialKind() == OpcodeStack.Item.NON_NEGATIVE) {
                     OpcodeStack.Item top = stack.getStackItem(0);
                     if (top.getRegisterNumber() != -1 && getMaxPC() > getNextPC() + 6) {
                         if (false) {
                             for(int i = -2; i <= 0; i++) {
                                 int o = getPrevOpcode(-i);
-                                System.out.printf("%2d %3d  %2x %s%n",  i, o, o, OPCODE_NAMES[o]);
+                                System.out.printf("%2d %3d  %2x %s%n",  i, o, o, Const.getOpcodeName(o));
                             }
                             for(int i = 0; i < 7; i++) {
                                 int o = getNextCodeByte(i);
-                                System.out.printf("%2d %3d %2x %s%n",  i, o, o, OPCODE_NAMES[o]);
+                                System.out.printf("%2d %3d %2x %s%n",  i, o, o, Const.getOpcodeName(o));
 
                             }
                         }
                         int jump1, jump2;
-                        if (seen == IFGE) {
-                            jump1 = IF_ICMPLT;
-                            jump2 = IF_ICMPLE;
+                        if (seen == Const.IFGE) {
+                            jump1 = Const.IF_ICMPLT;
+                            jump2 = Const.IF_ICMPLE;
                         } else {
-                            jump1 = IF_ICMPGE;
-                            jump2 = IF_ICMPGT;
+                            jump1 = Const.IF_ICMPGE;
+                            jump2 = Const.IF_ICMPGT;
                         }
                         int nextCodeByte0 = getNextCodeByte(0);
                         int loadConstant = 1;
-                        if (nextCodeByte0 == ILOAD) {
+                        if (nextCodeByte0 == Const.ILOAD) {
                             loadConstant = 2;
                         }
                         int nextCodeByte1 = getNextCodeByte(loadConstant);
                         int nextJumpOffset = loadConstant+2;
-                        if (nextCodeByte1 == SIPUSH) {
+                        if (nextCodeByte1 == Const.SIPUSH) {
                             nextJumpOffset++;
                         }
                         int nextCodeByteJump = getNextCodeByte(nextJumpOffset);
 
                         if (nextCodeByte0 == getPrevOpcode(1)
-                                && (nextCodeByte1 == BIPUSH || nextCodeByte1 == SIPUSH)
-                                && (IF_ICMPLT <= nextCodeByteJump && nextCodeByteJump <= IF_ICMPLE))
+                                && (nextCodeByte1 == Const.BIPUSH || nextCodeByte1 == Const.SIPUSH)
+                                && (Const.IF_ICMPLT <= nextCodeByteJump && nextCodeByteJump <= Const.IF_ICMPLE))
                         {
                             break;
                         }
@@ -1081,32 +1081,32 @@ public class DumbMethods extends OpcodeStackDetector {
                             NORMAL_PRIORITY).addClassAndMethod(this).addInt(0).describe(IntAnnotation.INT_VALUE).addValueSource(top, this), this);
                 }
                 break;
-            case IAND:
-            case LAND:
-            case IOR:
-            case LOR:
-            case IXOR:
-            case LXOR:
-                long badValue = (seen == IAND || seen == LAND) ? -1 : 0;
+            case Const.IAND:
+            case Const.LAND:
+            case Const.IOR:
+            case Const.LOR:
+            case Const.IXOR:
+            case Const.LXOR:
+                long badValue = (seen == Const.IAND || seen == Const.LAND) ? -1 : 0;
                 OpcodeStack.Item rhs = stack.getStackItem(0);
                 OpcodeStack.Item lhs = stack.getStackItem(1);
                 int prevOpcode = getPrevOpcode(1);
                 int prevPrevOpcode = getPrevOpcode(2);
                 if (rhs.hasConstantValue(badValue)
-                        && (prevOpcode == LDC || prevOpcode == ICONST_0 || prevOpcode == ICONST_M1 || prevOpcode == LCONST_0)
-                        && prevPrevOpcode != GOTO) {
+                        && (prevOpcode == Const.LDC || prevOpcode == Const.ICONST_0 || prevOpcode == Const.ICONST_M1 || prevOpcode == Const.LCONST_0)
+                        && prevPrevOpcode != Const.GOTO) {
                     reportVacuousBitOperation(seen, lhs);
                 }
 
             }
 
-            if (checkForBitIorofSignedByte && seen != I2B) {
-                String pattern = (prevOpcode == LOR || prevOpcode == IOR) ? "BIT_IOR_OF_SIGNED_BYTE" : "BIT_ADD_OF_SIGNED_BYTE";
-                int priority = (prevOpcode == LOR || prevOpcode == LADD) ? HIGH_PRIORITY : NORMAL_PRIORITY;
+            if (checkForBitIorofSignedByte && seen != Const.I2B) {
+                String pattern = (prevOpcode == Const.LOR || prevOpcode == Const.IOR) ? "BIT_IOR_OF_SIGNED_BYTE" : "BIT_ADD_OF_SIGNED_BYTE";
+                int priority = (prevOpcode == Const.LOR || prevOpcode == Const.LADD) ? HIGH_PRIORITY : NORMAL_PRIORITY;
                 accumulator.accumulateBug(new BugInstance(this, pattern, priority).addClassAndMethod(this), this);
 
                 checkForBitIorofSignedByte = false;
-            } else if ((seen == IOR || seen == LOR || seen == IADD || seen == LADD) && stack.getStackDepth() >= 2) {
+            } else if ((seen == Const.IOR || seen == Const.LOR || seen == Const.IADD || seen == Const.LADD) && stack.getStackDepth() >= 2) {
                 OpcodeStack.Item item0 = stack.getStackItem(0);
                 OpcodeStack.Item item1 = stack.getStackItem(1);
 
@@ -1123,40 +1123,40 @@ public class DumbMethods extends OpcodeStackDetector {
                 checkForBitIorofSignedByte = false;
             }
 
-            if (prevOpcodeWasReadLine && sinceBufferedInputStreamReady >= 100 && seen == INVOKEVIRTUAL
+            if (prevOpcodeWasReadLine && sinceBufferedInputStreamReady >= 100 && seen == Const.INVOKEVIRTUAL
                     && "java/lang/String".equals(getClassConstantOperand()) && getSigConstantOperand().startsWith("()")) {
                 accumulator.accumulateBug(
                         new BugInstance(this, "NP_IMMEDIATE_DEREFERENCE_OF_READLINE", NORMAL_PRIORITY).addClassAndMethod(this),
                         this);
             }
 
-            if (seen == INVOKEVIRTUAL && "java/io/BufferedReader".equals(getClassConstantOperand())
+            if (seen == Const.INVOKEVIRTUAL && "java/io/BufferedReader".equals(getClassConstantOperand())
                     && "ready".equals(getNameConstantOperand()) && "()Z".equals(getSigConstantOperand())) {
                 sinceBufferedInputStreamReady = 0;
             } else {
                 sinceBufferedInputStreamReady++;
             }
 
-            prevOpcodeWasReadLine = (seen == INVOKEVIRTUAL || seen == INVOKEINTERFACE)
+            prevOpcodeWasReadLine = (seen == Const.INVOKEVIRTUAL || seen == Const.INVOKEINTERFACE)
                     && "readLine".equals(getNameConstantOperand()) && "()Ljava/lang/String;".equals(getSigConstantOperand());
 
             // System.out.println(randomNextIntState + " " + OPCODE_NAMES[seen]
             // + " " + getMethodName());
             switch (randomNextIntState) {
             case 0:
-                if (seen == INVOKEVIRTUAL && "java/util/Random".equals(getClassConstantOperand())
-                && "nextDouble".equals(getNameConstantOperand()) || seen == INVOKESTATIC
+                if (seen == Const.INVOKEVIRTUAL && "java/util/Random".equals(getClassConstantOperand())
+                && "nextDouble".equals(getNameConstantOperand()) || seen == Const.INVOKESTATIC
                 && ClassName.isMathClass(getClassConstantOperand()) && "random".equals(getNameConstantOperand())) {
                     randomNextIntState = 1;
                 }
                 break;
             case 1:
-                if (seen == D2I) {
+                if (seen == Const.D2I) {
                     accumulator.accumulateBug(new BugInstance(this, "RV_01_TO_INT", HIGH_PRIORITY).addClassAndMethod(this), this);
                     randomNextIntState = 0;
-                } else if (seen == DMUL) {
+                } else if (seen == Const.DMUL) {
                     randomNextIntState = 4;
-                } else if (seen == LDC2_W && getConstantRefOperand() instanceof ConstantDouble
+                } else if (seen == Const.LDC2_W && getConstantRefOperand() instanceof ConstantDouble
                         && ((ConstantDouble) getConstantRefOperand()).getBytes() == Integer.MIN_VALUE) {
                     randomNextIntState = 0;
                 } else {
@@ -1165,23 +1165,23 @@ public class DumbMethods extends OpcodeStackDetector {
 
                 break;
             case 2:
-                if (seen == I2D) {
+                if (seen == Const.I2D) {
                     randomNextIntState = 3;
-                } else if (seen == DMUL) {
+                } else if (seen == Const.DMUL) {
                     randomNextIntState = 4;
                 } else {
                     randomNextIntState = 0;
                 }
                 break;
             case 3:
-                if (seen == DMUL) {
+                if (seen == Const.DMUL) {
                     randomNextIntState = 4;
                 } else {
                     randomNextIntState = 0;
                 }
                 break;
             case 4:
-                if (seen == D2I) {
+                if (seen == Const.D2I) {
                     accumulator.accumulateBug(
                             new BugInstance(this, "DM_NEXTINT_VIA_NEXTDOUBLE", NORMAL_PRIORITY).addClassAndMethod(this), this);
                 }
@@ -1191,7 +1191,7 @@ public class DumbMethods extends OpcodeStackDetector {
                 throw new IllegalStateException();
             }
             if (isPublicStaticVoidMain
-                    && seen == INVOKEVIRTUAL
+                    && seen == Const.INVOKEVIRTUAL
                     && getClassConstantOperand().startsWith("javax/swing/")
                     && ("show".equals(getNameConstantOperand()) && "()V".equals(getSigConstantOperand())
                             || "pack".equals(getNameConstantOperand()) && "()V".equals(getSigConstantOperand()) || "setVisible".equals(getNameConstantOperand()) && "(Z)V".equals(getSigConstantOperand()))) {
@@ -1200,7 +1200,7 @@ public class DumbMethods extends OpcodeStackDetector {
                         this);
             }
 
-            // if ((seen == INVOKEVIRTUAL)
+            // if ((seen == Const.INVOKEVIRTUAL)
             // && getClassConstantOperand().equals("java/lang/String")
             // && getNameConstantOperand().equals("substring")
             // && getSigConstantOperand().equals("(I)Ljava/lang/String;")
@@ -1217,7 +1217,7 @@ public class DumbMethods extends OpcodeStackDetector {
             // }
             // }
 
-            if ((seen == INVOKEVIRTUAL) && "isAnnotationPresent".equals(getNameConstantOperand())
+            if ((seen == Const.INVOKEVIRTUAL) && "isAnnotationPresent".equals(getNameConstantOperand())
                     && "(Ljava/lang/Class;)Z".equals(getSigConstantOperand()) && stack.getStackDepth() > 0) {
                 OpcodeStack.Item item = stack.getStackItem(0);
                 Object value = item.getConstant();
@@ -1236,7 +1236,7 @@ public class DumbMethods extends OpcodeStackDetector {
                 }
 
             }
-            if ((seen == INVOKEVIRTUAL) && "next".equals(getNameConstantOperand())
+            if ((seen == Const.INVOKEVIRTUAL) && "next".equals(getNameConstantOperand())
                     && "()Ljava/lang/Object;".equals(getSigConstantOperand()) && "hasNext".equals(getMethodName())
                     && "()Z".equals(getMethodSig()) && stack.getStackDepth() > 0) {
                 OpcodeStack.Item item = stack.getStackItem(0);
@@ -1247,7 +1247,7 @@ public class DumbMethods extends OpcodeStackDetector {
 
             }
 
-            if ((seen == INVOKESPECIAL) && "java/lang/String".equals(getClassConstantOperand())
+            if ((seen == Const.INVOKESPECIAL) && "java/lang/String".equals(getClassConstantOperand())
                     && "<init>".equals(getNameConstantOperand()) && "(Ljava/lang/String;)V".equals(getSigConstantOperand())
                     && !Subtypes2.isJSP(getThisClass())) {
 
@@ -1255,15 +1255,15 @@ public class DumbMethods extends OpcodeStackDetector {
 
             }
 
-            if (seen == INVOKESTATIC && "java/lang/System".equals(getClassConstantOperand())
-                    && "runFinalizersOnExit".equals(getNameConstantOperand()) || seen == INVOKEVIRTUAL
+            if (seen == Const.INVOKESTATIC && "java/lang/System".equals(getClassConstantOperand())
+                    && "runFinalizersOnExit".equals(getNameConstantOperand()) || seen == Const.INVOKEVIRTUAL
                     && "java/lang/Runtime".equals(getClassConstantOperand())
                     && "runFinalizersOnExit".equals(getNameConstantOperand())) {
                 accumulator.accumulateBug(
                         new BugInstance(this, "DM_RUN_FINALIZERS_ON_EXIT", HIGH_PRIORITY).addClassAndMethod(this), this);
             }
 
-            if ((seen == INVOKESPECIAL) && "java/lang/String".equals(getClassConstantOperand())
+            if ((seen == Const.INVOKESPECIAL) && "java/lang/String".equals(getClassConstantOperand())
                     && "<init>".equals(getNameConstantOperand()) && "()V".equals(getSigConstantOperand())) {
 
                 accumulator.accumulateBug(new BugInstance(this, "DM_STRING_VOID_CTOR", NORMAL_PRIORITY).addClassAndMethod(this),
@@ -1271,7 +1271,7 @@ public class DumbMethods extends OpcodeStackDetector {
 
             }
 
-            if (!isPublicStaticVoidMain && seen == INVOKESTATIC && "java/lang/System".equals(getClassConstantOperand())
+            if (!isPublicStaticVoidMain && seen == Const.INVOKESTATIC && "java/lang/System".equals(getClassConstantOperand())
                     && "exit".equals(getNameConstantOperand()) && !"processWindowEvent".equals(getMethodName())
                     && !getMethodName().startsWith("windowClos") && getMethodName().indexOf("exit") == -1
                     && getMethodName().indexOf("Exit") == -1 && getMethodName().indexOf("crash") == -1
@@ -1280,7 +1280,7 @@ public class DumbMethods extends OpcodeStackDetector {
                 accumulator.accumulateBug(new BugInstance(this, "DM_EXIT", getMethod().isStatic() ? LOW_PRIORITY
                         : NORMAL_PRIORITY).addClassAndMethod(this), SourceLineAnnotation.fromVisitedInstruction(this));
             }
-            if (((seen == INVOKESTATIC && "java/lang/System".equals(getClassConstantOperand())) || (seen == INVOKEVIRTUAL && "java/lang/Runtime".equals(getClassConstantOperand())))
+            if (((seen == Const.INVOKESTATIC && "java/lang/System".equals(getClassConstantOperand())) || (seen == Const.INVOKEVIRTUAL && "java/lang/Runtime".equals(getClassConstantOperand())))
                     && "gc".equals(getNameConstantOperand())
                     && "()V".equals(getSigConstantOperand())
                     && !getDottedClassName().startsWith("java.lang")
@@ -1303,20 +1303,20 @@ public class DumbMethods extends OpcodeStackDetector {
                     // System.out.println("GC invocation at pc " + PC);
                 }
             }
-            if (!isSynthetic && (seen == INVOKESPECIAL) && "java/lang/Boolean".equals(getClassConstantOperand())
+            if (!isSynthetic && (seen == Const.INVOKESPECIAL) && "java/lang/Boolean".equals(getClassConstantOperand())
                     && "<init>".equals(getNameConstantOperand()) && !"java/lang/Boolean".equals(getClassName())) {
                 int majorVersion = getThisClass().getMajor();
-                if (majorVersion >= MAJOR_1_4) {
+                if (majorVersion >= Const.MAJOR_1_4) {
                     accumulator.accumulateBug(new BugInstance(this, "DM_BOOLEAN_CTOR", NORMAL_PRIORITY).addClassAndMethod(this),
                             this);
                 }
 
             }
-            if ((seen == INVOKESTATIC) && "java/lang/System".equals(getClassConstantOperand())
+            if ((seen == Const.INVOKESTATIC) && "java/lang/System".equals(getClassConstantOperand())
                     && ("currentTimeMillis".equals(getNameConstantOperand()) || "nanoTime".equals(getNameConstantOperand()))) {
                 sawCurrentTimeMillis = true;
             }
-            if ((seen == INVOKEVIRTUAL) && "java/lang/String".equals(getClassConstantOperand())
+            if ((seen == Const.INVOKEVIRTUAL) && "java/lang/String".equals(getClassConstantOperand())
                     && "toString".equals(getNameConstantOperand()) && "()Ljava/lang/String;".equals(getSigConstantOperand())) {
 
                 accumulator
@@ -1324,7 +1324,7 @@ public class DumbMethods extends OpcodeStackDetector {
 
             }
 
-            if ((seen == INVOKEVIRTUAL) && "java/lang/String".equals(getClassConstantOperand())
+            if ((seen == Const.INVOKEVIRTUAL) && "java/lang/String".equals(getClassConstantOperand())
                     && ("toUpperCase".equals(getNameConstantOperand()) || "toLowerCase".equals(getNameConstantOperand()))
                     && "()Ljava/lang/String;".equals(getSigConstantOperand())) {
 
@@ -1332,7 +1332,7 @@ public class DumbMethods extends OpcodeStackDetector {
 
             }
 
-            if ((seen == INVOKESPECIAL) && "<init>".equals(getNameConstantOperand())) {
+            if ((seen == Const.INVOKESPECIAL) && "<init>".equals(getNameConstantOperand())) {
                 String cls = getClassConstantOperand();
                 String sig = getSigConstantOperand();
                 String primitiveType = ClassName.getPrimitiveType(cls);
@@ -1341,7 +1341,7 @@ public class DumbMethods extends OpcodeStackDetector {
                 } else {
                     primitiveObjCtorSeen = null;
                 }
-            } else if ((primitiveObjCtorSeen != null) && (seen == INVOKEVIRTUAL) && "toString".equals(getNameConstantOperand())
+            } else if ((primitiveObjCtorSeen != null) && (seen == Const.INVOKEVIRTUAL) && "toString".equals(getNameConstantOperand())
                     && getClassConstantOperand().equals(primitiveObjCtorSeen)
                     && "()Ljava/lang/String;".equals(getSigConstantOperand())) {
                 BugInstance bug = new BugInstance(this, "DM_BOXED_PRIMITIVE_TOSTRING", NORMAL_PRIORITY).addClassAndMethod(this).addCalledMethod(this);
@@ -1356,9 +1356,9 @@ public class DumbMethods extends OpcodeStackDetector {
                 primitiveObjCtorSeen = null;
             }
 
-            if ((seen == INVOKESPECIAL) && "<init>".equals(getNameConstantOperand())) {
+            if ((seen == Const.INVOKESPECIAL) && "<init>".equals(getNameConstantOperand())) {
                 ctorSeen = true;
-            } else if (ctorSeen && (seen == INVOKEVIRTUAL) && "java/lang/Object".equals(getClassConstantOperand())
+            } else if (ctorSeen && (seen == Const.INVOKEVIRTUAL) && "java/lang/Object".equals(getClassConstantOperand())
                     && "getClass".equals(getNameConstantOperand()) && "()Ljava/lang/Class;".equals(getSigConstantOperand())) {
                 accumulator.accumulateBug(new BugInstance(this, "DM_NEW_FOR_GETCLASS", NORMAL_PRIORITY).addClassAndMethod(this),
                         this);
@@ -1367,11 +1367,11 @@ public class DumbMethods extends OpcodeStackDetector {
                 ctorSeen = false;
             }
 
-            if ((seen == INVOKEVIRTUAL) && isMonitorWait(getNameConstantOperand(), getSigConstantOperand())) {
+            if ((seen == Const.INVOKEVIRTUAL) && isMonitorWait(getNameConstantOperand(), getSigConstantOperand())) {
                 checkMonitorWait();
             }
 
-            if ((seen == INVOKESPECIAL) && "<init>".equals(getNameConstantOperand())
+            if ((seen == Const.INVOKESPECIAL) && "<init>".equals(getNameConstantOperand())
                     && "java/lang/Thread".equals(getClassConstantOperand())) {
                 String sig = getSigConstantOperand();
                 if ("()V".equals(sig) || "(Ljava/lang/String;)V".equals(sig)
@@ -1385,7 +1385,7 @@ public class DumbMethods extends OpcodeStackDetector {
                 }
             }
 
-            if (seen == INVOKESPECIAL && "java/math/BigDecimal".equals(getClassConstantOperand())
+            if (seen == Const.INVOKESPECIAL && "java/math/BigDecimal".equals(getClassConstantOperand())
                     && "<init>".equals(getNameConstantOperand()) && "(D)V".equals(getSigConstantOperand())) {
                 OpcodeStack.Item top = stack.getStackItem(0);
                 Object value = top.getConstant();
@@ -1444,7 +1444,7 @@ public class DumbMethods extends OpcodeStackDetector {
             .accumulateBug(
                     new BugInstance(this, "INT_VACUOUS_BIT_OPERATION", NORMAL_PRIORITY)
                     .addClassAndMethod(this)
-                    .addString(OPCODE_NAMES[seen])
+                    .addString(Const.getOpcodeName(seen))
                     .addOptionalAnnotation(
                             LocalVariableAnnotation.getLocalVariableAnnotation(getMethod(), item, getPC())), this);
         }
@@ -1457,35 +1457,35 @@ public class DumbMethods extends OpcodeStackDetector {
      */
     private int stackEntryThatMustBeNonnegative(int seen) {
         switch (seen) {
-        case INVOKEINTERFACE:
+        case Const.INVOKEINTERFACE:
             if ("java/util/List".equals(getClassConstantOperand())) {
                 return getStackEntryOfListCallThatMustBeNonnegative();
             }
             break;
-        case INVOKEVIRTUAL:
+        case Const.INVOKEVIRTUAL:
             if ("java/util/LinkedList".equals(getClassConstantOperand())
                     || "java/util/ArrayList".equals(getClassConstantOperand())) {
                 return getStackEntryOfListCallThatMustBeNonnegative();
             }
             break;
 
-        case IALOAD:
-        case AALOAD:
-        case SALOAD:
-        case CALOAD:
-        case BALOAD:
-        case LALOAD:
-        case DALOAD:
-        case FALOAD:
+        case Const.IALOAD:
+        case Const.AALOAD:
+        case Const.SALOAD:
+        case Const.CALOAD:
+        case Const.BALOAD:
+        case Const.LALOAD:
+        case Const.DALOAD:
+        case Const.FALOAD:
             return 0;
-        case IASTORE:
-        case AASTORE:
-        case SASTORE:
-        case CASTORE:
-        case BASTORE:
-        case LASTORE:
-        case DASTORE:
-        case FASTORE:
+        case Const.IASTORE:
+        case Const.AASTORE:
+        case Const.SASTORE:
+        case Const.CASTORE:
+        case Const.BASTORE:
+        case Const.LASTORE:
+        case Const.DASTORE:
+        case Const.FASTORE:
             return 1;
         }
         return -1;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DumbMethods.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DumbMethods.java
@@ -353,7 +353,7 @@ public class DumbMethods extends OpcodeStackDetector {
                 }
                 if ((m.getSignature().startsWith("([BII)") || m.getSignature().startsWith("([CII)") || m.getSignature().startsWith("([III)"))
                         && (((m.getName().equals("write") || m.getName().equals("read")) && m.getSlashedClassName().startsWith(
-                                "java/io/")) || (m.getName().equals("<init>") && m.getSlashedClassName().equals("java/lang/String")))) {
+                                "java/io/")) || (m.getName().equals(Const.CONSTRUCTOR_NAME) && m.getSlashedClassName().equals("java/lang/String")))) {
                     Item arrayArg = stack.getStackItem(2);
                     Item offsetArg = stack.getStackItem(1);
                     Item lengthArg = stack.getStackItem(0);
@@ -499,7 +499,7 @@ public class DumbMethods extends OpcodeStackDetector {
             }
             freshRandomOneBelowTos = freshRandomOnTos && isRegisterLoad();
             freshRandomOnTos = seen == Const.INVOKESPECIAL && "java/util/Random".equals(getClassConstantOperand())
-                    && "<init>".equals(getNameConstantOperand());
+                    && Const.CONSTRUCTOR_NAME.equals(getNameConstantOperand());
         }
     }
 
@@ -663,7 +663,7 @@ public class DumbMethods extends OpcodeStackDetector {
                 }  else if ("intValue".equals(called.getName())
                         && "java/lang/Integer".equals(called.getClassDescriptor().getClassName())
                         && "java/lang/Integer".equals(previousMethodCall.getSlashedClassName())
-                        && ("<init>".equals(previousMethodCall.getName())
+                        && (Const.CONSTRUCTOR_NAME.equals(previousMethodCall.getName())
                                 && "(Ljava/lang/String;)V".equals(previousMethodCall.getSignature())
                                 || "valueOf".equals(previousMethodCall.getName())
                                 && "(Ljava/lang/String;)Ljava/lang/Integer;".equals(previousMethodCall.getSignature())
@@ -677,7 +677,7 @@ public class DumbMethods extends OpcodeStackDetector {
                 }  else if ("longValue".equals(called.getName())
                         && "java/lang/Long".equals(called.getClassDescriptor().getClassName())
                         && "java/lang/Long".equals(previousMethodCall.getSlashedClassName())
-                        && ( "<init>".equals(previousMethodCall.getName())
+                        && ( Const.CONSTRUCTOR_NAME.equals(previousMethodCall.getName())
                                 && "(Ljava/lang/String;)V".equals(previousMethodCall.getSignature())
                                 ||  "valueOf".equals(previousMethodCall.getName())
                                 && "(Ljava/lang/String;)Ljava/lang/Long;".equals(previousMethodCall.getSignature()))
@@ -856,7 +856,7 @@ public class DumbMethods extends OpcodeStackDetector {
          *
         if (false && seen == INVOKESPECIAL
                 && getClassConstantOperand().equals("java/util/concurrent/ScheduledThreadPoolExecutor")
-                && getNameConstantOperand().equals("<init>")) {
+                && getNameConstantOperand().equals(Const.CONSTRUCTOR_NAME)) {
 
             int arguments = getNumberArguments(getSigConstantOperand());
             OpcodeStack.Item item = stack.getStackItem(arguments - 1);
@@ -1248,7 +1248,7 @@ public class DumbMethods extends OpcodeStackDetector {
             }
 
             if ((seen == Const.INVOKESPECIAL) && "java/lang/String".equals(getClassConstantOperand())
-                    && "<init>".equals(getNameConstantOperand()) && "(Ljava/lang/String;)V".equals(getSigConstantOperand())
+                    && Const.CONSTRUCTOR_NAME.equals(getNameConstantOperand()) && "(Ljava/lang/String;)V".equals(getSigConstantOperand())
                     && !Subtypes2.isJSP(getThisClass())) {
 
                 accumulator.accumulateBug(new BugInstance(this, "DM_STRING_CTOR", NORMAL_PRIORITY).addClassAndMethod(this), this);
@@ -1264,7 +1264,7 @@ public class DumbMethods extends OpcodeStackDetector {
             }
 
             if ((seen == Const.INVOKESPECIAL) && "java/lang/String".equals(getClassConstantOperand())
-                    && "<init>".equals(getNameConstantOperand()) && "()V".equals(getSigConstantOperand())) {
+                    && Const.CONSTRUCTOR_NAME.equals(getNameConstantOperand()) && "()V".equals(getSigConstantOperand())) {
 
                 accumulator.accumulateBug(new BugInstance(this, "DM_STRING_VOID_CTOR", NORMAL_PRIORITY).addClassAndMethod(this),
                         this);
@@ -1304,7 +1304,7 @@ public class DumbMethods extends OpcodeStackDetector {
                 }
             }
             if (!isSynthetic && (seen == Const.INVOKESPECIAL) && "java/lang/Boolean".equals(getClassConstantOperand())
-                    && "<init>".equals(getNameConstantOperand()) && !"java/lang/Boolean".equals(getClassName())) {
+                    && Const.CONSTRUCTOR_NAME.equals(getNameConstantOperand()) && !"java/lang/Boolean".equals(getClassName())) {
                 int majorVersion = getThisClass().getMajor();
                 if (majorVersion >= Const.MAJOR_1_4) {
                     accumulator.accumulateBug(new BugInstance(this, "DM_BOOLEAN_CTOR", NORMAL_PRIORITY).addClassAndMethod(this),
@@ -1332,7 +1332,7 @@ public class DumbMethods extends OpcodeStackDetector {
 
             }
 
-            if ((seen == Const.INVOKESPECIAL) && "<init>".equals(getNameConstantOperand())) {
+            if ((seen == Const.INVOKESPECIAL) && Const.CONSTRUCTOR_NAME.equals(getNameConstantOperand())) {
                 String cls = getClassConstantOperand();
                 String sig = getSigConstantOperand();
                 String primitiveType = ClassName.getPrimitiveType(cls);
@@ -1356,7 +1356,7 @@ public class DumbMethods extends OpcodeStackDetector {
                 primitiveObjCtorSeen = null;
             }
 
-            if ((seen == Const.INVOKESPECIAL) && "<init>".equals(getNameConstantOperand())) {
+            if ((seen == Const.INVOKESPECIAL) && Const.CONSTRUCTOR_NAME.equals(getNameConstantOperand())) {
                 ctorSeen = true;
             } else if (ctorSeen && (seen == Const.INVOKEVIRTUAL) && "java/lang/Object".equals(getClassConstantOperand())
                     && "getClass".equals(getNameConstantOperand()) && "()Ljava/lang/Class;".equals(getSigConstantOperand())) {
@@ -1371,13 +1371,13 @@ public class DumbMethods extends OpcodeStackDetector {
                 checkMonitorWait();
             }
 
-            if ((seen == Const.INVOKESPECIAL) && "<init>".equals(getNameConstantOperand())
+            if ((seen == Const.INVOKESPECIAL) && Const.CONSTRUCTOR_NAME.equals(getNameConstantOperand())
                     && "java/lang/Thread".equals(getClassConstantOperand())) {
                 String sig = getSigConstantOperand();
                 if ("()V".equals(sig) || "(Ljava/lang/String;)V".equals(sig)
                         || "(Ljava/lang/ThreadGroup;Ljava/lang/String;)V".equals(sig)) {
                     OpcodeStack.Item invokedOn = stack.getItemMethodInvokedOn(this);
-                    if (!"<init>".equals(getMethodName()) || invokedOn.getRegisterNumber() != 0) {
+                    if (!Const.CONSTRUCTOR_NAME.equals(getMethodName()) || invokedOn.getRegisterNumber() != 0) {
                         accumulator.accumulateBug(
                                 new BugInstance(this, "DM_USELESS_THREAD", LOW_PRIORITY).addClassAndMethod(this), this);
 
@@ -1386,7 +1386,7 @@ public class DumbMethods extends OpcodeStackDetector {
             }
 
             if (seen == Const.INVOKESPECIAL && "java/math/BigDecimal".equals(getClassConstantOperand())
-                    && "<init>".equals(getNameConstantOperand()) && "(D)V".equals(getSigConstantOperand())) {
+                    && Const.CONSTRUCTOR_NAME.equals(getNameConstantOperand()) && "(D)V".equals(getSigConstantOperand())) {
                 OpcodeStack.Item top = stack.getStackItem(0);
                 Object value = top.getConstant();
                 if (value instanceof Double && !((Double)value).isInfinite() && !((Double)value).isNaN()) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/EmptyZipFileEntry.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/EmptyZipFileEntry.java
@@ -19,6 +19,7 @@
 
 package edu.umd.cs.findbugs.detect;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.classfile.Method;
 
@@ -56,7 +57,7 @@ public class EmptyZipFileEntry extends BytecodeScanningDetector implements State
 
     @Override
     public void sawOpcode(int seen) {
-        if (seen == INVOKEVIRTUAL && "putNextEntry".equals(getNameConstantOperand())) {
+        if (seen == Const.INVOKEVIRTUAL && "putNextEntry".equals(getNameConstantOperand())) {
             streamType = getClassConstantOperand();
             if ("java/util/zip/ZipOutputStream".equals(streamType) || "java/util/jar/JarOutputStream".equals(streamType)) {
                 sawPutEntry = getPC();
@@ -64,7 +65,7 @@ public class EmptyZipFileEntry extends BytecodeScanningDetector implements State
                 streamType = "";
             }
         } else {
-            if (getPC() - sawPutEntry <= 7 && seen == INVOKEVIRTUAL && "closeEntry".equals(getNameConstantOperand())
+            if (getPC() - sawPutEntry <= 7 && seen == Const.INVOKEVIRTUAL && "closeEntry".equals(getNameConstantOperand())
                     && getClassConstantOperand().equals(streamType)) {
                 bugReporter
                 .reportBug(new BugInstance(this,

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/EqualsOperandShouldHaveClassCompatibleWithThis.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/EqualsOperandShouldHaveClassCompatibleWithThis.java
@@ -19,6 +19,7 @@
 
 package edu.umd.cs.findbugs.detect;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 import org.apache.bcel.generic.Type;
 
@@ -71,7 +72,7 @@ public class EqualsOperandShouldHaveClassCompatibleWithThis extends OpcodeStackD
      */
     @Override
     public void sawOpcode(int seen) {
-        if (seen == INVOKEVIRTUAL) {
+        if (seen == Const.INVOKEVIRTUAL) {
             if ("equals".equals(getNameConstantOperand()) && "(Ljava/lang/Object;)Z".equals(getSigConstantOperand())) {
                 OpcodeStack.Item item = stack.getStackItem(1);
                 ClassDescriptor c = DescriptorFactory.createClassDescriptorFromSignature(item.getSignature());
@@ -90,7 +91,7 @@ public class EqualsOperandShouldHaveClassCompatibleWithThis extends OpcodeStackD
 
             }
 
-        } else if (seen == INSTANCEOF || seen == CHECKCAST) {
+        } else if (seen == Const.INSTANCEOF || seen == Const.CHECKCAST) {
             check(getClassDescriptorOperand());
         }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ExplicitSerialization.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ExplicitSerialization.java
@@ -23,6 +23,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.JavaClass;
 
 import edu.umd.cs.findbugs.BugReporter;
@@ -67,7 +68,7 @@ public class ExplicitSerialization extends OpcodeStackDetector implements NonRep
 
     @Override
     public void sawOpcode(int seen) {
-        if (seen == INVOKEVIRTUAL && writeObject.equals(getXMethodOperand())) {
+        if (seen == Const.INVOKEVIRTUAL && writeObject.equals(getXMethodOperand())) {
             OpcodeStack.Item top = stack.getStackItem(0);
             String signature = top.getSignature();
             while (signature.charAt(0) == '[') {
@@ -95,7 +96,7 @@ public class ExplicitSerialization extends OpcodeStackDetector implements NonRep
             }
 
         }
-        if (seen == CHECKCAST) {
+        if (seen == Const.CHECKCAST) {
             OpcodeStack.Item top = stack.getStackItem(0);
             if (readObject.equals(top.getReturnValueOf())) {
                 ClassDescriptor c = getClassDescriptorOperand();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FieldItemSummary.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FieldItemSummary.java
@@ -22,6 +22,7 @@ package edu.umd.cs.findbugs.detect;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.JavaClass;
 
@@ -59,7 +60,7 @@ public class FieldItemSummary extends OpcodeStackDetector implements NonReportin
 
     @Override
     public void sawOpcode(int seen) {
-        if ("<init>".equals(getMethodName()) && seen == INVOKEVIRTUAL) {
+        if ("<init>".equals(getMethodName()) && seen == Const.INVOKEVIRTUAL) {
             XMethod m = getXMethodOperand();
             if (m != null && !m.isPrivate() && !m.isFinal()) {
                 int args = PreorderVisitor.getNumberArguments(m.getSignature());
@@ -85,7 +86,7 @@ public class FieldItemSummary extends OpcodeStackDetector implements NonReportin
 
         }
 
-        if (seen == INVOKESPECIAL && "<init>".equals(getMethodName()) && "<init>".equals(getNameConstantOperand())) {
+        if (seen == Const.INVOKESPECIAL && "<init>".equals(getMethodName()) && "<init>".equals(getNameConstantOperand())) {
 
             String classOperand = getClassConstantOperand();
             OpcodeStack.Item invokedOn = stack.getItemMethodInvokedOn(this);
@@ -99,7 +100,7 @@ public class FieldItemSummary extends OpcodeStackDetector implements NonReportin
 
         }
 
-        if (seen == PUTFIELD || seen == PUTSTATIC) {
+        if (seen == Const.PUTFIELD || seen == Const.PUTSTATIC) {
             XField fieldOperand = getXFieldOperand();
             if (fieldOperand == null) {
                 return;
@@ -107,14 +108,14 @@ public class FieldItemSummary extends OpcodeStackDetector implements NonReportin
             touched.add(fieldOperand);
             if (!fieldOperand.getClassDescriptor().getClassName().equals(getClassName())) {
                 fieldSummary.addWrittenOutsideOfConstructor(fieldOperand);
-            } else if (seen == PUTFIELD) {
+            } else if (seen == Const.PUTFIELD) {
                 OpcodeStack.Item addr = stack.getStackItem(1);
                 {
                     if (addr.getRegisterNumber() != 0 || !"<init>".equals(getMethodName())) {
                         fieldSummary.addWrittenOutsideOfConstructor(fieldOperand);
                     }
                 }
-            } else if (seen == PUTSTATIC && !"<clinit>".equals(getMethodName())) {
+            } else if (seen == Const.PUTSTATIC && !"<clinit>".equals(getMethodName())) {
                 fieldSummary.addWrittenOutsideOfConstructor(fieldOperand);
             }
             OpcodeStack.Item top = stack.getStackItem(0);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FieldItemSummary.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FieldItemSummary.java
@@ -60,7 +60,7 @@ public class FieldItemSummary extends OpcodeStackDetector implements NonReportin
 
     @Override
     public void sawOpcode(int seen) {
-        if ("<init>".equals(getMethodName()) && seen == Const.INVOKEVIRTUAL) {
+        if (Const.CONSTRUCTOR_NAME.equals(getMethodName()) && seen == Const.INVOKEVIRTUAL) {
             XMethod m = getXMethodOperand();
             if (m != null && !m.isPrivate() && !m.isFinal()) {
                 int args = PreorderVisitor.getNumberArguments(m.getSignature());
@@ -86,7 +86,7 @@ public class FieldItemSummary extends OpcodeStackDetector implements NonReportin
 
         }
 
-        if (seen == Const.INVOKESPECIAL && "<init>".equals(getMethodName()) && "<init>".equals(getNameConstantOperand())) {
+        if (seen == Const.INVOKESPECIAL && Const.CONSTRUCTOR_NAME.equals(getMethodName()) && Const.CONSTRUCTOR_NAME.equals(getNameConstantOperand())) {
 
             String classOperand = getClassConstantOperand();
             OpcodeStack.Item invokedOn = stack.getItemMethodInvokedOn(this);
@@ -111,11 +111,11 @@ public class FieldItemSummary extends OpcodeStackDetector implements NonReportin
             } else if (seen == Const.PUTFIELD) {
                 OpcodeStack.Item addr = stack.getStackItem(1);
                 {
-                    if (addr.getRegisterNumber() != 0 || !"<init>".equals(getMethodName())) {
+                    if (addr.getRegisterNumber() != 0 || !Const.CONSTRUCTOR_NAME.equals(getMethodName())) {
                         fieldSummary.addWrittenOutsideOfConstructor(fieldOperand);
                     }
                 }
-            } else if (seen == Const.PUTSTATIC && !"<clinit>".equals(getMethodName())) {
+            } else if (seen == Const.PUTSTATIC && !Const.STATIC_INITIALIZER_NAME.equals(getMethodName())) {
                 fieldSummary.addWrittenOutsideOfConstructor(fieldOperand);
             }
             OpcodeStack.Item top = stack.getStackItem(0);
@@ -129,7 +129,7 @@ public class FieldItemSummary extends OpcodeStackDetector implements NonReportin
         sawInitializeSuper = false;
         super.visit(obj);
         fieldSummary.setFieldsWritten(getXMethod(), touched);
-        if ("<init>".equals(getMethodName()) && sawInitializeSuper) {
+        if (Const.CONSTRUCTOR_NAME.equals(getMethodName()) && sawInitializeSuper) {
             XClass thisClass = getXClass();
             for (XField f : thisClass.getXFields()) {
                 if (!f.isStatic() && !f.isFinal() && !touched.contains(f)) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FinalizerNullsFields.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FinalizerNullsFields.java
@@ -22,6 +22,7 @@
 
 package edu.umd.cs.findbugs.detect;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.Field;
 import org.apache.bcel.classfile.Method;
@@ -81,17 +82,17 @@ public class FinalizerNullsFields extends BytecodeScanningDetector {
 
     @Override
     public void sawOpcode(int seen) {
-        if (state == 0 && seen == ALOAD_0) {
+        if (state == 0 && seen == Const.ALOAD_0) {
             state++;
-        } else if (state == 1 && seen == ACONST_NULL) {
+        } else if (state == 1 && seen == Const.ACONST_NULL) {
             state++;
-        } else if (state == 2 && seen == PUTFIELD) {
+        } else if (state == 2 && seen == Const.PUTFIELD) {
             bugAccumulator.accumulateBug(
                     new BugInstance(this, "FI_FINALIZER_NULLS_FIELDS", NORMAL_PRIORITY).addClassAndMethod(this)
                     .addReferencedField(this), this);
             sawFieldNulling = true;
             state = 0;
-        } else if (seen == RETURN) {
+        } else if (seen == Const.RETURN) {
             state = 0;
         } else {
             state = 0;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindBadForLoop.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindBadForLoop.java
@@ -19,6 +19,7 @@
 
 package edu.umd.cs.findbugs.detect;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.LineNumberTable;
 
@@ -49,12 +50,12 @@ public class FindBadForLoop extends OpcodeStackDetector implements StatelessDete
 
     @Override
     public void sawOpcode(int seen) {
-        if (seen == ISTORE || seen == ISTORE_0 || seen == ISTORE_1 || seen == ISTORE_2 || seen == ISTORE_3) {
+        if (seen == Const.ISTORE || seen == Const.ISTORE_0 || seen == Const.ISTORE_1 || seen == Const.ISTORE_2 || seen == Const.ISTORE_3) {
             lastRegStore = getRegisterOperand();
         }
         if (lineNumbers != null
                 && stack.getStackDepth() >= 2
-                && (seen == IF_ICMPGE || seen == IF_ICMPGT || seen == IF_ICMPLT || seen == IF_ICMPLE || seen == IF_ICMPNE || seen == IF_ICMPEQ)) {
+                && (seen == Const.IF_ICMPGE || seen == Const.IF_ICMPGT || seen == Const.IF_ICMPLT || seen == Const.IF_ICMPLE || seen == Const.IF_ICMPNE || seen == Const.IF_ICMPEQ)) {
             OpcodeStack.Item item0 = stack.getStackItem(0);
             OpcodeStack.Item item1 = stack.getStackItem(1);
             int r0 = item0.getRegisterNumber();
@@ -65,7 +66,7 @@ public class FindBadForLoop extends OpcodeStackDetector implements StatelessDete
             if (rMin == -1 && rMax > 0 && rMax == lastRegStore && branchTarget - 6 > getPC()) {
                 int beforeTarget = getCodeByte(branchTarget - 3);
                 int beforeGoto = getCodeByte(branchTarget - 6);
-                if (beforeTarget == GOTO && beforeGoto == IINC) {
+                if (beforeTarget == Const.GOTO && beforeGoto == Const.IINC) {
                     int offset1 = (byte) getCodeByte(branchTarget - 2);
                     int offset2 = getCodeByte(branchTarget - 1);
                     int offset = offset1 << 8 | offset2;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindCircularDependencies.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindCircularDependencies.java
@@ -26,6 +26,7 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.JavaClass;
 
 import edu.umd.cs.findbugs.BugInstance;
@@ -51,7 +52,7 @@ public class FindCircularDependencies extends BytecodeScanningDetector {
 
     @Override
     public void sawOpcode(int seen) {
-        if ((seen == INVOKESPECIAL) || (seen == INVOKESTATIC) || (seen == INVOKEVIRTUAL)) {
+        if ((seen == Const.INVOKESPECIAL) || (seen == Const.INVOKESTATIC) || (seen == Const.INVOKEVIRTUAL)) {
             String refClsName = getClassConstantOperand();
             refClsName = refClsName.replace('/', '.');
             if (refClsName.startsWith("java")) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindComparatorProblems.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindComparatorProblems.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 
 import edu.umd.cs.findbugs.BugAccumulator;
@@ -82,7 +83,7 @@ public class FindComparatorProblems extends OpcodeStackDetector {
         if(getStack().getStackDepth() == 0) {
             this.lastEmptyStackPC = getPC();
         }
-        if((seen == DCMPG || seen == DCMPL || seen == FCMPL || seen == FCMPG) && getStack().getStackDepth() == 2) {
+        if((seen == Const.DCMPG || seen == Const.DCMPL || seen == Const.FCMPL || seen == Const.FCMPG) && getStack().getStackDepth() == 2) {
             int[] startEnd = new int[] {this.lastEmptyStackPC, getPC()};
             for(Iterator<int[]> iterator = twoDoublesInStack.iterator(); iterator.hasNext(); ) {
                 int[] oldStartEnd = iterator.next();
@@ -101,7 +102,7 @@ public class FindComparatorProblems extends OpcodeStackDetector {
             }
             twoDoublesInStack.add(startEnd);
         }
-        if (seen == IRETURN) {
+        if (seen == Const.IRETURN) {
             OpcodeStack.Item top = stack.getStackItem(0);
             Object o = top.getConstant();
             if (o instanceof Integer && ((Integer)o).intValue() == Integer.MIN_VALUE) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindDeadLocalStores.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindDeadLocalStores.java
@@ -508,7 +508,7 @@ public class FindDeadLocalStores implements Detector {
                     // Look for objects created but never used
 
                     Instruction prevIns = prev.getInstruction();
-                    if ((prevIns instanceof INVOKESPECIAL && "<init>".equals(((INVOKESPECIAL) prevIns).getMethodName(methodGen.getConstantPool())))
+                    if ((prevIns instanceof INVOKESPECIAL && Const.CONSTRUCTOR_NAME.equals(((INVOKESPECIAL) prevIns).getMethodName(methodGen.getConstantPool())))
                             || prevIns instanceof ANEWARRAY
                             || prevIns instanceof NEWARRAY
                             || prevIns instanceof MULTIANEWARRAY) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindEmptySynchronizedBlock.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindEmptySynchronizedBlock.java
@@ -19,6 +19,8 @@
 
 package edu.umd.cs.findbugs.detect;
 
+import org.apache.bcel.Const;
+
 import edu.umd.cs.findbugs.BugInstance;
 import edu.umd.cs.findbugs.BugReporter;
 import edu.umd.cs.findbugs.BytecodeScanningDetector;
@@ -33,7 +35,7 @@ public class FindEmptySynchronizedBlock extends BytecodeScanningDetector {
 
     @Override
     public void sawOpcode(int seen) {
-        if (seen == MONITOREXIT && (getPrevOpcode(2) == MONITORENTER || getPrevOpcode(1) == MONITORENTER)) {
+        if (seen == Const.MONITOREXIT && (getPrevOpcode(2) == Const.MONITORENTER || getPrevOpcode(1) == Const.MONITORENTER)) {
             bugReporter.reportBug(new BugInstance(this, "ESync_EMPTY_SYNC", NORMAL_PRIORITY).addClassAndMethod(this)
                     .addSourceLine(this));
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindFieldSelfAssignment.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindFieldSelfAssignment.java
@@ -22,6 +22,7 @@ package edu.umd.cs.findbugs.detect;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 
 import edu.umd.cs.findbugs.BugInstance;
@@ -71,9 +72,9 @@ public class FindFieldSelfAssignment extends OpcodeStackDetector implements Stat
     public void sawOpcode(int seen) {
 
         if (DEBUG) {
-            System.out.printf("%5d %12s %s%n", getPC(), OPCODE_NAMES[seen],stack);
+            System.out.printf("%5d %12s %s%n", getPC(), Const.getOpcodeName(seen),stack);
         }
-        if (seen == PUTFIELD) {
+        if (seen == Const.PUTFIELD) {
             OpcodeStack.Item top = stack.getStackItem(0);
             OpcodeStack.Item next = stack.getStackItem(1);
 
@@ -84,7 +85,7 @@ public class FindFieldSelfAssignment extends OpcodeStackDetector implements Stat
             }
             possibleOverwrite = null;
 
-            if (stack.getStackDepth() >= 4 && getNextOpcode() == PUTFIELD) {
+            if (stack.getStackDepth() >= 4 && getNextOpcode() == Const.PUTFIELD) {
                 OpcodeStack.Item third = stack.getStackItem(2);
                 OpcodeStack.Item fourth = stack.getStackItem(3);
                 XField f2 = third.getXField();
@@ -135,7 +136,7 @@ public class FindFieldSelfAssignment extends OpcodeStackDetector implements Stat
         }
         switch (state) {
         case 0:
-            if (seen == DUP) {
+            if (seen == Const.DUP) {
                 state = 6;
             }
             break;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindFinalizeInvocations.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindFinalizeInvocations.java
@@ -19,6 +19,7 @@
 
 package edu.umd.cs.findbugs.detect;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.Method;
 
@@ -49,7 +50,7 @@ public class FindFinalizeInvocations extends BytecodeScanningDetector implements
         if (DEBUG) {
             System.out.println("FFI: visiting " + getFullyQualifiedMethodName());
         }
-        if ("finalize".equals(getMethodName()) && "()V".equals(getMethodSig()) && (obj.getAccessFlags() & (ACC_PUBLIC)) != 0) {
+        if ("finalize".equals(getMethodName()) && "()V".equals(getMethodSig()) && (obj.getAccessFlags() & (Const.ACC_PUBLIC)) != 0) {
             bugReporter
             .reportBug(new BugInstance(this, "FI_PUBLIC_SHOULD_BE_PROTECTED", NORMAL_PRIORITY).addClassAndMethod(this));
         }
@@ -85,14 +86,14 @@ public class FindFinalizeInvocations extends BytecodeScanningDetector implements
 
     @Override
     public void sawOpcode(int seen) {
-        if (seen == INVOKEVIRTUAL && "finalize".equals(getNameConstantOperand()) && "()V".equals(getSigConstantOperand())) {
+        if (seen == Const.INVOKEVIRTUAL && "finalize".equals(getNameConstantOperand()) && "()V".equals(getSigConstantOperand())) {
             bugAccumulator.accumulateBug(
                     new BugInstance(this, "FI_EXPLICIT_INVOCATION", "finalize".equals(getMethodName())
                             && "()V".equals(getMethodSig()) ? HIGH_PRIORITY : NORMAL_PRIORITY).addClassAndMethod(this)
                             .addCalledMethod(this), this);
 
         }
-        if (seen == INVOKESPECIAL && "finalize".equals(getNameConstantOperand())) {
+        if (seen == Const.INVOKESPECIAL && "finalize".equals(getNameConstantOperand())) {
             sawSuperFinalize = true;
         }
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindFloatEquality.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindFloatEquality.java
@@ -23,6 +23,7 @@ package edu.umd.cs.findbugs.detect;
 import java.util.Collection;
 import java.util.LinkedList;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 
 import edu.umd.cs.findbugs.BugAccumulator;
@@ -105,10 +106,10 @@ public class FindFloatEquality extends OpcodeStackDetector implements StatelessD
     @Override
     public void sawOpcode(int seen) {
         switch (seen) {
-        case FCMPG:
-        case FCMPL:
-        case DCMPG:
-        case DCMPL:
+        case Const.FCMPG:
+        case Const.FCMPL:
+        case Const.DCMPG:
+        case Const.DCMPL:
             if (stack.getStackDepth() >= 2) {
                 OpcodeStack.Item first = stack.getStackItem(0);
                 OpcodeStack.Item second = stack.getStackItem(1);
@@ -168,8 +169,8 @@ public class FindFloatEquality extends OpcodeStackDetector implements StatelessD
             }
             break;
 
-        case IFEQ:
-        case IFNE:
+        case Const.IFEQ:
+        case Const.IFNE:
             if (state == SAW_COMP) {
                 SourceLineAnnotation sourceLineAnnotation = SourceLineAnnotation.fromVisitedInstruction(getClassContext(), this,
                         getPC());

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindFloatMath.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindFloatMath.java
@@ -19,6 +19,8 @@
 
 package edu.umd.cs.findbugs.detect;
 
+import org.apache.bcel.Const;
+
 import edu.umd.cs.findbugs.BugInstance;
 import edu.umd.cs.findbugs.BugReporter;
 import edu.umd.cs.findbugs.BytecodeScanningDetector;
@@ -34,20 +36,20 @@ public class FindFloatMath extends BytecodeScanningDetector implements Stateless
     @Override
     public void sawOpcode(int seen) {
         switch (seen) {
-        case FMUL:
-        case FDIV:
+        case Const.FMUL:
+        case Const.FDIV:
             if (getFullyQualifiedMethodName().indexOf("float") == -1 && getFullyQualifiedMethodName().indexOf("Float") == -1
             && getFullyQualifiedMethodName().indexOf("FLOAT") == -1) {
                 bugReporter.reportBug(new BugInstance(this, "FL_MATH_USING_FLOAT_PRECISION", LOW_PRIORITY)
                 .addClassAndMethod(this).addSourceLine(this));
             }
             break;
-        case FCMPG:
-        case FCMPL:
+        case Const.FCMPG:
+        case Const.FCMPL:
             break;
-        case FADD:
-        case FSUB:
-        case FREM:
+        case Const.FADD:
+        case Const.FSUB:
+        case Const.FREM:
             if (getFullyQualifiedMethodName().indexOf("float") == -1 && getFullyQualifiedMethodName().indexOf("Float") == -1
             && getFullyQualifiedMethodName().indexOf("FLOAT") == -1) {
                 bugReporter.reportBug(new BugInstance(this, "FL_MATH_USING_FLOAT_PRECISION", NORMAL_PRIORITY).addClassAndMethod(

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindHEmismatch.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindHEmismatch.java
@@ -27,6 +27,7 @@ import java.util.regex.Pattern;
 
 import javax.annotation.CheckForNull;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.Repository;
 import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.Field;
@@ -131,7 +132,7 @@ public class FindHEmismatch extends OpcodeStackDetector implements StatelessDete
             return;
         }
         int accessFlags = obj.getAccessFlags();
-        if ((accessFlags & ACC_INTERFACE) != 0) {
+        if ((accessFlags & Const.ACC_INTERFACE) != 0) {
             return;
         }
         visibleOutsidePackage = obj.isPublic() || obj.isProtected();
@@ -380,7 +381,7 @@ public class FindHEmismatch extends OpcodeStackDetector implements StatelessDete
     @Override
     public void visit(Field obj) {
         int accessFlags = obj.getAccessFlags();
-        if ((accessFlags & ACC_STATIC) != 0) {
+        if ((accessFlags & Const.ACC_STATIC) != 0) {
             return;
         }
         if (!obj.getName().startsWith("this$") && !BCELUtil.isSynthetic(obj) && !obj.isTransient()) {
@@ -392,12 +393,12 @@ public class FindHEmismatch extends OpcodeStackDetector implements StatelessDete
     public void visit(Method obj) {
 
         int accessFlags = obj.getAccessFlags();
-        if ((accessFlags & ACC_STATIC) != 0) {
+        if ((accessFlags & Const.ACC_STATIC) != 0) {
             return;
         }
         String name = obj.getName();
         String sig = obj.getSignature();
-        if ((accessFlags & ACC_ABSTRACT) != 0) {
+        if ((accessFlags & Const.ACC_ABSTRACT) != 0) {
             if ("equals".equals(name) && sig.equals("(L" + getClassName() + ";)Z")) {
                 bugReporter.reportBug(new BugInstance(this, "EQ_ABSTRACT_SELF", LOW_PRIORITY).addClass(getDottedClassName()));
                 return;
@@ -433,9 +434,9 @@ public class FindHEmismatch extends OpcodeStackDetector implements StatelessDete
                             int op6 = opcode(codeBytes, 6);
                             int op7 = opcode(codeBytes, 7);
                             int op8 = opcode(codeBytes, 8);
-                            if ((op0 == ALOAD_0 && op1 == ALOAD_1 || op0 == ALOAD_1 && op1 == ALOAD_0)
-                                    && (op2 == IF_ACMPEQ || op2 == IF_ACMPNE) && (op5 == ICONST_0 || op5 == ICONST_1)
-                                    && op6 == IRETURN && (op7 == ICONST_0 || op7 == ICONST_1) && op8 == IRETURN) {
+                            if ((op0 == Const.ALOAD_0 && op1 == Const.ALOAD_1 || op0 == Const.ALOAD_1 && op1 == Const.ALOAD_0)
+                                    && (op2 == Const.IF_ACMPEQ || op2 == Const.IF_ACMPNE) && (op5 == Const.ICONST_0 || op5 == Const.ICONST_1)
+                                    && op6 == Const.IRETURN && (op7 == Const.ICONST_0 || op7 == Const.ICONST_1) && op8 == Const.IRETURN) {
                                 equalsMethodIsInstanceOfEquals = true;
                             }
                         } else if (codeBytes.length == 11) {
@@ -446,14 +447,14 @@ public class FindHEmismatch extends OpcodeStackDetector implements StatelessDete
                             int op6 = opcode(codeBytes, 6);
                             int op9 = opcode(codeBytes, 9);
                             int op10 = opcode(codeBytes, 10);
-                            if ((op0 == ALOAD_0 && op1 == ALOAD_1 || op0 == ALOAD_1 && op1 == ALOAD_0)
-                                    && (op2 == IF_ACMPEQ || op2 == IF_ACMPNE) && (op5 == ICONST_0 || op5 == ICONST_1)
-                                    && op6 == GOTO && (op9 == ICONST_0 || op9 == ICONST_1) && op10 == IRETURN) {
+                            if ((op0 == Const.ALOAD_0 && op1 == Const.ALOAD_1 || op0 == Const.ALOAD_1 && op1 == Const.ALOAD_0)
+                                    && (op2 == Const.IF_ACMPEQ || op2 == Const.IF_ACMPNE) && (op5 == Const.ICONST_0 || op5 == Const.ICONST_1)
+                                    && op6 == Const.GOTO && (op9 == Const.ICONST_0 || op9 == Const.ICONST_1) && op10 == Const.IRETURN) {
                                 equalsMethodIsInstanceOfEquals = true;
                             }
 
-                        } else if ((codeBytes.length == 5 && (codeBytes[1] & 0xff) == INSTANCEOF)
-                                || (codeBytes.length == 15 && (codeBytes[1] & 0xff) == INSTANCEOF && (codeBytes[11] & 0xff) == INVOKESPECIAL)) {
+                        } else if ((codeBytes.length == 5 && (codeBytes[1] & 0xff) == Const.INSTANCEOF)
+                                || (codeBytes.length == 15 && (codeBytes[1] & 0xff) == Const.INSTANCEOF && (codeBytes[11] & 0xff) == Const.INVOKESPECIAL)) {
                             equalsMethodIsInstanceOfEquals = true;
                         }
                     }
@@ -502,7 +503,7 @@ public class FindHEmismatch extends OpcodeStackDetector implements StatelessDete
 
     @Override
     public void sawOpcode(int seen) {
-        if (seen == INVOKEVIRTUAL || seen == INVOKEINTERFACE) {
+        if (seen == Const.INVOKEVIRTUAL || seen == Const.INVOKEINTERFACE) {
             String className = getClassConstantOperand();
             if ("java/util/Map".equals(className) || "java/util/HashMap".equals(className)
                     || "java/util/LinkedHashMap".equals(className) || "java/util/concurrent/ConcurrentHashMap".equals(className)

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindInconsistentSync2.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindInconsistentSync2.java
@@ -397,7 +397,7 @@ public class FindInconsistentSync2 implements Detector {
 
             String name = method.getName();
 
-            boolean inConstructor = "<init>".equals(name) || "<clinit>".equals(name)
+            boolean inConstructor = Const.CONSTRUCTOR_NAME.equals(name) || Const.STATIC_INITIALIZER_NAME.equals(name)
                     || "readObject".equals(name) || "clone".equals(name) || "close".equals(name)
                     || "finalize".equals(name);
 
@@ -616,7 +616,7 @@ public class FindInconsistentSync2 implements Detector {
      */
 
     private static boolean isConstructor(String methodName) {
-        return "<init>".equals(methodName) || "<clinit>".equals(methodName) || "readObject".equals(methodName)
+        return Const.CONSTRUCTOR_NAME.equals(methodName) || Const.STATIC_INITIALIZER_NAME.equals(methodName) || "readObject".equals(methodName)
                 || "clone".equals(methodName) || "close".equals(methodName) || "writeObject".equals(methodName)
                 || "toString".equals(methodName) || "init".equals(methodName) || "initialize".equals(methodName)
                 || "dispose".equals(methodName) || "finalize".equals(methodName) || "this".equals(methodName)

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindLocalSelfAssignment2.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindLocalSelfAssignment2.java
@@ -74,7 +74,7 @@ public class FindLocalSelfAssignment2 extends BytecodeScanningDetector implement
                     if (previousLoadOf == getRegisterOperand() && gotoCount < 2 && getPC() != previousGotoTarget) {
                         int priority = NORMAL_PRIORITY;
                         String methodName = getMethodName();
-                        if ("<init>".equals(methodName) || methodName.startsWith("set") && getCode().getCode().length <= 5
+                        if (Const.CONSTRUCTOR_NAME.equals(methodName) || methodName.startsWith("set") && getCode().getCode().length <= 5
                                 || !previousStores.get(getRegisterOperand())) {
                             priority = HIGH_PRIORITY;
                         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindLocalSelfAssignment2.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindLocalSelfAssignment2.java
@@ -21,6 +21,7 @@ package edu.umd.cs.findbugs.detect;
 
 import java.util.BitSet;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 
 import edu.umd.cs.findbugs.BugInstance;
@@ -59,7 +60,7 @@ public class FindLocalSelfAssignment2 extends BytecodeScanningDetector implement
 
     @Override
     public void sawOpcode(int seen) {
-        if (seen == GOTO) {
+        if (seen == Const.GOTO) {
             previousGotoTarget = getBranchTarget();
             gotoCount++;
             if (previousGotoTarget < getPC()) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNakedNotify.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNakedNotify.java
@@ -19,6 +19,7 @@
 
 package edu.umd.cs.findbugs.detect;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.Method;
 
@@ -50,7 +51,7 @@ public class FindNakedNotify extends BytecodeScanningDetector implements Statele
     @Override
     public void visit(Method obj) {
         int flags = obj.getAccessFlags();
-        synchronizedMethod = (flags & ACC_SYNCHRONIZED) != 0;
+        synchronizedMethod = (flags & Const.ACC_SYNCHRONIZED) != 0;
     }
 
     @Override
@@ -67,7 +68,7 @@ public class FindNakedNotify extends BytecodeScanningDetector implements Statele
     public void sawOpcode(int seen) {
         switch (stage) {
         case 0:
-            if (seen == MONITORENTER) {
+            if (seen == Const.MONITORENTER) {
                 stage = 1;
             }
             break;
@@ -75,7 +76,7 @@ public class FindNakedNotify extends BytecodeScanningDetector implements Statele
             stage = 2;
             break;
         case 2:
-            if (seen == INVOKEVIRTUAL
+            if (seen == Const.INVOKEVIRTUAL
             && ("notify".equals(getNameConstantOperand()) || "notifyAll".equals(getNameConstantOperand()))
             && "()V".equals(getSigConstantOperand())) {
                 stage = 3;
@@ -88,7 +89,7 @@ public class FindNakedNotify extends BytecodeScanningDetector implements Statele
             stage = 4;
             break;
         case 4:
-            if (seen == MONITOREXIT) {
+            if (seen == Const.MONITOREXIT) {
                 bugReporter.reportBug(new BugInstance(this, "NN_NAKED_NOTIFY", NORMAL_PRIORITY).addClassAndMethod(this)
                         .addSourceLine(this, notifyPC));
                 stage = 5;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNonShortCircuit.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNonShortCircuit.java
@@ -19,6 +19,7 @@
 
 package edu.umd.cs.findbugs.detect;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.Method;
 
@@ -64,7 +65,7 @@ public class FindNonShortCircuit extends OpcodeStackDetector implements Stateles
     @Override
     public void visit(Method obj) {
         clearAll();
-        prevOpcode = NOP;
+        prevOpcode = Const.NOP;
     }
 
     private void clearAll() {
@@ -103,40 +104,40 @@ public class FindNonShortCircuit extends OpcodeStackDetector implements Stateles
 
     private void scanForDanger(int seen) {
         switch (seen) {
-        case AALOAD:
-        case BALOAD:
-        case SALOAD:
-        case CALOAD:
-        case IALOAD:
-        case LALOAD:
-        case FALOAD:
-        case DALOAD:
+        case Const.AALOAD:
+        case Const.BALOAD:
+        case Const.SALOAD:
+        case Const.CALOAD:
+        case Const.IALOAD:
+        case Const.LALOAD:
+        case Const.FALOAD:
+        case Const.DALOAD:
             sawArrayDanger = true;
             sawDanger = true;
             break;
 
-        case INVOKEVIRTUAL:
+        case Const.INVOKEVIRTUAL:
             if ("length".equals(getNameConstantOperand()) && "java/lang/String".equals(getClassConstantOperand())) {
                 break;
             }
             sawDanger = true;
             sawMethodCall = true;
             break;
-        case INVOKEINTERFACE:
-        case INVOKESPECIAL:
-        case INVOKESTATIC:
+        case Const.INVOKEINTERFACE:
+        case Const.INVOKESPECIAL:
+        case Const.INVOKESTATIC:
             sawDanger = true;
             sawMethodCall = true;
             break;
-        case IDIV:
-        case IREM:
-        case LDIV:
-        case LREM:
+        case Const.IDIV:
+        case Const.IREM:
+        case Const.LDIV:
+        case Const.LREM:
             sawDanger = true;
             break;
 
-        case ARRAYLENGTH:
-        case GETFIELD:
+        case Const.ARRAYLENGTH:
+        case Const.GETFIELD:
             // null pointer detector will handle these
             break;
         default:
@@ -147,8 +148,8 @@ public class FindNonShortCircuit extends OpcodeStackDetector implements Stateles
 
     private void scanForShortCircuit(int seen) {
         switch (seen) {
-        case IAND:
-        case IOR:
+        case Const.IAND:
+        case Const.IOR:
 
             // System.out.println("Saw IOR or IAND at distance " + distance);
             OpcodeStack.Item item0 = stack.getStackItem(0);
@@ -165,18 +166,18 @@ public class FindNonShortCircuit extends OpcodeStackDetector implements Stateles
                 stage2 = 0;
             }
             break;
-        case IFEQ:
-        case IFNE:
+        case Const.IFEQ:
+        case Const.IFNE:
             if (stage2 == 1) {
                 // System.out.println("Found nsc");
                 reportBug();
             }
             stage2 = 0;
             break;
-        case PUTFIELD:
-        case PUTSTATIC:
-        case IRETURN:
-            if (operator == IAND && stage2 == 1) {
+        case Const.PUTFIELD:
+        case Const.PUTSTATIC:
+        case Const.IRETURN:
+            if (operator == Const.IAND && stage2 == 1) {
                 reportBug();
             }
             stage2 = 0;
@@ -209,37 +210,37 @@ public class FindNonShortCircuit extends OpcodeStackDetector implements Stateles
     private void scanForBooleanValue(int seen) {
         switch (seen) {
 
-        case IAND:
-        case IOR:
+        case Const.IAND:
+        case Const.IOR:
             switch (prevOpcode) {
-            case ILOAD:
-            case ILOAD_0:
-            case ILOAD_1:
-            case ILOAD_2:
-            case ILOAD_3:
+            case Const.ILOAD:
+            case Const.ILOAD_0:
+            case Const.ILOAD_1:
+            case Const.ILOAD_2:
+            case Const.ILOAD_3:
                 clearAll();
                 break;
             default:
                 break;
             }
             break;
-        case ICONST_1:
+        case Const.ICONST_1:
             stage1 = 1;
             switch (prevOpcode) {
-            case IFNONNULL:
-            case IFNULL:
+            case Const.IFNONNULL:
+            case Const.IFNULL:
                 sawNullTest = true;
                 break;
-            case IF_ICMPGT:
-            case IF_ICMPGE:
-            case IF_ICMPLT:
-            case IF_ICMPLE:
+            case Const.IF_ICMPGT:
+            case Const.IF_ICMPGE:
+            case Const.IF_ICMPLT:
+            case Const.IF_ICMPLE:
                 sawNumericTest = true;
                 break;
             }
 
             break;
-        case GOTO:
+        case Const.GOTO:
             if (stage1 == 1) {
                 stage1 = 2;
             } else {
@@ -247,16 +248,16 @@ public class FindNonShortCircuit extends OpcodeStackDetector implements Stateles
                 clearAll();
             }
             break;
-        case ICONST_0:
+        case Const.ICONST_0:
             if (stage1 == 2) {
                 sawBooleanValue();
             }
             stage1 = 0;
             break;
-        case INVOKEINTERFACE:
-        case INVOKEVIRTUAL:
-        case INVOKESPECIAL:
-        case INVOKESTATIC:
+        case Const.INVOKEINTERFACE:
+        case Const.INVOKEVIRTUAL:
+        case Const.INVOKESPECIAL:
+        case Const.INVOKESTATIC:
             String sig = getSigConstantOperand();
             if (sig.endsWith(")Z")) {
                 sawBooleanValue();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNullDerefsInvolvingNonShortCircuitEvaluation.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNullDerefsInvolvingNonShortCircuitEvaluation.java
@@ -24,6 +24,7 @@ import java.util.Set;
 
 import javax.annotation.CheckForNull;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 import org.apache.bcel.generic.IfInstruction;
 import org.apache.bcel.generic.InstructionHandle;
@@ -68,10 +69,10 @@ public class FindNullDerefsInvolvingNonShortCircuitEvaluation extends OpcodeStac
 
     @Override
     public void sawOpcode(int seen) {
-        if (seen == IAND || seen == IOR) {
+        if (seen == Const.IAND || seen == Const.IOR) {
 
             int nextOpcode = getCodeByte(getPC() + 1);
-            if (nextOpcode == IFEQ || nextOpcode == IFNE) {
+            if (nextOpcode == Const.IFEQ || nextOpcode == Const.IFNE) {
                 OpcodeStack.Item left = stack.getStackItem(1);
                 OpcodeStack.Item right = stack.getStackItem(0);
                 checkForNullForcingABranch(seen, nextOpcode, left);
@@ -84,8 +85,8 @@ public class FindNullDerefsInvolvingNonShortCircuitEvaluation extends OpcodeStac
     private void checkForNullForcingABranch(int seen, int nextOpcode, OpcodeStack.Item item) {
         if (nullGuaranteesBranch(seen, item)) {
             // null guarantees a branch
-            boolean nullGuaranteesZero = seen == IAND;
-            boolean nullGuaranteesBranch = nullGuaranteesZero ^ (nextOpcode == IFNE);
+            boolean nullGuaranteesZero = seen == Const.IAND;
+            boolean nullGuaranteesBranch = nullGuaranteesZero ^ (nextOpcode == Const.IFNE);
             if (DEBUG) {
                 System.out.println(item.getPC() + " null guarantees " + nullGuaranteesBranch + " branch");
             }
@@ -193,8 +194,8 @@ public class FindNullDerefsInvolvingNonShortCircuitEvaluation extends OpcodeStac
     }
 
     private boolean nullGuaranteesBranch(int seen, OpcodeStack.Item item) {
-        return item.getSpecialKind() == OpcodeStack.Item.ZERO_MEANS_NULL && seen == IAND
-                || item.getSpecialKind() == OpcodeStack.Item.NONZERO_MEANS_NULL && seen == IOR;
+        return item.getSpecialKind() == OpcodeStack.Item.ZERO_MEANS_NULL && seen == Const.IAND
+                || item.getSpecialKind() == OpcodeStack.Item.NONZERO_MEANS_NULL && seen == Const.IOR;
     }
 
     /*

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindPuzzlers.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindPuzzlers.java
@@ -191,7 +191,7 @@ public class FindPuzzlers extends OpcodeStackDetector {
         }
         becameTop = -1;
 
-        if (seen == Const.INVOKESPECIAL && "<init>".equals(getNameConstantOperand()) && "(Ljava/util/Collection;)V".equals(getSigConstantOperand())
+        if (seen == Const.INVOKESPECIAL && Const.CONSTRUCTOR_NAME.equals(getNameConstantOperand()) && "(Ljava/util/Collection;)V".equals(getSigConstantOperand())
                 && getClassConstantOperand().contains("Set")
                 || (seen == Const.INVOKEVIRTUAL || seen == Const.INVOKEINTERFACE) && "addAll".equals(getNameConstantOperand()) && "(Ljava/util/Collection;)Z".equals(getSigConstantOperand())) {
             OpcodeStack.Item top = stack.getStackItem(0);
@@ -269,7 +269,7 @@ public class FindPuzzlers extends OpcodeStackDetector {
             }
         }
 
-        if ("<clinit>".equals(getMethodName()) && (seen == Const.PUTSTATIC || seen == Const.GETSTATIC || seen == Const.INVOKESTATIC)) {
+        if (Const.STATIC_INITIALIZER_NAME.equals(getMethodName()) && (seen == Const.PUTSTATIC || seen == Const.GETSTATIC || seen == Const.INVOKESTATIC)) {
             String clazz = getClassConstantOperand();
             if (!clazz.equals(getClassName())) {
                 try {
@@ -419,7 +419,7 @@ public class FindPuzzlers extends OpcodeStackDetector {
                 && "set".equals(getNameConstantOperand())
 
                 || seen == Const.INVOKESPECIAL && stack.getStackDepth() > 1
-                && "java/util/GregorianCalendar".equals(getClassConstantOperand()) && "<init>".equals(getNameConstantOperand())
+                && "java/util/GregorianCalendar".equals(getClassConstantOperand()) && Const.CONSTRUCTOR_NAME.equals(getNameConstantOperand())
 
                 ) {
             String sig = getSigConstantOperand();
@@ -664,7 +664,7 @@ public class FindPuzzlers extends OpcodeStackDetector {
             }
         }
         if (seen == Const.INVOKESPECIAL && getClassConstantOperand().startsWith("java/lang/")
-                && "<init>".equals(getNameConstantOperand()) && getSigConstantOperand().length() == 4) {
+                && Const.CONSTRUCTOR_NAME.equals(getNameConstantOperand()) && getSigConstantOperand().length() == 4) {
             previousMethodInvocation = XFactory.createReferencedXMethod(this);
         } else if (seen == Const.INVOKESTATIC && getClassConstantOperand().startsWith("java/lang/")
                 && "valueOf".equals(getNameConstantOperand()) && getSigConstantOperand().length() == 4) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindPuzzlers.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindPuzzlers.java
@@ -26,6 +26,7 @@ import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.Map;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.Repository;
 import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.CodeException;
@@ -77,7 +78,7 @@ public class FindPuzzlers extends OpcodeStackDetector {
     public void visit(Code obj) {
         prevOpcodeIncrementedRegister = -1;
         best_priority_for_ICAST_INTEGER_MULTIPLY_CAST_TO_LONG = LOW_PRIORITY + 1;
-        prevOpCode = NOP;
+        prevOpCode = Const.NOP;
         previousMethodInvocation = null;
         badlyComputingOddState = 0;
         resetIMulCastLong();
@@ -122,7 +123,7 @@ public class FindPuzzlers extends OpcodeStackDetector {
 
     @Override
     public void visit(JavaClass obj) {
-        isTigerOrHigher = obj.getMajor() >= MAJOR_1_5;
+        isTigerOrHigher = obj.getMajor() >= Const.MAJOR_1_5;
         try {
             Subtypes2 subtypes2 = AnalysisContext.currentAnalysisContext().getSubtypes2();
             ClassDescriptor me = getClassDescriptor();
@@ -177,7 +178,7 @@ public class FindPuzzlers extends OpcodeStackDetector {
             if (becameTop == -1) {
                 becameTop = getPC();
             }
-            if (testingEnabled && seen == GOTO && getBranchTarget() < becameTop)  {
+            if (testingEnabled && seen == Const.GOTO && getBranchTarget() < becameTop)  {
                 pendingUnreachableBranch = new BugInstance(this, "TESTING", NORMAL_PRIORITY)
                 .addClassAndMethod(this).addString("Unreachable loop body").addSourceLineRange(this, becameTop, getPC());
             }
@@ -190,9 +191,9 @@ public class FindPuzzlers extends OpcodeStackDetector {
         }
         becameTop = -1;
 
-        if (seen == INVOKESPECIAL && "<init>".equals(getNameConstantOperand()) && "(Ljava/util/Collection;)V".equals(getSigConstantOperand())
+        if (seen == Const.INVOKESPECIAL && "<init>".equals(getNameConstantOperand()) && "(Ljava/util/Collection;)V".equals(getSigConstantOperand())
                 && getClassConstantOperand().contains("Set")
-                || (seen == INVOKEVIRTUAL || seen == INVOKEINTERFACE) && "addAll".equals(getNameConstantOperand()) && "(Ljava/util/Collection;)Z".equals(getSigConstantOperand())) {
+                || (seen == Const.INVOKEVIRTUAL || seen == Const.INVOKEINTERFACE) && "addAll".equals(getNameConstantOperand()) && "(Ljava/util/Collection;)Z".equals(getSigConstantOperand())) {
             OpcodeStack.Item top = stack.getStackItem(0);
             XMethod returnValueOf = top.getReturnValueOf();
             if (returnValueOf != null && "entrySet".equals(returnValueOf.getName())) {
@@ -211,7 +212,7 @@ public class FindPuzzlers extends OpcodeStackDetector {
 
         }
 
-        if (seen == INVOKEVIRTUAL && "hashCode".equals(getNameConstantOperand()) && "()I".equals(getSigConstantOperand())
+        if (seen == Const.INVOKEVIRTUAL && "hashCode".equals(getNameConstantOperand()) && "()I".equals(getSigConstantOperand())
                 && stack.getStackDepth() > 0) {
             OpcodeStack.Item item0 = stack.getStackItem(0);
             if (item0.getSignature().charAt(0) == '[') {
@@ -219,7 +220,7 @@ public class FindPuzzlers extends OpcodeStackDetector {
                 .addClassAndMethod(this).addValueSource(item0, this).addSourceLine(this));
             }
         }
-        if (seen != RETURN && isReturn(seen) && isRegisterStore(getPrevOpcode(1))) {
+        if (seen != Const.RETURN && isReturn(seen) && isRegisterStore(getPrevOpcode(1))) {
 
             int priority = Priorities.NORMAL_PRIORITY;
             if (getMethodSig().endsWith(")Z")) {
@@ -237,7 +238,7 @@ public class FindPuzzlers extends OpcodeStackDetector {
         }
         // System.out.println(getPC() + " " + OPCODE_NAMES[seen] + " " +
         // ternaryConversionState);
-        if (seen == IMUL) {
+        if (seen == Const.IMUL) {
             if (imul_distance != 1) {
                 resetIMulCastLong();
             }
@@ -256,7 +257,7 @@ public class FindPuzzlers extends OpcodeStackDetector {
             imul_distance++;
         }
 
-        if (prevOpCode == IMUL && seen == I2L) {
+        if (prevOpCode == Const.IMUL && seen == Const.I2L) {
             int priority = adjustPriority(imul_constant, NORMAL_PRIORITY);
             if (priority >= LOW_PRIORITY && imul_constant != 1000 && imul_constant != 60 && imul_operand_is_parameter) {
                 priority = NORMAL_PRIORITY;
@@ -268,14 +269,14 @@ public class FindPuzzlers extends OpcodeStackDetector {
             }
         }
 
-        if ("<clinit>".equals(getMethodName()) && (seen == PUTSTATIC || seen == GETSTATIC || seen == INVOKESTATIC)) {
+        if ("<clinit>".equals(getMethodName()) && (seen == Const.PUTSTATIC || seen == Const.GETSTATIC || seen == Const.INVOKESTATIC)) {
             String clazz = getClassConstantOperand();
             if (!clazz.equals(getClassName())) {
                 try {
                     JavaClass targetClass = Repository.lookupClass(clazz);
                     if (Repository.instanceOf(targetClass, getThisClass())) {
                         int priority = NORMAL_PRIORITY;
-                        if (seen == GETSTATIC) {
+                        if (seen == Const.GETSTATIC) {
                             priority--;
                         }
                         if (!targetClass.isPublic()) {
@@ -292,7 +293,7 @@ public class FindPuzzlers extends OpcodeStackDetector {
             }
         }
         /*
-        if (false && (seen == INVOKEVIRTUAL) && getNameConstantOperand().equals("equals")
+        if (false && (seen == Const.INVOKEVIRTUAL) && getNameConstantOperand().equals("equals")
                 && getSigConstantOperand().equals("(Ljava/lang/Object;)Z") && stack.getStackDepth() > 1) {
             OpcodeStack.Item item0 = stack.getStackItem(0);
             OpcodeStack.Item item1 = stack.getStackItem(1);
@@ -304,7 +305,7 @@ public class FindPuzzlers extends OpcodeStackDetector {
         }
          */
 
-        if (seen >= IALOAD && seen <= SALOAD || seen >= IASTORE && seen <= SASTORE) {
+        if (seen >= Const.IALOAD && seen <= Const.SALOAD || seen >= Const.IASTORE && seen <= Const.SASTORE) {
             Item index = stack.getStackItem(0);
             if (index.getSpecialKind() == Item.AVERAGE_COMPUTED_USING_DIVISION) {
                 SourceLineAnnotation where;
@@ -320,15 +321,15 @@ public class FindPuzzlers extends OpcodeStackDetector {
 
         }
 
-        if ((seen == IFEQ || seen == IFNE) && getPrevOpcode(1) == IMUL
-                && (getPrevOpcode(2) == SIPUSH || getPrevOpcode(2) == BIPUSH) && getPrevOpcode(3) == IREM) {
+        if ((seen == Const.IFEQ || seen == Const.IFNE) && getPrevOpcode(1) == Const.IMUL
+                && (getPrevOpcode(2) == Const.SIPUSH || getPrevOpcode(2) == Const.BIPUSH) && getPrevOpcode(3) == Const.IREM) {
             bugAccumulator.accumulateBug(
                     new BugInstance(this, "IM_MULTIPLYING_RESULT_OF_IREM", LOW_PRIORITY).addClassAndMethod(this), this);
         }
 
-        if (seen == I2S && getPrevOpcode(1) == IUSHR && !shiftOfNonnegativeValue
-                && (!constantArgumentToShift || valueOfConstantArgumentToShift % 16 != 0) || seen == I2B
-                && getPrevOpcode(1) == IUSHR && !shiftOfNonnegativeValue
+        if (seen == Const.I2S && getPrevOpcode(1) == Const.IUSHR && !shiftOfNonnegativeValue
+                && (!constantArgumentToShift || valueOfConstantArgumentToShift % 16 != 0) || seen == Const.I2B
+                && getPrevOpcode(1) == Const.IUSHR && !shiftOfNonnegativeValue
                 && (!constantArgumentToShift || valueOfConstantArgumentToShift % 8 != 0)) {
             bugAccumulator.accumulateBug(
                     new BugInstance(this, "ICAST_QUESTIONABLE_UNSIGNED_RIGHT_SHIFT", NORMAL_PRIORITY).addClassAndMethod(this),
@@ -336,7 +337,7 @@ public class FindPuzzlers extends OpcodeStackDetector {
         }
 
 
-        if (seen == IADD && (getNextOpcode() == ISHL || getNextOpcode() == LSHL) && stack.getStackDepth() >=3) {
+        if (seen == Const.IADD && (getNextOpcode() == Const.ISHL || getNextOpcode() == Const.LSHL) && stack.getStackDepth() >=3) {
             OpcodeStack.Item l = stack.getStackItem(2);
             OpcodeStack.Item v = stack.getStackItem(1);
             Object constantValue = v.getConstant();
@@ -346,15 +347,15 @@ public class FindPuzzlers extends OpcodeStackDetector {
                 int priority = LOW_PRIORITY;
                 // If (foo << 32 + var) encountered, then ((foo << 32) + var) is absolutely meaningless,
                 // but (foo << (32 + var)) can be meaningful for negative var values
-                if (c < 32 || (c < 64 && getNextOpcode() == LSHL)) {
+                if (c < 32 || (c < 64 && getNextOpcode() == Const.LSHL)) {
                     if (c == 8) {
                         priority--;
                     }
-                    if (getPrevOpcode(1) == IAND) {
+                    if (getPrevOpcode(1) == Const.IAND) {
                         priority--;
                     }
                     if (getMethodName().equals("hashCode") && getMethodSig().equals("()I")
-                            && (getCode().getCode()[getNextPC() + 1] & 0xFF) == IRETURN) {
+                            && (getCode().getCode()[getNextPC() + 1] & 0xFF) == Const.IRETURN) {
                         // commonly observed error is hashCode body like "return foo << 16 + bar;"
                         priority = HIGH_PRIORITY;
                     }
@@ -370,7 +371,7 @@ public class FindPuzzlers extends OpcodeStackDetector {
         }
         constantArgumentToShift = false;
         shiftOfNonnegativeValue = false;
-        if ((seen == IUSHR || seen == ISHR || seen == ISHL)) {
+        if ((seen == Const.IUSHR || seen == Const.ISHR || seen == Const.ISHL)) {
             if (stack.getStackDepth() <= 1) {
                 // don't understand; lie so other detectors won't get concerned
                 constantArgumentToShift = true;
@@ -400,7 +401,7 @@ public class FindPuzzlers extends OpcodeStackDetector {
             }
         }
 
-        if (seen == INVOKEVIRTUAL && stack.getStackDepth() > 0
+        if (seen == Const.INVOKEVIRTUAL && stack.getStackDepth() > 0
                 && ("java/util/Date".equals(getClassConstantOperand()) || "java/sql/Date".equals(getClassConstantOperand()))
                 && "setMonth".equals(getNameConstantOperand()) && "(I)V".equals(getSigConstantOperand())) {
             OpcodeStack.Item item = stack.getStackItem(0);
@@ -414,10 +415,10 @@ public class FindPuzzlers extends OpcodeStackDetector {
             }
         }
 
-        if (seen == INVOKEVIRTUAL && stack.getStackDepth() > 1 && "java/util/Calendar".equals(getClassConstantOperand())
+        if (seen == Const.INVOKEVIRTUAL && stack.getStackDepth() > 1 && "java/util/Calendar".equals(getClassConstantOperand())
                 && "set".equals(getNameConstantOperand())
 
-                || seen == INVOKESPECIAL && stack.getStackDepth() > 1
+                || seen == Const.INVOKESPECIAL && stack.getStackDepth() > 1
                 && "java/util/GregorianCalendar".equals(getClassConstantOperand()) && "<init>".equals(getNameConstantOperand())
 
                 ) {
@@ -436,13 +437,13 @@ public class FindPuzzlers extends OpcodeStackDetector {
             }
         }
 
-        if (isRegisterStore() && (seen == ISTORE || seen == ISTORE_0 || seen == ISTORE_1 || seen == ISTORE_2 || seen == ISTORE_3)
+        if (isRegisterStore() && (seen == Const.ISTORE || seen == Const.ISTORE_0 || seen == Const.ISTORE_1 || seen == Const.ISTORE_2 || seen == Const.ISTORE_3)
                 && getRegisterOperand() == prevOpcodeIncrementedRegister) {
             bugAccumulator.accumulateBug(
                     new BugInstance(this, "DLS_OVERWRITTEN_INCREMENT", HIGH_PRIORITY).addClassAndMethod(this), this);
 
         }
-        if (seen == IINC) {
+        if (seen == Const.IINC) {
             prevOpcodeIncrementedRegister = getRegisterOperand();
         } else {
             prevOpcodeIncrementedRegister = -1;
@@ -453,12 +454,12 @@ public class FindPuzzlers extends OpcodeStackDetector {
 
         switch (badlyComputingOddState) {
         case 0:
-            if (seen == ICONST_2) {
+            if (seen == Const.ICONST_2) {
                 badlyComputingOddState++;
             }
             break;
         case 1:
-            if (seen == IREM) {
+            if (seen == Const.IREM) {
                 OpcodeStack.Item item = stack.getStackItem(1);
                 if (!item.isNonNegative() && item.getSpecialKind() != OpcodeStack.Item.MATH_ABS) {
                     badlyComputingOddState++;
@@ -470,14 +471,14 @@ public class FindPuzzlers extends OpcodeStackDetector {
             }
             break;
         case 2:
-            if (seen == ICONST_1) {
+            if (seen == Const.ICONST_1) {
                 badlyComputingOddState++;
             } else {
                 badlyComputingOddState = 0;
             }
             break;
         case 3:
-            if (seen == IF_ICMPEQ || seen == IF_ICMPNE) {
+            if (seen == Const.IF_ICMPEQ || seen == Const.IF_ICMPNE) {
                 bugAccumulator.accumulateBug(
                         new BugInstance(this, "IM_BAD_CHECK_FOR_ODD", NORMAL_PRIORITY).addClassAndMethod(this), this);
             }
@@ -488,7 +489,7 @@ public class FindPuzzlers extends OpcodeStackDetector {
         }
 
         // Java Puzzlers, chapter 3, puzzle 12
-        if (seen == INVOKEVIRTUAL
+        if (seen == Const.INVOKEVIRTUAL
                 && stack.getStackDepth() > 0
                 && ("toString".equals(getNameConstantOperand()) && "()Ljava/lang/String;".equals(getSigConstantOperand())
                         || "append".equals(getNameConstantOperand())
@@ -570,7 +571,7 @@ public class FindPuzzlers extends OpcodeStackDetector {
         }
 
         if (isTigerOrHigher) {
-            if (previousMethodInvocation != null && prevOpCode == INVOKEVIRTUAL && seen == INVOKESTATIC) {
+            if (previousMethodInvocation != null && prevOpCode == Const.INVOKEVIRTUAL && seen == Const.INVOKESTATIC) {
                 String classNameForPreviousMethod = previousMethodInvocation.getClassName();
                 String classNameForThisMethod = getClassConstantOperand();
                 if (classNameForPreviousMethod.startsWith("java.lang.")
@@ -587,7 +588,7 @@ public class FindPuzzlers extends OpcodeStackDetector {
 
             }
 
-            if (previousMethodInvocation != null && prevOpCode == INVOKESPECIAL && seen == INVOKEVIRTUAL) {
+            if (previousMethodInvocation != null && prevOpCode == Const.INVOKESPECIAL && seen == Const.INVOKEVIRTUAL) {
                 String classNameForPreviousMethod = previousMethodInvocation.getClassName();
                 String classNameForThisMethod = getClassConstantOperand();
                 if (classNameForPreviousMethod.startsWith("java.lang.")
@@ -607,7 +608,7 @@ public class FindPuzzlers extends OpcodeStackDetector {
                     ternaryConversionState = 0;
                 }
 
-            } else if (seen == INVOKEVIRTUAL) {
+            } else if (seen == Const.INVOKEVIRTUAL) {
                 if (getClassConstantOperand().startsWith("java/lang") && getNameConstantOperand().endsWith("Value")
                         && getSigConstantOperand().length() == 3) {
                     ternaryConversionState = 1;
@@ -615,14 +616,14 @@ public class FindPuzzlers extends OpcodeStackDetector {
                     ternaryConversionState = 0;
                 }
             } else if (ternaryConversionState == 1) {
-                if (I2L < seen && seen <= I2S) {
+                if (Const.I2L < seen && seen <= Const.I2S) {
                     ternaryConversionState = 2;
                 } else {
                     ternaryConversionState = 0;
                 }
             } else if (ternaryConversionState == 2) {
                 ternaryConversionState = 0;
-                if (seen == GOTO) {
+                if (seen == Const.GOTO) {
                     bugReporter.reportBug(new BugInstance(this, "BX_UNBOXED_AND_COERCED_FOR_TERNARY_OPERATOR", NORMAL_PRIORITY)
                     .addClassAndMethod(this).addSourceLine(this));
                 }
@@ -631,7 +632,7 @@ public class FindPuzzlers extends OpcodeStackDetector {
             }
         }
 
-        AssertInvokedFromRun: if (seen == INVOKESTATIC) {
+        AssertInvokedFromRun: if (seen == Const.INVOKESTATIC) {
             if ((getNameConstantOperand().startsWith("assert") || getNameConstantOperand().startsWith("fail"))
                     && "run".equals(getMethodName()) && implementsRunnable(getThisClass())) {
                 int size1 = Util.getSizeOfSurroundingTryBlock(getConstantPool(), getMethod().getCode(), "java/lang/Throwable",
@@ -662,13 +663,13 @@ public class FindPuzzlers extends OpcodeStackDetector {
 
             }
         }
-        if (seen == INVOKESPECIAL && getClassConstantOperand().startsWith("java/lang/")
+        if (seen == Const.INVOKESPECIAL && getClassConstantOperand().startsWith("java/lang/")
                 && "<init>".equals(getNameConstantOperand()) && getSigConstantOperand().length() == 4) {
             previousMethodInvocation = XFactory.createReferencedXMethod(this);
-        } else if (seen == INVOKESTATIC && getClassConstantOperand().startsWith("java/lang/")
+        } else if (seen == Const.INVOKESTATIC && getClassConstantOperand().startsWith("java/lang/")
                 && "valueOf".equals(getNameConstantOperand()) && getSigConstantOperand().length() == 4) {
             previousMethodInvocation = XFactory.createReferencedXMethod(this);
-        } else if (seen == INVOKEVIRTUAL && getClassConstantOperand().startsWith("java/lang/")
+        } else if (seen == Const.INVOKEVIRTUAL && getClassConstantOperand().startsWith("java/lang/")
                 && getNameConstantOperand().endsWith("Value")
                 && getSigConstantOperand().length() == 3) {
             previousMethodInvocation = XFactory.createReferencedXMethod(this);
@@ -676,7 +677,7 @@ public class FindPuzzlers extends OpcodeStackDetector {
             previousMethodInvocation = null;
         }
 
-        if (testingEnabled && seen == IAND || seen == LAND) {
+        if (testingEnabled && seen == Const.IAND || seen == Const.LAND) {
             OpcodeStack.Item rhs = stack.getStackItem(0);
             OpcodeStack.Item lhs = stack.getStackItem(1);
             Object constant = rhs.getConstant();
@@ -685,11 +686,11 @@ public class FindPuzzlers extends OpcodeStackDetector {
                 constant = lhs.getConstant();
                 value = rhs;
             }
-            if (constant instanceof Number && (seen == LAND || value.getSpecialKind() == OpcodeStack.Item.RESULT_OF_L2I)) {
+            if (constant instanceof Number && (seen == Const.LAND || value.getSpecialKind() == OpcodeStack.Item.RESULT_OF_L2I)) {
                 long constantValue = ((Number) constant).longValue();
-                if ((constantValue == 0xEFFFFFFFL || constantValue == 0xEFFFFFFFFFFFFFFFL || seen == IAND
+                if ((constantValue == 0xEFFFFFFFL || constantValue == 0xEFFFFFFFFFFFFFFFL || seen == Const.IAND
                         && constantValue == 0xEFFFFFFF)) {
-                    bugAccumulator.accumulateBug(new BugInstance(this, "TESTING", seen == LAND ? HIGH_PRIORITY : NORMAL_PRIORITY)
+                    bugAccumulator.accumulateBug(new BugInstance(this, "TESTING", seen == Const.LAND ? HIGH_PRIORITY : NORMAL_PRIORITY)
                     .addClassAndMethod(this).addString("Possible failed attempt to mask lower 31 bits of an int")
                     .addValueSource(value, this), this);
                 }
@@ -697,7 +698,7 @@ public class FindPuzzlers extends OpcodeStackDetector {
             }
         }
 
-        if (seen == INEG) {
+        if (seen == Const.INEG) {
             OpcodeStack.Item top = stack.getStackItem(0);
             XMethod m = top.getReturnValueOf();
             if (m != null) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindReturnRef.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindReturnRef.java
@@ -19,6 +19,7 @@
 
 package edu.umd.cs.findbugs.detect;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.classfile.Method;
@@ -74,11 +75,11 @@ public class FindReturnRef extends OpcodeStackDetector {
 
     @Override
     public void visit(Method obj) {
-        check = publicClass && (obj.getAccessFlags() & (ACC_PUBLIC)) != 0;
+        check = publicClass && (obj.getAccessFlags() & (Const.ACC_PUBLIC)) != 0;
         if (!check) {
             return;
         }
-        staticMethod = (obj.getAccessFlags() & (ACC_STATIC)) != 0;
+        staticMethod = (obj.getAccessFlags() & (Const.ACC_STATIC)) != 0;
         // variableNames = obj.getLocalVariableTable();
         parameterCount = getNumberMethodArguments();
 
@@ -107,7 +108,7 @@ public class FindReturnRef extends OpcodeStackDetector {
             return;
         }
 
-        if (staticMethod && seen == PUTSTATIC && nonPublicFieldOperand()
+        if (staticMethod && seen == Const.PUTSTATIC && nonPublicFieldOperand()
                 && MutableStaticFields.mutableSignature(getSigConstantOperand())) {
             OpcodeStack.Item top = stack.getStackItem(0);
             if (isPotentialCapture(top)) {
@@ -119,7 +120,7 @@ public class FindReturnRef extends OpcodeStackDetector {
                                 getPC(), getPC() - 1)), this);
             }
         }
-        if (!staticMethod && seen == PUTFIELD && nonPublicFieldOperand()
+        if (!staticMethod && seen == Const.PUTFIELD && nonPublicFieldOperand()
                 && MutableStaticFields.mutableSignature(getSigConstantOperand())) {
             OpcodeStack.Item top = stack.getStackItem(0);
             OpcodeStack.Item target = stack.getStackItem(1);
@@ -133,13 +134,13 @@ public class FindReturnRef extends OpcodeStackDetector {
             }
         }
 
-        if (seen == ALOAD_0 && !staticMethod) {
+        if (seen == Const.ALOAD_0 && !staticMethod) {
             thisOnTOS = true;
             fieldOnTOS = false;
             return;
         }
 
-        if (thisOnTOS && seen == GETFIELD && getClassConstantOperand().equals(getClassName()) && nonPublicFieldOperand()
+        if (thisOnTOS && seen == Const.GETFIELD && getClassConstantOperand().equals(getClassName()) && nonPublicFieldOperand()
                 && !AnalysisContext.currentXFactory().isEmptyArrayField(getXFieldOperand())) {
             fieldOnTOS = true;
             thisOnTOS = false;
@@ -149,7 +150,7 @@ public class FindReturnRef extends OpcodeStackDetector {
             fieldIsStatic = false;
             return;
         }
-        if (seen == GETSTATIC && getClassConstantOperand().equals(getClassName()) && nonPublicFieldOperand()
+        if (seen == Const.GETSTATIC && getClassConstantOperand().equals(getClassName()) && nonPublicFieldOperand()
                 && !AnalysisContext.currentXFactory().isEmptyArrayField(getXFieldOperand())) {
             fieldOnTOS = true;
             thisOnTOS = false;
@@ -161,7 +162,7 @@ public class FindReturnRef extends OpcodeStackDetector {
             return;
         }
         thisOnTOS = false;
-        if (check && fieldOnTOS && seen == ARETURN
+        if (check && fieldOnTOS && seen == Const.ARETURN
                 /*
                  * && !sigOnStack.equals("Ljava/lang/String;") &&
                  * sigOnStack.indexOf("Exception") == -1 && sigOnStack.indexOf("[") >= 0
@@ -184,7 +185,7 @@ public class FindReturnRef extends OpcodeStackDetector {
         if (!top.isInitialParameter()) {
             return false;
         }
-        if ((getMethod().getAccessFlags() & ACC_VARARGS) == 0) {
+        if ((getMethod().getAccessFlags() & Const.ACC_VARARGS) == 0) {
             return true;
         }
         if (top.getRegisterNumber() == parameterCount - 1)

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindRoughConstants.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindRoughConstants.java
@@ -24,6 +24,7 @@ import java.math.RoundingMode;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Constant;
 import org.apache.bcel.classfile.ConstantDouble;
 import org.apache.bcel.classfile.ConstantFloat;
@@ -127,7 +128,7 @@ public class FindRoughConstants extends BytecodeScanningDetector {
 
     @Override
     public void sawOpcode(int seen) {
-        if (seen == LDC || seen == LDC_W || seen == LDC2_W) {
+        if (seen == Const.LDC || seen == Const.LDC_W || seen == Const.LDC2_W) {
             Constant c = getConstantRefOperand();
             if (c instanceof ConstantFloat) {
                 checkConst(((ConstantFloat) c).getBytes());
@@ -138,8 +139,8 @@ public class FindRoughConstants extends BytecodeScanningDetector {
         }
         // Lower priority if the constant is put into array immediately or after the boxing:
         // this is likely to be just similar number in some predefined dataset (like lookup table)
-        if(seen == INVOKESTATIC && lastBug != null) {
-            if (getNextOpcode() == AASTORE
+        if(seen == Const.INVOKESTATIC && lastBug != null) {
+            if (getNextOpcode() == Const.AASTORE
                     && getNameConstantOperand().equals("valueOf")
                     && (getClassConstantOperand().equals("java/lang/Double") || getClassConstantOperand().equals(
                             "java/lang/Float"))) {
@@ -204,7 +205,7 @@ public class FindRoughConstants extends BytecodeScanningDetector {
         }
         for (BadConstant badConstant : badConstants) {
             int priority = getPriority(badConstant, constValue, candidate);
-            if(getNextOpcode() == FASTORE || getNextOpcode() == DASTORE) {
+            if(getNextOpcode() == Const.FASTORE || getNextOpcode() == Const.DASTORE) {
                 priority++;
             }
             if(priority < IGNORE_PRIORITY) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindRunInvocations.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindRunInvocations.java
@@ -19,6 +19,7 @@
 
 package edu.umd.cs.findbugs.detect;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 
 import edu.umd.cs.findbugs.BugAccumulator;
@@ -62,7 +63,7 @@ public class FindRunInvocations extends BytecodeScanningDetector implements Stat
         if (alreadySawStart) {
             return;
         }
-        if ((seen == INVOKEVIRTUAL || seen == INVOKEINTERFACE) && "()V".equals(getSigConstantOperand())
+        if ((seen == Const.INVOKEVIRTUAL || seen == Const.INVOKEINTERFACE) && "()V".equals(getSigConstantOperand())
                 && isThread(getDottedClassConstantOperand())) {
             if ("start".equals(getNameConstantOperand())) {
                 alreadySawStart = true;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindSelfComparison.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindSelfComparison.java
@@ -21,6 +21,7 @@ package edu.umd.cs.findbugs.detect;
 
 import java.util.BitSet;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.LineNumberTable;
 
@@ -90,7 +91,7 @@ public class FindSelfComparison extends OpcodeStackDetector {
     @Override
     public void sawOpcode(int seen) {
         if (DEBUG) {
-            System.out.printf("%3d %-15s %s%n", getPC(), OPCODE_NAMES[seen], stack);
+            System.out.printf("%3d %-15s %s%n", getPC(), Const.getOpcodeName(seen), stack);
         }
 
 
@@ -98,7 +99,7 @@ public class FindSelfComparison extends OpcodeStackDetector {
             resetDoubleAssignmentState();
         }
 
-        if (seen == PUTFIELD) {
+        if (seen == Const.PUTFIELD) {
             OpcodeStack.Item obj = stack.getStackItem(1);
             OpcodeStack.Item value = stack.getStackItem(0);
             XField f = getXFieldOperand();
@@ -167,7 +168,7 @@ public class FindSelfComparison extends OpcodeStackDetector {
 
         } else if (isReturn(seen)) {
             resetDoubleAssignmentState();
-        } else if (seen == GETFIELD && Util.nullSafeEquals(getXFieldOperand(), putFieldXField)) {
+        } else if (seen == Const.GETFIELD && Util.nullSafeEquals(getXFieldOperand(), putFieldXField)) {
             OpcodeStack.Item obj = stack.getStackItem(0);
             if (obj.sameValue(putFieldObj)) {
                 resetDoubleAssignmentState();
@@ -175,8 +176,8 @@ public class FindSelfComparison extends OpcodeStackDetector {
         }
 
         switch (seen) {
-        case INVOKEVIRTUAL:
-        case INVOKEINTERFACE:
+        case Const.INVOKEVIRTUAL:
+        case Const.INVOKEINTERFACE:
             //        case INVOKESTATIC:
             if (getClassName().toLowerCase().indexOf("test") >= 0) {
                 break;
@@ -187,7 +188,7 @@ public class FindSelfComparison extends OpcodeStackDetector {
             if (getSuperclassName().toLowerCase().indexOf("test") >= 0) {
                 break;
             }
-            if (getNextOpcode() == POP) {
+            if (getNextOpcode() == Const.POP) {
                 break;
             }
             String name = getNameConstantOperand();
@@ -197,7 +198,7 @@ public class FindSelfComparison extends OpcodeStackDetector {
                 String sig = getSigConstantOperand();
                 SignatureParser parser = new SignatureParser(sig);
                 int numParameters = parser.getNumParameters();
-                if ((numParameters == 1 ||  seen == INVOKESTATIC && numParameters  == 2)
+                if ((numParameters == 1 ||  seen == Const.INVOKESTATIC && numParameters  == 2)
                         && (booleanComparisonMethod && sig.endsWith(";)Z")
                                 ||  FindSelfComparison2.comparatorMethod(name) && sig.endsWith(";)I"))) {
                     checkForSelfOperation(seen, "COMPARISON");
@@ -205,36 +206,36 @@ public class FindSelfComparison extends OpcodeStackDetector {
             }
             break;
 
-        case LOR:
-        case LAND:
-        case LXOR:
-        case LSUB:
-        case IOR:
-        case IAND:
-        case IXOR:
-        case ISUB:
+        case Const.LOR:
+        case Const.LAND:
+        case Const.LXOR:
+        case Const.LSUB:
+        case Const.IOR:
+        case Const.IAND:
+        case Const.IXOR:
+        case Const.ISUB:
             checkForSelfOperation(seen, "COMPUTATION");
             break;
-        case FCMPG:
-        case DCMPG:
-        case DCMPL:
-        case FCMPL:
+        case Const.FCMPG:
+        case Const.DCMPG:
+        case Const.DCMPL:
+        case Const.FCMPL:
             break;
-        case LCMP:
-        case IF_ACMPEQ:
-        case IF_ACMPNE:
-        case IF_ICMPNE:
-        case IF_ICMPEQ:
-        case IF_ICMPGT:
-        case IF_ICMPLE:
-        case IF_ICMPLT:
-        case IF_ICMPGE:
+        case Const.LCMP:
+        case Const.IF_ACMPEQ:
+        case Const.IF_ACMPNE:
+        case Const.IF_ICMPNE:
+        case Const.IF_ICMPEQ:
+        case Const.IF_ICMPGT:
+        case Const.IF_ICMPLE:
+        case Const.IF_ICMPLT:
+        case Const.IF_ICMPGE:
             checkForSelfOperation(seen, "COMPARISON");
             break;
         default:
             break;
         }
-        if (isRegisterLoad() && seen != IINC) {
+        if (isRegisterLoad() && seen != Const.IINC) {
             if (getRegisterOperand() == whichRegister) {
                 registerLoadCount++;
             } else {
@@ -320,7 +321,7 @@ public class FindSelfComparison extends OpcodeStackDetector {
                 bugAccumulator.accumulateBug(bug, this);
             }
 
-            else if (opCode == IXOR && item0.sameValue(item1)) {
+            else if (opCode == Const.IXOR && item0.sameValue(item1)) {
                 LocalVariableAnnotation localVariableAnnotation = LocalVariableAnnotation.getLocalVariableAnnotation(this, item0);
                 if (localVariableAnnotation != null) {
                     bugAccumulator.accumulateBug(

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindSpinLoop.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindSpinLoop.java
@@ -19,6 +19,7 @@
 
 package edu.umd.cs.findbugs.detect;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Method;
 
 import edu.umd.cs.findbugs.BugInstance;
@@ -56,18 +57,18 @@ public class FindSpinLoop extends BytecodeScanningDetector implements StatelessD
 
         // System.out.println("PC: " + PC + ", stage: " + stage1);
         switch (seen) {
-        case ALOAD_0:
-        case ALOAD_1:
-        case ALOAD_2:
-        case ALOAD_3:
-        case ALOAD:
+        case Const.ALOAD_0:
+        case Const.ALOAD_1:
+        case Const.ALOAD_2:
+        case Const.ALOAD_3:
+        case Const.ALOAD:
             if (DEBUG) {
                 System.out.println("   ALOAD at PC " + getPC());
             }
             start = getPC();
             stage = 1;
             break;
-        case GETSTATIC:
+        case Const.GETSTATIC:
             if (DEBUG) {
                 System.out.println("   getfield in stage " + stage);
             }
@@ -75,7 +76,7 @@ public class FindSpinLoop extends BytecodeScanningDetector implements StatelessD
             start = getPC();
             stage = 2;
             break;
-        case GETFIELD:
+        case Const.GETFIELD:
             if (DEBUG) {
                 System.out.println("   getfield in stage " + stage);
             }
@@ -86,11 +87,11 @@ public class FindSpinLoop extends BytecodeScanningDetector implements StatelessD
                 stage = 0;
             }
             break;
-        case GOTO:
-        case IFNE:
-        case IFEQ:
-        case IFNULL:
-        case IFNONNULL:
+        case Const.GOTO:
+        case Const.IFNE:
+        case Const.IFEQ:
+        case Const.IFNULL:
+        case Const.IFNONNULL:
             if (DEBUG) {
                 System.out.println("   conditional branch in stage " + stage + " to " + getBranchTarget());
             }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindUncalledPrivateMethods.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindUncalledPrivateMethods.java
@@ -21,6 +21,7 @@ package edu.umd.cs.findbugs.detect;
 
 import java.util.HashSet;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.AnnotationEntry;
 import org.apache.bcel.classfile.Constant;
 import org.apache.bcel.classfile.ConstantCP;
@@ -81,13 +82,13 @@ public class FindUncalledPrivateMethods extends BytecodeScanningDetector impleme
     @Override
     public void sawOpcode(int seen) {
         switch (seen) {
-        case INVOKEVIRTUAL:
-        case INVOKESPECIAL:
-        case INVOKESTATIC:
+        case Const.INVOKEVIRTUAL:
+        case Const.INVOKESPECIAL:
+        case Const.INVOKESTATIC:
             if (getDottedClassConstantOperand().equals(className)) {
                 String className = getDottedClassConstantOperand();
                 MethodAnnotation called = new MethodAnnotation(className, getNameConstantOperand(), getSigConstantOperand(),
-                        seen == INVOKESTATIC);
+                        seen == Const.INVOKESTATIC);
                 calledMethods.add(called);
                 calledMethodNames.add(getNameConstantOperand().toLowerCase());
             }
@@ -113,7 +114,7 @@ public class FindUncalledPrivateMethods extends BytecodeScanningDetector impleme
                 if(kind >= 5 && kind <= 9) {
                     Constant ref = cp.getConstant(((ConstantMethodHandle)constant).getReferenceIndex());
                     if(ref instanceof ConstantCP) {
-                        String className = cp.getConstantString(((ConstantCP) ref).getClassIndex(), CONSTANT_Class);
+                        String className = cp.getConstantString(((ConstantCP) ref).getClassIndex(), Const.CONSTANT_Class);
                         ConstantNameAndType nameAndType = (ConstantNameAndType) cp.getConstant(((ConstantCP) ref).getNameAndTypeIndex());
                         String name = ((ConstantUtf8)cp.getConstant(nameAndType.getNameIndex())).getBytes();
                         String signature = ((ConstantUtf8)cp.getConstant(nameAndType.getSignatureIndex())).getBytes();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindUncalledPrivateMethods.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindUncalledPrivateMethods.java
@@ -67,7 +67,7 @@ public class FindUncalledPrivateMethods extends BytecodeScanningDetector impleme
                 && !"writeObject".equals(methodName)
                 && methodName.indexOf("debug") == -1 && methodName.indexOf("Debug") == -1
                 && methodName.indexOf("trace") == -1 && methodName.indexOf("Trace") == -1
-                && !"<init>".equals(methodName) && !"<clinit>".equals(methodName)) {
+                && !Const.CONSTRUCTOR_NAME.equals(methodName) && !Const.STATIC_INITIALIZER_NAME.equals(methodName)) {
             for(AnnotationEntry a : obj.getAnnotationEntries()) {
                 String typeName =  a.getAnnotationType();
                 if ("Ljavax/annotation/PostConstruct;".equals(typeName)

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindUnconditionalWait.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindUnconditionalWait.java
@@ -19,6 +19,7 @@
 
 package edu.umd.cs.findbugs.detect;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Method;
 
 import edu.umd.cs.findbugs.BugInstance;
@@ -58,12 +59,12 @@ public class FindUnconditionalWait extends BytecodeScanningDetector implements S
     public void sawOpcode(int seen) {
         switch (stage) {
         case 0:
-            if (seen == MONITORENTER) {
+            if (seen == Const.MONITORENTER) {
                 stage = 1;
             }
             break;
         case 1:
-            if (seen == INVOKEVIRTUAL && "wait".equals(getNameConstantOperand())) {
+            if (seen == Const.INVOKEVIRTUAL && "wait".equals(getNameConstantOperand())) {
                 bugReporter.reportBug(new BugInstance(this, "UW_UNCOND_WAIT",
                         "()V".equals(getSigConstantOperand()) ? NORMAL_PRIORITY : LOW_PRIORITY).addClassAndMethod(this)
                         .addSourceLine(this));

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindUninitializedGet.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindUninitializedGet.java
@@ -26,6 +26,7 @@ import java.util.LinkedList;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.ElementValue;
 import org.apache.bcel.classfile.Field;
@@ -131,25 +132,25 @@ public class FindUninitializedGet extends BytecodeScanningDetector implements St
             return;
         }
         if (uninitializedFieldReadAndCheckedForNonnull != null) {
-            if (seen == NEW && getClassConstantOperand().endsWith("Exception")) {
+            if (seen == Const.NEW && getClassConstantOperand().endsWith("Exception")) {
                 uninitializedFieldReadAndCheckedForNonnull.raisePriority();
             }
             uninitializedFieldReadAndCheckedForNonnull = null;
         }
 
-        if (seen == ALOAD_0) {
+        if (seen == Const.ALOAD_0) {
             thisOnTOS = true;
             return;
         }
 
-        if (seen == PUTFIELD && getClassConstantOperand().equals(getClassName())) {
+        if (seen == Const.PUTFIELD && getClassConstantOperand().equals(getClassName())) {
             initializedFields.add(FieldAnnotation.fromReferencedField(this));
-        } else if (thisOnTOS && seen == GETFIELD && getClassConstantOperand().equals(getClassName())) {
+        } else if (thisOnTOS && seen == Const.GETFIELD && getClassConstantOperand().equals(getClassName())) {
             UnreadFieldsData unreadFields = AnalysisContext.currentAnalysisContext().getUnreadFieldsData();
             XField xField = XFactory.createReferencedXField(this);
             FieldAnnotation f = FieldAnnotation.fromReferencedField(this);
             int nextOpcode = 0xff & codeBytes[getPC() + 3];
-            if (nextOpcode != POP && !initializedFields.contains(f) && declaredFields.contains(f) && !containerFields.contains(f)
+            if (nextOpcode != Const.POP && !initializedFields.contains(f) && declaredFields.contains(f) && !containerFields.contains(f)
                     && !unreadFields.isContainerField(xField)) {
                 // System.out.println("Next opcode: " +
                 // OPCODE_NAMES[nextOpcode]);
@@ -167,7 +168,7 @@ public class FindUninitializedGet extends BytecodeScanningDetector implements St
                     FieldSummary fieldSummary = AnalysisContext.currentAnalysisContext().getFieldSummary();
                     if (fieldSummary.callsOverriddenMethodsFromSuperConstructor(getClassDescriptor())) {
                         priority++;
-                    } else if (nextOpcode == IFNONNULL) {
+                    } else if (nextOpcode == Const.IFNONNULL) {
                         priority++;
                         priorityLoweredBecauseOfIfNonnullTest = true;
                     }
@@ -181,11 +182,11 @@ public class FindUninitializedGet extends BytecodeScanningDetector implements St
                 }
                 initializedFields.add(f);
             }
-        } else if ((seen == INVOKESPECIAL && !("<init>".equals(getNameConstantOperand()) && !getClassConstantOperand().equals(
+        } else if ((seen == Const.INVOKESPECIAL && !("<init>".equals(getNameConstantOperand()) && !getClassConstantOperand().equals(
                 getClassName())))
-                || (seen == INVOKESTATIC && "doPrivileged".equals(getNameConstantOperand()) && "java/security/AccessController".equals(getClassConstantOperand()))
-                        || (seen == INVOKEVIRTUAL && getClassConstantOperand().equals(getClassName()))
-                        || (seen == INVOKEVIRTUAL && "start".equals(getNameConstantOperand()))) {
+                || (seen == Const.INVOKESTATIC && "doPrivileged".equals(getNameConstantOperand()) && "java/security/AccessController".equals(getClassConstantOperand()))
+                        || (seen == Const.INVOKEVIRTUAL && getClassConstantOperand().equals(getClassName()))
+                        || (seen == Const.INVOKEVIRTUAL && "start".equals(getNameConstantOperand()))) {
 
             inConstructor = false;
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindUninitializedGet.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindUninitializedGet.java
@@ -98,7 +98,7 @@ public class FindUninitializedGet extends BytecodeScanningDetector implements St
         initializedFields.clear();
 
         thisOnTOS = false;
-        inConstructor = "<init>".equals(getMethodName()) && getMethodSig().indexOf(getClassName()) == -1;
+        inConstructor = Const.CONSTRUCTOR_NAME.equals(getMethodName()) && getMethodSig().indexOf(getClassName()) == -1;
 
     }
 
@@ -182,7 +182,7 @@ public class FindUninitializedGet extends BytecodeScanningDetector implements St
                 }
                 initializedFields.add(f);
             }
-        } else if ((seen == Const.INVOKESPECIAL && !("<init>".equals(getNameConstantOperand()) && !getClassConstantOperand().equals(
+        } else if ((seen == Const.INVOKESPECIAL && !(Const.CONSTRUCTOR_NAME.equals(getNameConstantOperand()) && !getClassConstantOperand().equals(
                 getClassName())))
                 || (seen == Const.INVOKESTATIC && "doPrivileged".equals(getNameConstantOperand()) && "java/security/AccessController".equals(getClassConstantOperand()))
                         || (seen == Const.INVOKEVIRTUAL && getClassConstantOperand().equals(getClassName()))

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindUnsatisfiedObligation.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindUnsatisfiedObligation.java
@@ -321,7 +321,7 @@ public class FindUnsatisfiedObligation extends CFGDetector {
                 return;
             }
 
-            if (methodDescriptor.getName().equals("<init>")) {
+            if (methodDescriptor.getName().equals(Const.CONSTRUCTOR_NAME)) {
                 try {
 
                     if (subtypes2.isSubtype(methodDescriptor.getClassDescriptor(), DescriptorFactory.createClassDescriptorFromDottedClassName(obligation.getClassName()))) {
@@ -528,7 +528,7 @@ public class FindUnsatisfiedObligation extends CFGDetector {
                 }
 
                 String methodName = inv.getMethodName(cpg);
-                Type producedType = "<init>".equals(methodName) ? inv.getReferenceType(cpg) : inv.getReturnType(cpg);
+                Type producedType = Const.CONSTRUCTOR_NAME.equals(methodName) ? inv.getReferenceType(cpg) : inv.getReturnType(cpg);
 
                 if (DEBUG_FP && !(producedType instanceof ObjectType)) {
                     System.out.println("Produced type " + producedType + " not an ObjectType");

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindUnsyncGet.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindUnsyncGet.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.classfile.Method;
 
@@ -36,7 +37,7 @@ public class FindUnsyncGet extends BytecodeScanningDetector {
 
     private final BugReporter bugReporter;
 
-    static final int doNotConsider = ACC_PRIVATE | ACC_STATIC | ACC_NATIVE;
+    static final int doNotConsider = Const.ACC_PRIVATE | Const.ACC_STATIC | Const.ACC_NATIVE;
 
     // Maps of property names to get and set methods
     private final HashMap<String, MethodAnnotation> getMethods = new HashMap<String, MethodAnnotation>();
@@ -79,7 +80,7 @@ public class FindUnsyncGet extends BytecodeScanningDetector {
             return;
         }
         String name = obj.getName();
-        boolean isSynchronized = (flags & ACC_SYNCHRONIZED) != 0;
+        boolean isSynchronized = (flags & Const.ACC_SYNCHRONIZED) != 0;
         /*
          * String sig = obj.getSignature(); char firstArg = sig.charAt(1); char
          * returnValue = sig.charAt(1 + sig.indexOf(')')); boolean firstArgIsRef

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindUselessObjects.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindUselessObjects.java
@@ -139,7 +139,7 @@ public class FindUselessObjects implements Detector {
                     }
                 } else if(instruction instanceof INVOKESPECIAL) {
                     InvokeInstruction inv = (InvokeInstruction) instruction;
-                    if (inv.getMethodName(cpg).equals("<init>")
+                    if (inv.getMethodName(cpg).equals(CONSTRUCTOR_NAME)
                             && noSideEffectMethods.hasNoSideEffect(new MethodDescriptor(inv, cpg))) {
                         int number = vna.getFactAtLocation(location).getStackValue(inv.consumeStack(cpg)-1).getNumber();
                         TypeFrame typeFrame = ta.getFactAtLocation(location);
@@ -666,7 +666,7 @@ public class FindUselessObjects implements Detector {
                                 }
                                 MethodSideEffectStatus status = noSideEffectMethods.status(m);
                                 if(status == MethodSideEffectStatus.NSE || status == MethodSideEffectStatus.SE_CLINIT) {
-                                    if(m.getName().equals("<init>")) {
+                                    if(m.getName().equals(CONSTRUCTOR_NAME)) {
                                         if(vns[0].equals(context.thisValue)) {
                                             changed |= context.setEscape(vals);
                                         } else {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FormatStringChecker.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FormatStringChecker.java
@@ -20,6 +20,7 @@
 
 package edu.umd.cs.findbugs.detect;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 
 import edu.umd.cs.findbugs.BugInstance;
@@ -81,7 +82,7 @@ public class FormatStringChecker extends OpcodeStackDetector {
             stackDepth = 0;
             arguments = null;
         }
-        if (seen == ANEWARRAY && stack.getStackDepth() >= 2) {
+        if (seen == Const.ANEWARRAY && stack.getStackDepth() >= 2) {
             Object size = stack.getStackItem(0).getConstant();
             Object formatStr = stack.getStackItem(1).getConstant();
             if (size instanceof Integer && formatStr instanceof String) {
@@ -90,9 +91,9 @@ public class FormatStringChecker extends OpcodeStackDetector {
                 state = FormatState.READY_FOR_FORMAT;
                 stackDepth = stack.getStackDepth();
             }
-        } else if (state == FormatState.READY_FOR_FORMAT && seen == DUP) {
+        } else if (state == FormatState.READY_FOR_FORMAT && seen == Const.DUP) {
             state = FormatState.EXPECTING_ASSIGNMENT;
-        } else if (state == FormatState.EXPECTING_ASSIGNMENT && stack.getStackDepth() == stackDepth + 3 && seen == AASTORE) {
+        } else if (state == FormatState.EXPECTING_ASSIGNMENT && stack.getStackDepth() == stackDepth + 3 && seen == Const.AASTORE) {
             Object pos = stack.getStackItem(1).getConstant();
             OpcodeStack.Item value = stack.getStackItem(0);
             if (pos instanceof Integer) {
@@ -107,7 +108,7 @@ public class FormatStringChecker extends OpcodeStackDetector {
                 state = FormatState.NONE;
             }
         } else if (state == FormatState.READY_FOR_FORMAT
-                && (seen == INVOKESPECIAL || seen == INVOKEVIRTUAL || seen == INVOKESTATIC || seen == INVOKEINTERFACE)
+                && (seen == Const.INVOKESPECIAL || seen == Const.INVOKEVIRTUAL || seen == Const.INVOKESTATIC || seen == Const.INVOKEINTERFACE)
                 && stack.getStackDepth() == stackDepth) {
 
             String cl = getClassConstantOperand();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FunctionsThatMightBeMistakenForProcedures.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FunctionsThatMightBeMistakenForProcedures.java
@@ -245,7 +245,7 @@ public class FunctionsThatMightBeMistakenForProcedures extends OpcodeStackDetect
                 returnSelf++;
                 break;
             }
-            if ("<init>".equals(xMethod.getName())) {
+            if (Const.CONSTRUCTOR_NAME.equals(xMethod.getName())) {
                 String sig = xMethod.getSignature();
                 // returning a newly constructed value
                 boolean voidConstructor;
@@ -270,12 +270,12 @@ public class FunctionsThatMightBeMistakenForProcedures extends OpcodeStackDetect
                 returnUnknown++;
                 break;
             }
-            if ("<init>".equals(xMethod.getName()) || doNotIgnoreHigh.contains(xMethod)) {
+            if (Const.CONSTRUCTOR_NAME.equals(xMethod.getName()) || doNotIgnoreHigh.contains(xMethod)) {
                 returnOther++;
                 // System.out.println("  calls " + xMethod);
                 // System.out.println("  at " +
                 // MethodAnnotation.fromXMethod(xMethod).getSourceLines());
-                if ("<init>".equals(xMethod.getName()) || doNotIgnore.contains(xMethod)) {
+                if (Const.CONSTRUCTOR_NAME.equals(xMethod.getName()) || doNotIgnore.contains(xMethod)) {
                     returnNew++;
                 }
             } else if (doNotIgnore.contains(xMethod)) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FunctionsThatMightBeMistakenForProcedures.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FunctionsThatMightBeMistakenForProcedures.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 
 import javax.annotation.CheckForNull;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.Field;
 import org.apache.bcel.classfile.JavaClass;
@@ -202,8 +203,8 @@ public class FunctionsThatMightBeMistakenForProcedures extends OpcodeStackDetect
     @Override
     public void sawOpcode(int seen) {
         switch (seen) {
-        case INVOKEVIRTUAL:
-        case INVOKESPECIAL: {
+        case Const.INVOKEVIRTUAL:
+        case Const.INVOKESPECIAL: {
             if (getMethod().isStatic() || !hasNonFinalFields) {
                 break;
             }
@@ -222,7 +223,7 @@ public class FunctionsThatMightBeMistakenForProcedures extends OpcodeStackDetect
             break;
         }
 
-        case ARETURN: {
+        case Const.ARETURN: {
             OpcodeStack.Item rv = stack.getStackItem(0);
             if (rv.isNull()) {
                 break;
@@ -289,7 +290,7 @@ public class FunctionsThatMightBeMistakenForProcedures extends OpcodeStackDetect
 
         }
         break;
-        case PUTFIELD: {
+        case Const.PUTFIELD: {
 
             OpcodeStack.Item rv = stack.getStackItem(1);
             if (rv.getRegisterNumber() == 0 && rv.isInitialParameter()) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/IDivResultCastToDouble.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/IDivResultCastToDouble.java
@@ -1,5 +1,6 @@
 package edu.umd.cs.findbugs.detect;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.Method;
 
@@ -44,16 +45,16 @@ public class IDivResultCastToDouble extends BytecodeScanningDetector {
     public void sawOpcode(int seen) {
 
         if (DEBUG) {
-            System.out.println("Saw opcode " + OPCODE_NAMES[seen] + " " + pendingIdivCastToDivBugLocation);
+            System.out.println("Saw opcode " + Const.getOpcodeName(seen) + " " + pendingIdivCastToDivBugLocation);
         }
 
-        if ((prevOpCode == I2D || prevOpCode == L2D) && seen == INVOKESTATIC && ClassName.isMathClass(getClassConstantOperand())
+        if ((prevOpCode == Const.I2D || prevOpCode == Const.L2D) && seen == Const.INVOKESTATIC && ClassName.isMathClass(getClassConstantOperand())
                 && "ceil".equals(getNameConstantOperand())) {
             bugAccumulator
             .accumulateBug(new BugInstance(this, "ICAST_INT_CAST_TO_DOUBLE_PASSED_TO_CEIL", HIGH_PRIORITY)
             .addClassAndMethod(this), this);
             pendingIdivCastToDivBugLocation = null;
-        } else if ((prevOpCode == I2F || prevOpCode == L2F) && seen == INVOKESTATIC
+        } else if ((prevOpCode == Const.I2F || prevOpCode == Const.L2F) && seen == Const.INVOKESTATIC
                 && ClassName.isMathClass(getClassConstantOperand()) && "round".equals(getNameConstantOperand())) {
             bugAccumulator.accumulateBug(
                     new BugInstance(this, "ICAST_INT_CAST_TO_FLOAT_PASSED_TO_ROUND", NORMAL_PRIORITY).addClassAndMethod(this),
@@ -66,7 +67,7 @@ public class IDivResultCastToDouble extends BytecodeScanningDetector {
             pendingIdivCastToDivBugLocation = null;
         }
 
-        if (prevOpCode == IDIV && (seen == I2D || seen == I2F) || prevOpCode == LDIV && (seen == L2D || seen == L2F)) {
+        if (prevOpCode == Const.IDIV && (seen == Const.I2D || seen == Const.I2F) || prevOpCode == Const.LDIV && (seen == Const.L2D || seen == Const.L2F)) {
             pendingIdivCastToDivBugLocation = SourceLineAnnotation.fromVisitedInstruction(this);
         }
         prevOpCode = seen;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/IncompatMask.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/IncompatMask.java
@@ -19,6 +19,7 @@
 
 package edu.umd.cs.findbugs.detect;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 
 import edu.umd.cs.findbugs.BugInstance;
@@ -72,39 +73,39 @@ public class IncompatMask extends OpcodeStackDetector {
     @Override
     public void sawOpcode(int seen) {
         switch (seen) {
-        case IAND:
-        case LAND:
+        case Const.IAND:
+        case Const.LAND:
             arg1 = getArg();
-            bitop = IAND;
+            bitop = Const.IAND;
             return;
-        case IOR:
-        case LOR:
+        case Const.IOR:
+        case Const.LOR:
             arg1 = getArg();
-            bitop = IOR;
+            bitop = Const.IOR;
             return;
-        case LCMP:
+        case Const.LCMP:
             if (checkItem(2)) {
                 arg2 = getArg();
             }
             return;
-        case IF_ICMPEQ:
-        case IF_ICMPNE:
+        case Const.IF_ICMPEQ:
+        case Const.IF_ICMPNE:
             if (checkItem(2)) {
                 arg2 = getArg();
                 equality = true;
             }
             break;
-        case IFEQ:
-        case IFNE:
+        case Const.IFEQ:
+        case Const.IFNE:
             if (arg1 instanceof Integer && checkItem(1)) {
                 arg2 = 0;
             }
             equality = true;
             break;
-        case IFLE:
-        case IFLT:
-        case IFGT:
-        case IFGE:
+        case Const.IFLE:
+        case Const.IFLT:
+        case Const.IFGT:
+        case Const.IFGE:
             if (arg1 instanceof Integer && checkItem(1)) {
                 arg2 = 0;
             }
@@ -123,7 +124,7 @@ public class IncompatMask extends OpcodeStackDetector {
             boolean onlyLowBits = bits >>> 12 == 0;
             BugInstance bug;
             if (highbit) {
-                bug = new BugInstance(this, "BIT_SIGNED_CHECK_HIGH_BIT", (seen == IFLE || seen == IFGT) ? HIGH_PRIORITY
+                bug = new BugInstance(this, "BIT_SIGNED_CHECK_HIGH_BIT", (seen == Const.IFLE || seen == Const.IFGT) ? HIGH_PRIORITY
                         : NORMAL_PRIORITY);
             } else {
                 bug = new BugInstance(this, "BIT_SIGNED_CHECK", onlyLowBits ? LOW_PRIORITY : NORMAL_PRIORITY);
@@ -138,7 +139,7 @@ public class IncompatMask extends OpcodeStackDetector {
             long val1 = arg1.longValue();
             long val2 = arg2.longValue();
 
-            if (bitop == IOR) {
+            if (bitop == Const.IOR) {
                 dif = val1 & ~val2;
                 t = "BIT_IOR";
             } else if (val1 != 0 || val2 != 0) {
@@ -182,10 +183,10 @@ public class IncompatMask extends OpcodeStackDetector {
     public void afterOpcode(int seen) {
         super.afterOpcode(seen);
         switch (seen) {
-        case IAND:
-        case LAND:
-        case IOR:
-        case LOR:
+        case Const.IAND:
+        case Const.LAND:
+        case Const.IOR:
+        case Const.LOR:
             if(stack.getStackDepth() > 0) {
                 bitresultItem = stack.getStackItem(0);
             }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InefficientIndexOf.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InefficientIndexOf.java
@@ -22,6 +22,8 @@ package edu.umd.cs.findbugs.detect;
 import java.util.Arrays;
 import java.util.List;
 
+import org.apache.bcel.Const;
+
 import edu.umd.cs.findbugs.BugInstance;
 import edu.umd.cs.findbugs.BugReporter;
 import edu.umd.cs.findbugs.OpcodeStack;
@@ -59,7 +61,7 @@ public class InefficientIndexOf extends OpcodeStackDetector {
 
     @Override
     public void sawOpcode(int seen) {
-        if (seen == INVOKEVIRTUAL && stack.getStackDepth() > 0 && "java/lang/String".equals(getClassConstantOperand())) {
+        if (seen == Const.INVOKEVIRTUAL && stack.getStackDepth() > 0 && "java/lang/String".equals(getClassConstantOperand())) {
 
             boolean lastIndexOf = "lastIndexOf".equals(getNameConstantOperand());
             if (lastIndexOf || "indexOf".equals(getNameConstantOperand())) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InefficientInitializationInsideLoop.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InefficientInitializationInsideLoop.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Method;
 
 import edu.umd.cs.findbugs.BugInstance;
@@ -110,11 +111,11 @@ public class InefficientInitializationInsideLoop extends OpcodeStackDetector {
 
     @Override
     public void sawOpcode(int seen) {
-        if (seen == INVOKEINTERFACE && getClassConstantOperand().equals("java/sql/Connection")
+        if (seen == Const.INVOKEINTERFACE && getClassConstantOperand().equals("java/sql/Connection")
                 && getMethodDescriptorOperand().getName().equals("prepareStatement") && hasConstantArguments()) {
             matched.put(getPC(), new BugInstance(this, "IIL_PREPARE_STATEMENT_IN_LOOP", NORMAL_PRIORITY).addClassAndMethod(this)
                     .addSourceLine(this, getPC()).addCalledMethod(this));
-        } else if (seen == INVOKEINTERFACE && getMethodDescriptorOperand().equals(NODELIST_GET_LENGTH)) {
+        } else if (seen == Const.INVOKEINTERFACE && getMethodDescriptorOperand().equals(NODELIST_GET_LENGTH)) {
             Item item = getStack().getStackItem(0);
             XMethod returnValueOf = item.getReturnValueOf();
             if(returnValueOf != null && returnValueOf.getClassName().startsWith("org.w3c.dom.") && returnValueOf.getName().startsWith("getElementsByTagName")) {
@@ -123,13 +124,13 @@ public class InefficientInitializationInsideLoop extends OpcodeStackDetector {
                         .addSourceLine(this, getPC()).addCalledMethod(this));
                 sources.put(getPC(), item.getPC());
             }
-        } else if (seen == INVOKESTATIC
+        } else if (seen == Const.INVOKESTATIC
                 && (getMethodDescriptorOperand().equals(PATTERN_COMPILE) || getMethodDescriptorOperand()
                         .equals(PATTERN_COMPILE_2)) && hasConstantArguments()) {
             String regex = getFirstArgument();
             matched.put(getPC(), new BugInstance(this, "IIL_PATTERN_COMPILE_IN_LOOP", NORMAL_PRIORITY).addClassAndMethod(this)
                     .addSourceLine(this, getPC()).addCalledMethod(this).addString(regex).describe(StringAnnotation.REGEX_ROLE));
-        } else if ((seen == INVOKESTATIC || seen == INVOKEVIRTUAL) && implicitPatternMethods.contains(getMethodDescriptorOperand())) {
+        } else if ((seen == Const.INVOKESTATIC || seen == Const.INVOKEVIRTUAL) && implicitPatternMethods.contains(getMethodDescriptorOperand())) {
             String regex = getFirstArgument();
             if (regex != null && !(getNameConstantOperand().equals("split") && isFastPath(regex))) {
                 BugInstance bug = new BugInstance(this, "IIL_PATTERN_COMPILE_IN_LOOP_INDIRECT", LOW_PRIORITY)

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InefficientMemberAccess.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InefficientMemberAccess.java
@@ -19,6 +19,7 @@
  */
 package edu.umd.cs.findbugs.detect;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.generic.Type;
 
@@ -55,7 +56,7 @@ public class InefficientMemberAccess extends BytecodeScanningDetector implements
     @Override
     public void sawOpcode(int seen) {
 
-        if (seen == INVOKESTATIC) {
+        if (seen == Const.INVOKESTATIC) {
             String methodName = getNameConstantOperand();
             if (!methodName.startsWith(ACCESS_PREFIX)) {
                 return;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InefficientToArray.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InefficientToArray.java
@@ -23,6 +23,7 @@ package edu.umd.cs.findbugs.detect;
 import java.util.Collections;
 import java.util.List;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.Repository;
 import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.JavaClass;
@@ -106,18 +107,18 @@ public class InefficientToArray extends BytecodeScanningDetector implements Stat
     @Override
     public void sawOpcode(int seen) {
         if (DEBUG) {
-            System.out.println("State: " + state + "  Opcode: " + OPCODE_NAMES[seen]);
+            System.out.println("State: " + state + "  Opcode: " + Const.getOpcodeName(seen));
         }
 
         switch (state) {
         case SEEN_NOTHING:
-            if (seen == ICONST_0) {
+            if (seen == Const.ICONST_0) {
                 state = SEEN_ICONST_0;
             }
             break;
 
         case SEEN_ICONST_0:
-            if (seen == ANEWARRAY) {
+            if (seen == Const.ANEWARRAY) {
                 state = SEEN_ANEWARRAY;
             } else {
                 state = SEEN_NOTHING;
@@ -125,7 +126,7 @@ public class InefficientToArray extends BytecodeScanningDetector implements Stat
             break;
 
         case SEEN_ANEWARRAY:
-            if (((seen == INVOKEVIRTUAL) || (seen == INVOKEINTERFACE)) && ("toArray".equals(getNameConstantOperand()))
+            if (((seen == Const.INVOKEVIRTUAL) || (seen == Const.INVOKEINTERFACE)) && ("toArray".equals(getNameConstantOperand()))
                     && ("([Ljava/lang/Object;)[Ljava/lang/Object;".equals(getSigConstantOperand()))) {
                 try {
                     String clsName = getDottedClassConstantOperand();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InfiniteLoop.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InfiniteLoop.java
@@ -28,6 +28,7 @@ import java.util.List;
 
 import javax.annotation.Nonnull;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 
 import edu.umd.cs.findbugs.BugInstance;
@@ -309,13 +310,13 @@ public class InfiniteLoop extends OpcodeStackDetector {
     @Override
     public void sawOpcode(int seen) {
         if (DEBUG) {
-            System.out.printf("%3d %-15s %s%n", getPC(),  OPCODE_NAMES[seen], stack);
+            System.out.printf("%3d %-15s %s%n", getPC(),  Const.getOpcodeName(seen), stack);
         }
         if (isRegisterStore()) {
             regModifiedAt(getRegisterOperand(), getPC());
         }
         switch (seen) {
-        case GOTO:
+        case Const.GOTO:
             if (getBranchOffset() < 0) {
                 BackwardsBranch bb = new BackwardsBranch(stack, getPC(), getBranchTarget());
                 if (bb.invariantRegisters.size() > 0) {
@@ -337,18 +338,18 @@ public class InfiniteLoop extends OpcodeStackDetector {
             }
 
             break;
-        case ARETURN:
-        case IRETURN:
-        case RETURN:
-        case DRETURN:
-        case FRETURN:
-        case LRETURN:
-        case ATHROW:
+        case Const.ARETURN:
+        case Const.IRETURN:
+        case Const.RETURN:
+        case Const.DRETURN:
+        case Const.FRETURN:
+        case Const.LRETURN:
+        case Const.ATHROW:
             addForwardJump(getPC(), Integer.MAX_VALUE);
             break;
 
-        case LOOKUPSWITCH:
-        case TABLESWITCH: {
+        case Const.LOOKUPSWITCH:
+        case Const.TABLESWITCH: {
             OpcodeStack.Item item0 = stack.getStackItem(0);
             if (getDefaultSwitchOffset() > 0) {
                 forwardConditionalBranches.add(new ForwardConditionalBranch(item0, item0, getPC(), getPC()
@@ -361,14 +362,14 @@ public class InfiniteLoop extends OpcodeStackDetector {
             }
             break;
         }
-        case IFNE:
-        case IFEQ:
-        case IFLE:
-        case IFLT:
-        case IFGE:
-        case IFGT:
-        case IFNONNULL:
-        case IFNULL: {
+        case Const.IFNE:
+        case Const.IFEQ:
+        case Const.IFLE:
+        case Const.IFLT:
+        case Const.IFGE:
+        case Const.IFGT:
+        case Const.IFNONNULL:
+        case Const.IFNULL: {
             addBackwardsReach();
             OpcodeStack.Item item0 = stack.getStackItem(0);
             int target = getBranchTarget();
@@ -396,14 +397,14 @@ public class InfiniteLoop extends OpcodeStackDetector {
             }
         }
         break;
-        case IF_ACMPEQ:
-        case IF_ACMPNE:
-        case IF_ICMPNE:
-        case IF_ICMPEQ:
-        case IF_ICMPGT:
-        case IF_ICMPLE:
-        case IF_ICMPLT:
-        case IF_ICMPGE: {
+        case Const.IF_ACMPEQ:
+        case Const.IF_ACMPNE:
+        case Const.IF_ICMPNE:
+        case Const.IF_ICMPEQ:
+        case Const.IF_ICMPGT:
+        case Const.IF_ICMPLE:
+        case Const.IF_ICMPLT:
+        case Const.IF_ICMPGE: {
             addBackwardsReach();
             OpcodeStack.Item item0 = stack.getStackItem(0);
             OpcodeStack.Item item1 = stack.getStackItem(1);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InfiniteRecursiveLoop.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InfiniteRecursiveLoop.java
@@ -110,7 +110,7 @@ public class InfiniteRecursiveLoop extends OpcodeStackDetector implements Statel
                 && getNameConstantOperand().equals(getMethodName())
                 && getSigConstantOperand().equals(getMethodSig())
                 && (seen == Const.INVOKESTATIC) == getMethod().isStatic()
-                && (seen == Const.INVOKESPECIAL) == (getMethod().isPrivate() && !getMethod().isStatic() || "<init>".equals(getMethodName()))) {
+                && (seen == Const.INVOKESPECIAL) == (getMethod().isPrivate() && !getMethod().isStatic() || Const.CONSTRUCTOR_NAME.equals(getMethodName()))) {
             Type arguments[] = getMethod().getArgumentTypes();
             // stack.getStackDepth() >= parameters
             int parameters = arguments.length;
@@ -128,7 +128,7 @@ public class InfiniteRecursiveLoop extends OpcodeStackDetector implements Statel
                 // Invocation of same method
                 // Now need to see if parameters are the same
                 int firstParameter = 0;
-                if ("<init>".equals(getMethodName())) {
+                if (Const.CONSTRUCTOR_NAME.equals(getMethodName())) {
                     firstParameter = 1;
                 }
 
@@ -148,7 +148,7 @@ public class InfiniteRecursiveLoop extends OpcodeStackDetector implements Statel
                     }
                 }
 
-                boolean sameMethod = seen == Const.INVOKESTATIC || "<init>".equals(getNameConstantOperand());
+                boolean sameMethod = seen == Const.INVOKESTATIC || Const.CONSTRUCTOR_NAME.equals(getNameConstantOperand());
                 if (!sameMethod) {
                     // Have to check if first parmeter is the same
                     // know there must be a this argument

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InfiniteRecursiveLoop.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InfiniteRecursiveLoop.java
@@ -19,6 +19,7 @@
 
 package edu.umd.cs.findbugs.detect;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Method;
 import org.apache.bcel.generic.Type;
 
@@ -90,10 +91,10 @@ public class InfiniteRecursiveLoop extends OpcodeStackDetector implements Statel
 
         if (DEBUG) {
             System.out.println(stack);
-            System.out.println(getPC() + " : " + OPCODE_NAMES[seen]);
+            System.out.println(getPC() + " : " + Const.getOpcodeName(seen));
         }
 
-        if ((seen == INVOKEVIRTUAL || seen == INVOKEINTERFACE) && "add".equals(getNameConstantOperand())
+        if ((seen == Const.INVOKEVIRTUAL || seen == Const.INVOKEINTERFACE) && "add".equals(getNameConstantOperand())
                 && "(Ljava/lang/Object;)Z".equals(getSigConstantOperand()) && stack.getStackDepth() >= 2) {
             OpcodeStack.Item it0 = stack.getStackItem(0);
             int r0 = it0.getRegisterNumber();
@@ -105,11 +106,11 @@ public class InfiniteRecursiveLoop extends OpcodeStackDetector implements Statel
             }
         }
 
-        if ((seen == INVOKEVIRTUAL || seen == INVOKESPECIAL || seen == INVOKEINTERFACE || seen == INVOKESTATIC)
+        if ((seen == Const.INVOKEVIRTUAL || seen == Const.INVOKESPECIAL || seen == Const.INVOKEINTERFACE || seen == Const.INVOKESTATIC)
                 && getNameConstantOperand().equals(getMethodName())
                 && getSigConstantOperand().equals(getMethodSig())
-                && (seen == INVOKESTATIC) == getMethod().isStatic()
-                && (seen == INVOKESPECIAL) == (getMethod().isPrivate() && !getMethod().isStatic() || "<init>".equals(getMethodName()))) {
+                && (seen == Const.INVOKESTATIC) == getMethod().isStatic()
+                && (seen == Const.INVOKESPECIAL) == (getMethod().isPrivate() && !getMethod().isStatic() || "<init>".equals(getMethodName()))) {
             Type arguments[] = getMethod().getArgumentTypes();
             // stack.getStackDepth() >= parameters
             int parameters = arguments.length;
@@ -123,7 +124,7 @@ public class InfiniteRecursiveLoop extends OpcodeStackDetector implements Statel
                 System.out.println("vs. " + getClassName() + "." + getMethodName() + " : " + getMethodSig());
 
             }
-            if (xMethod.getClassName().replace('.', '/').equals(getClassName()) || seen == INVOKEINTERFACE) {
+            if (xMethod.getClassName().replace('.', '/').equals(getClassName()) || seen == Const.INVOKEINTERFACE) {
                 // Invocation of same method
                 // Now need to see if parameters are the same
                 int firstParameter = 0;
@@ -147,7 +148,7 @@ public class InfiniteRecursiveLoop extends OpcodeStackDetector implements Statel
                     }
                 }
 
-                boolean sameMethod = seen == INVOKESTATIC || "<init>".equals(getNameConstantOperand());
+                boolean sameMethod = seen == Const.INVOKESTATIC || "<init>".equals(getNameConstantOperand());
                 if (!sameMethod) {
                     // Have to check if first parmeter is the same
                     // know there must be a this argument
@@ -182,7 +183,7 @@ public class InfiniteRecursiveLoop extends OpcodeStackDetector implements Statel
                     //                    int priority = HIGH_PRIORITY;
                     //                    if (!match1 && !match2 && seenThrow)
                     //                        priority = NORMAL_PRIORITY;
-                    //                    if (seen == INVOKEINTERFACE)
+                    //                    if (seen == Const.INVOKEINTERFACE)
                     //                        priority = NORMAL_PRIORITY;
                     bugReporter.reportBug(new BugInstance(this, "IL_INFINITE_RECURSIVE_LOOP", HIGH_PRIORITY).addClassAndMethod(
                             this).addSourceLine(this));
@@ -191,35 +192,35 @@ public class InfiniteRecursiveLoop extends OpcodeStackDetector implements Statel
         }
 
         switch (seen) {
-        case ARETURN:
-        case IRETURN:
-        case LRETURN:
-        case RETURN:
-        case DRETURN:
-        case FRETURN:
+        case Const.ARETURN:
+        case Const.IRETURN:
+        case Const.LRETURN:
+        case Const.RETURN:
+        case Const.DRETURN:
+        case Const.FRETURN:
             seenReturn = true;
             seenTransferOfControl = true;
             break;
-        case ATHROW:
+        case Const.ATHROW:
             //            seenThrow = true;
             seenTransferOfControl = true;
             break;
-        case PUTSTATIC:
-        case PUTFIELD:
-        case IASTORE:
-        case AASTORE:
-        case DASTORE:
-        case FASTORE:
-        case LASTORE:
-        case SASTORE:
-        case CASTORE:
-        case BASTORE:
+        case Const.PUTSTATIC:
+        case Const.PUTFIELD:
+        case Const.IASTORE:
+        case Const.AASTORE:
+        case Const.DASTORE:
+        case Const.FASTORE:
+        case Const.LASTORE:
+        case Const.SASTORE:
+        case Const.CASTORE:
+        case Const.BASTORE:
             seenStateChange = true;
             break;
-        case INVOKEVIRTUAL:
-        case INVOKESPECIAL:
-        case INVOKEINTERFACE:
-        case INVOKESTATIC:
+        case Const.INVOKEVIRTUAL:
+        case Const.INVOKESPECIAL:
+        case Const.INVOKEINTERFACE:
+        case Const.INVOKESTATIC:
             if ("print".equals(getNameConstantOperand()) || "println".equals(getNameConstantOperand())
                     || "log".equals(getNameConstantOperand()) || "toString".equals(getNameConstantOperand())) {
                 break;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InheritanceUnsafeGetResource.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InheritanceUnsafeGetResource.java
@@ -21,6 +21,7 @@ package edu.umd.cs.findbugs.detect;
 
 import java.util.Set;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Constant;
 import org.apache.bcel.classfile.ConstantClass;
 import org.apache.bcel.classfile.ConstantString;
@@ -82,7 +83,7 @@ public class InheritanceUnsafeGetResource extends BytecodeScanningDetector imple
         }
 
         switch (seen) {
-        case LDC:
+        case Const.LDC:
             Constant constantValue = getConstantRefOperand();
             if (constantValue instanceof ConstantClass) {
                 sawGetClass = -100;
@@ -91,15 +92,15 @@ public class InheritanceUnsafeGetResource extends BytecodeScanningDetector imple
             }
             break;
 
-        case ALOAD_0:
+        case Const.ALOAD_0:
             state = 1;
             break;
-        case INVOKEVIRTUAL:
+        case Const.INVOKEVIRTUAL:
             if ("java/lang/Class".equals(getClassConstantOperand())
                     && ("getResource".equals(getNameConstantOperand()) || "getResourceAsStream".equals(getNameConstantOperand()))
                     && sawGetClass + 10 >= getPC()) {
                 int priority = NORMAL_PRIORITY;
-                if (prevOpcode == LDC && stringConstant != null && stringConstant.length() > 0 && stringConstant.charAt(0) == '/') {
+                if (prevOpcode == Const.LDC && stringConstant != null && stringConstant.length() > 0 && stringConstant.charAt(0) == '/') {
                     priority = LOW_PRIORITY;
                 } else {
                     priority = adjustPriority(priority);
@@ -118,7 +119,7 @@ public class InheritanceUnsafeGetResource extends BytecodeScanningDetector imple
             state = 0;
             break;
         }
-        if (seen != LDC) {
+        if (seen != Const.LDC) {
             stringConstant = null;
         }
         prevOpcode = seen;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InitializationChain.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InitializationChain.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.classfile.Method;
@@ -135,14 +136,14 @@ public class InitializationChain extends BytecodeScanningDetector {
         InvocationInfo prev = lastInvocation;
         lastInvocation = null;
         if ("<init>".equals(getMethodName())) {
-            if (seen == GETSTATIC && getClassConstantOperand().equals(getClassName())) {
+            if (seen == Const.GETSTATIC && getClassConstantOperand().equals(getClassName())) {
                 staticFieldsReadInAnyConstructor.add(getXFieldOperand());
                 fieldsReadInThisConstructor.add(getXFieldOperand());
             }
             return;
         }
 
-        if (seen == INVOKESPECIAL && "<init>".equals(getNameConstantOperand()) &&  getClassConstantOperand().equals(getClassName())) {
+        if (seen == Const.INVOKESPECIAL && "<init>".equals(getNameConstantOperand()) &&  getClassConstantOperand().equals(getClassName())) {
 
             XMethod m = getXMethodOperand();
             Set<XField> read = staticFieldsRead.get(m);
@@ -153,7 +154,7 @@ public class InitializationChain extends BytecodeScanningDetector {
             }
 
         }
-        if (seen == PUTSTATIC && getClassConstantOperand().equals(getClassName())) {
+        if (seen == Const.PUTSTATIC && getClassConstantOperand().equals(getClassName())) {
             XField f = getXFieldOperand();
             if (prev != null) {
                 prev.field = f;
@@ -176,7 +177,7 @@ public class InitializationChain extends BytecodeScanningDetector {
                 }
             }
 
-        } else if (seen == PUTSTATIC || seen == GETSTATIC || seen == INVOKESTATIC || seen == NEW) {
+        } else if (seen == Const.PUTSTATIC || seen == Const.GETSTATIC || seen == Const.INVOKESTATIC || seen == Const.NEW) {
             if (getPC() + 6 < codeBytes.length) {
                 requires.add(getDottedClassConstantOperand());
             }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InitializationChain.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InitializationChain.java
@@ -84,9 +84,9 @@ public class InitializationChain extends BytecodeScanningDetector {
         Method staticInitializer = null;
         for(Method m : obj.getMethods()) {
             String name = m.getName();
-            if ("<clinit>".equals(name)) {
+            if (Const.STATIC_INITIALIZER_NAME.equals(name)) {
                 staticInitializer = m;
-            } else if ("<init>".equals(name)) {
+            } else if (Const.CONSTRUCTOR_NAME.equals(name)) {
                 visitOrder.add(m);
             }
 
@@ -135,7 +135,7 @@ public class InitializationChain extends BytecodeScanningDetector {
     public void sawOpcode(int seen) {
         InvocationInfo prev = lastInvocation;
         lastInvocation = null;
-        if ("<init>".equals(getMethodName())) {
+        if (Const.CONSTRUCTOR_NAME.equals(getMethodName())) {
             if (seen == Const.GETSTATIC && getClassConstantOperand().equals(getClassName())) {
                 staticFieldsReadInAnyConstructor.add(getXFieldOperand());
                 fieldsReadInThisConstructor.add(getXFieldOperand());
@@ -143,7 +143,7 @@ public class InitializationChain extends BytecodeScanningDetector {
             return;
         }
 
-        if (seen == Const.INVOKESPECIAL && "<init>".equals(getNameConstantOperand()) &&  getClassConstantOperand().equals(getClassName())) {
+        if (seen == Const.INVOKESPECIAL && Const.CONSTRUCTOR_NAME.equals(getNameConstantOperand()) &&  getClassConstantOperand().equals(getClassName())) {
 
             XMethod m = getXMethodOperand();
             Set<XField> read = staticFieldsRead.get(m);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InitializeNonnullFieldsInConstructor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InitializeNonnullFieldsInConstructor.java
@@ -89,7 +89,7 @@ public class InitializeNonnullFieldsInConstructor extends OpcodeStackDetector {
 
     @Override
     public void visit(Code code) {
-        boolean interesting = "<init>".equals(getMethodName()) || "<clinit>".equals(getMethodName());
+        boolean interesting = Const.CONSTRUCTOR_NAME.equals(getMethodName()) || Const.STATIC_INITIALIZER_NAME.equals(getMethodName());
         if (!interesting) {
             return;
         }
@@ -133,7 +133,7 @@ public class InitializeNonnullFieldsInConstructor extends OpcodeStackDetector {
 
         switch (seen) {
         case Const.INVOKESPECIAL:
-            if (!getMethod().isStatic() && "<init>".equals(getNameConstantOperand()) && isSelfOperation()) {
+            if (!getMethod().isStatic() && Const.CONSTRUCTOR_NAME.equals(getNameConstantOperand()) && isSelfOperation()) {
                 OpcodeStack.Item invokedOn = stack.getItemMethodInvokedOn(this);
                 if (invokedOn.isInitialParameter() && invokedOn.getRegisterNumber() == 0) {
                     secondaryConstructor = true;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InstantiateStaticClass.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InstantiateStaticClass.java
@@ -42,7 +42,7 @@ public class InstantiateStaticClass extends BytecodeScanningDetector {
     @Override
     public void sawOpcode(int seen) {
 
-        if ((seen == Const.INVOKESPECIAL) && "<init>".equals(getNameConstantOperand()) && "()V".equals(getSigConstantOperand())) {
+        if ((seen == Const.INVOKESPECIAL) && Const.CONSTRUCTOR_NAME.equals(getNameConstantOperand()) && "()V".equals(getSigConstantOperand())) {
             XClass xClass = getXClassOperand();
             if (xClass == null) {
                 return;
@@ -53,12 +53,12 @@ public class InstantiateStaticClass extends BytecodeScanningDetector {
             }
 
             // ignore superclass synthesized ctor calls
-            if ("<init>".equals(getMethodName()) && (getPC() == 1)) {
+            if (Const.CONSTRUCTOR_NAME.equals(getMethodName()) && (getPC() == 1)) {
                 return;
             }
 
             // ignore the typesafe enumerated constant pattern
-            if ("<clinit>".equals(getMethodName()) && (getClassName().equals(clsName))) {
+            if (Const.STATIC_INITIALIZER_NAME.equals(getMethodName()) && (getClassName().equals(clsName))) {
                 return;
             }
 
@@ -90,7 +90,7 @@ public class InstantiateStaticClass extends BytecodeScanningDetector {
             // !m.isSynthetic(): bug #1282: No warning should be generated if only static methods are synthetic
             if (m.isStatic() && !m.isSynthetic()) {
                 staticCount++;
-            } else if (!"<init>".equals(m.getName()) || !"()V".equals(m.getSignature())) {
+            } else if (!Const.CONSTRUCTOR_NAME.equals(m.getName()) || !"()V".equals(m.getSignature())) {
                 return false;
             }
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InstantiateStaticClass.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InstantiateStaticClass.java
@@ -22,6 +22,8 @@ package edu.umd.cs.findbugs.detect;
 
 import java.util.List;
 
+import org.apache.bcel.Const;
+
 import edu.umd.cs.findbugs.BugInstance;
 import edu.umd.cs.findbugs.BugReporter;
 import edu.umd.cs.findbugs.BytecodeScanningDetector;
@@ -40,7 +42,7 @@ public class InstantiateStaticClass extends BytecodeScanningDetector {
     @Override
     public void sawOpcode(int seen) {
 
-        if ((seen == INVOKESPECIAL) && "<init>".equals(getNameConstantOperand()) && "()V".equals(getSigConstantOperand())) {
+        if ((seen == Const.INVOKESPECIAL) && "<init>".equals(getNameConstantOperand()) && "()V".equals(getSigConstantOperand())) {
             XClass xClass = getXClassOperand();
             if (xClass == null) {
                 return;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/IntCast2LongAsInstant.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/IntCast2LongAsInstant.java
@@ -19,6 +19,8 @@
 
 package edu.umd.cs.findbugs.detect;
 
+import org.apache.bcel.Const;
+
 import edu.umd.cs.findbugs.BugInstance;
 import edu.umd.cs.findbugs.BugReporter;
 import edu.umd.cs.findbugs.OpcodeStack;
@@ -45,10 +47,10 @@ public class IntCast2LongAsInstant extends OpcodeStackDetector {
 
     @Override
     public void sawOpcode(int seen) {
-        if (seen == SIPUSH) {
+        if (seen == Const.SIPUSH) {
             lastConstantForSIPUSH = getIntConstant();
         }
-        if (seen == INVOKEINTERFACE || seen == INVOKEVIRTUAL || seen == INVOKESPECIAL || seen == INVOKESTATIC) {
+        if (seen == Const.INVOKEINTERFACE || seen == Const.INVOKEVIRTUAL || seen == Const.INVOKESPECIAL || seen == Const.INVOKESTATIC) {
             String signature = getSigConstantOperand();
 
             int numberArguments = PreorderVisitor.getNumberArguments(signature);
@@ -60,11 +62,11 @@ public class IntCast2LongAsInstant extends OpcodeStackDetector {
                     if (property != null && property.hasProperty(i)) {
                         int priority = NORMAL_PRIORITY;
 
-                        if (getPrevOpcode(1) == I2L && getPrevOpcode(2) == IMUL && getPrevOpcode(3) == SIPUSH
+                        if (getPrevOpcode(1) == Const.I2L && getPrevOpcode(2) == Const.IMUL && getPrevOpcode(3) == Const.SIPUSH
                                 && lastConstantForSIPUSH == 1000) {
                             priority = HIGH_PRIORITY;
 
-                        } else if (getPrevOpcode(1) == I2L && getPrevOpcode(2) == IMUL && getPrevOpcode(4) == SIPUSH
+                        } else if (getPrevOpcode(1) == Const.I2L && getPrevOpcode(2) == Const.IMUL && getPrevOpcode(4) == Const.SIPUSH
                                 && lastConstantForSIPUSH == 1000) {
                             priority = HIGH_PRIORITY;
                         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InvalidJUnitTest.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InvalidJUnitTest.java
@@ -21,6 +21,7 @@
 
 package edu.umd.cs.findbugs.detect;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.classfile.Method;
@@ -67,7 +68,7 @@ public class InvalidJUnitTest extends BytecodeScanningDetector {
             if (!isJunit3TestCase(xClass)) {
                 return;
             }
-            if ((jClass.getAccessFlags() & ACC_ABSTRACT) == 0) {
+            if ((jClass.getAccessFlags() & Const.ACC_ABSTRACT) == 0) {
                 if (!hasTestMethods(jClass)) {
                     bugReporter.reportBug(new BugInstance(this, "IJU_NO_TESTS", LOW_PRIORITY).addClass(jClass));
                 }
@@ -205,13 +206,13 @@ public class InvalidJUnitTest extends BytecodeScanningDetector {
     public void sawOpcode(int seen) {
         switch (state) {
         case SEEN_NOTHING:
-            if (seen == ALOAD_0) {
+            if (seen == Const.ALOAD_0) {
                 state = SEEN_ALOAD_0;
             }
             break;
 
         case SEEN_ALOAD_0:
-            if ((seen == INVOKESPECIAL) && (getNameConstantOperand().equals(getMethodName()))
+            if ((seen == Const.INVOKESPECIAL) && (getNameConstantOperand().equals(getMethodName()))
                     && (getSigConstantOperand().equals("()V"))) {
                 sawSuperCall = true;
             }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/IteratorIdioms.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/IteratorIdioms.java
@@ -19,6 +19,7 @@
 
 package edu.umd.cs.findbugs.detect;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.Method;
 
@@ -88,9 +89,9 @@ public class IteratorIdioms extends BytecodeScanningDetector implements Stateles
 
     @Override
     public void sawOpcode(int seen) {
-        if (seen == NEW && "java/util/NoSuchElementException".equals(getClassConstantOperand())) {
+        if (seen == Const.NEW && "java/util/NoSuchElementException".equals(getClassConstantOperand())) {
             sawNoSuchElement = true;
-        } else if (seen == INVOKESPECIAL || seen == INVOKEVIRTUAL || seen == INVOKEINTERFACE) {
+        } else if (seen == Const.INVOKESPECIAL || seen == Const.INVOKEVIRTUAL || seen == Const.INVOKEINTERFACE) {
             sawCall = true;
             String name = getNameConstantOperand().toLowerCase();
             if (name.indexOf("next") >= 0

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/LazyInit.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/LazyInit.java
@@ -122,7 +122,7 @@ public final class LazyInit extends ByteCodePatternDetector implements Stateless
 
     @Override
     public boolean prescreen(Method method, ClassContext classContext) {
-        if ("<clinit>".equals(method.getName())) {
+        if (Const.STATIC_INITIALIZER_NAME.equals(method.getName())) {
             return false;
         }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/LostLoggerDueToWeakReference.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/LostLoggerDueToWeakReference.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 
 import edu.umd.cs.findbugs.BugAccumulator;
@@ -102,7 +103,7 @@ public class LostLoggerDueToWeakReference extends OpcodeStackDetector {
             return;
         }
         switch (seen) {
-        case INVOKESTATIC:
+        case Const.INVOKESTATIC:
             if ("java/util/logging/Logger".equals(getClassConstantOperand()) && "getLogger".equals(getNameConstantOperand())) {
                 OpcodeStack.Item item = stack.getStackItem(0);
                 if (!"".equals(item.getConstant())) {
@@ -112,7 +113,7 @@ public class LostLoggerDueToWeakReference extends OpcodeStackDetector {
             }
             checkForImport();
             break;
-        case INVOKEVIRTUAL:
+        case Const.INVOKEVIRTUAL:
             if ("java/util/logging/Logger".equals(getClassConstantOperand())
                     && namesOfSetterMethods.contains(getNameConstantOperand())) {
                 int priority = HIGH_PRIORITY;
@@ -130,25 +131,25 @@ public class LostLoggerDueToWeakReference extends OpcodeStackDetector {
             checkForMethodExportImport();
             break;
 
-        case INVOKEINTERFACE:
-        case INVOKESPECIAL:
+        case Const.INVOKEINTERFACE:
+        case Const.INVOKESPECIAL:
             checkForImport();
             checkForMethodExportImport();
             break;
 
-        case CHECKCAST:
+        case Const.CHECKCAST:
             String sig = getClassConstantOperand();
             if (sig.indexOf("Logger") >= 0) {
                 loggerImported = true;
             }
             break;
 
-        case GETFIELD:
-        case GETSTATIC:
+        case Const.GETFIELD:
+        case Const.GETSTATIC:
             checkForImport();
             break;
-        case PUTFIELD:
-        case PUTSTATIC:
+        case Const.PUTFIELD:
+        case Const.PUTSTATIC:
             checkForFieldEscape();
             break;
         default:

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MethodReturnCheck.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MethodReturnCheck.java
@@ -150,7 +150,7 @@ public class MethodReturnCheck extends OpcodeStackDetector implements UseAnnotat
     public void sawOpcode(int seen) {
 
         if (DEBUG) {
-            System.out.printf("%3d %10s %3s %s%n", getPC(), OPCODE_NAMES[seen], state, stack);
+            System.out.printf("%3d %10s %3s %s%n", getPC(), Const.getOpcodeName(seen), state, stack);
         }
 
         switch (seen) {
@@ -175,7 +175,7 @@ public class MethodReturnCheck extends OpcodeStackDetector implements UseAnnotat
             break;
         }
 
-        checkForInitWithoutCopyOnStack: if (seen == INVOKESPECIAL && "<init>".equals(getNameConstantOperand())) {
+        checkForInitWithoutCopyOnStack: if (seen == Const.INVOKESPECIAL && "<init>".equals(getNameConstantOperand())) {
             int arguments = PreorderVisitor.getNumberArguments(getSigConstantOperand());
             OpcodeStack.Item invokedOn = stack.getStackItem(arguments);
             if (invokedOn.isNewlyAllocated() && (!"<init>".equals(getMethodName()) || invokedOn.getRegisterNumber() != 0)) {
@@ -210,10 +210,10 @@ public class MethodReturnCheck extends OpcodeStackDetector implements UseAnnotat
             state = SCAN;
         }
 
-        if (seen == NEW) {
+        if (seen == Const.NEW) {
             previousOpcodeWasNEW = true;
         } else {
-            if (seen == INVOKESPECIAL && previousOpcodeWasNEW) {
+            if (seen == Const.INVOKESPECIAL && previousOpcodeWasNEW) {
                 CheckReturnValueAnnotation annotation = checkReturnAnnotationDatabase.getResolvedAnnotation(callSeen, false);
                 if (annotation != null && annotation != CheckReturnValueAnnotation.CHECK_RETURN_VALUE_IGNORE) {
                     int priority = annotation.getPriority();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MethodReturnCheck.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MethodReturnCheck.java
@@ -175,10 +175,10 @@ public class MethodReturnCheck extends OpcodeStackDetector implements UseAnnotat
             break;
         }
 
-        checkForInitWithoutCopyOnStack: if (seen == Const.INVOKESPECIAL && "<init>".equals(getNameConstantOperand())) {
+        checkForInitWithoutCopyOnStack: if (seen == Const.INVOKESPECIAL && Const.CONSTRUCTOR_NAME.equals(getNameConstantOperand())) {
             int arguments = PreorderVisitor.getNumberArguments(getSigConstantOperand());
             OpcodeStack.Item invokedOn = stack.getStackItem(arguments);
-            if (invokedOn.isNewlyAllocated() && (!"<init>".equals(getMethodName()) || invokedOn.getRegisterNumber() != 0)) {
+            if (invokedOn.isNewlyAllocated() && (!Const.CONSTRUCTOR_NAME.equals(getMethodName()) || invokedOn.getRegisterNumber() != 0)) {
 
                 for (int i = arguments + 1; i < stack.getStackDepth(); i++) {
                     OpcodeStack.Item item = stack.getStackItem(i);
@@ -248,7 +248,7 @@ public class MethodReturnCheck extends OpcodeStackDetector implements UseAnnotat
                     if(callReturnType.equals(methodReturnType) && callReturnType != Type.BOOLEAN && callReturnType != Type.VOID) {
                         priority = HIGH_PRIORITY;
                     } else {
-                        String callReturnClass = callSeen.getName().equals("<init>") ?
+                        String callReturnClass = callSeen.getName().equals(Const.CONSTRUCTOR_NAME) ?
                                 callSeen.getClassDescriptor().getClassName() :
                                     ClassName.fromFieldSignature(callReturnType.getSignature());
 
@@ -297,7 +297,7 @@ public class MethodReturnCheck extends OpcodeStackDetector implements UseAnnotat
                     priority++;
                 }
                 String pattern = annotation.getPattern();
-                if ("<init>".equals(callSeen.getName())
+                if (Const.CONSTRUCTOR_NAME.equals(callSeen.getName())
                         && (callSeen.getClassName().endsWith("Exception") || callSeen.getClassName().endsWith("Error"))) {
                     pattern = "RV_EXCEPTION_NOT_THROWN";
                 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MultithreadedInstanceAccess.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MultithreadedInstanceAccess.java
@@ -22,6 +22,7 @@ package edu.umd.cs.findbugs.detect;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.Repository;
 import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.Constant;
@@ -179,13 +180,13 @@ public class MultithreadedInstanceAccess extends OpcodeStackDetector {
 
     @Override
     public void sawOpcode(int seen) {
-        if (seen == MONITORENTER) {
+        if (seen == Const.MONITORENTER) {
             monitorCount++;
-        } else if (seen == MONITOREXIT) {
+        } else if (seen == Const.MONITOREXIT) {
             monitorCount--;
         }
 
-        writingField = ((seen == PUTFIELD) || (seen == PUTFIELD_QUICK) || (seen == PUTFIELD_QUICK_W));
+        writingField = ((seen == Const.PUTFIELD) || (seen == Const.PUTFIELD_QUICK) || (seen == Const.PUTFIELD_QUICK_W));
     }
 
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MultithreadedInstanceAccess.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MultithreadedInstanceAccess.java
@@ -130,7 +130,7 @@ public class MultithreadedInstanceAccess extends OpcodeStackDetector {
 
     @Override
     public boolean shouldVisitCode(Code code) {
-        return !"<init>".equals(getMethodName()) && !"init".equals(getMethodName());
+        return !Const.CONSTRUCTOR_NAME.equals(getMethodName()) && !"init".equals(getMethodName());
 
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MutableEnum.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MutableEnum.java
@@ -19,6 +19,7 @@
 
 package edu.umd.cs.findbugs.detect;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 
 import edu.umd.cs.findbugs.BugInstance;
@@ -75,10 +76,10 @@ public class MutableEnum extends OpcodeStackDetector {
         if(skip) {
             return;
         }
-        if(isBranch(seen) || seen == ATHROW || isReturn(seen)) {
+        if(isBranch(seen) || seen == Const.ATHROW || isReturn(seen)) {
             skip = true;
         }
-        if(seen == PUTFIELD) {
+        if(seen == Const.PUTFIELD) {
             XField xField = getXFieldOperand();
             if(xField != null && xField.getClassDescriptor().getClassName().equals(getClassName())) {
                 Item val = getStack().getStackItem(0);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MutableLock.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MutableLock.java
@@ -22,6 +22,7 @@ package edu.umd.cs.findbugs.detect;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Field;
 import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.classfile.Method;
@@ -69,20 +70,20 @@ public class MutableLock extends BytecodeScanningDetector implements StatelessDe
     public void sawOpcode(int seen) {
 
         switch (seen) {
-        case ALOAD_0:
+        case Const.ALOAD_0:
             thisOnTOS = true;
             return;
-        case MONITOREXIT:
+        case Const.MONITOREXIT:
             setFields.clear();
             break;
-        case PUTFIELD:
+        case Const.PUTFIELD:
             if (getClassConstantOperand().equals(getClassName())) {
                 setFields.add(getNameConstantOperand());
             }
             break;
-        case GETFIELD:
+        case Const.GETFIELD:
             if (thisOnTOS && getClassConstantOperand().equals(getClassName()) && setFields.contains(getNameConstantOperand())
-                    && asUnsignedByte(codeBytes[getPC() + 3]) == DUP && asUnsignedByte(codeBytes[getPC() + 5]) == MONITORENTER
+                    && asUnsignedByte(codeBytes[getPC() + 3]) == Const.DUP && asUnsignedByte(codeBytes[getPC() + 5]) == Const.MONITORENTER
 
                     && !finalFields.contains(getNameConstantOperand())) {
                 bugReporter.reportBug(new BugInstance(this, "ML_SYNC_ON_UPDATED_FIELD", NORMAL_PRIORITY).addClassAndMethod(this)

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MutableStaticFields.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MutableStaticFields.java
@@ -148,7 +148,7 @@ public class MutableStaticFields extends BytecodeScanningDetector {
     public void visit(Method obj) {
         zeroOnTOS = false;
         // System.out.println(methodName);
-        inStaticInitializer = getMethodName().equals("<clinit>");
+        inStaticInitializer = getMethodName().equals(Const.STATIC_INITIALIZER_NAME);
     }
 
     @Override
@@ -227,7 +227,7 @@ public class MutableStaticFields extends BytecodeScanningDetector {
             emptyArrayOnTOS = false;
             return;
         case Const.INVOKESPECIAL:
-            if (inStaticInitializer && "<init>".equals(getMethodDescriptorOperand().getName())) {
+            if (inStaticInitializer && Const.CONSTRUCTOR_NAME.equals(getMethodDescriptorOperand().getName())) {
                 ClassDescriptor classDescriptor = getClassDescriptorOperand();
                 if (MUTABLE_COLLECTION_CLASSES.contains(classDescriptor.getClassName())) {
                     mutableCollectionJustCreated = true;
@@ -245,7 +245,7 @@ public class MutableStaticFields extends BytecodeScanningDetector {
                             && MUTABLE_COLLECTION_CLASSES.contains(superclassDescriptor.getClassName())) {
                         mutableCollectionJustCreated = true;
                         for (XMethod xMethod : xClass.getXMethods()) {
-                            if (xMethod != null && !"<init>".equals(xMethod.getName()) && !"<clinit>".equals(xMethod.getName())) {
+                            if (xMethod != null && !Const.CONSTRUCTOR_NAME.equals(xMethod.getName()) && !Const.STATIC_INITIALIZER_NAME.equals(xMethod.getName())) {
                                 mutableCollectionJustCreated = false;
                                 break;
                             }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MutableStaticFields.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MutableStaticFields.java
@@ -27,6 +27,7 @@ import java.util.LinkedList;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.Field;
 import org.apache.bcel.classfile.JavaClass;
@@ -137,7 +138,7 @@ public class MutableStaticFields extends BytecodeScanningDetector {
     public void visit(JavaClass obj) {
         super.visit(obj);
         int flags = obj.getAccessFlags();
-        publicClass = (flags & ACC_PUBLIC) != 0 && !getDottedClassName().startsWith("sun.");
+        publicClass = (flags & Const.ACC_PUBLIC) != 0 && !getDottedClassName().startsWith("sun.");
 
         packageName = extractPackage(getClassName());
         isEclipseNLS = "org.eclipse.osgi.util.NLS".equals(obj.getSuperclassName());
@@ -166,8 +167,8 @@ public class MutableStaticFields extends BytecodeScanningDetector {
     public void sawOpcode(int seen) {
         // System.out.println("saw\t" + OPCODE_NAMES[seen] + "\t" + zeroOnTOS);
         switch (seen) {
-        case GETSTATIC:
-        case PUTSTATIC:
+        case Const.GETSTATIC:
+        case Const.PUTSTATIC:
 
             XField xField = getXFieldOperand();
             if (xField == null) {
@@ -178,14 +179,14 @@ public class MutableStaticFields extends BytecodeScanningDetector {
             }
 
             boolean samePackage = packageName.equals(extractPackage(xField.getFieldDescriptor().getSlashedClassName()));
-            boolean initOnly = seen == GETSTATIC || getClassName().equals(getClassConstantOperand()) && inStaticInitializer;
-            boolean safeValue = seen == GETSTATIC || emptyArrayOnTOS
+            boolean initOnly = seen == Const.GETSTATIC || getClassName().equals(getClassConstantOperand()) && inStaticInitializer;
+            boolean safeValue = seen == Const.GETSTATIC || emptyArrayOnTOS
                     || AnalysisContext.currentXFactory().isEmptyArrayField(xField) || !mutableSignature(getSigConstantOperand());
 
-            if (seen == GETSTATIC) {
+            if (seen == Const.GETSTATIC) {
                 readAnywhere.add(xField);
             }
-            if (seen == PUTSTATIC) {
+            if (seen == Const.PUTSTATIC) {
                 if (xField.isFinal() && mutableCollectionJustCreated) {
                     mutableCollection.add(xField);
                 }
@@ -214,18 +215,18 @@ public class MutableStaticFields extends BytecodeScanningDetector {
                 firstFieldUse.put(xField, sla);
             }
             break;
-        case ANEWARRAY:
-        case NEWARRAY:
+        case Const.ANEWARRAY:
+        case Const.NEWARRAY:
             if (zeroOnTOS) {
                 emptyArrayOnTOS = true;
             }
             zeroOnTOS = false;
             return;
-        case ICONST_0:
+        case Const.ICONST_0:
             zeroOnTOS = true;
             emptyArrayOnTOS = false;
             return;
-        case INVOKESPECIAL:
+        case Const.INVOKESPECIAL:
             if (inStaticInitializer && "<init>".equals(getMethodDescriptorOperand().getName())) {
                 ClassDescriptor classDescriptor = getClassDescriptorOperand();
                 if (MUTABLE_COLLECTION_CLASSES.contains(classDescriptor.getClassName())) {
@@ -256,7 +257,7 @@ public class MutableStaticFields extends BytecodeScanningDetector {
                 }
             }
             break;
-        case INVOKESTATIC:
+        case Const.INVOKESTATIC:
             if (inStaticInitializer) {
                 Map<String, AllowedParameter> methods = MUTABLE_COLLECTION_METHODS.get(getMethodDescriptorOperand()
                         .getSlashedClassName());
@@ -307,17 +308,17 @@ public class MutableStaticFields extends BytecodeScanningDetector {
     public void visit(Field obj) {
         super.visit(obj);
         int flags = obj.getAccessFlags();
-        boolean isStatic = (flags & ACC_STATIC) != 0;
+        boolean isStatic = (flags & Const.ACC_STATIC) != 0;
         if (!isStatic) {
             return;
         }
-        boolean isVolatile = (flags & ACC_VOLATILE) != 0;
+        boolean isVolatile = (flags & Const.ACC_VOLATILE) != 0;
         if (isVolatile) {
             return;
         }
-        boolean isFinal = (flags & ACC_FINAL) != 0;
-        boolean isPublic = publicClass && (flags & ACC_PUBLIC) != 0;
-        boolean isProtected = publicClass && (flags & ACC_PROTECTED) != 0;
+        boolean isFinal = (flags & Const.ACC_FINAL) != 0;
+        boolean isPublic = publicClass && (flags & Const.ACC_PUBLIC) != 0;
+        boolean isProtected = publicClass && (flags & Const.ACC_PROTECTED) != 0;
         if (!isPublic && !isProtected) {
             return;
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/Naming.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/Naming.java
@@ -30,6 +30,7 @@ import java.util.regex.Pattern;
 
 import javax.annotation.CheckForNull;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.Repository;
 import org.apache.bcel.classfile.Attribute;
 import org.apache.bcel.classfile.Code;
@@ -442,7 +443,7 @@ public class Naming extends PreorderVisitor implements Detector {
 
         if (isEclipseNLS) {
             int flags = obj.getAccessFlags();
-            if ((flags & ACC_STATIC) != 0 && ((flags & ACC_PUBLIC) != 0) && "Ljava/lang/String;".equals(getFieldSig())) {
+            if ((flags & Const.ACC_STATIC) != 0 && ((flags & Const.ACC_PUBLIC) != 0) && "Ljava/lang/String;".equals(getFieldSig())) {
                 // ignore "public statis String InstallIUCommandTooltip;"
                 // messages from Eclipse NLS bundles
                 return;
@@ -489,11 +490,11 @@ public class Naming extends PreorderVisitor implements Detector {
         byte[] codeBytes = code.getCode();
         if (codeBytes.length > 1 && codeBytes.length < 10) {
             int lastOpcode = codeBytes[codeBytes.length - 1] & 0xff;
-            if (lastOpcode != ATHROW) {
+            if (lastOpcode != Const.ATHROW) {
                 return false;
             }
             for (int b : codeBytes) {
-                if ((b & 0xff) == RETURN) {
+                if ((b & 0xff) == Const.RETURN) {
                     return false;
                 }
             }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/Naming.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/Naming.java
@@ -147,7 +147,7 @@ public class Naming extends PreorderVisitor implements Detector {
         if (m.isStatic()) {
             return false;
         }
-        if ("<init>".equals(m.getName()) || "<clinit>".equals(m.getName())) {
+        if (Const.CONSTRUCTOR_NAME.equals(m.getName()) || Const.STATIC_INITIALIZER_NAME.equals(m.getName())) {
             return false;
         }
         for (XMethod m2 : others) {
@@ -251,7 +251,7 @@ public class Naming extends PreorderVisitor implements Detector {
         if (m.isStatic()) {
             return false;
         }
-        if (m.getName().startsWith("<init>") || m.getName().startsWith("<clinit>")) {
+        if (m.getName().startsWith(Const.CONSTRUCTOR_NAME) || m.getName().startsWith(Const.STATIC_INITIALIZER_NAME)) {
             return false;
         }
         for (XMethod m2 : others) {
@@ -591,7 +591,7 @@ public class Naming extends PreorderVisitor implements Detector {
             return;
         }
 
-        if (obj.isPrivate() || obj.isStatic() || "<init>".equals(mName)) {
+        if (obj.isPrivate() || obj.isStatic() || Const.CONSTRUCTOR_NAME.equals(mName)) {
             return;
         }
 
@@ -615,7 +615,7 @@ public class Naming extends PreorderVisitor implements Detector {
         if (outerClassSignature == null) {
             outerClassSignature = "";
         }
-        return "<init>".equals(m.getName()) && m.getSignature().equals("(" + outerClassSignature + ")V");
+        return Const.CONSTRUCTOR_NAME.equals(m.getName()) && m.getSignature().equals("(" + outerClassSignature + ")V");
     }
 
     private boolean badMethodName(String mName) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/Noise.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/Noise.java
@@ -22,6 +22,7 @@ package edu.umd.cs.findbugs.detect;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 
 import edu.umd.cs.findbugs.BugAccumulator;
@@ -156,10 +157,10 @@ public class Noise extends OpcodeStackDetector {
     public void sawOpcode(int seen) {
         int priority;
         switch (seen) {
-        case INVOKEINTERFACE:
-        case INVOKEVIRTUAL:
-        case INVOKESPECIAL:
-        case INVOKESTATIC:
+        case Const.INVOKEINTERFACE:
+        case Const.INVOKEVIRTUAL:
+        case Const.INVOKESPECIAL:
+        case Const.INVOKESTATIC:
             hq.pushHash(getClassConstantOperand());
             if (getNameConstantOperand().indexOf('$') == -1) {
                 hq.pushHash(getNameConstantOperand());
@@ -172,10 +173,10 @@ public class Noise extends OpcodeStackDetector {
                         .addCalledMethod(this), this);
             }
             break;
-        case GETFIELD:
-        case PUTFIELD:
-        case GETSTATIC:
-        case PUTSTATIC:
+        case Const.GETFIELD:
+        case Const.PUTFIELD:
+        case Const.GETSTATIC:
+        case Const.PUTSTATIC:
             hq.pushHash(getClassConstantOperand());
             if (getNameConstantOperand().indexOf('$') == -1) {
                 hq.pushHash(getNameConstantOperand());
@@ -187,65 +188,65 @@ public class Noise extends OpcodeStackDetector {
                         .addReferencedField(this), this);
             }
             break;
-        case CHECKCAST:
-        case INSTANCEOF:
-        case NEW:
+        case Const.CHECKCAST:
+        case Const.INSTANCEOF:
+        case Const.NEW:
             hq.pushHash(getClassConstantOperand());
             break;
-        case IFEQ:
-        case IFNE:
-        case IFNONNULL:
-        case IFNULL:
-        case IF_ICMPEQ:
-        case IF_ICMPNE:
-        case IF_ICMPLE:
-        case IF_ICMPGE:
-        case IF_ICMPGT:
-        case IF_ICMPLT:
-        case IF_ACMPEQ:
-        case IF_ACMPNE:
-        case RETURN:
-        case ARETURN:
-        case IRETURN:
-        case MONITORENTER:
-        case MONITOREXIT:
-        case IINC:
-        case NEWARRAY:
-        case TABLESWITCH:
-        case LOOKUPSWITCH:
-        case LCMP:
-        case INEG:
-        case IADD:
-        case IMUL:
-        case ISUB:
-        case IDIV:
-        case IREM:
-        case IXOR:
-        case ISHL:
-        case ISHR:
-        case IUSHR:
-        case IAND:
-        case IOR:
-        case LAND:
-        case LOR:
-        case LADD:
-        case LMUL:
-        case LSUB:
-        case LDIV:
-        case LSHL:
-        case LSHR:
-        case LUSHR:
-        case AALOAD:
-        case AASTORE:
-        case IALOAD:
-        case IASTORE:
-        case BALOAD:
-        case BASTORE:
+        case Const.IFEQ:
+        case Const.IFNE:
+        case Const.IFNONNULL:
+        case Const.IFNULL:
+        case Const.IF_ICMPEQ:
+        case Const.IF_ICMPNE:
+        case Const.IF_ICMPLE:
+        case Const.IF_ICMPGE:
+        case Const.IF_ICMPGT:
+        case Const.IF_ICMPLT:
+        case Const.IF_ACMPEQ:
+        case Const.IF_ACMPNE:
+        case Const.RETURN:
+        case Const.ARETURN:
+        case Const.IRETURN:
+        case Const.MONITORENTER:
+        case Const.MONITOREXIT:
+        case Const.IINC:
+        case Const.NEWARRAY:
+        case Const.TABLESWITCH:
+        case Const.LOOKUPSWITCH:
+        case Const.LCMP:
+        case Const.INEG:
+        case Const.IADD:
+        case Const.IMUL:
+        case Const.ISUB:
+        case Const.IDIV:
+        case Const.IREM:
+        case Const.IXOR:
+        case Const.ISHL:
+        case Const.ISHR:
+        case Const.IUSHR:
+        case Const.IAND:
+        case Const.IOR:
+        case Const.LAND:
+        case Const.LOR:
+        case Const.LADD:
+        case Const.LMUL:
+        case Const.LSUB:
+        case Const.LDIV:
+        case Const.LSHL:
+        case Const.LSHR:
+        case Const.LUSHR:
+        case Const.AALOAD:
+        case Const.AASTORE:
+        case Const.IALOAD:
+        case Const.IASTORE:
+        case Const.BALOAD:
+        case Const.BASTORE:
             hq.push(seen);
             priority = hq.getPriority();
             if (priority <= Priorities.LOW_PRIORITY) {
                 accumulator.accumulateBug(
-                        new BugInstance(this, "NOISE_OPERATION", priority).addClassAndMethod(this).addString(OPCODE_NAMES[seen]),
+                        new BugInstance(this, "NOISE_OPERATION", priority).addClassAndMethod(this).addString(Const.getOpcodeName(seen)),
                         this);
             }
             break;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/NoteDirectlyRelevantTypeQualifiers.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/NoteDirectlyRelevantTypeQualifiers.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.JavaClass;
 
@@ -87,10 +88,10 @@ public class NoteDirectlyRelevantTypeQualifiers extends DismantleBytecode implem
     @Override
     public void sawOpcode(int seen) {
         switch (seen) {
-        case INVOKEINTERFACE:
-        case INVOKEVIRTUAL:
-        case INVOKESTATIC:
-        case INVOKESPECIAL:
+        case Const.INVOKEINTERFACE:
+        case Const.INVOKEVIRTUAL:
+        case Const.INVOKESTATIC:
+        case Const.INVOKESPECIAL:
             // We don't need to look for method invocations
             // if Analysis.FIND_EFFECTIVE_RELEVANT_QUALIFIERS is enabled -
             // that will build an interprocedural call graph which
@@ -105,10 +106,10 @@ public class NoteDirectlyRelevantTypeQualifiers extends DismantleBytecode implem
             }
             break;
 
-        case GETSTATIC:
-        case PUTSTATIC:
-        case GETFIELD:
-        case PUTFIELD: {
+        case Const.GETSTATIC:
+        case Const.PUTSTATIC:
+        case Const.GETFIELD:
+        case Const.PUTFIELD: {
             XField f = getXFieldOperand();
             if (f != null) {
                 Collection<TypeQualifierAnnotation> annotations = TypeQualifierApplications.getApplicableApplications(f);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/NumberConstructor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/NumberConstructor.java
@@ -26,6 +26,7 @@ import java.util.Map;
 
 import javax.annotation.CheckForNull;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 
 import edu.umd.cs.findbugs.BugAccumulator;
@@ -104,7 +105,7 @@ public class NumberConstructor extends OpcodeStackDetector {
     @Override
     public void visitClassContext(ClassContext classContext) {
         int majorVersion = classContext.getJavaClass().getMajor();
-        if (majorVersion >= MAJOR_1_5 && hasInterestingMethod(classContext.getJavaClass().getConstantPool(), methods)) {
+        if (majorVersion >= Const.MAJOR_1_5 && hasInterestingMethod(classContext.getJavaClass().getConstantPool(), methods)) {
             super.visitClassContext(classContext);
         }
     }
@@ -147,7 +148,7 @@ public class NumberConstructor extends OpcodeStackDetector {
     @Override
     public void sawOpcode(int seen) {
         // only acts on constructor invoke
-        if (seen != INVOKESPECIAL) {
+        if (seen != Const.INVOKESPECIAL) {
             return;
         }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/NumberConstructor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/NumberConstructor.java
@@ -92,8 +92,8 @@ public class NumberConstructor extends OpcodeStackDetector {
         MethodDescriptor boxingMethod = new MethodDescriptor(className, "valueOf", sig + "L" + className +";", true);
         MethodDescriptor parsingMethod = new MethodDescriptor(className, "valueOf", "(Ljava/lang/String;)" + "L" + className +";", true);
         boxClasses.put(className, new Pair(boxingMethod, parsingMethod));
-        methods.add(new MethodDescriptor(className, "<init>", "(Ljava/lang/String;)V"));
-        methods.add(new MethodDescriptor(className, "<init>", sig+"V"));
+        methods.add(new MethodDescriptor(className, Const.CONSTRUCTOR_NAME, "(Ljava/lang/String;)V"));
+        methods.add(new MethodDescriptor(className, Const.CONSTRUCTOR_NAME, sig+"V"));
     }
 
     /**
@@ -152,7 +152,7 @@ public class NumberConstructor extends OpcodeStackDetector {
             return;
         }
 
-        if (!"<init>".equals(getNameConstantOperand())) {
+        if (!Const.CONSTRUCTOR_NAME.equals(getNameConstantOperand())) {
             return;
         }
         @SlashedClassName String cls = getClassConstantOperand();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/PreferZeroLengthArrays.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/PreferZeroLengthArrays.java
@@ -22,6 +22,7 @@ package edu.umd.cs.findbugs.detect;
 import java.util.Collection;
 import java.util.LinkedList;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 
 import edu.umd.cs.findbugs.BugInstance;
@@ -68,10 +69,10 @@ public class PreferZeroLengthArrays extends BytecodeScanningDetector implements 
     public void sawOpcode(int seen) {
 
         switch (seen) {
-        case ACONST_NULL:
+        case Const.ACONST_NULL:
             nullOnTOS = true;
             return;
-        case ARETURN:
+        case Const.ARETURN:
             if (nullOnTOS) {
                 SourceLineAnnotation sourceLineAnnotation = SourceLineAnnotation.fromVisitedInstruction(getClassContext(), this,
                         getPC());

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/PublicSemaphores.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/PublicSemaphores.java
@@ -19,6 +19,7 @@
  */
 package edu.umd.cs.findbugs.detect;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.classfile.Method;
@@ -81,13 +82,13 @@ public class PublicSemaphores extends BytecodeScanningDetector implements Statel
 
         switch (state) {
         case SEEN_NOTHING:
-            if (seen == ALOAD_0) {
+            if (seen == Const.ALOAD_0) {
                 state = SEEN_ALOAD_0;
             }
             break;
 
         case SEEN_ALOAD_0:
-            if ((seen == INVOKEVIRTUAL) && "java/lang/Object".equals(getClassConstantOperand())) {
+            if ((seen == Const.INVOKEVIRTUAL) && "java/lang/Object".equals(getClassConstantOperand())) {
                 String methodName = getNameConstantOperand();
                 if ("wait".equals(methodName) || "notify".equals(methodName) || "notifyAll".equals(methodName)) {
                     bugReporter.reportBug(new BugInstance(this, "PS_PUBLIC_SEMAPHORES", NORMAL_PRIORITY).addClassAndMethod(this)

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/QuestionableBooleanAssignment.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/QuestionableBooleanAssignment.java
@@ -19,6 +19,7 @@
  */
 package edu.umd.cs.findbugs.detect;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 
 import edu.umd.cs.findbugs.BugInstance;
@@ -58,18 +59,18 @@ public class QuestionableBooleanAssignment extends BytecodeScanningDetector impl
 
     @Override
     public void sawOpcode(int seen) {
-        if (seen == GOTO && getBranchOffset() == 4) {
+        if (seen == Const.GOTO && getBranchOffset() == 4) {
             state = SEEN_GOTO;
         } else {
             switch (state) {
             case SEEN_NOTHING:
-                if ((seen == ICONST_1) || (seen == ICONST_0)) {
+                if ((seen == Const.ICONST_1) || (seen == Const.ICONST_0)) {
                     state = SEEN_ICONST_0_OR_1;
                 }
                 break;
 
             case SEEN_ICONST_0_OR_1:
-                if (seen == DUP) {
+                if (seen == Const.DUP) {
                     state = SEEN_DUP;
                 } else {
                     state = SEEN_NOTHING;
@@ -77,7 +78,7 @@ public class QuestionableBooleanAssignment extends BytecodeScanningDetector impl
                 break;
 
             case SEEN_DUP:
-                if (((seen >= ISTORE_0) && (seen <= ISTORE_3)) || (seen == ISTORE)) {
+                if (((seen >= Const.ISTORE_0) && (seen <= Const.ISTORE_3)) || (seen == Const.ISTORE)) {
                     state = SEEN_ISTORE;
                 } else {
                     state = SEEN_NOTHING;
@@ -85,7 +86,7 @@ public class QuestionableBooleanAssignment extends BytecodeScanningDetector impl
                 break;
 
             case SEEN_ISTORE:
-                if (seen == IFEQ || seen == IFNE) {
+                if (seen == Const.IFEQ || seen == Const.IFNE) {
                     bug = new BugInstance(this, "QBA_QUESTIONABLE_BOOLEAN_ASSIGNMENT", HIGH_PRIORITY).addClassAndMethod(this)
                             .addSourceLine(this);
                     state = SEEN_IF;
@@ -96,7 +97,7 @@ public class QuestionableBooleanAssignment extends BytecodeScanningDetector impl
 
             case SEEN_IF:
                 state = SEEN_NOTHING;
-                if (seen == NEW) {
+                if (seen == Const.NEW) {
                     String cName = getClassConstantOperand();
                     if ("java/lang/AssertionError".equals(cName)) {
                         break;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ReadOfInstanceFieldInMethodInvokedByConstructorInSuperclass.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ReadOfInstanceFieldInMethodInvokedByConstructorInSuperclass.java
@@ -170,7 +170,7 @@ public class ReadOfInstanceFieldInMethodInvokedByConstructorInSuperclass extends
 
         XMethod lookfor = "()V".equals(superConstructor.getSignature()) ? null : superConstructor;
         for (XMethod m : getXClass().getXMethods()) {
-            if ("<init>".equals(m.getName())) {
+            if (Const.CONSTRUCTOR_NAME.equals(m.getName())) {
                 if (fieldSummary.getSuperCall(m) == lookfor) {
                     return m;
                 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ReadOfInstanceFieldInMethodInvokedByConstructorInSuperclass.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ReadOfInstanceFieldInMethodInvokedByConstructorInSuperclass.java
@@ -25,6 +25,7 @@ import java.util.Set;
 
 import javax.annotation.CheckForNull;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.Method;
 
@@ -67,7 +68,7 @@ public class ReadOfInstanceFieldInMethodInvokedByConstructorInSuperclass extends
 
     @Override
     public void sawOpcode(int opcode) {
-        if (opcode == PUTFIELD) {
+        if (opcode == Const.PUTFIELD) {
             XField f = getXFieldOperand();
             OpcodeStack.Item item = stack.getStackItem(1);
             if (item.getRegisterNumber() != 0) {
@@ -76,7 +77,7 @@ public class ReadOfInstanceFieldInMethodInvokedByConstructorInSuperclass extends
             initializedFields.add(f);
             return;
         }
-        if (opcode != GETFIELD) {
+        if (opcode != Const.GETFIELD) {
             return;
         }
         OpcodeStack.Item item = stack.getStackItem(0);
@@ -117,8 +118,8 @@ public class ReadOfInstanceFieldInMethodInvokedByConstructorInSuperclass extends
         }
 
         int nextOpcode = getNextOpcode();
-        if (nullCheckedFields.contains(f) || nextOpcode == IFNULL || nextOpcode == IFNONNULL || nextOpcode == IFEQ
-                || nextOpcode == IFNE) {
+        if (nullCheckedFields.contains(f) || nextOpcode == Const.IFNULL || nextOpcode == Const.IFNONNULL || nextOpcode == Const.IFEQ
+                || nextOpcode == Const.IFNE) {
             priority++;
             nullCheckedFields.add(f);
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ReadReturnShouldBeChecked.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ReadReturnShouldBeChecked.java
@@ -19,6 +19,7 @@
 
 package edu.umd.cs.findbugs.detect;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.Repository;
 import org.apache.bcel.classfile.Code;
 
@@ -97,13 +98,13 @@ public class ReadReturnShouldBeChecked extends BytecodeScanningDetector implemen
     @Override
     public void sawOpcode(int seen) {
 
-        if (seen == INVOKEVIRTUAL || seen == INVOKEINTERFACE) {
+        if (seen == Const.INVOKEVIRTUAL || seen == Const.INVOKEINTERFACE) {
             lastCallClass = getDottedClassConstantOperand();
             lastCallMethod = getNameConstantOperand();
             lastCallSig = getSigConstantOperand();
         }
 
-        if (seen == INVOKEVIRTUAL || seen == INVOKEINTERFACE) {
+        if (seen == Const.INVOKEVIRTUAL || seen == Const.INVOKEINTERFACE) {
             if ("available".equals(getNameConstantOperand()) && "()I".equals(getSigConstantOperand())
                     || getNameConstantOperand().startsWith("get") && getNameConstantOperand().endsWith("Length")
                     && "()I".equals(getSigConstantOperand()) || "java/io/File".equals(getClassConstantOperand())
@@ -113,7 +114,7 @@ public class ReadReturnShouldBeChecked extends BytecodeScanningDetector implemen
             }
         }
         sawAvailable--;
-        if ((seen == INVOKEVIRTUAL || seen == INVOKEINTERFACE)
+        if ((seen == Const.INVOKEVIRTUAL || seen == Const.INVOKEINTERFACE)
                 && "read".equals(getNameConstantOperand())
 
                 && ("([B)I".equals(getSigConstantOperand()) || "([BII)I".equals(getSigConstantOperand())
@@ -124,7 +125,7 @@ public class ReadReturnShouldBeChecked extends BytecodeScanningDetector implemen
             locationOfCall = getPC();
             return;
         }
-        if ((seen == INVOKEVIRTUAL || seen == INVOKEINTERFACE)
+        if ((seen == Const.INVOKEVIRTUAL || seen == Const.INVOKEINTERFACE)
                 && ("skip".equals(getNameConstantOperand()) && "(J)J".equals(getSigConstantOperand()) || "skipBytes".equals(getNameConstantOperand()) && "(I)I".equals(getSigConstantOperand())) && isInputStream()
                         && !isImageIOInputStream()) {
             // if not ByteArrayInput Stream
@@ -139,7 +140,7 @@ public class ReadReturnShouldBeChecked extends BytecodeScanningDetector implemen
 
         }
 
-        if ((seen == POP) || (seen == POP2)) {
+        if ((seen == Const.POP) || (seen == Const.POP2)) {
 
             if (sawRead) {
                 accumulator.accumulateBug(

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ReflectiveClasses.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ReflectiveClasses.java
@@ -19,6 +19,8 @@
 
 package edu.umd.cs.findbugs.detect;
 
+import org.apache.bcel.Const;
+
 import edu.umd.cs.findbugs.BugReporter;
 import edu.umd.cs.findbugs.BytecodeScanningDetector;
 import edu.umd.cs.findbugs.NonReportingDetector;
@@ -47,14 +49,14 @@ public class ReflectiveClasses extends BytecodeScanningDetector implements NonRe
     @Override
     public void sawClass() {
         int opcode = getOpcode();
-        if ((opcode == LDC) || (opcode == LDC_W)) {
+        if ((opcode == Const.LDC) || (opcode == Const.LDC_W)) {
             process(getClassConstantOperand());
         }
     }
 
     @Override
     public void sawOpcode(int seen) {
-        if (seen == INVOKESTATIC) {
+        if (seen == Const.INVOKESTATIC) {
             // System.out.println(getClassConstantOperand()+ "." +
             // getNameConstantOperand());
             if (constantString != null && "java/lang/Class".equals(getClassConstantOperand())

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/RepeatedConditionals.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/RepeatedConditionals.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 import org.apache.bcel.generic.BranchInstruction;
 import org.apache.bcel.generic.Instruction;
@@ -216,11 +217,11 @@ public class RepeatedConditionals extends OpcodeStackDetector {
     }
 
     private boolean hasSideEffect(int seen) {
-        if(seen == INVOKEVIRTUAL || seen == INVOKESPECIAL || seen == INVOKEINTERFACE || seen == INVOKESTATIC) {
+        if(seen == Const.INVOKEVIRTUAL || seen == Const.INVOKESPECIAL || seen == Const.INVOKEINTERFACE || seen == Const.INVOKESTATIC) {
             return noSideEffectMethods.is(getMethodDescriptorOperand(), MethodSideEffectStatus.SE, MethodSideEffectStatus.OBJ);
         }
-        return isRegisterStore() || isReturn(seen) || isSwitch(seen) || seen == INVOKEDYNAMIC || seen == PUTFIELD
-                || seen == PUTSTATIC;
+        return isRegisterStore() || isReturn(seen) || isSwitch(seen) || seen == Const.INVOKEDYNAMIC || seen == Const.PUTFIELD
+                || seen == Const.PUTSTATIC;
     }
 
     private void reset() {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ResolveAllReferences.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ResolveAllReferences.java
@@ -4,6 +4,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.Repository;
 import org.apache.bcel.classfile.Constant;
 import org.apache.bcel.classfile.ConstantCP;
@@ -97,13 +98,13 @@ public class ResolveAllReferences extends PreorderVisitor implements Detector {
     }
 
     private String getClassName(JavaClass c, int classIndex) {
-        String name = c.getConstantPool().getConstantString(classIndex, CONSTANT_Class);
+        String name = c.getConstantPool().getConstantString(classIndex, Const.CONSTANT_Class);
         return ClassName.extractClassName(name).replace('/', '.');
     }
 
     private String getMemberName(JavaClass c, String className, int memberNameIndex, int signatureIndex) {
-        return className + "." + ((ConstantUtf8) c.getConstantPool().getConstant(memberNameIndex, CONSTANT_Utf8)).getBytes()
-                + " : " + ((ConstantUtf8) c.getConstantPool().getConstant(signatureIndex, CONSTANT_Utf8)).getBytes();
+        return className + "." + ((ConstantUtf8) c.getConstantPool().getConstant(memberNameIndex, Const.CONSTANT_Utf8)).getBytes()
+                + " : " + ((ConstantUtf8) c.getConstantPool().getConstant(signatureIndex, Const.CONSTANT_Utf8)).getBytes();
     }
 
     private String getMemberName(String className, String memberName, String signature) {
@@ -159,8 +160,8 @@ public class ResolveAllReferences extends PreorderVisitor implements Detector {
                     continue checkConstant;
                 }
                 ConstantNameAndType nt = (ConstantNameAndType) cp.getConstant(co2.getNameAndTypeIndex());
-                String name = ((ConstantUtf8) obj.getConstantPool().getConstant(nt.getNameIndex(), CONSTANT_Utf8)).getBytes();
-                String signature = ((ConstantUtf8) obj.getConstantPool().getConstant(nt.getSignatureIndex(), CONSTANT_Utf8))
+                String name = ((ConstantUtf8) obj.getConstantPool().getConstant(nt.getNameIndex(), Const.CONSTANT_Utf8)).getBytes();
+                String signature = ((ConstantUtf8) obj.getConstantPool().getConstant(nt.getSignatureIndex(), Const.CONSTANT_Utf8))
                         .getBytes();
 
                 try {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/RuntimeExceptionCapture.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/RuntimeExceptionCapture.java
@@ -27,6 +27,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.CodeException;
 import org.apache.bcel.classfile.JavaClass;
@@ -218,7 +219,7 @@ public class RuntimeExceptionCapture extends OpcodeStackDetector implements Stat
     @Override
     public void sawOpcode(int seen) {
         switch (seen) {
-        case ATHROW:
+        case Const.ATHROW:
             if (stack.getStackDepth() > 0) {
                 OpcodeStack.Item item = stack.getStackItem(0);
                 String signature = item.getSignature();
@@ -233,16 +234,16 @@ public class RuntimeExceptionCapture extends OpcodeStackDetector implements Stat
             }
             break;
 
-        case INVOKEVIRTUAL:
-        case INVOKESPECIAL:
-        case INVOKESTATIC:
+        case Const.INVOKEVIRTUAL:
+        case Const.INVOKESPECIAL:
+        case Const.INVOKESTATIC:
             String className = getClassConstantOperand();
             if (!className.startsWith("[")) {
                 try {
                     XClass c = Global.getAnalysisCache().getClassAnalysis(XClass.class,
                             DescriptorFactory.createClassDescriptor(className));
                     XMethod m = Hierarchy2.findInvocationLeastUpperBound(c, getNameConstantOperand(), getSigConstantOperand(),
-                            seen == INVOKESTATIC, seen == INVOKEINTERFACE);
+                            seen == Const.INVOKESTATIC, seen == Const.INVOKEINTERFACE);
                     if (m == null) {
                         break;
                     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SerializableIdiom.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SerializableIdiom.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Attribute;
 import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.Field;
@@ -164,7 +165,7 @@ public class SerializableIdiom extends OpcodeStackDetector {
             return;
         }
         int flags = obj.getAccessFlags();
-        isAbstract = (flags & ACC_ABSTRACT) != 0 || (flags & ACC_INTERFACE) != 0;
+        isAbstract = (flags & Const.ACC_ABSTRACT) != 0 || (flags & Const.ACC_INTERFACE) != 0;
         isAnonymousInnerClass = anonymousInnerClassNamePattern.matcher(getClassName()).matches();
         innerClassHasOuterInstance = false;
         for (Field f : obj.getFields()) {
@@ -423,8 +424,8 @@ public class SerializableIdiom extends OpcodeStackDetector {
     public void visit(Method obj) {
 
         int accessFlags = obj.getAccessFlags();
-        boolean isSynchronized = (accessFlags & ACC_SYNCHRONIZED) != 0;
-        if ("<init>".equals(getMethodName()) && "()V".equals(getMethodSig()) && (accessFlags & ACC_PUBLIC) != 0) {
+        boolean isSynchronized = (accessFlags & Const.ACC_SYNCHRONIZED) != 0;
+        if ("<init>".equals(getMethodName()) && "()V".equals(getMethodSig()) && (accessFlags & Const.ACC_PUBLIC) != 0) {
             hasPublicVoidConstructor = true;
         }
         if (!"<init>".equals(getMethodName()) && isSynthetic(obj))
@@ -536,7 +537,7 @@ public class SerializableIdiom extends OpcodeStackDetector {
 
     @Override
     public void sawOpcode(int seen) {
-        if (seen == PUTFIELD) {
+        if (seen == Const.PUTFIELD) {
             XField xField = getXFieldOperand();
             if (xField != null && xField.getClassDescriptor().equals(getClassDescriptor())) {
                 Item first = stack.getStackItem(0);
@@ -720,7 +721,7 @@ public class SerializableIdiom extends OpcodeStackDetector {
         if (!"serialVersionUID".equals(getFieldName())) {
             return;
         }
-        int mask = ACC_STATIC | ACC_FINAL;
+        int mask = Const.ACC_STATIC | Const.ACC_FINAL;
         if (!"I".equals(fieldSig) && !"J".equals(fieldSig)) {
             return;
         }
@@ -729,11 +730,11 @@ public class SerializableIdiom extends OpcodeStackDetector {
                     .addVisitedField(this));
             sawSerialVersionUID = true;
             return;
-        } else if ((flags & ACC_STATIC) == 0) {
+        } else if ((flags & Const.ACC_STATIC) == 0) {
             bugReporter.reportBug(new BugInstance(this, "SE_NONSTATIC_SERIALVERSIONID", NORMAL_PRIORITY).addClass(this)
                     .addVisitedField(this));
             return;
-        } else if ((flags & ACC_FINAL) == 0) {
+        } else if ((flags & Const.ACC_FINAL) == 0) {
             bugReporter.reportBug(new BugInstance(this, "SE_NONFINAL_SERIALVERSIONID", NORMAL_PRIORITY).addClass(this)
                     .addVisitedField(this));
             return;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SerializableIdiom.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SerializableIdiom.java
@@ -241,7 +241,7 @@ public class SerializableIdiom extends OpcodeStackDetector {
                                     DescriptorFactory.createClassDescriptor(java.io.Serializable.class));
                     superClassHasVoidConstructor = false;
                     for (XMethod m : superXClass.getXMethods()) {
-                        if ("<init>".equals(m.getName()) && "()V".equals(m.getSignature()) && !m.isPrivate()) {
+                        if (Const.CONSTRUCTOR_NAME.equals(m.getName()) && "()V".equals(m.getSignature()) && !m.isPrivate()) {
                             superClassHasVoidConstructor = true;
                         }
                         if ("readObject".equals(m.getName()) && "(Ljava/io/ObjectInputStream;)V".equals(m.getSignature())
@@ -425,10 +425,10 @@ public class SerializableIdiom extends OpcodeStackDetector {
 
         int accessFlags = obj.getAccessFlags();
         boolean isSynchronized = (accessFlags & Const.ACC_SYNCHRONIZED) != 0;
-        if ("<init>".equals(getMethodName()) && "()V".equals(getMethodSig()) && (accessFlags & Const.ACC_PUBLIC) != 0) {
+        if (Const.CONSTRUCTOR_NAME.equals(getMethodName()) && "()V".equals(getMethodSig()) && (accessFlags & Const.ACC_PUBLIC) != 0) {
             hasPublicVoidConstructor = true;
         }
-        if (!"<init>".equals(getMethodName()) && isSynthetic(obj))
+        if (!Const.CONSTRUCTOR_NAME.equals(getMethodName()) && isSynthetic(obj))
         {
             foundSynthetic = true;
             // System.out.println(methodName + isSynchronized);
@@ -552,14 +552,14 @@ public class SerializableIdiom extends OpcodeStackDetector {
                 }
 
                 if (isPutOfDefaultValue) {
-                    if ("<init>".equals(getMethodName())) {
+                    if (Const.CONSTRUCTOR_NAME.equals(getMethodName())) {
                         transientFieldsSetToDefaultValueInConstructor.add(xField);
                     }
                 } else {
                     String nameOfField = getNameConstantOperand();
 
                     if (transientFieldsUpdates.containsKey(xField)) {
-                        if ("<init>".equals(getMethodName())) {
+                        if (Const.CONSTRUCTOR_NAME.equals(getMethodName())) {
                             transientFieldsSetInConstructor.add(xField);
                         } else {
                             transientFieldsUpdates.put(xField, transientFieldsUpdates.get(xField) + 1);
@@ -583,7 +583,7 @@ public class SerializableIdiom extends OpcodeStackDetector {
                                 String genSig = "L" + classStored.getClassName().replace('.', '/') + ";";
                                 if (!sig.equals(genSig)) {
                                     double bias = 0.0;
-                                    if (!"<init>".equals(getMethodName())) {
+                                    if (!Const.CONSTRUCTOR_NAME.equals(getMethodName())) {
                                         bias = 1.0;
                                     }
                                     int priority = computePriority(isSerializable, bias);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/StartInConstructor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/StartInConstructor.java
@@ -55,7 +55,7 @@ public class StartInConstructor extends BytecodeScanningDetector implements Stat
 
     @Override
     public void visit(Code obj) {
-        if ("<init>".equals(getMethodName()) && (getMethod().isPublic() || getMethod().isProtected())) {
+        if (Const.CONSTRUCTOR_NAME.equals(getMethodName()) && (getMethod().isPublic() || getMethod().isProtected())) {
             super.visit(obj);
             bugAccumulator.reportAccumulatedBugs();
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/StartInConstructor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/StartInConstructor.java
@@ -21,6 +21,7 @@ package edu.umd.cs.findbugs.detect;
 
 import java.util.Set;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.JavaClass;
 
@@ -48,7 +49,7 @@ public class StartInConstructor extends BytecodeScanningDetector implements Stat
 
     @Override
     public boolean shouldVisit(JavaClass obj) {
-        boolean isFinal = (obj.getAccessFlags() & ACC_FINAL) != 0 || (obj.getAccessFlags() & ACC_PUBLIC) == 0;
+        boolean isFinal = (obj.getAccessFlags() & Const.ACC_FINAL) != 0 || (obj.getAccessFlags() & Const.ACC_PUBLIC) == 0;
         return !isFinal;
     }
 
@@ -62,7 +63,7 @@ public class StartInConstructor extends BytecodeScanningDetector implements Stat
 
     @Override
     public void sawOpcode(int seen) {
-        if (seen == INVOKEVIRTUAL && "start".equals(getNameConstantOperand()) && "()V".equals(getSigConstantOperand())) {
+        if (seen == Const.INVOKEVIRTUAL && "start".equals(getNameConstantOperand()) && "()V".equals(getSigConstantOperand())) {
             try {
                 if (Hierarchy.isSubtype(getDottedClassConstantOperand(), "java.lang.Thread")) {
                     int priority = Priorities.NORMAL_PRIORITY;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/StaticCalendarDetector.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/StaticCalendarDetector.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.Constant;
 import org.apache.bcel.classfile.ConstantClass;
@@ -252,7 +253,7 @@ public class StaticCalendarDetector extends OpcodeStackDetector {
     @Override
     public void sawOpcode(int seen) {
 
-        if (seen == GETSTATIC) {
+        if (seen == Const.GETSTATIC) {
             XField f = getXFieldOperand();
             if (pendingBugs.containsKey(f)) {
                 if (!isLocked()) {
@@ -263,7 +264,7 @@ public class StaticCalendarDetector extends OpcodeStackDetector {
             }
         }
         // we are only interested in method calls
-        if (seen != INVOKEVIRTUAL) {
+        if (seen != Const.INVOKEVIRTUAL) {
             return;
         }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/StaticCalendarDetector.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/StaticCalendarDetector.java
@@ -296,7 +296,7 @@ public class StaticCalendarDetector extends OpcodeStackDetector {
                 return;
             }
 
-            if ("<clinit>".equals(getMethodName()) && field.getClassName().equals(getDottedClassName())) {
+            if (Const.STATIC_INITIALIZER_NAME.equals(getMethodName()) && field.getClassName().equals(getDottedClassName())) {
                 return;
             }
             String invokedName = getNameConstantOperand();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/Stream.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/Stream.java
@@ -194,7 +194,7 @@ public class Stream extends ResourceCreationPoint implements Comparable<Stream> 
         INVOKESPECIAL inv = (INVOKESPECIAL) ins;
 
         return frame.isValid() && getInstanceValue(frame, inv, cpg).isInstance()
-                && matchMethod(inv, cpg, this.getResourceClass(), "<init>");
+                && matchMethod(inv, cpg, this.getResourceClass(), Const.CONSTRUCTOR_NAME);
     }
 
     public static boolean mightCloseStream(BasicBlock basicBlock, InstructionHandle handle, ConstantPoolGen cpg) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/StringConcatenation.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/StringConcatenation.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Method;
 
 import edu.umd.cs.findbugs.BugInstance;
@@ -103,15 +104,15 @@ public class StringConcatenation extends BytecodeScanningDetector implements Sta
 
     private boolean storeIntoRegister(int seen, int reg) {
         switch (seen) {
-        case ASTORE_0:
+        case Const.ASTORE_0:
             return reg == 0;
-        case ASTORE_1:
+        case Const.ASTORE_1:
             return reg == 1;
-        case ASTORE_2:
+        case Const.ASTORE_2:
             return reg == 2;
-        case ASTORE_3:
+        case Const.ASTORE_3:
             return reg == 3;
-        case ASTORE:
+        case Const.ASTORE:
             return reg == getRegisterOperand();
         default:
             return false;
@@ -133,19 +134,19 @@ public class StringConcatenation extends BytecodeScanningDetector implements Sta
         // not including stores due to string concatenations
         int storeTo = -1;
         switch (seen) {
-        case ASTORE_0:
+        case Const.ASTORE_0:
             storeTo = 0;
             break;
-        case ASTORE_1:
+        case Const.ASTORE_1:
             storeTo = 1;
             break;
-        case ASTORE_2:
+        case Const.ASTORE_2:
             storeTo = 2;
             break;
-        case ASTORE_3:
+        case Const.ASTORE_3:
             storeTo = 3;
             break;
-        case ASTORE:
+        case Const.ASTORE:
             storeTo = getRegisterOperand();
             break;
         default:
@@ -157,19 +158,19 @@ public class StringConcatenation extends BytecodeScanningDetector implements Sta
 
         switch (state) {
         case SEEN_NOTHING:
-            if ((seen == NEW) && getClassConstantOperand().startsWith("java/lang/StringBu")) {
+            if ((seen == Const.NEW) && getClassConstantOperand().startsWith("java/lang/StringBu")) {
                 state = SEEN_NEW;
                 createPC = getPC();
             }
             break;
 
         case SEEN_NEW:
-            if (seen == INVOKESPECIAL && "<init>".equals(getNameConstantOperand())
+            if (seen == Const.INVOKESPECIAL && "<init>".equals(getNameConstantOperand())
             && "(Ljava/lang/String;)V".equals(getSigConstantOperand())
             && getClassConstantOperand().startsWith("java/lang/StringBu") && registerOnStack >= 0) {
                 state = SEEN_APPEND1;
                 stringSource = registerOnStack;
-            } else if (seen == INVOKEVIRTUAL && "append".equals(getNameConstantOperand())
+            } else if (seen == Const.INVOKEVIRTUAL && "append".equals(getNameConstantOperand())
                     && getClassConstantOperand().startsWith("java/lang/StringBu")) {
                 if (DEBUG) {
                     System.out.println("Saw string being appended from register " + registerOnStack);
@@ -188,7 +189,7 @@ public class StringConcatenation extends BytecodeScanningDetector implements Sta
         case SEEN_APPEND1:
             if (storeIntoRegister(seen, stringSource)) {
                 reset();
-            } else if (seen == INVOKEVIRTUAL && "append".equals(getNameConstantOperand())
+            } else if (seen == Const.INVOKEVIRTUAL && "append".equals(getNameConstantOperand())
                     && getClassConstantOperand().startsWith("java/lang/StringBu")) {
                 state = SEEN_APPEND2;
             }
@@ -197,7 +198,7 @@ public class StringConcatenation extends BytecodeScanningDetector implements Sta
         case SEEN_APPEND2:
             if (storeIntoRegister(seen, stringSource)) {
                 reset();
-            } else if (seen == INVOKEVIRTUAL && "toString".equals(getNameConstantOperand())
+            } else if (seen == Const.INVOKEVIRTUAL && "toString".equals(getNameConstantOperand())
                     && getClassConstantOperand().startsWith("java/lang/StringBu")) {
                 state = CONSTRUCTED_STRING_ON_STACK;
             }
@@ -243,7 +244,7 @@ public class StringConcatenation extends BytecodeScanningDetector implements Sta
                 // getBranchTarget()));
                 reset();
                 reportedThisMethod = true;
-            } else if ((seen == NEW) && getClassConstantOperand().startsWith("java/lang/StringBu")) {
+            } else if ((seen == Const.NEW) && getClassConstantOperand().startsWith("java/lang/StringBu")) {
                 state = SEEN_NEW;
                 createPC = getPC();
             } else {
@@ -259,26 +260,26 @@ public class StringConcatenation extends BytecodeScanningDetector implements Sta
             break;
         }
 
-        if (seen == INVOKESTATIC && "valueOf".equals(getNameConstantOperand())
+        if (seen == Const.INVOKESTATIC && "valueOf".equals(getNameConstantOperand())
                 && "java/lang/String".equals(getClassConstantOperand())
                 && "(Ljava/lang/Object;)Ljava/lang/String;".equals(getSigConstantOperand())) {
             // leave registerOnStack unchanged
         } else {
             registerOnStack = -1;
             switch (seen) {
-            case ALOAD_0:
+            case Const.ALOAD_0:
                 registerOnStack = 0;
                 break;
-            case ALOAD_1:
+            case Const.ALOAD_1:
                 registerOnStack = 1;
                 break;
-            case ALOAD_2:
+            case Const.ALOAD_2:
                 registerOnStack = 2;
                 break;
-            case ALOAD_3:
+            case Const.ALOAD_3:
                 registerOnStack = 3;
                 break;
-            case ALOAD:
+            case Const.ALOAD:
                 registerOnStack = getRegisterOperand();
                 break;
             default:

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/StringConcatenation.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/StringConcatenation.java
@@ -165,7 +165,7 @@ public class StringConcatenation extends BytecodeScanningDetector implements Sta
             break;
 
         case SEEN_NEW:
-            if (seen == Const.INVOKESPECIAL && "<init>".equals(getNameConstantOperand())
+            if (seen == Const.INVOKESPECIAL && Const.CONSTRUCTOR_NAME.equals(getNameConstantOperand())
             && "(Ljava/lang/String;)V".equals(getSigConstantOperand())
             && getClassConstantOperand().startsWith("java/lang/StringBu") && registerOnStack >= 0) {
                 state = SEEN_APPEND1;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SuperfluousInstanceOf.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SuperfluousInstanceOf.java
@@ -20,6 +20,7 @@
 
 package edu.umd.cs.findbugs.detect;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.LocalVariable;
 import org.apache.bcel.classfile.LocalVariableTable;
@@ -76,10 +77,10 @@ public class SuperfluousInstanceOf extends BytecodeScanningDetector implements S
     public void sawOpcode(int seen) {
         switch (state) {
         case SEEN_NOTHING:
-            if (seen == ALOAD) {
+            if (seen == Const.ALOAD) {
                 register = getRegisterOperand();
-            } else if ((seen >= ALOAD_0) && (seen <= ALOAD_3)) {
-                register = seen - ALOAD_0;
+            } else if ((seen >= Const.ALOAD_0) && (seen <= Const.ALOAD_3)) {
+                register = seen - Const.ALOAD_0;
             } else {
                 return;
             }
@@ -88,7 +89,7 @@ public class SuperfluousInstanceOf extends BytecodeScanningDetector implements S
 
         case SEEN_ALOAD:
             try {
-                if (seen == INSTANCEOF) {
+                if (seen == Const.INSTANCEOF) {
                     LocalVariable lv = LVTHelper.getLocalVariableAtPC(varTable, register, getPC());
                     if (lv != null) {
                         String objSignature = lv.getSignature();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SwitchFallthrough.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SwitchFallthrough.java
@@ -27,6 +27,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Set;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.LineNumber;
 import org.apache.bcel.classfile.LineNumberTable;
@@ -149,18 +150,18 @@ public class SwitchFallthrough extends OpcodeStackDetector implements StatelessD
         boolean isCaseOffset = switchHdlr.isOnSwitchOffset(this);
 
         if (DEBUG) {
-            if (seen == GOTO) {
+            if (seen == Const.GOTO) {
                 System.out.printf("%4d: goto %-7d %s %s %s %d%n", getPC(), getBranchTarget(), reachable, isCaseOffset,
                         isDefaultOffset, switchHdlr.stackSize());
             } else {
-                System.out.printf("%4d: %-12s %s %s %s %d%n", getPC(), OPCODE_NAMES[seen], reachable, isCaseOffset,
+                System.out.printf("%4d: %-12s %s %s %s %d%n", getPC(), Const.getOpcodeName(seen), reachable, isCaseOffset,
                         isDefaultOffset, switchHdlr.stackSize());
             }
         }
 
         if (reachable && (isDefaultOffset || isCaseOffset)) {
             if (DEBUG) {
-                System.out.println("Fallthrough at : " + getPC() + ": " + OPCODE_NAMES[seen]);
+                System.out.println("Fallthrough at : " + getPC() + ": " + Const.getOpcodeName(seen));
             }
             fallthroughDistance = 0;
             potentiallyDeadStoresFromBeforeFallthrough = (BitSet) potentiallyDeadStores.clone();
@@ -182,19 +183,19 @@ public class SwitchFallthrough extends OpcodeStackDetector implements StatelessD
 
         }
 
-        if (isBranch(seen) || isSwitch(seen) || seen == GOTO || seen == ARETURN || seen == IRETURN || seen == RETURN
-                || seen == LRETURN || seen == DRETURN || seen == FRETURN) {
+        if (isBranch(seen) || isSwitch(seen) || seen == Const.GOTO || seen == Const.ARETURN || seen == Const.IRETURN || seen == Const.RETURN
+                || seen == Const.LRETURN || seen == Const.DRETURN || seen == Const.FRETURN) {
             clearAllDeadStores();
         }
 
-        if (seen == GETFIELD && stack.getStackDepth() > 0) {
+        if (seen == Const.GETFIELD && stack.getStackDepth() > 0) {
             OpcodeStack.Item top = stack.getStackItem(0);
             if (top.getRegisterNumber() == 0) {
                 potentiallyDeadFields.remove(getXFieldOperand());
             }
         }
 
-        else if (seen == PUTFIELD && stack.getStackDepth() >= 2) {
+        else if (seen == Const.PUTFIELD && stack.getStackDepth() >= 2) {
             OpcodeStack.Item obj = stack.getStackItem(1);
             if (obj.getRegisterNumber() == 0) {
                 XField f = getXFieldOperand();
@@ -209,7 +210,7 @@ public class SwitchFallthrough extends OpcodeStackDetector implements StatelessD
             }
         }
 
-        if (seen == ATHROW) {
+        if (seen == Const.ATHROW) {
             int sz = edu.umd.cs.findbugs.visitclass.Util.getSizeOfSurroundingTryBlock(getMethod(), (String) null, getPC());
             if (sz == Integer.MAX_VALUE) {
 
@@ -243,7 +244,7 @@ public class SwitchFallthrough extends OpcodeStackDetector implements StatelessD
         }
 
 
-        if (seen == INVOKEVIRTUAL && "ordinal".equals(getNameConstantOperand()) && "()I".equals(getSigConstantOperand())) {
+        if (seen == Const.INVOKEVIRTUAL && "ordinal".equals(getNameConstantOperand()) && "()I".equals(getSigConstantOperand())) {
             XClass c = getXClassOperand();
             if (c != null) {
                 ClassDescriptor superclassDescriptor = c.getSuperclassDescriptor();
@@ -254,13 +255,13 @@ public class SwitchFallthrough extends OpcodeStackDetector implements StatelessD
                     System.out.println("Saw " + enumType + ".ordinal()");
                 }
             }
-        } else if (seen != TABLESWITCH && seen != LOOKUPSWITCH && seen != IALOAD) {
+        } else if (seen != Const.TABLESWITCH && seen != Const.LOOKUPSWITCH && seen != Const.IALOAD) {
             enumType = null;
         }
 
         switch (seen) {
-        case TABLESWITCH:
-        case LOOKUPSWITCH:
+        case Const.TABLESWITCH:
+        case Const.LOOKUPSWITCH:
             if (justSawHashcode)
             {
                 break; // javac compiled switch statement
@@ -273,8 +274,8 @@ public class SwitchFallthrough extends OpcodeStackDetector implements StatelessD
             }
             break;
 
-        case GOTO_W:
-        case GOTO:
+        case Const.GOTO_W:
+        case Const.GOTO:
             if (biggestJumpTarget < getBranchTarget()) {
                 biggestJumpTarget = getBranchTarget();
                 if (DEBUG) {
@@ -285,17 +286,17 @@ public class SwitchFallthrough extends OpcodeStackDetector implements StatelessD
             reachable = false;
             break;
 
-        case ATHROW:
-        case RETURN:
-        case ARETURN:
-        case IRETURN:
-        case LRETURN:
-        case DRETURN:
-        case FRETURN:
+        case Const.ATHROW:
+        case Const.RETURN:
+        case Const.ARETURN:
+        case Const.IRETURN:
+        case Const.LRETURN:
+        case Const.DRETURN:
+        case Const.FRETURN:
             reachable = false;
             break;
 
-        case INVOKESTATIC:
+        case Const.INVOKESTATIC:
             reachable = !("exit".equals(getNameConstantOperand()) && "java/lang/System".equals(getClassConstantOperand()));
             break;
 
@@ -303,7 +304,7 @@ public class SwitchFallthrough extends OpcodeStackDetector implements StatelessD
             reachable = true;
         }
 
-        justSawHashcode =   seen == INVOKEVIRTUAL && "hashCode".equals(getNameConstantOperand()) && "()I".equals(getSigConstantOperand());
+        justSawHashcode =   seen == Const.INVOKEVIRTUAL && "hashCode".equals(getNameConstantOperand()) && "()I".equals(getSigConstantOperand());
         lastPC = getPC();
         fallthroughDistance++;
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SynchronizationOnSharedBuiltinConstant.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SynchronizationOnSharedBuiltinConstant.java
@@ -24,6 +24,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 
 import edu.umd.cs.findbugs.BugAccumulator;
@@ -79,7 +80,7 @@ public class SynchronizationOnSharedBuiltinConstant extends OpcodeStackDetector 
     @Override
     public void sawOpcode(int seen) {
         switch (seen) {
-        case MONITORENTER:
+        case Const.MONITORENTER:
             OpcodeStack.Item top = stack.getStackItem(0);
 
             if (pendingBug != null) {
@@ -122,7 +123,7 @@ public class SynchronizationOnSharedBuiltinConstant extends OpcodeStackDetector 
                 }
             }
             break;
-        case MONITOREXIT:
+        case Const.MONITOREXIT:
             accumulateBug();
             break;
         default:

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SynchronizationOnSharedBuiltinConstant.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SynchronizationOnSharedBuiltinConstant.java
@@ -57,7 +57,7 @@ public class SynchronizationOnSharedBuiltinConstant extends OpcodeStackDetector 
         if (method == null) {
             return false;
         }
-        return "<init>".equals(method.getName());
+        return Const.CONSTRUCTOR_NAME.equals(method.getName());
     }
 
     private static final Pattern identified = Pattern.compile("\\p{Alnum}+");

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SynchronizeAndNullCheckField.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SynchronizeAndNullCheckField.java
@@ -19,6 +19,7 @@
 
 package edu.umd.cs.findbugs.detect;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Method;
 
 import edu.umd.cs.findbugs.BugInstance;
@@ -61,34 +62,34 @@ public class SynchronizeAndNullCheckField extends BytecodeScanningDetector {
         // currState);
         switch (currState) {
         case 0:
-            if (seen == GETFIELD || seen == GETSTATIC) {
+            if (seen == Const.GETFIELD || seen == Const.GETSTATIC) {
                 syncField = FieldAnnotation.fromReferencedField(this);
                 currState = 1;
             }
             break;
         case 1:
-            if (seen == DUP) {
+            if (seen == Const.DUP) {
                 currState = 2;
             } else {
                 currState = 0;
             }
             break;
         case 2:
-            if (seen == ASTORE || seen == ASTORE_0 || seen == ASTORE_1 || seen == ASTORE_2 || seen == ASTORE_3) {
+            if (seen == Const.ASTORE || seen == Const.ASTORE_0 || seen == Const.ASTORE_1 || seen == Const.ASTORE_2 || seen == Const.ASTORE_3) {
                 currState = 3;
             } else {
                 currState = 0;
             }
             break;
         case 3:
-            if (seen == MONITORENTER) {
+            if (seen == Const.MONITORENTER) {
                 currState = 4;
             } else {
                 currState = 0;
             }
             break;
         case 4:
-            if (seen == GETFIELD || seen == GETSTATIC) {
+            if (seen == Const.GETFIELD || seen == Const.GETSTATIC) {
                 gottenField = FieldAnnotation.fromReferencedField(this);
                 currState = 5;
             } else {
@@ -96,7 +97,7 @@ public class SynchronizeAndNullCheckField extends BytecodeScanningDetector {
             }
             break;
         case 5:
-            if ((seen == IFNONNULL || seen == IFNULL) && gottenField.equals(syncField)) {
+            if ((seen == Const.IFNONNULL || seen == Const.IFNULL) && gottenField.equals(syncField)) {
                 BugInstance bug = new BugInstance(this, "NP_SYNC_AND_NULL_CHECK_FIELD", NORMAL_PRIORITY).addClass(this)
                         .addMethod(this).addField(syncField).addSourceLine(this);
                 bugReporter.reportBug(bug);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SynchronizeOnClassLiteralNotGetClass.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SynchronizeOnClassLiteralNotGetClass.java
@@ -21,6 +21,7 @@ package edu.umd.cs.findbugs.detect;
 
 import java.util.Set;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 
 import edu.umd.cs.findbugs.BugInstance;
@@ -64,19 +65,19 @@ public class SynchronizeOnClassLiteralNotGetClass extends OpcodeStackDetector {
     @Override
     public void sawOpcode(int seen) {
         if (pendingBug != null) {
-            if (seen == PUTSTATIC) {
+            if (seen == Const.PUTSTATIC) {
                 String classConstantOperand = getClassConstantOperand();
                 String thisClassName = getThisClass().getClassName().replace('.', '/');
                 if (classConstantOperand.equals(thisClassName)) {
                     seenPutStatic = true;
                 }
-            } else if (seen == GETSTATIC) {
+            } else if (seen == Const.GETSTATIC) {
                 String classConstantOperand = getClassConstantOperand();
                 String thisClassName = getThisClass().getClassName().replace('.', '/');
                 if (classConstantOperand.equals(thisClassName)) {
                     seenGetStatic = true;
                 }
-            } else if (seen == MONITOREXIT) {
+            } else if (seen == Const.MONITOREXIT) {
                 int priority = LOW_PRIORITY;
                 if (seenPutStatic || seenGetStatic) {
                     priority--;
@@ -101,12 +102,12 @@ public class SynchronizeOnClassLiteralNotGetClass extends OpcodeStackDetector {
         }
         switch (state) {
         case 0:
-            if (seen == ALOAD_0) {
+            if (seen == Const.ALOAD_0) {
                 state = 1;
             }
             break;
         case 1:
-            if (seen == INVOKEVIRTUAL && "getClass".equals(getNameConstantOperand())
+            if (seen == Const.INVOKEVIRTUAL && "getClass".equals(getNameConstantOperand())
             && "()Ljava/lang/Class;".equals(getSigConstantOperand())) {
                 state = 2;
             } else {
@@ -114,7 +115,7 @@ public class SynchronizeOnClassLiteralNotGetClass extends OpcodeStackDetector {
             }
             break;
         case 2:
-            if (seen == DUP) {
+            if (seen == Const.DUP) {
                 state = 3;
             } else {
                 state = 0;
@@ -128,7 +129,7 @@ public class SynchronizeOnClassLiteralNotGetClass extends OpcodeStackDetector {
             }
             break;
         case 4:
-            if (seen == MONITORENTER) {
+            if (seen == Const.MONITORENTER) {
                 pendingBug = new BugInstance(this, "WL_USING_GETCLASS_RATHER_THAN_CLASS_LITERAL", NORMAL_PRIORITY)
                 .addClassAndMethod(this).addSourceLine(this);
             }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SynchronizingOnContentsOfFieldToProtectField.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SynchronizingOnContentsOfFieldToProtectField.java
@@ -19,6 +19,7 @@
 
 package edu.umd.cs.findbugs.detect;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.CodeException;
 
@@ -62,7 +63,7 @@ public class SynchronizingOnContentsOfFieldToProtectField extends OpcodeStackDet
     @Override
     public void sawOpcode(int seen) {
         // System.out.println(state + " " + getPC() + " " + OPCODE_NAMES[seen]);
-        if (countDown == 2 && seen == GOTO) {
+        if (countDown == 2 && seen == Const.GOTO) {
             CodeException tryBlock = getSurroundingTryBlock(getPC());
             if (tryBlock != null && tryBlock.getEndPC() == getPC()) {
                 pendingBug.lowerPriority();
@@ -71,7 +72,7 @@ public class SynchronizingOnContentsOfFieldToProtectField extends OpcodeStackDet
         if (countDown > 0) {
             countDown--;
             if (countDown == 0) {
-                if (seen == MONITOREXIT) {
+                if (seen == Const.MONITOREXIT) {
                     pendingBug.lowerPriority();
                 }
 
@@ -79,9 +80,9 @@ public class SynchronizingOnContentsOfFieldToProtectField extends OpcodeStackDet
                 pendingBug = null;
             }
         }
-        if (seen == PUTFIELD) {
+        if (seen == Const.PUTFIELD) {
 
-            if (syncField != null && getPrevOpcode(1) != ALOAD_0 && syncField.equals(getXFieldOperand())) {
+            if (syncField != null && getPrevOpcode(1) != Const.ALOAD_0 && syncField.equals(getXFieldOperand())) {
                 OpcodeStack.Item value = stack.getStackItem(0);
                 int priority = Priorities.HIGH_PRIORITY;
                 if (value.isNull()) {
@@ -94,23 +95,23 @@ public class SynchronizingOnContentsOfFieldToProtectField extends OpcodeStackDet
             }
 
         }
-        if (seen == MONITOREXIT) {
+        if (seen == Const.MONITOREXIT) {
             pendingBug = null;
             countDown = 0;
         }
 
-        if (seen == MONITORENTER) {
+        if (seen == Const.MONITORENTER) {
             syncField = null;
         }
 
         switch (state) {
         case 0:
-            if (seen == ALOAD_0) {
+            if (seen == Const.ALOAD_0) {
                 state = 1;
             }
             break;
         case 1:
-            if (seen == GETFIELD) {
+            if (seen == Const.GETFIELD) {
                 state = 2;
                 field = getXFieldOperand();
             } else {
@@ -118,7 +119,7 @@ public class SynchronizingOnContentsOfFieldToProtectField extends OpcodeStackDet
             }
             break;
         case 2:
-            if (seen == DUP) {
+            if (seen == Const.DUP) {
                 state = 3;
             } else {
                 state = 0;
@@ -132,7 +133,7 @@ public class SynchronizingOnContentsOfFieldToProtectField extends OpcodeStackDet
             }
             break;
         case 4:
-            if (seen == MONITORENTER) {
+            if (seen == Const.MONITORENTER) {
                 state = 0;
                 syncField = field;
             } else {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/TestingGround.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/TestingGround.java
@@ -19,6 +19,7 @@
 
 package edu.umd.cs.findbugs.detect;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 
 import edu.umd.cs.findbugs.BugReporter;
@@ -44,7 +45,7 @@ public class TestingGround extends OpcodeStackDetector {
 
     @Override
     public void sawOpcode(int seen) {
-        System.out.printf("%3d %-15s %s%n", getPC(), OPCODE_NAMES[seen], stack);
+        System.out.printf("%3d %-15s %s%n", getPC(), Const.getOpcodeName(seen), stack);
 
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/TypeReturnNull.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/TypeReturnNull.java
@@ -19,6 +19,7 @@
 
 package edu.umd.cs.findbugs.detect;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 
 import edu.umd.cs.findbugs.BugAccumulator;
@@ -72,7 +73,7 @@ public abstract class TypeReturnNull extends OpcodeStackDetector {
 
     @Override
     public void sawOpcode(int seen) {
-        if (seen == ARETURN && getPrevOpcode(1) == ACONST_NULL){
+        if (seen == Const.ARETURN && getPrevOpcode(1) == Const.ACONST_NULL){
             accumulateBug();
         }
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/URLProblems.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/URLProblems.java
@@ -21,6 +21,7 @@ package edu.umd.cs.findbugs.detect;
 import java.util.Arrays;
 import java.util.List;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.classfile.Signature;
@@ -127,13 +128,13 @@ public class URLProblems extends OpcodeStackDetector {
     @Override
     public void sawOpcode(int seen) {
 
-        if (seen == INVOKEVIRTUAL || seen == INVOKEINTERFACE) {
+        if (seen == Const.INVOKEVIRTUAL || seen == Const.INVOKEINTERFACE) {
             check("Ljava/util/HashSet;", HASHSET_KEY_METHODS, 1, 0);
             check("Ljava/util/HashMap;", HASHMAP_KEY_METHODS, 1, 0);
             check("Ljava/util/HashMap;", HASHMAP_TWO_ARG_KEY_METHODS, 2, 1);
         }
 
-        if (seen == INVOKEVIRTUAL && (getMethodDescriptorOperand().equals(URL_EQUALS)
+        if (seen == Const.INVOKEVIRTUAL && (getMethodDescriptorOperand().equals(URL_EQUALS)
                 || getMethodDescriptorOperand().equals(URL_HASHCODE))) {
             accumulator.accumulateBug(
                     new BugInstance(this, "DMI_BLOCKING_METHODS_ON_URL", HIGH_PRIORITY).addClassAndMethod(this)

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UncallableMethodOfAnonymousClass.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UncallableMethodOfAnonymousClass.java
@@ -158,10 +158,10 @@ public class UncallableMethodOfAnonymousClass extends BytecodeScanningDetector {
 
         String methodName = obj.getName();
         String sig = obj.getSignature();
-        if ("<init>".equals(methodName)) {
+        if (Const.CONSTRUCTOR_NAME.equals(methodName)) {
             return true;
         }
-        if ("<clinit>".equals(methodName)) {
+        if (Const.STATIC_INITIALIZER_NAME.equals(methodName)) {
             return true;
         }
         if ("()Ljava/lang/Object;".equals(sig) && ("readResolve".equals(methodName) || "writeReplace".equals(methodName))) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UncallableMethodOfAnonymousClass.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UncallableMethodOfAnonymousClass.java
@@ -22,6 +22,7 @@ package edu.umd.cs.findbugs.detect;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Attribute;
 import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.JavaClass;
@@ -92,7 +93,7 @@ public class UncallableMethodOfAnonymousClass extends BytecodeScanningDetector {
 
     @Override
     public void sawOpcode(int seen) {
-        if (seen == INVOKESPECIAL) {
+        if (seen == Const.INVOKESPECIAL) {
             XMethod m = getXMethodOperand();
             if (m == null) {
                 return;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UnnecessaryMath.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UnnecessaryMath.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.Constant;
 import org.apache.bcel.classfile.ConstantDouble;
@@ -132,10 +133,10 @@ public class UnnecessaryMath extends BytecodeScanningDetector implements Statele
     @Override
     public void sawOpcode(int seen) {
         if (state == SEEN_NOTHING) {
-            if ((seen == DCONST_0) || (seen == DCONST_1)) {
-                constValue = seen - DCONST_0;
+            if ((seen == Const.DCONST_0) || (seen == Const.DCONST_1)) {
+                constValue = seen - Const.DCONST_0;
                 state = SEEN_DCONST;
-            } else if ((seen == LDC2_W) || (seen == LDC_W)) {
+            } else if ((seen == Const.LDC2_W) || (seen == Const.LDC_W)) {
                 state = SEEN_DCONST;
                 Constant c = this.getConstantRefOperand();
                 if (c instanceof ConstantDouble) {
@@ -149,7 +150,7 @@ public class UnnecessaryMath extends BytecodeScanningDetector implements Statele
                 }
             }
         } else if (state == SEEN_DCONST) {
-            if (seen == INVOKESTATIC) {
+            if (seen == Const.INVOKESTATIC) {
                 state = SEEN_NOTHING;
                 if ("java.lang.Math".equals(getDottedClassConstantOperand())) {
                     String methodName = getNameConstantOperand();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UnnecessaryMath.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UnnecessaryMath.java
@@ -122,7 +122,7 @@ public class UnnecessaryMath extends BytecodeScanningDetector implements Statele
     public void visit(Code obj) {
         // Don't complain about unnecessary math calls in class initializers,
         // since they may be there to improve readability.
-        if ("<clinit>".equals(getMethod().getName())) {
+        if (Const.STATIC_INITIALIZER_NAME.equals(getMethod().getName())) {
             return;
         }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UnreadFields.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UnreadFields.java
@@ -360,7 +360,7 @@ public class UnreadFields extends OpcodeStackDetector {
         seenMonitorEnter = getMethod().isSynchronized();
         data.staticFieldsReadInThisMethod.clear();
         super.visit(obj);
-        if ("<init>".equals(getMethodName()) && count_aload_1 > 1
+        if (Const.CONSTRUCTOR_NAME.equals(getMethodName()) && count_aload_1 > 1
                 && (getClassName().indexOf('$') >= 0 || getClassName().indexOf('+') >= 0)) {
             data.needsOuterObjectInConstructor.add(getDottedClassName());
             // System.out.println(betterClassName +
@@ -374,7 +374,7 @@ public class UnreadFields extends OpcodeStackDetector {
         if (DEBUG) {
             System.out.println("Checking " + getClassName() + "." + obj.getName());
         }
-        if ("<init>".equals(getMethodName()) && (obj.isPublic() || obj.isProtected())) {
+        if (Const.CONSTRUCTOR_NAME.equals(getMethodName()) && (obj.isPublic() || obj.isProtected())) {
             publicOrProtectedConstructor = true;
         }
         pendingGetField = null;
@@ -584,7 +584,7 @@ public class UnreadFields extends OpcodeStackDetector {
         }
 
         // Store annotation for the anonymous class creation
-        if (seen == Const.INVOKESPECIAL && getMethodDescriptorOperand().getName().equals("<init>") && ClassName.isAnonymous(getClassConstantOperand())) {
+        if (seen == Const.INVOKESPECIAL && getMethodDescriptorOperand().getName().equals(Const.CONSTRUCTOR_NAME) && ClassName.isAnonymous(getClassConstantOperand())) {
             List<BugAnnotation> annotation = new ArrayList<>();
             annotation.add(ClassAnnotation.fromClassDescriptor(getClassDescriptor()));
             annotation.add(MethodAnnotation.fromVisitedMethod(this));
@@ -595,7 +595,7 @@ public class UnreadFields extends OpcodeStackDetector {
         if (seen == Const.PUTFIELD || seen == Const.ASTORE || seen == Const.ASTORE_0 || seen == Const.ASTORE_1 || seen == Const.ASTORE_2 || seen == Const.ASTORE_3) {
             Item item = stack.getStackItem(0);
             XMethod xMethod = item.getReturnValueOf();
-            if(xMethod != null && xMethod.getName().equals("<init>") && ClassName.isAnonymous(xMethod.getClassName())) {
+            if(xMethod != null && xMethod.getName().equals(Const.CONSTRUCTOR_NAME) && ClassName.isAnonymous(xMethod.getClassName())) {
                 List<BugAnnotation> annotations = anonymousClassAnnotation.get(xMethod.getClassName());
                 if(annotations == null) {
                     annotations = new ArrayList<>();
@@ -614,7 +614,7 @@ public class UnreadFields extends OpcodeStackDetector {
             String sig = getSigConstantOperand();
             String invokedClassName = getClassConstantOperand();
             if (invokedClassName.equals(getClassName())
-                    && ("<init>".equals(getMethodName()) || "<clinit>".equals(getMethodName()))) {
+                    && (Const.CONSTRUCTOR_NAME.equals(getMethodName()) || Const.STATIC_INITIALIZER_NAME.equals(getMethodName()))) {
 
                 data.calledFromConstructors.add(getNameConstantOperand() + ":" + sig);
             }
@@ -628,7 +628,7 @@ public class UnreadFields extends OpcodeStackDetector {
                 }
 
                 boolean selfCall = item.getRegisterNumber() == 0 && !superCall;
-                if (selfCall && "<init>".equals(getMethodName())) {
+                if (selfCall && Const.CONSTRUCTOR_NAME.equals(getMethodName())) {
                     sawSelfCallInConstructor = true;
                     if (DEBUG) {
                         System.out.println("Saw self call in " + getFullyQualifiedMethodName() + " to " + invokedClassName + "."
@@ -779,7 +779,7 @@ public class UnreadFields extends OpcodeStackDetector {
                 data.fieldAccess.put(f, SourceLineAnnotation.fromVisitedInstruction(this));
             }
 
-            boolean isConstructor = "<init>".equals(getMethodName()) || "<clinit>".equals(getMethodName());
+            boolean isConstructor = Const.CONSTRUCTOR_NAME.equals(getMethodName()) || Const.STATIC_INITIALIZER_NAME.equals(getMethodName());
             if (getMethod().isStatic() == f.isStatic()
                     && (isConstructor || data.calledFromConstructors.contains(getMethodName() + ":" + getMethodSig())
                             || "init".equals(getMethodName()) || "initialize".equals(getMethodName())

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UnreadFields.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UnreadFields.java
@@ -32,6 +32,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.Repository;
 import org.apache.bcel.classfile.Attribute;
 import org.apache.bcel.classfile.Code;
@@ -155,7 +156,7 @@ public class UnreadFields extends OpcodeStackDetector {
         return data.isWrittenInConstructor(f);
     }
 
-    static final int DO_NOT_CONSIDER = ACC_PUBLIC | ACC_PROTECTED;
+    static final int DO_NOT_CONSIDER = Const.ACC_PUBLIC | Const.ACC_PROTECTED;
 
     final ClassDescriptor externalizable = DescriptorFactory.createClassDescriptor(java.io.Externalizable.class);
 
@@ -380,7 +381,7 @@ public class UnreadFields extends OpcodeStackDetector {
         saState = 0;
         super.visit(obj);
         int flags = obj.getAccessFlags();
-        if ((flags & ACC_NATIVE) != 0) {
+        if ((flags & Const.ACC_NATIVE) != 0) {
             hasNativeMethods = true;
         }
     }
@@ -397,33 +398,33 @@ public class UnreadFields extends OpcodeStackDetector {
     @Override
     public void sawOpcode(int seen) {
         if (DEBUG) {
-            System.out.println(getPC() + ": " + OPCODE_NAMES[seen] + " " + saState);
+            System.out.println(getPC() + ": " + Const.getOpcodeName(seen) + " " + saState);
         }
-        if (seen == MONITORENTER) {
+        if (seen == Const.MONITORENTER) {
             seenMonitorEnter = true;
         }
         switch (saState) {
         case 0:
-            if (seen == ALOAD_0) {
+            if (seen == Const.ALOAD_0) {
                 saState = 1;
             }
             break;
         case 1:
-            if (seen == ALOAD_0) {
+            if (seen == Const.ALOAD_0) {
                 saState = 2;
             } else {
                 saState = 0;
             }
             break;
         case 2:
-            if (seen == GETFIELD) {
+            if (seen == Const.GETFIELD) {
                 saState = 3;
             } else {
                 saState = 0;
             }
             break;
         case 3:
-            if (seen == PUTFIELD) {
+            if (seen == Const.PUTFIELD) {
                 saState = 4;
             } else {
                 saState = 0;
@@ -434,9 +435,9 @@ public class UnreadFields extends OpcodeStackDetector {
         }
         boolean selfAssignment = false;
         if (pendingGetField != null) {
-            if (seen != PUTFIELD && seen != PUTSTATIC) {
+            if (seen != Const.PUTFIELD && seen != Const.PUTSTATIC) {
                 data.readFields.add(pendingGetField);
-            } else if (XFactory.createReferencedXField(this).equals(pendingGetField) && (saState == 4 || seen == PUTSTATIC)) {
+            } else if (XFactory.createReferencedXField(this).equals(pendingGetField) && (saState == 4 || seen == Const.PUTSTATIC)) {
                 selfAssignment = true;
             } else {
                 data.readFields.add(pendingGetField);
@@ -447,7 +448,7 @@ public class UnreadFields extends OpcodeStackDetector {
             saState = 0;
         }
 
-        if (seen == INVOKESTATIC && "java/util/concurrent/atomic/AtomicReferenceFieldUpdater".equals(getClassConstantOperand())
+        if (seen == Const.INVOKESTATIC && "java/util/concurrent/atomic/AtomicReferenceFieldUpdater".equals(getClassConstantOperand())
                 && "newUpdater".equals(getNameConstantOperand())) {
             String fieldName = (String) stack.getStackItem(0).getConstant();
             String fieldSignature = (String) stack.getStackItem(1).getConstant();
@@ -459,7 +460,7 @@ public class UnreadFields extends OpcodeStackDetector {
             }
 
         }
-        if (seen == INVOKESTATIC && "java/util/concurrent/atomic/AtomicIntegerFieldUpdater".equals(getClassConstantOperand())
+        if (seen == Const.INVOKESTATIC && "java/util/concurrent/atomic/AtomicIntegerFieldUpdater".equals(getClassConstantOperand())
                 && "newUpdater".equals(getNameConstantOperand())) {
             String fieldName = (String) stack.getStackItem(0).getConstant();
             String fieldClass = (String) stack.getStackItem(1).getConstant();
@@ -469,7 +470,7 @@ public class UnreadFields extends OpcodeStackDetector {
             }
 
         }
-        if (seen == INVOKESTATIC && "java/util/concurrent/atomic/AtomicLongFieldUpdater".equals(getClassConstantOperand())
+        if (seen == Const.INVOKESTATIC && "java/util/concurrent/atomic/AtomicLongFieldUpdater".equals(getClassConstantOperand())
                 && "newUpdater".equals(getNameConstantOperand())) {
             String fieldName = (String) stack.getStackItem(0).getConstant();
             String fieldClass = (String) stack.getStackItem(1).getConstant();
@@ -480,12 +481,12 @@ public class UnreadFields extends OpcodeStackDetector {
 
         }
 
-        if (seen == GETSTATIC) {
+        if (seen == Const.GETSTATIC) {
             XField f = XFactory.createReferencedXField(this);
             data.staticFieldsReadInThisMethod.add(f);
-        } else if (seen == INVOKESTATIC) {
+        } else if (seen == Const.INVOKESTATIC) {
             seenInvokeStatic = true;
-        } else if (seen == PUTSTATIC && !getMethod().isStatic()) {
+        } else if (seen == Const.PUTSTATIC && !getMethod().isStatic()) {
             XField f = XFactory.createReferencedXField(this);
             OpcodeStack.Item valuePut = getStack().getStackItem(0);
 
@@ -583,7 +584,7 @@ public class UnreadFields extends OpcodeStackDetector {
         }
 
         // Store annotation for the anonymous class creation
-        if (seen == INVOKESPECIAL && getMethodDescriptorOperand().getName().equals("<init>") && ClassName.isAnonymous(getClassConstantOperand())) {
+        if (seen == Const.INVOKESPECIAL && getMethodDescriptorOperand().getName().equals("<init>") && ClassName.isAnonymous(getClassConstantOperand())) {
             List<BugAnnotation> annotation = new ArrayList<>();
             annotation.add(ClassAnnotation.fromClassDescriptor(getClassDescriptor()));
             annotation.add(MethodAnnotation.fromVisitedMethod(this));
@@ -591,7 +592,7 @@ public class UnreadFields extends OpcodeStackDetector {
             anonymousClassAnnotation.put(getClassDescriptorOperand().getDottedClassName(), annotation);
         }
 
-        if (seen == PUTFIELD || seen == ASTORE || seen == ASTORE_0 || seen == ASTORE_1 || seen == ASTORE_2 || seen == ASTORE_3) {
+        if (seen == Const.PUTFIELD || seen == Const.ASTORE || seen == Const.ASTORE_0 || seen == Const.ASTORE_1 || seen == Const.ASTORE_2 || seen == Const.ASTORE_3) {
             Item item = stack.getStackItem(0);
             XMethod xMethod = item.getReturnValueOf();
             if(xMethod != null && xMethod.getName().equals("<init>") && ClassName.isAnonymous(xMethod.getClassName())) {
@@ -599,7 +600,7 @@ public class UnreadFields extends OpcodeStackDetector {
                 if(annotations == null) {
                     annotations = new ArrayList<>();
                 }
-                if(seen == PUTFIELD) {
+                if(seen == Const.PUTFIELD) {
                     annotations.add(FieldAnnotation.fromReferencedField(this));
                 } else {
                     annotations.add(LocalVariableAnnotation.getLocalVariableAnnotation(getMethod(), getRegisterOperand(), getPC(), getNextPC()));
@@ -608,7 +609,7 @@ public class UnreadFields extends OpcodeStackDetector {
             }
         }
 
-        if (seen == INVOKEVIRTUAL || seen == INVOKEINTERFACE || seen == INVOKESPECIAL || seen == INVOKESTATIC) {
+        if (seen == Const.INVOKEVIRTUAL || seen == Const.INVOKEINTERFACE || seen == Const.INVOKESPECIAL || seen == Const.INVOKESTATIC) {
 
             String sig = getSigConstantOperand();
             String invokedClassName = getClassConstantOperand();
@@ -620,7 +621,7 @@ public class UnreadFields extends OpcodeStackDetector {
             int pos = PreorderVisitor.getNumberArguments(sig);
             if (stack.getStackDepth() > pos) {
                 OpcodeStack.Item item = stack.getStackItem(pos);
-                boolean superCall = seen == INVOKESPECIAL && !invokedClassName.equals(getClassName());
+                boolean superCall = seen == Const.INVOKESPECIAL && !invokedClassName.equals(getClassName());
 
                 if (DEBUG) {
                     System.out.println("In " + getFullyQualifiedMethodName() + " saw call on " + item);
@@ -637,7 +638,7 @@ public class UnreadFields extends OpcodeStackDetector {
             }
         }
 
-        if ((seen == IFNULL || seen == IFNONNULL) && stack.getStackDepth() > 0) {
+        if ((seen == Const.IFNULL || seen == Const.IFNONNULL) && stack.getStackDepth() > 0) {
             OpcodeStack.Item item = stack.getStackItem(0);
             XField f = item.getXField();
             if (f != null) {
@@ -648,7 +649,7 @@ public class UnreadFields extends OpcodeStackDetector {
             }
         }
 
-        if ((seen == IF_ACMPEQ || seen == IF_ACMPNE) && stack.getStackDepth() >= 2) {
+        if ((seen == Const.IF_ACMPEQ || seen == Const.IF_ACMPNE) && stack.getStackDepth() >= 2) {
             OpcodeStack.Item item0 = stack.getStackItem(0);
             OpcodeStack.Item item1 = stack.getStackItem(1);
             XField field1 = item1.getXField();
@@ -662,35 +663,35 @@ public class UnreadFields extends OpcodeStackDetector {
             }
         }
 
-        computePlacesAssumedNonnull: if (seen == GETFIELD || seen == INVOKEVIRTUAL || seen == INVOKEINTERFACE
-                || seen == INVOKESPECIAL || seen == PUTFIELD || seen == IALOAD || seen == AALOAD || seen == BALOAD
-                || seen == CALOAD || seen == SALOAD || seen == IASTORE || seen == AASTORE || seen == BASTORE || seen == CASTORE
-                || seen == SASTORE || seen == ARRAYLENGTH) {
+        computePlacesAssumedNonnull: if (seen == Const.GETFIELD || seen == Const.INVOKEVIRTUAL || seen == Const.INVOKEINTERFACE
+                || seen == Const.INVOKESPECIAL || seen == Const.PUTFIELD || seen == Const.IALOAD || seen == Const.AALOAD || seen == Const.BALOAD
+                || seen == Const.CALOAD || seen == Const.SALOAD || seen == Const.IASTORE || seen == Const.AASTORE || seen == Const.BASTORE || seen == Const.CASTORE
+                || seen == Const.SASTORE || seen == Const.ARRAYLENGTH) {
             int pos = 0;
             switch (seen) {
-            case ARRAYLENGTH:
-            case GETFIELD:
+            case Const.ARRAYLENGTH:
+            case Const.GETFIELD:
                 pos = 0;
                 break;
-            case INVOKEVIRTUAL:
-            case INVOKEINTERFACE:
-            case INVOKESPECIAL:
+            case Const.INVOKEVIRTUAL:
+            case Const.INVOKEINTERFACE:
+            case Const.INVOKESPECIAL:
                 String sig = getSigConstantOperand();
                 pos = PreorderVisitor.getNumberArguments(sig);
                 break;
-            case PUTFIELD:
-            case IALOAD:
-            case AALOAD:
-            case BALOAD:
-            case CALOAD:
-            case SALOAD:
+            case Const.PUTFIELD:
+            case Const.IALOAD:
+            case Const.AALOAD:
+            case Const.BALOAD:
+            case Const.CALOAD:
+            case Const.SALOAD:
                 pos = 1;
                 break;
-            case IASTORE:
-            case AASTORE:
-            case BASTORE:
-            case CASTORE:
-            case SASTORE:
+            case Const.IASTORE:
+            case Const.AASTORE:
+            case Const.BASTORE:
+            case Const.CASTORE:
+            case Const.SASTORE:
                 pos = 2;
                 break;
             default:
@@ -735,12 +736,12 @@ public class UnreadFields extends OpcodeStackDetector {
             }
         }
 
-        if (seen == ALOAD_1) {
+        if (seen == Const.ALOAD_1) {
             count_aload_1++;
-        } else if (seen == GETFIELD || seen == GETSTATIC) {
+        } else if (seen == Const.GETFIELD || seen == Const.GETSTATIC) {
             XField f = XFactory.createReferencedXField(this);
             pendingGetField = f;
-            if ("readResolve".equals(getMethodName()) && seen == GETFIELD) {
+            if ("readResolve".equals(getMethodName()) && seen == Const.GETFIELD) {
                 data.writtenFields.add(f);
                 data.writtenNonNullFields.add(f);
             }
@@ -752,7 +753,7 @@ public class UnreadFields extends OpcodeStackDetector {
             } else if (!data.fieldAccess.containsKey(f)) {
                 data.fieldAccess.put(f, SourceLineAnnotation.fromVisitedInstruction(this));
             }
-        } else if ((seen == PUTFIELD || seen == PUTSTATIC) && !selfAssignment) {
+        } else if ((seen == Const.PUTFIELD || seen == Const.PUTSTATIC) && !selfAssignment) {
             XField f = XFactory.createReferencedXField(this);
             OpcodeStack.Item item = null;
             if (stack.getStackDepth() > 0) {
@@ -763,7 +764,7 @@ public class UnreadFields extends OpcodeStackDetector {
             }
             data.writtenFields.add(f);
 
-            boolean writtingNonNull = previousOpcode != ACONST_NULL || previousPreviousOpcode == GOTO;
+            boolean writtingNonNull = previousOpcode != Const.ACONST_NULL || previousPreviousOpcode == Const.GOTO;
             if (writtingNonNull) {
                 data.writtenNonNullFields.add(f);
                 if (DEBUG) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UselessSubclassMethod.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UselessSubclassMethod.java
@@ -127,7 +127,7 @@ public class UselessSubclassMethod extends BytecodeScanningDetector implements S
                 }
 
                 byte[] codeBytes = obj.getCode();
-                if ((codeBytes.length == 0) || (codeBytes[0] != ALOAD_0)) {
+                if ((codeBytes.length == 0) || (codeBytes[0] != Const.ALOAD_0)) {
                     return;
                 }
 
@@ -167,7 +167,7 @@ public class UselessSubclassMethod extends BytecodeScanningDetector implements S
     public void sawOpcode(int seen) {
         switch (state) {
         case SEEN_NOTHING:
-            if (seen == ALOAD_0) {
+            if (seen == Const.ALOAD_0) {
                 argTypes = Type.getArgumentTypes(this.getMethodSig());
                 curParm = 0;
                 curParmOffset = 1;
@@ -188,15 +188,15 @@ public class UselessSubclassMethod extends BytecodeScanningDetector implements S
                 String signature = argTypes[curParm++].getSignature();
                 char typeChar0 = signature.charAt(0);
                 if ((typeChar0 == 'L') || (typeChar0 == '[')) {
-                    checkParm(seen, ALOAD_0, ALOAD, 1);
+                    checkParm(seen, Const.ALOAD_0, Const.ALOAD, 1);
                 } else if (typeChar0 == 'D') {
-                    checkParm(seen, DLOAD_0, DLOAD, 2);
+                    checkParm(seen, Const.DLOAD_0, Const.DLOAD, 2);
                 } else if (typeChar0 == 'F') {
-                    checkParm(seen, FLOAD_0, FLOAD, 1);
+                    checkParm(seen, Const.FLOAD_0, Const.FLOAD, 1);
                 } else if (typeChar0 == 'I' || typeChar0 == 'Z' || typeChar0 == 'S' || typeChar0 == 'C') {
-                    checkParm(seen, ILOAD_0, ILOAD, 1);
+                    checkParm(seen, Const.ILOAD_0, Const.ILOAD, 1);
                 } else if (typeChar0 == 'J') {
-                    checkParm(seen, LLOAD_0, LLOAD, 2);
+                    checkParm(seen, Const.LLOAD_0, Const.LLOAD, 2);
                 } else {
                     state = State.SEEN_INVALID;
                 }
@@ -209,7 +209,7 @@ public class UselessSubclassMethod extends BytecodeScanningDetector implements S
             break;
 
         case SEEN_LAST_PARM:
-            if ((seen == INVOKENONVIRTUAL) && getMethodName().equals(getNameConstantOperand())
+            if ((seen == Const.INVOKENONVIRTUAL) && getMethodName().equals(getNameConstantOperand())
                     && getMethodSig().equals(getSigConstantOperand())) {
                 invokePC = getPC();
                 state = State.SEEN_INVOKE;
@@ -221,18 +221,18 @@ public class UselessSubclassMethod extends BytecodeScanningDetector implements S
         case SEEN_INVOKE:
             Type returnType = getMethod().getReturnType();
             char retSigChar0 = returnType.getSignature().charAt(0);
-            if ((retSigChar0 == 'V') && (seen == RETURN)) {
+            if ((retSigChar0 == 'V') && (seen == Const.RETURN)) {
                 state = State.SEEN_RETURN;
-            } else if (((retSigChar0 == 'L') || (retSigChar0 == '[')) && (seen == ARETURN)) {
+            } else if (((retSigChar0 == 'L') || (retSigChar0 == '[')) && (seen == Const.ARETURN)) {
                 state = State.SEEN_RETURN;
-            } else if ((retSigChar0 == 'D') && (seen == DRETURN)) {
+            } else if ((retSigChar0 == 'D') && (seen == Const.DRETURN)) {
                 state = State.SEEN_RETURN;
-            } else if ((retSigChar0 == 'F') && (seen == FRETURN)) {
+            } else if ((retSigChar0 == 'F') && (seen == Const.FRETURN)) {
                 state = State.SEEN_RETURN;
             } else if ((retSigChar0 == 'I' || retSigChar0 == 'S' || retSigChar0 == 'C' || retSigChar0 == 'B' || retSigChar0 == 'Z')
-                    && (seen == IRETURN)) {
+                    && (seen == Const.IRETURN)) {
                 state = State.SEEN_RETURN;
-            } else if ((retSigChar0 == 'J') && (seen == LRETURN)) {
+            } else if ((retSigChar0 == 'J') && (seen == Const.LRETURN)) {
                 state = State.SEEN_RETURN;
             } else {
                 state = State.SEEN_INVALID;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UselessSubclassMethod.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UselessSubclassMethod.java
@@ -112,7 +112,7 @@ public class UselessSubclassMethod extends BytecodeScanningDetector implements S
         try {
             String methodName = getMethodName();
 
-            if (!"<init>".equals(methodName) && !"clone".equals(methodName)
+            if (!Const.CONSTRUCTOR_NAME.equals(methodName) && !"clone".equals(methodName)
                     && ((getMethod().getAccessFlags() & (Const.ACC_STATIC | Const.ACC_SYNTHETIC)) == 0)) {
 
                 /*

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/VarArgsProblems.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/VarArgsProblems.java
@@ -21,6 +21,7 @@ package edu.umd.cs.findbugs.detect;
 
 import java.util.regex.Pattern;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 
 import edu.umd.cs.findbugs.BugInstance;
@@ -78,18 +79,18 @@ public class VarArgsProblems extends BytecodeScanningDetector implements Statele
     @Override
     public void sawOpcode(int seen) {
         // System.out.println("State:" + state);
-        if (seen == GOTO && getBranchOffset() == 4) {
+        if (seen == Const.GOTO && getBranchOffset() == 4) {
             state = SEEN_GOTO;
         } else {
             switch (state) {
             case SEEN_NOTHING:
-                if ((seen == ICONST_1)) {
+                if ((seen == Const.ICONST_1)) {
                     state = SEEN_ICONST_1;
                 }
                 break;
 
             case SEEN_ICONST_1:
-                if (seen == ANEWARRAY && primitiveArray.matcher(getClassConstantOperand()).matches()) {
+                if (seen == Const.ANEWARRAY && primitiveArray.matcher(getClassConstantOperand()).matches()) {
                     // System.out.println("Allocation of array of type " +
                     // getClassConstantOperand());
                     primitiveArraySig = getClassConstantOperand();
@@ -100,21 +101,21 @@ public class VarArgsProblems extends BytecodeScanningDetector implements Statele
                 break;
 
             case SEEN_ANEWARRAY:
-                if (seen == DUP) {
+                if (seen == Const.DUP) {
                     state = SEEN_DUP;
                 } else {
                     state = SEEN_NOTHING;
                 }
                 break;
             case SEEN_DUP:
-                if (seen == ICONST_0) {
+                if (seen == Const.ICONST_0) {
                     state = SEEN_ICONST_0;
                 } else {
                     state = SEEN_NOTHING;
                 }
                 break;
             case SEEN_ICONST_0:
-                if (((seen >= ALOAD_0) && (seen < ALOAD_3)) || (seen == ALOAD)) {
+                if (((seen >= Const.ALOAD_0) && (seen < Const.ALOAD_3)) || (seen == Const.ALOAD)) {
                     state = SEEN_ALOAD;
                 } else {
                     state = SEEN_NOTHING;
@@ -122,7 +123,7 @@ public class VarArgsProblems extends BytecodeScanningDetector implements Statele
                 break;
 
             case SEEN_ALOAD:
-                if (seen == AASTORE) {
+                if (seen == Const.AASTORE) {
                     state = SEEN_AASTORE;
                 } else {
                     state = SEEN_NOTHING;
@@ -130,7 +131,7 @@ public class VarArgsProblems extends BytecodeScanningDetector implements Statele
                 break;
 
             case SEEN_AASTORE:
-                if (seen == INVOKESTATIC || seen == INVOKEINTERFACE || seen == INVOKESPECIAL || seen == INVOKEVIRTUAL) {
+                if (seen == Const.INVOKESTATIC || seen == Const.INVOKEINTERFACE || seen == Const.INVOKESPECIAL || seen == Const.INVOKEVIRTUAL) {
                     // System.out.println(getClassConstantOperand());
                     // System.out.println(getNameConstantOperand());
                     // System.out.println(getSigConstantOperand());

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/VolatileUsage.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/VolatileUsage.java
@@ -22,6 +22,7 @@ package edu.umd.cs.findbugs.detect;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 
 import edu.umd.cs.findbugs.BugInstance;
@@ -67,7 +68,7 @@ public class VolatileUsage extends BytecodeScanningDetector {
     public void sawOpcode(int seen) {
         switch (state) {
         case START:
-            if (seen == GETFIELD) {
+            if (seen == Const.GETFIELD) {
                 XField f = getXFieldOperand();
                 if (isVolatile(f)) {
                     incrementField = f;
@@ -76,7 +77,7 @@ public class VolatileUsage extends BytecodeScanningDetector {
             }
             break;
         case GETFIELD:
-            if (seen == ICONST_1 || seen == LCONST_1 || seen == ICONST_M1) {
+            if (seen == Const.ICONST_1 || seen == Const.LCONST_1 || seen == Const.ICONST_M1) {
                 state = IncrementState.LOADCONSTANT;
             } else {
                 resetIncrementState();
@@ -84,14 +85,14 @@ public class VolatileUsage extends BytecodeScanningDetector {
 
             break;
         case LOADCONSTANT:
-            if (seen == IADD || seen == ISUB || seen == LADD || seen == LSUB) {
+            if (seen == Const.IADD || seen == Const.ISUB || seen == Const.LADD || seen == Const.LSUB) {
                 state = IncrementState.ADD;
             } else {
                 resetIncrementState();
             }
             break;
         case ADD:
-            if (seen == PUTFIELD && incrementField.equals(getXFieldOperand())) {
+            if (seen == Const.PUTFIELD && incrementField.equals(getXFieldOperand())) {
                 bugReporter.reportBug(new BugInstance(this, "VO_VOLATILE_INCREMENT",
                         "J".equals(incrementField.getSignature()) ? Priorities.HIGH_PRIORITY : Priorities.NORMAL_PRIORITY)
                 .addClassAndMethod(this).addField(incrementField).addSourceLine(this));
@@ -100,7 +101,7 @@ public class VolatileUsage extends BytecodeScanningDetector {
             break;
         }
         switch (seen) {
-        case PUTSTATIC: {
+        case Const.PUTSTATIC: {
             XField f = getXFieldOperand();
             if (!isVolatileArray(f)) {
                 return;
@@ -112,7 +113,7 @@ public class VolatileUsage extends BytecodeScanningDetector {
             }
             break;
         }
-        case PUTFIELD: {
+        case Const.PUTFIELD: {
             XField f = getXFieldOperand();
             if (!isVolatileArray(f)) {
                 return;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/VolatileUsage.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/VolatileUsage.java
@@ -106,7 +106,7 @@ public class VolatileUsage extends BytecodeScanningDetector {
             if (!isVolatileArray(f)) {
                 return;
             }
-            if ("<clinit>".equals(getMethodName())) {
+            if (Const.STATIC_INITIALIZER_NAME.equals(getMethodName())) {
                 initializationWrites.add(f);
             } else {
                 otherWrites.add(f);
@@ -119,7 +119,7 @@ public class VolatileUsage extends BytecodeScanningDetector {
                 return;
             }
 
-            if ("<init>".equals(getMethodName())) {
+            if (Const.CONSTRUCTOR_NAME.equals(getMethodName())) {
                 initializationWrites.add(f);
             } else {
                 otherWrites.add(f);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/WaitInLoop.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/WaitInLoop.java
@@ -19,6 +19,7 @@
 
 package edu.umd.cs.findbugs.detect;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 
 import edu.umd.cs.findbugs.BugInstance;
@@ -70,12 +71,12 @@ public class WaitInLoop extends BytecodeScanningDetector implements StatelessDet
     @Override
     public void sawOpcode(int seen) {
 
-        if ((seen == INVOKEVIRTUAL || seen == INVOKEINTERFACE) && "notify".equals(getNameConstantOperand())
+        if ((seen == Const.INVOKEVIRTUAL || seen == Const.INVOKEINTERFACE) && "notify".equals(getNameConstantOperand())
                 && "()V".equals(getSigConstantOperand())) {
             sawNotify = true;
             notifyPC = getPC();
         }
-        if (!(sawWait || sawAwait) && (seen == INVOKEVIRTUAL || seen == INVOKEINTERFACE)
+        if (!(sawWait || sawAwait) && (seen == Const.INVOKEVIRTUAL || seen == Const.INVOKEINTERFACE)
                 && (isMonitorWait() || isConditionAwait())) {
 
             if ("wait".equals(getNameConstantOperand())) {
@@ -88,7 +89,7 @@ public class WaitInLoop extends BytecodeScanningDetector implements StatelessDet
             earliestJump = getPC() + 1;
             return;
         }
-        if (seen >= IFEQ && seen <= GOTO || seen >= IFNULL && seen <= GOTO_W) {
+        if (seen >= Const.IFEQ && seen <= Const.GOTO || seen >= Const.IFNULL && seen <= Const.GOTO_W) {
             earliestJump = Math.min(earliestJump, getBranchTarget());
         }
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/WrongMapIterator.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/WrongMapIterator.java
@@ -23,6 +23,7 @@ package edu.umd.cs.findbugs.detect;
 import java.util.Collections;
 import java.util.Set;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.Method;
 
@@ -76,9 +77,9 @@ public class WrongMapIterator extends BytecodeScanningDetector implements Statel
                 return new LoadedVariable(LoadedVariableState.LOCAL, getRegisterOperand(), null);
             }
             switch(opcode) {
-            case GETSTATIC:
+            case Const.GETSTATIC:
                 return new LoadedVariable(LoadedVariableState.FIELD, 0, getFieldDescriptorOperand());
-            case GETFIELD:
+            case Const.GETFIELD:
                 if(lvState == LoadedVariableState.LOCAL && num == 0) {
                     // Ignore fields from other classes
                     return new LoadedVariable(LoadedVariableState.FIELD, 0, getFieldDescriptorOperand());
@@ -227,8 +228,8 @@ public class WrongMapIterator extends BytecodeScanningDetector implements Statel
             handleStore(getRegisterOperand());
         } else {
             switch (seen) {
-            case INVOKEINTERFACE:
-            case INVOKEVIRTUAL:
+            case Const.INVOKEINTERFACE:
+            case Const.INVOKEVIRTUAL:
                 if (!loadedVariable.none() &&
                         "keySet".equals(getNameConstantOperand()) && "()Ljava/util/Set;".equals(getSigConstantOperand())
                         // Following check solves sourceforge bug 1830576
@@ -271,7 +272,7 @@ public class WrongMapIterator extends BytecodeScanningDetector implements Statel
                     removedFromStack(true);
                 }
                 break;
-            case INVOKESTATIC:
+            case Const.INVOKESTATIC:
                 if ("valueOf".equals(getNameConstantOperand())
                         && ("java/lang/Integer".equals(getClassConstantOperand())
                                 || "java/lang/Long".equals(getClassConstantOperand())
@@ -281,7 +282,7 @@ public class WrongMapIterator extends BytecodeScanningDetector implements Statel
                 }
                 removedFromStack(true);
                 break;
-            case CHECKCAST:
+            case Const.CHECKCAST:
                 removedFromStack(false);
                 break;
             default:

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/XMLFactoryBypass.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/XMLFactoryBypass.java
@@ -22,6 +22,7 @@ package edu.umd.cs.findbugs.detect;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.Repository;
 import org.apache.bcel.classfile.JavaClass;
 
@@ -69,7 +70,7 @@ public class XMLFactoryBypass extends BytecodeScanningDetector {
     @Override
     public void sawOpcode(int seen) {
         try {
-            if (seen == INVOKESPECIAL) {
+            if (seen == Const.INVOKESPECIAL) {
                 String newClsName = getClassConstantOperand();
                 if (rejectedXMLClasses.contains(newClsName)) {
                     return;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/XMLFactoryBypass.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/XMLFactoryBypass.java
@@ -85,7 +85,7 @@ public class XMLFactoryBypass extends BytecodeScanningDetector {
                     return;
                 }
 
-                if (!"<init>".equals(getNameConstantOperand())) {
+                if (!Const.CONSTRUCTOR_NAME.equals(getNameConstantOperand())) {
                     return;
                 }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/visitclass/DismantleBytecode.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/visitclass/DismantleBytecode.java
@@ -26,6 +26,7 @@ import java.text.NumberFormat;
 
 import javax.annotation.CheckForNull;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.CodeException;
 import org.apache.bcel.classfile.Constant;
@@ -201,10 +202,10 @@ abstract public class DismantleBytecode extends AnnotationVisitor {
     public boolean isMethodCall() {
         switch(opcode) {
         default: return false;
-        case INVOKEINTERFACE:
-        case INVOKESPECIAL:
-        case INVOKEVIRTUAL:
-        case INVOKESTATIC:
+        case Const.INVOKEINTERFACE:
+        case Const.INVOKESPECIAL:
+        case Const.INVOKEVIRTUAL:
+        case Const.INVOKESTATIC:
             return true;
 
         }
@@ -218,7 +219,7 @@ abstract public class DismantleBytecode extends AnnotationVisitor {
 
         if (referencedMethod == null) {
             referencedMethod = DescriptorFactory.instance().getMethodDescriptor(classConstantOperand, nameConstantOperand,
-                    sigConstantOperand, opcode == INVOKESTATIC);
+                    sigConstantOperand, opcode == Const.INVOKESTATIC);
         }
         return referencedMethod;
     }
@@ -232,7 +233,7 @@ abstract public class DismantleBytecode extends AnnotationVisitor {
 
         if (getReferencedXClass() != null && referencedXMethod == null) {
             referencedXMethod = Hierarchy2.findInvocationLeastUpperBound(getReferencedXClass(), nameConstantOperand,
-                    sigConstantOperand, opcode == INVOKESTATIC, opcode == INVOKEINTERFACE);
+                    sigConstantOperand, opcode == Const.INVOKESTATIC, opcode == Const.INVOKEINTERFACE);
         }
 
         return referencedXMethod;
@@ -246,7 +247,7 @@ abstract public class DismantleBytecode extends AnnotationVisitor {
 
         if (referencedField == null) {
             referencedField = DescriptorFactory.instance().getFieldDescriptor(classConstantOperand, nameConstantOperand,
-                    sigConstantOperand, opcode == GETSTATIC || opcode == PUTSTATIC);
+                    sigConstantOperand, opcode == Const.GETSTATIC || opcode == Const.PUTSTATIC);
         }
         return referencedField;
     }
@@ -255,7 +256,7 @@ abstract public class DismantleBytecode extends AnnotationVisitor {
     XField getXFieldOperand() {
         if (getReferencedXClass() != null && referencedXField == null) {
             referencedXField = getReferencedXClass().findField(nameConstantOperand, sigConstantOperand,
-                    opcode == GETSTATIC || opcode == PUTSTATIC);
+                    opcode == Const.GETSTATIC || opcode == Const.PUTSTATIC);
         }
 
         return referencedXField;
@@ -365,11 +366,11 @@ abstract public class DismantleBytecode extends AnnotationVisitor {
     }
 
     public int getIntConstant() {
-        assert getOpcode() != LDC || getConstantRefOperand() instanceof ConstantInteger;
+        assert getOpcode() != Const.LDC || getConstantRefOperand() instanceof ConstantInteger;
         return intConstant;
     }
     public long getLongConstant() {
-        assert getOpcode() != LDC2_W || getConstantRefOperand() instanceof ConstantLong;
+        assert getOpcode() != Const.LDC2_W || getConstantRefOperand() instanceof ConstantLong;
         return longConstant;
     }
     public int getBranchOffset() {
@@ -419,7 +420,7 @@ abstract public class DismantleBytecode extends AnnotationVisitor {
             throw new IllegalArgumentException("offset (" + offset + ") must be nonnegative");
         }
         if (offset >= prevOpcode.length || offset > sizePrevOpcodeBuffer) {
-            return NOP;
+            return Const.NOP;
         }
         int pos = currentPosInPrevOpcodeBuffer - offset;
         if (pos < 0) {
@@ -452,7 +453,7 @@ abstract public class DismantleBytecode extends AnnotationVisitor {
      * @return true if instruction is a switch, false if not
      */
     public static boolean isSwitch(int opcode) {
-        return opcode == LOOKUPSWITCH || opcode == TABLESWITCH;
+        return opcode == Const.LOOKUPSWITCH || opcode == Const.TABLESWITCH;
     }
 
     @SuppressFBWarnings("EI")
@@ -562,10 +563,10 @@ abstract public class DismantleBytecode extends AnnotationVisitor {
                 prevOpcode[currentPosInPrevOpcodeBuffer] = opcode;
                 i++;
                 // System.out.println(OPCODE_NAMES[opCode]);
-                int byteStreamArgCount = NO_OF_OPERANDS[opcode];
-                if (byteStreamArgCount == UNPREDICTABLE) {
+                int byteStreamArgCount = Const.getNoOfOperands(opcode);
+                if (byteStreamArgCount == Const.UNPREDICTABLE) {
 
-                    if (opcode == LOOKUPSWITCH) {
+                    if (opcode == Const.LOOKUPSWITCH) {
                         int pad = 4 - (i & 3);
                         if (pad == 4) {
                             pad = 0;
@@ -589,7 +590,7 @@ abstract public class DismantleBytecode extends AnnotationVisitor {
                             i += 8;
                         }
                         sortByOffset(switchOffsets, switchLabels);
-                    } else if (opcode == TABLESWITCH) {
+                    } else if (opcode == Const.TABLESWITCH) {
                         int pad = 4 - (i & 3);
                         if (pad == 4) {
                             pad = 0;
@@ -616,49 +617,49 @@ abstract public class DismantleBytecode extends AnnotationVisitor {
                             i += 4;
                         }
                         sortByOffset(switchOffsets, switchLabels);
-                    } else if (opcode == WIDE) {
+                    } else if (opcode == Const.WIDE) {
                         opcodeIsWide = true;
                         opcode = byteStream.readUnsignedByte();
                         i++;
                         switch (opcode) {
-                        case ILOAD:
-                        case FLOAD:
-                        case ALOAD:
-                        case LLOAD:
-                        case DLOAD:
-                        case ISTORE:
-                        case FSTORE:
-                        case ASTORE:
-                        case LSTORE:
-                        case DSTORE:
-                        case RET:
+                        case Const.ILOAD:
+                        case Const.FLOAD:
+                        case Const.ALOAD:
+                        case Const.LLOAD:
+                        case Const.DLOAD:
+                        case Const.ISTORE:
+                        case Const.FSTORE:
+                        case Const.ASTORE:
+                        case Const.LSTORE:
+                        case Const.DSTORE:
+                        case Const.RET:
                             registerOperand = byteStream.readUnsignedShort();
                             i += 2;
                             break;
-                        case IINC:
+                        case Const.IINC:
                             registerOperand = byteStream.readUnsignedShort();
                             i += 2;
                             intConstant = byteStream.readShort();
                             i += 2;
                             break;
                         default:
-                            throw new IllegalStateException(String.format("bad wide bytecode %d: %s" , opcode, OPCODE_NAMES[opcode]));
+                            throw new IllegalStateException(String.format("bad wide bytecode %d: %s" , opcode, Const.getOpcodeName(opcode)));
                         }
                     } else {
-                        throw new IllegalStateException(String.format("bad unpredicatable bytecode %d: %s" , opcode, OPCODE_NAMES[opcode]));
+                        throw new IllegalStateException(String.format("bad unpredicatable bytecode %d: %s" , opcode, Const.getOpcodeName(opcode)));
                     }
                 } else {
                     if (byteStreamArgCount < 0) {
-                        throw new IllegalStateException(String.format("bad length for bytecode %d: %s" , opcode, OPCODE_NAMES[opcode]));
+                        throw new IllegalStateException(String.format("bad length for bytecode %d: %s" , opcode, Const.getOpcodeName(opcode)));
                     }
-                    for (int k = 0; k < TYPE_OF_OPERANDS[opcode].length; k++) {
+                    for (int k = 0; k < Const.getOperandTypeCount(opcode); k++) {
 
                         int v;
-                        int t = TYPE_OF_OPERANDS[opcode][k];
+                        int t = Const.getOperandType(opcode, k);
                         int m = MEANING_OF_OPERANDS[opcode][k];
                         boolean unsigned = (m == M_CP || m == M_R || m == M_UINT);
                         switch (t) {
-                        case T_BYTE:
+                        case Const.T_BYTE:
                             if (unsigned) {
                                 v = byteStream.readUnsignedByte();
                             } else {
@@ -670,7 +671,7 @@ abstract public class DismantleBytecode extends AnnotationVisitor {
                              */
                             i++;
                             break;
-                        case T_SHORT:
+                        case Const.T_SHORT:
                             if (unsigned) {
                                 v = byteStream.readUnsignedShort();
                             } else {
@@ -678,7 +679,7 @@ abstract public class DismantleBytecode extends AnnotationVisitor {
                             }
                             i += 2;
                             break;
-                        case T_INT:
+                        case Const.T_INT:
                             v = byteStream.readInt();
                             i += 4;
                             break;
@@ -745,101 +746,101 @@ abstract public class DismantleBytecode extends AnnotationVisitor {
 
                 }
                 switch (opcode) {
-                case IINC:
+                case Const.IINC:
                     isRegisterLoad = true;
                     isRegisterStore = true;
                     break;
-                case ILOAD_0:
-                case ILOAD_1:
-                case ILOAD_2:
-                case ILOAD_3:
-                    registerOperand = opcode - ILOAD_0;
+                case Const.ILOAD_0:
+                case Const.ILOAD_1:
+                case Const.ILOAD_2:
+                case Const.ILOAD_3:
+                    registerOperand = opcode - Const.ILOAD_0;
                     isRegisterLoad = true;
                     break;
 
-                case ALOAD_0:
-                case ALOAD_1:
-                case ALOAD_2:
-                case ALOAD_3:
-                    registerOperand = opcode - ALOAD_0;
+                case Const.ALOAD_0:
+                case Const.ALOAD_1:
+                case Const.ALOAD_2:
+                case Const.ALOAD_3:
+                    registerOperand = opcode - Const.ALOAD_0;
                     isRegisterLoad = true;
                     break;
 
-                case FLOAD_0:
-                case FLOAD_1:
-                case FLOAD_2:
-                case FLOAD_3:
-                    registerOperand = opcode - FLOAD_0;
+                case Const.FLOAD_0:
+                case Const.FLOAD_1:
+                case Const.FLOAD_2:
+                case Const.FLOAD_3:
+                    registerOperand = opcode - Const.FLOAD_0;
                     isRegisterLoad = true;
                     break;
 
-                case DLOAD_0:
-                case DLOAD_1:
-                case DLOAD_2:
-                case DLOAD_3:
-                    registerOperand = opcode - DLOAD_0;
+                case Const.DLOAD_0:
+                case Const.DLOAD_1:
+                case Const.DLOAD_2:
+                case Const.DLOAD_3:
+                    registerOperand = opcode - Const.DLOAD_0;
                     isRegisterLoad = true;
                     break;
 
-                case LLOAD_0:
-                case LLOAD_1:
-                case LLOAD_2:
-                case LLOAD_3:
-                    registerOperand = opcode - LLOAD_0;
+                case Const.LLOAD_0:
+                case Const.LLOAD_1:
+                case Const.LLOAD_2:
+                case Const.LLOAD_3:
+                    registerOperand = opcode - Const.LLOAD_0;
                     isRegisterLoad = true;
                     break;
-                case ILOAD:
-                case FLOAD:
-                case ALOAD:
-                case LLOAD:
-                case DLOAD:
+                case Const.ILOAD:
+                case Const.FLOAD:
+                case Const.ALOAD:
+                case Const.LLOAD:
+                case Const.DLOAD:
                     isRegisterLoad = true;
                     break;
 
-                case ISTORE_0:
-                case ISTORE_1:
-                case ISTORE_2:
-                case ISTORE_3:
-                    registerOperand = opcode - ISTORE_0;
+                case Const.ISTORE_0:
+                case Const.ISTORE_1:
+                case Const.ISTORE_2:
+                case Const.ISTORE_3:
+                    registerOperand = opcode - Const.ISTORE_0;
                     isRegisterStore = true;
                     break;
 
-                case ASTORE_0:
-                case ASTORE_1:
-                case ASTORE_2:
-                case ASTORE_3:
-                    registerOperand = opcode - ASTORE_0;
+                case Const.ASTORE_0:
+                case Const.ASTORE_1:
+                case Const.ASTORE_2:
+                case Const.ASTORE_3:
+                    registerOperand = opcode - Const.ASTORE_0;
                     isRegisterStore = true;
                     break;
 
-                case FSTORE_0:
-                case FSTORE_1:
-                case FSTORE_2:
-                case FSTORE_3:
-                    registerOperand = opcode - FSTORE_0;
+                case Const.FSTORE_0:
+                case Const.FSTORE_1:
+                case Const.FSTORE_2:
+                case Const.FSTORE_3:
+                    registerOperand = opcode - Const.FSTORE_0;
                     isRegisterStore = true;
                     break;
 
-                case DSTORE_0:
-                case DSTORE_1:
-                case DSTORE_2:
-                case DSTORE_3:
-                    registerOperand = opcode - DSTORE_0;
+                case Const.DSTORE_0:
+                case Const.DSTORE_1:
+                case Const.DSTORE_2:
+                case Const.DSTORE_3:
+                    registerOperand = opcode - Const.DSTORE_0;
                     isRegisterStore = true;
                     break;
 
-                case LSTORE_0:
-                case LSTORE_1:
-                case LSTORE_2:
-                case LSTORE_3:
-                    registerOperand = opcode - LSTORE_0;
+                case Const.LSTORE_0:
+                case Const.LSTORE_1:
+                case Const.LSTORE_2:
+                case Const.LSTORE_3:
+                    registerOperand = opcode - Const.LSTORE_0;
                     isRegisterStore = true;
                     break;
-                case ISTORE:
-                case FSTORE:
-                case ASTORE:
-                case LSTORE:
-                case DSTORE:
+                case Const.ISTORE:
+                case Const.FSTORE:
+                case Const.ASTORE:
+                case Const.LSTORE:
+                case Const.DSTORE:
                     isRegisterStore = true;
                     break;
                 default:
@@ -847,29 +848,29 @@ abstract public class DismantleBytecode extends AnnotationVisitor {
                 }
 
                 switch (opcode) {
-                case ILOAD:
-                case FLOAD:
-                case ALOAD:
-                case LLOAD:
-                case DLOAD:
+                case Const.ILOAD:
+                case Const.FLOAD:
+                case Const.ALOAD:
+                case Const.LLOAD:
+                case Const.DLOAD:
                     // registerKind = opcode - ILOAD;
                     break;
-                case ISTORE:
-                case FSTORE:
-                case ASTORE:
-                case LSTORE:
-                case DSTORE:
+                case Const.ISTORE:
+                case Const.FSTORE:
+                case Const.ASTORE:
+                case Const.LSTORE:
+                case Const.DSTORE:
                     // registerKind = opcode - ISTORE;
                     break;
-                case RET:
+                case Const.RET:
                     // registerKind = R_REF;
                     break;
-                case GETSTATIC:
-                case PUTSTATIC:
+                case Const.GETSTATIC:
+                case Const.PUTSTATIC:
                     refFieldIsStatic = true;
                     break;
-                case GETFIELD:
-                case PUTFIELD:
+                case Const.GETFIELD:
+                case Const.PUTFIELD:
                     refFieldIsStatic = false;
                     break;
                 default:
@@ -882,7 +883,7 @@ abstract public class DismantleBytecode extends AnnotationVisitor {
                 }
                 afterOpcode(opcode);
 
-                if (opcode == TABLESWITCH) {
+                if (opcode == Const.TABLESWITCH) {
                     sawInt(switchLow);
                     sawInt(switchHigh);
                     //                    int prevOffset = i - PC;
@@ -891,7 +892,7 @@ abstract public class DismantleBytecode extends AnnotationVisitor {
                         //                        prevOffset = switchOffsets[o];
                     }
                     sawBranchTo(defaultSwitchOffset + PC);
-                } else if (opcode == LOOKUPSWITCH) {
+                } else if (opcode == Const.LOOKUPSWITCH) {
                     sawInt(switchOffsets.length);
                     //                    int prevOffset = i - PC;
                     for (int o = 0; o < switchOffsets.length; o++) {
@@ -901,7 +902,7 @@ abstract public class DismantleBytecode extends AnnotationVisitor {
                     }
                     sawBranchTo(defaultSwitchOffset + PC);
                 } else {
-                    for (int k = 0; k < TYPE_OF_OPERANDS[opcode].length; k++) {
+                    for (int k = 0; k < Const.getOperandTypeCount(opcode); k++) {
                         int m = MEANING_OF_OPERANDS[opcode][k];
                         switch (m) {
                         case M_BR:
@@ -1003,10 +1004,10 @@ abstract public class DismantleBytecode extends AnnotationVisitor {
     }
 
     public void printOpCode(int seen) {
-        System.out.print("  " + this.getClass().getSimpleName() + ": [" + formatter.format(getPC()) + "]  " + OPCODE_NAMES[seen]);
-        if ((seen == INVOKEVIRTUAL) || (seen == INVOKESPECIAL) || (seen == INVOKEINTERFACE) || (seen == INVOKESTATIC)) {
+        System.out.print("  " + this.getClass().getSimpleName() + ": [" + formatter.format(getPC()) + "]  " + Const.getOpcodeName(seen));
+        if ((seen == Const.INVOKEVIRTUAL) || (seen == Const.INVOKESPECIAL) || (seen == Const.INVOKEINTERFACE) || (seen == Const.INVOKESTATIC)) {
             System.out.print("   " + getClassConstantOperand() + "." + getNameConstantOperand() + " " + getSigConstantOperand());
-        } else if (seen == LDC || seen == LDC_W || seen == LDC2_W) {
+        } else if (seen == Const.LDC || seen == Const.LDC_W || seen == Const.LDC2_W) {
             Constant c = getConstantRefOperand();
             if (c instanceof ConstantString) {
                 System.out.print("   \"" + getStringConstantOperand() + "\"");
@@ -1015,16 +1016,16 @@ abstract public class DismantleBytecode extends AnnotationVisitor {
             } else {
                 System.out.print("   " + c);
             }
-        } else if ((seen == ALOAD) || (seen == ASTORE)) {
+        } else if ((seen == Const.ALOAD) || (seen == Const.ASTORE)) {
             System.out.print("   " + getRegisterOperand());
-        } else if ((seen == GOTO) || (seen == GOTO_W) || (seen == IF_ACMPEQ) || (seen == IF_ACMPNE) || (seen == IF_ICMPEQ)
-                || (seen == IF_ICMPGE) || (seen == IF_ICMPGT) || (seen == IF_ICMPLE) || (seen == IF_ICMPLT)
-                || (seen == IF_ICMPNE) || (seen == IFEQ) || (seen == IFGE) || (seen == IFGT) || (seen == IFLE) || (seen == IFLT)
-                || (seen == IFNE) || (seen == IFNONNULL) || (seen == IFNULL)) {
+        } else if ((seen == Const.GOTO) || (seen == Const.GOTO_W) || (seen == Const.IF_ACMPEQ) || (seen == Const.IF_ACMPNE) || (seen == Const.IF_ICMPEQ)
+                || (seen == Const.IF_ICMPGE) || (seen == Const.IF_ICMPGT) || (seen == Const.IF_ICMPLE) || (seen == Const.IF_ICMPLT)
+                || (seen == Const.IF_ICMPNE) || (seen == Const.IFEQ) || (seen == Const.IFGE) || (seen == Const.IFGT) || (seen == Const.IFLE) || (seen == Const.IFLT)
+                || (seen == Const.IFNE) || (seen == Const.IFNONNULL) || (seen == Const.IFNULL)) {
             System.out.print("   " + getBranchTarget());
-        } else if ((seen == NEW) || (seen == INSTANCEOF)) {
+        } else if ((seen == Const.NEW) || (seen == Const.INSTANCEOF)) {
             System.out.print("   " + getClassConstantOperand());
-        } else if ((seen == TABLESWITCH) || (seen == LOOKUPSWITCH)) {
+        } else if ((seen == Const.TABLESWITCH) || (seen == Const.LOOKUPSWITCH)) {
             System.out.print("    [");
             int switchPC = getPC();
             int[] offsets = getSwitchOffsets();
@@ -1053,12 +1054,12 @@ abstract public class DismantleBytecode extends AnnotationVisitor {
     }
     public boolean isReturn(int opcode) {
         switch (opcode) {
-        case IRETURN:
-        case ARETURN:
-        case LRETURN:
-        case DRETURN:
-        case FRETURN:
-        case RETURN:
+        case Const.IRETURN:
+        case Const.ARETURN:
+        case Const.LRETURN:
+        case Const.DRETURN:
+        case Const.FRETURN:
+        case Const.RETURN:
             return true;
         default:
             return false;
@@ -1066,12 +1067,12 @@ abstract public class DismantleBytecode extends AnnotationVisitor {
     }
     public boolean isShift(int opcode) {
         switch (opcode) {
-        case IUSHR:
-        case ISHR:
-        case ISHL:
-        case LUSHR:
-        case LSHR:
-        case LSHL:
+        case Const.IUSHR:
+        case Const.ISHR:
+        case Const.ISHL:
+        case Const.LUSHR:
+        case Const.LSHR:
+        case Const.LSHL:
             return true;
         default:
             return false;
@@ -1080,31 +1081,31 @@ abstract public class DismantleBytecode extends AnnotationVisitor {
 
     public static boolean areOppositeBranches(int opcode1, int opcode2) {
         if (!isBranch(opcode1)) {
-            throw new IllegalArgumentException(OPCODE_NAMES[opcode1] + " isn't a branch");
+            throw new IllegalArgumentException(Const.getOpcodeName(opcode1) + " isn't a branch");
         }
         if (!isBranch(opcode2)) {
-            throw new IllegalArgumentException(OPCODE_NAMES[opcode2] + " isn't a branch");
+            throw new IllegalArgumentException(Const.getOpcodeName(opcode2) + " isn't a branch");
         }
         switch (opcode1) {
-        case IF_ACMPEQ:
-        case IF_ACMPNE:
-        case IF_ICMPEQ:
-        case IF_ICMPNE:
-        case IF_ICMPLT:
-        case IF_ICMPLE:
-        case IF_ICMPGT:
-        case IF_ICMPGE:
-        case IFNE:
-        case IFEQ:
-        case IFLT:
-        case IFLE:
-        case IFGT:
-        case IFGE:
+        case Const.IF_ACMPEQ:
+        case Const.IF_ACMPNE:
+        case Const.IF_ICMPEQ:
+        case Const.IF_ICMPNE:
+        case Const.IF_ICMPLT:
+        case Const.IF_ICMPLE:
+        case Const.IF_ICMPGT:
+        case Const.IF_ICMPGE:
+        case Const.IFNE:
+        case Const.IFEQ:
+        case Const.IFLT:
+        case Const.IFLE:
+        case Const.IFGT:
+        case Const.IFGE:
             return ((opcode1 + 1) ^ 1) == opcode2 + 1;
-        case IFNONNULL:
-            return opcode2 == IFNULL;
-        case IFNULL:
-            return opcode2 == IFNONNULL;
+        case Const.IFNONNULL:
+            return opcode2 == Const.IFNULL;
+        case Const.IFNULL:
+            return opcode2 == Const.IFNONNULL;
         default:
             return false;
 
@@ -1113,36 +1114,36 @@ abstract public class DismantleBytecode extends AnnotationVisitor {
 
     public boolean isRegisterStore(int opcode) {
         switch (opcode) {
-        case ISTORE_0:
-        case ISTORE_1:
-        case ISTORE_2:
-        case ISTORE_3:
+        case Const.ISTORE_0:
+        case Const.ISTORE_1:
+        case Const.ISTORE_2:
+        case Const.ISTORE_3:
 
-        case ASTORE_0:
-        case ASTORE_1:
-        case ASTORE_2:
-        case ASTORE_3:
+        case Const.ASTORE_0:
+        case Const.ASTORE_1:
+        case Const.ASTORE_2:
+        case Const.ASTORE_3:
 
-        case FSTORE_0:
-        case FSTORE_1:
-        case FSTORE_2:
-        case FSTORE_3:
+        case Const.FSTORE_0:
+        case Const.FSTORE_1:
+        case Const.FSTORE_2:
+        case Const.FSTORE_3:
 
-        case DSTORE_0:
-        case DSTORE_1:
-        case DSTORE_2:
-        case DSTORE_3:
+        case Const.DSTORE_0:
+        case Const.DSTORE_1:
+        case Const.DSTORE_2:
+        case Const.DSTORE_3:
 
-        case LSTORE_0:
-        case LSTORE_1:
-        case LSTORE_2:
-        case LSTORE_3:
+        case Const.LSTORE_0:
+        case Const.LSTORE_1:
+        case Const.LSTORE_2:
+        case Const.LSTORE_3:
 
-        case ISTORE:
-        case FSTORE:
-        case ASTORE:
-        case LSTORE:
-        case DSTORE:
+        case Const.ISTORE:
+        case Const.FSTORE:
+        case Const.ASTORE:
+        case Const.LSTORE:
+        case Const.DSTORE:
             return true;
         default:
             return false;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/visitclass/PreorderVisitor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/visitclass/PreorderVisitor.java
@@ -25,6 +25,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.AnnotationDefault;
 import org.apache.bcel.classfile.AnnotationEntry;
 import org.apache.bcel.classfile.Annotations;
@@ -267,7 +268,7 @@ public class PreorderVisitor extends BetterVisitor implements Constants2 {
         for (int i = 1; i < constant_pool.length; i++) {
             constant_pool[i].accept(this);
             byte tag = constant_pool[i].getTag();
-            if ((tag == CONSTANT_Double) || (tag == CONSTANT_Long)) {
+            if ((tag == Const.CONSTANT_Double) || (tag == Const.CONSTANT_Long)) {
                 i++;
             }
         }
@@ -641,7 +642,7 @@ public class PreorderVisitor extends BetterVisitor implements Constants2 {
             if(c instanceof ConstantMethodref || c instanceof ConstantInterfaceMethodref) {
                 ConstantCP desc = (ConstantCP)c;
                 ConstantNameAndType nameAndType = (ConstantNameAndType) cp.getConstant(desc.getNameAndTypeIndex());
-                String className = cp.getConstantString(desc.getClassIndex(), CONSTANT_Class);
+                String className = cp.getConstantString(desc.getClassIndex(), Const.CONSTANT_Class);
                 String name = ((ConstantUtf8)cp.getConstant(nameAndType.getNameIndex())).getBytes();
                 String signature = ((ConstantUtf8)cp.getConstant(nameAndType.getSignatureIndex())).getBytes();
                 // We don't know whether method is static thus cannot use equals


### PR DESCRIPTION
This brings the number of warnings on the `spotbugs` project down from 1,739 to 233.

Unfortunately, we cannot yet use `import static org.apache.bcel.Const.*`, as we still implement the deprecated `org.apache.bcel.Constants` for compatibility reasons (part 2 of the changes described in #262) and the constants therein get picked over the ones from the static import.