### PR TITLE
Clean up CountMatcher Hamcrest Matcher

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/AbstractIntegrationTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/AbstractIntegrationTest.java
@@ -89,10 +89,6 @@ public class AbstractIntegrationTest {
         return bugReporter.getBugCollection();
     }
 
-    protected static <T> Matcher<Iterable<T>> containsExactly(final Matcher<T> matcher, final int count) {
-        return new CountMatcher<T>(count, matcher);
-    }
-
     /**
      * Sets up a FB engine to run on the 'spotbugsTestCases' project. It enables
      * all the available detectors and reports all the bug categories. Uses a

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/integration/FindNullDerefIntegrationTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/integration/FindNullDerefIntegrationTest.java
@@ -19,6 +19,7 @@
 
 package edu.umd.cs.findbugs.integration;
 
+import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
 import static org.hamcrest.Matchers.hasItem;
 import static org.junit.Assert.assertThat;
 
@@ -39,7 +40,7 @@ public class FindNullDerefIntegrationTest extends AbstractIntegrationTest {
         // There should only be 1 issue of this type
         final BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
                 .bugType("SI_INSTANCE_BEFORE_FINALS_ASSIGNED").build();
-        assertThat(getBugCollection(), containsExactly(bugTypeMatcher, 1));
+        assertThat(getBugCollection(), containsExactly(1, bugTypeMatcher));
 
         // It must be on the INSTANCE field
         final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
@@ -57,7 +58,7 @@ public class FindNullDerefIntegrationTest extends AbstractIntegrationTest {
         // There should only be 1 issue of this type
         final BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
                 .bugType("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE").build();
-        assertThat(getBugCollection(), containsExactly(bugTypeMatcher, 1));
+        assertThat(getBugCollection(), containsExactly(1, bugTypeMatcher));
 
         // It must be on the lambda method, checking by line number
         final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/nullness/AndroidNullabilityTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/nullness/AndroidNullabilityTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 
 import java.nio.file.Paths;
 
-import static edu.umd.cs.findbugs.test.SpotBugsRule.containsExactly;
+import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
 import static org.hamcrest.Matchers.emptyIterable;
 import static org.junit.Assert.assertThat;
 
@@ -34,7 +34,7 @@ public class AndroidNullabilityTest {
         BugCollection bugCollection = spotbugs.performAnalysis(
                 Paths.get("../spotbugsTestCases/build/classes/main/androidAnnotations/NullForNonNullParam.class"));
 
-        assertThat(bugCollection, containsExactly(bug("NP_NONNULL_PARAM_VIOLATION"), 1));
+        assertThat(bugCollection, containsExactly(1, bug("NP_NONNULL_PARAM_VIOLATION")));
     }
 
     @Test
@@ -49,7 +49,7 @@ public class AndroidNullabilityTest {
         BugCollection bugCollection = spotbugs.performAnalysis(
                 Paths.get("../spotbugsTestCases/build/classes/main/androidAnnotations/UncheckedNullableReturn.class"));
 
-        assertThat(bugCollection, containsExactly(bug("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"), 1));
+        assertThat(bugCollection, containsExactly(1, bug("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")));
     }
 
     private BugInstanceMatcher bug(String type) {

--- a/test-harness/src/main/java/edu/umd/cs/findbugs/test/CountMatcher.java
+++ b/test-harness/src/main/java/edu/umd/cs/findbugs/test/CountMatcher.java
@@ -1,40 +1,50 @@
 package edu.umd.cs.findbugs.test;
 
-import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
+import org.hamcrest.Factory;
 import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
 
-public final class CountMatcher<T> extends BaseMatcher<Iterable<T>> {
+public final class CountMatcher<T> extends TypeSafeMatcher<Iterable<T>> {
+
     private final int count;
     private final Matcher<T> matcher;
 
-    /**
-     * @param count
-     * @param matcher
-     */
     public CountMatcher(int count, Matcher<T> matcher) {
         this.count = count;
         this.matcher = matcher;
     }
 
-    @Override
-    public boolean matches(final Object obj) {
-        int matches = 0;
+    /**
+     * Creates a matcher for {@link Iterable}s that only matches if exactly
+     * {@code count} items match the specified {@code matcher}.
+     * 
+     * @param matcher
+     *            A non-{@code null} matcher that must match exactly {@code count}
+     *            times.
+     * @param count
+     *            How many times the {@code matcher} must match.
+     */
+    @Factory
+    public static <T> Matcher<Iterable<T>> containsExactly(final int count, final Matcher<T> matcher) {
+        return new CountMatcher<T>(count, matcher);
+    }
 
-        if (obj instanceof Iterable<?>) {
-            final Iterable<?> it = (Iterable<?>) obj;
-            for (final Object o : it) {
-                if (matcher.matches(o)) {
-                    matches++;
-                }
+    @Override
+    protected boolean matchesSafely(Iterable<T> iterable) {
+        int numberOfmatches = 0;
+
+        for (final Object item : iterable) {
+            if (matcher.matches(item)) {
+                numberOfmatches++;
             }
         }
 
-        return matches == count;
+        return numberOfmatches == count;
     }
 
     @Override
     public void describeTo(final Description desc) {
-        desc.appendText("Iterable containing exactly " + count + " ").appendDescriptionOf(matcher);
+        desc.appendText("Iterable containing exactly ").appendValue(count).appendText(" ").appendDescriptionOf(matcher);
     }
 }

--- a/test-harness/src/main/java/edu/umd/cs/findbugs/test/SpotBugsRule.java
+++ b/test-harness/src/main/java/edu/umd/cs/findbugs/test/SpotBugsRule.java
@@ -5,13 +5,9 @@ import java.nio.file.Path;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.hamcrest.Matcher;
 import org.junit.rules.ExternalResource;
 
 import edu.umd.cs.findbugs.BugCollection;
-import edu.umd.cs.findbugs.BugInstance;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
 /**
  * <p>
@@ -55,31 +51,6 @@ public class SpotBugsRule extends ExternalResource {
     @Override
     protected void after() {
         runner = null;
-    }
-
-    /**
-     * <p>
-     * A factory method to build a {@link Matcher} instance to check how many
-     * {@link BugInstance} matches in {@link BugCollection}. Basic usage:
-     * </p>
-     * <pre>
-     * <code>
-     * BugCollection bugCollection = spotBugsRule.performAnalysis(...);
-     * assertThat(
-     *     bugCollection,
-     *     containsExactly(bugInstanceMatcher, 1));
-     * </code>
-     * </pre>
-     * @param matcher
-     *            A matcher to match {@link BugInstance}. non-null.
-     * @param count
-     *            How many times you expect that specified matcher matches.
-     * @return A matcher which matches specified times
-     * @see BugInstanceMatcher
-     * @see BugInstanceMatcherBuilder
-     */
-    public static <T> Matcher<Iterable<T>> containsExactly(final Matcher<T> matcher, final int count) {
-        return new CountMatcher<T>(count, matcher);
     }
 
     /**


### PR DESCRIPTION
Don’t duplicate `Matcher` factory methods, but keep them in `Matcher` class following Hamcrest's convention. Also, make `CountMatcher` a `TypeSafeMatcher`; it will no longer consider `null` or non-`Iterable`s a match for count 0.