### PR TITLE
document report configuration for gradle

### DIFF
--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -124,10 +124,18 @@ Please use spotbugs plugin found on https://plugins.gradle.org/plugin/com.github
 .. code-block:: groovy
 
   plugins {
-    id  'com.github.spotbugs' version '1.1'
+    id  'com.github.spotbugs' version '1.2'
   }
   spotbugs {
-    toolVersion = '3.1.0-RC3'
+    toolVersion = '3.1.0-RC4'
+  }
+
+  // To generate an HTML report instead of XML
+  tasks.withType(com.github.spotbugs.SpotBugsTask) {
+    reports {
+      xml.enabled = false
+      html.enabled = true
+    }
   }
 
 FindBugs Eclipse plugin


### PR DESCRIPTION
Updates the migration guide to cover the new class
name to use when [customizing the report][1] in gradle.

[1]: https://docs.gradle.org/3.5/userguide/findbugs_plugin.html#sec:findbugs_customize_xsl