### PR TITLE
Avoid "-O: command not found" error in CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
   - if [[ $JDK_FOR_TEST == "oraclejdk9" ]]; then sudo dpkg -i deps/oracle-java9-installer.deb; fi
 
 install:
-  - if [[ ! -e deps/eclipse.tar.gz ]]; then wget https://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops4/R-4.6.3-201703010400/eclipse-SDK-4.6.3-linux-gtk-x86_64.tar.gz&r=1 -O deps/eclipse.tar.gz; fi
+  - if [[ ! -e deps/eclipse.tar.gz ]]; then wget 'https://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops4/R-4.6.3-201703010400/eclipse-SDK-4.6.3-linux-gtk-x86_64.tar.gz&r=1' -O deps/eclipse.tar.gz; fi
   - tar xzvf deps/eclipse.tar.gz eclipse
   - echo eclipseRoot.dir=$(pwd)/eclipse > eclipsePlugin/local.properties
 


### PR DESCRIPTION
By current script we cannot download Eclipse tarball, you can refer [this build](https://travis-ci.org/KengoTODA/spotbugs/builds/261538248) as example.

This is because bash separates command by `&` in URL, so wrapping it by quote solves problem.