### PR TITLE
Fix issue 292

### DIFF
--- a/eclipsePlugin-junit/build.gradle
+++ b/eclipsePlugin-junit/build.gradle
@@ -9,5 +9,5 @@ dependencies {
 
 jacocoTestReport {
   additionalSourceDirs = files(project(':eclipsePlugin').sourceSets.main.java.srcDirs)
-  additionalClassDirs = files(project(':eclipsePlugin').sourceSets.main.output.classesDir)
+  additionalClassDirs = files(project(':eclipsePlugin').sourceSets.main.output.classesDirs)
 }

--- a/eclipsePlugin-test/build.gradle
+++ b/eclipsePlugin-test/build.gradle
@@ -47,5 +47,5 @@ artifacts {
 
 jacocoTestReport {
   additionalSourceDirs = files(project(':spotbugs').sourceSets.main.java.srcDirs)
-  additionalClassDirs = files(project(':spotbugs').sourceSets.main.output.classesDir)
+  additionalClassDirs = files(project(':spotbugs').sourceSets.main.output.classesDirs)
 }

--- a/gradlePlugin/CHANGELOG.md
+++ b/gradlePlugin/CHANGELOG.md
@@ -5,6 +5,7 @@ This is the changelog for SpotBugs Gradle Plugin. This follows [Keep a Changelog
 ## Unreleased (2017/??/??)
 
 * Stop using [single class directory](https://docs.gradle.org/4.0.2/release-notes.html#multiple-class-directories-for-a-single-source-set) to prepare for Gradle v5 ([#299](https://github.com/spotbugs/spotbugs/issues/299))
+* Print 'SpotBugs' instead of 'FindBugs' ([#291](https://github.com/spotbugs/spotbugs/issues/291))
 
 ## 1.2 (2017/Jul/21)
 

--- a/gradlePlugin/CHANGELOG.md
+++ b/gradlePlugin/CHANGELOG.md
@@ -4,6 +4,8 @@ This is the changelog for SpotBugs Gradle Plugin. This follows [Keep a Changelog
 
 ## Unreleased (2017/??/??)
 
+* Stop using [single class directory](https://docs.gradle.org/4.0.2/release-notes.html#multiple-class-directories-for-a-single-source-set) to prepare for Gradle v5 ([#299](https://github.com/spotbugs/spotbugs/issues/299))
+
 ## 1.2 (2017/Jul/21)
 
 * Use SpotBugs 3.1.0-RC4

--- a/gradlePlugin/src/main/java/com/github/spotbugs/SpotBugsPlugin.java
+++ b/gradlePlugin/src/main/java/com/github/spotbugs/SpotBugsPlugin.java
@@ -193,7 +193,7 @@ public class SpotBugsPlugin extends AbstractCodeQualityPlugin<SpotBugsTask> {
             public FileCollection call() {
                 // the simple "classes = sourceSet.output" may lead to non-existing resources directory
                 // being passed to SpotBugs Ant task, resulting in an error
-                return project.fileTree(sourceSet.getOutput().getClassesDir()).builtBy(sourceSet.getOutput());
+                return project.fileTree(sourceSet.getOutput().getClassesDirs()).builtBy(sourceSet.getOutput());
             }
         });
         taskMapping.map("classpath", new Callable<FileCollection>() {


### PR DESCRIPTION
This PR replaces deprecated API in both of `build.gradle` and Gradle plugin implementation.
I've confirmed that this fix can pass all existing unit tests, but if you have time please have a test with your Gradle projects too.
