### PR TITLE
Travis build fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,10 @@ script:
   - ./gradlew build smoketest sonarqube -S
 
 after_success:
-  - if [[ $JDK_FOR_TEST == "oraclejdk8" ]]; then ./gradlew coveralls; fi
+  - if [[ $JDK_FOR_TEST == "oraclejdk8" ]]; then ./gradlew --stacktrace coveralls; fi
+  # Coveralls task above deletes generated site data, so we should re-generate it
+  # to deploy the daily build on the update site, see "deploy" task below
+  - ./gradlew eclipsePlugin:generateP2MetadataDaily
 
 before_cache:
   - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,11 @@ task jacocoRootReport(type: JacocoReport) {
 
   executionData project(':spotbugs').file('build/jacoco/test.exec')
   sourceDirectories = files(subprojects.sourceSets.main.allSource.srcDirs)
-  classDirectories = files(subprojects.sourceSets.main.output)
+  
+  // Only enable class directories related to non-test project
+  classDirectories = files(subprojects.sourceSets.main.output).filter {
+    !it.toString().contains("test") && !it.toString().contains("Test") && !it.toString().contains("junit")
+  }
 
   reports {
     xml.enabled = true

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ task jacocoRootReport(type: JacocoReport) {
   
   // Only enable class directories related to non-test project
   classDirectories = files(subprojects.sourceSets.main.output).filter {
-    !it.toString().contains("test") && !it.toString().contains("Test") && !it.toString().contains("junit")
+    !it.toString().contains("-test") && !it.toString().contains("Test") && !it.toString().contains("junit")
   }
 
   reports {

--- a/gradle/jacoco.gradle
+++ b/gradle/jacoco.gradle
@@ -1,7 +1,7 @@
 apply plugin: "jacoco"
 
 jacoco {
-  toolVersion = "0.7.8"
+  toolVersion = "0.7.9"
 }
 
 jacocoTestReport {


### PR DESCRIPTION
The fix for broken build due broken eclipse site upload due some weird coveralls task side effects.
First commit fixes coveralls build scope (so that jacoco doesn't abort build on duplicated classes), second one re-creates the deleted eclipse site after the coveralls task.

The link to the last fixed build is: https://travis-ci.org/spotbugs/spotbugs/builds/262279475