### PR TITLE
Deploy released Eclipse Plugin to Update Site automaticallt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,14 @@ deploy:
     on:
       tags: true
       condition: "$JDK_FOR_TEST = oraclejdk8"
+  - provider: pages
+    skip_cleanup: true
+    github_token: $GITHUB_TOKEN
+    local_dir: $TRAVIS_BUILD_DIR/eclipsePlugin/build/site/eclipse
+    repo: spotbugs/eclipse
+    on:
+      tags: true
+      condition: "$JDK_FOR_TEST = oraclejdk8 && $TRAVIS_TAG != *'_RC'*"
   - provider: script
     skip_cleanup: true
     script: ./gradlew uploadArchives -PossrhUsername="$SONATYPE_USERNAME" -PossrhPassword="$SONATYPE_PASSWORD"

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,14 @@ deploy:
     on:
       branch: master
       condition: "$JDK_FOR_TEST = oraclejdk8"
+  - provider: pages
+    skip_cleanup: true
+    github_token: $GITHUB_TOKEN
+    local_dir: $TRAVIS_BUILD_DIR/eclipsePlugin/build/site/eclipse-candidate
+    repo: spotbugs/eclipse-candidate
+    on:
+      tags: true
+      condition: "$JDK_FOR_TEST = oraclejdk8"
   - provider: script
     skip_cleanup: true
     script: ./gradlew uploadArchives -PossrhUsername="$SONATYPE_USERNAME" -PossrhPassword="$SONATYPE_PASSWORD"

--- a/RELEASE_PROCEDURE.md
+++ b/RELEASE_PROCEDURE.md
@@ -17,10 +17,12 @@ Check [SonaType official page](http://central.sonatype.org/pages/gradle.html) fo
 
 ## Release to Eclipse Update Site
 
-Send pull-request to spotbugs/spotbugs.github.io, to update contents.
-As files to upload, you can use the zip file which is uploaded to Maven Central when you release to there.
+It's automated by Travis CI.
 
-See [this pull-request](https://github.com/spotbugs/spotbugs.github.io/pull/12) as example.
+When we push tag, the build result will be deployed to [eclipse-candidate repository](https://github.com/spotbugs/eclipse-candidate).
+When we push tag and its name doesn't contain `_RC`, the build result will be deployed to [eclipse repository](https://github.com/spotbugs/eclipse).
+
+See `deploy` phase in `.travis.yml` for detail.
 
 ## Release to Eclipse Marketplace
 


### PR DESCRIPTION
By these two `deploy` tasks, we can publish Eclipse Plugin to Update Site automatically.

For `eclipse` site, we deploy changes which is tagged by non-RC version. So the commit with tag `3.1.0_RCx` will not be deployed, but the commit with tag `3.1.0` will be deployed to https://spotbugs.github.io/eclipse/.

For `eclipse-candidate` site, we deploy all tagged changes. So both of `3.1.0_RCx` and `3.1.0` will be hosted at https://spotbugs.github.io/eclipse-candidate/.