### PR TITLE
replace non-UTF8 char with UTF8 char

### DIFF
--- a/eclipsePlugin-test/src/de/tobject/findbugs/actions/test/ContextMenuActionsTest.java
+++ b/eclipsePlugin-test/src/de/tobject/findbugs/actions/test/ContextMenuActionsTest.java
@@ -1,6 +1,6 @@
 /*
  * Contributions to FindBugs
- * Copyright (C) 2009, Tom�s Pollak
+ * Copyright (C) 2009, Tomás Pollak
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -38,7 +38,7 @@ import de.tobject.findbugs.test.TestScenario;
 /**
  * This class tests the FindBugsAction, SaveXMLAction and LoadXMLAction.
  *
- * @author Tom�s Pollak
+ * @author Tomás Pollak
  */
 public class ContextMenuActionsTest extends AbstractFindBugsTest {
     @BeforeClass

--- a/eclipsePlugin-test/src/de/tobject/findbugs/actions/test/GroupByActionTest.java
+++ b/eclipsePlugin-test/src/de/tobject/findbugs/actions/test/GroupByActionTest.java
@@ -1,6 +1,6 @@
 /*
  * Contributions to FindBugs
- * Copyright (C) 2009, Tom�s Pollak
+ * Copyright (C) 2009, Tomás Pollak
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -39,7 +39,7 @@ import org.junit.Test;
 /**
  * This class tests the GroupByAction.
  *
- * @author Tom�s Pollak
+ * @author Tomás Pollak
  */
 public class GroupByActionTest extends AbstractFindBugsTest {
     @BeforeClass

--- a/eclipsePlugin-test/src/de/tobject/findbugs/actions/test/LoadXMLActionTestSubclass.java
+++ b/eclipsePlugin-test/src/de/tobject/findbugs/actions/test/LoadXMLActionTestSubclass.java
@@ -1,6 +1,6 @@
 /*
  * Contributions to FindBugs
- * Copyright (C) 2009, Tom·s Pollak
+ * Copyright (C) 2009, Tom√°s Pollak
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,7 +26,7 @@ import de.tobject.findbugs.actions.LoadXmlAction;
  * Test subclass of LoadXmlAction that overrides the opening of the FileDialog
  * for testing purposes.
  * 
- * @author Tom·s Pollak
+ * @author Tom√°s Pollak
  */
 public class LoadXMLActionTestSubclass extends LoadXmlAction {
     private final String filePath;

--- a/eclipsePlugin-test/src/de/tobject/findbugs/actions/test/SaveXMLActionTestSubclass.java
+++ b/eclipsePlugin-test/src/de/tobject/findbugs/actions/test/SaveXMLActionTestSubclass.java
@@ -1,6 +1,6 @@
 /*
  * Contributions to FindBugs
- * Copyright (C) 2009, Tom·s Pollak
+ * Copyright (C) 2009, Tom√°s Pollak
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,7 +26,7 @@ import de.tobject.findbugs.actions.SaveXmlAction;
  * Test subclass of SaveXmlAction that overrides the opening of the FileDialog
  * for testing purposes.
  * 
- * @author Tom·s Pollak
+ * @author Tom√°s Pollak
  */
 public class SaveXMLActionTestSubclass extends SaveXmlAction {
     private final String filePath;

--- a/eclipsePlugin-test/src/de/tobject/findbugs/builder/test/FindBugsWorkerTest.java
+++ b/eclipsePlugin-test/src/de/tobject/findbugs/builder/test/FindBugsWorkerTest.java
@@ -1,6 +1,6 @@
 /*
  * Contributions to FindBugs
- * Copyright (C) 2009, Tom�s Pollak
+ * Copyright (C) 2009, Tomás Pollak
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -35,7 +35,7 @@ import de.tobject.findbugs.test.TestScenario;
 /**
  * This class tests the public methods for FindBugsWorker.
  *
- * @author Tom�s Pollak
+ * @author Tomás Pollak
  */
 public class FindBugsWorkerTest extends AbstractFindBugsTest {
     @BeforeClass

--- a/eclipsePlugin-test/src/de/tobject/findbugs/builder/test/ResourceUtilsTest.java
+++ b/eclipsePlugin-test/src/de/tobject/findbugs/builder/test/ResourceUtilsTest.java
@@ -1,6 +1,6 @@
 /*
  * Contributions to FindBugs
- * Copyright (C) 2009, Tom·s Pollak
+ * Copyright (C) 2009, Tom√°s Pollak
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -42,7 +42,7 @@ import de.tobject.findbugs.test.TestScenario;
 /**
  * This class tests the public methods for ResourceUtils.
  * 
- * @author Tom·s Pollak
+ * @author Tom√°s Pollak
  */
 public class ResourceUtilsTest extends AbstractFindBugsTest {
     @BeforeClass

--- a/eclipsePlugin-test/src/de/tobject/findbugs/decorator/test/LabelDecoratorTest.java
+++ b/eclipsePlugin-test/src/de/tobject/findbugs/decorator/test/LabelDecoratorTest.java
@@ -1,6 +1,6 @@
 /*
  * Contributions to FindBugs
- * Copyright (C) 2009, Tom·s Pollak
+ * Copyright (C) 2009, Tom√°s Pollak
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -33,7 +33,7 @@ import de.tobject.findbugs.test.TestScenario;
 /**
  * This class tests the ResourceBugCountDecorator.
  * 
- * @author Tom·s Pollak
+ * @author Tom√°s Pollak
  */
 public class LabelDecoratorTest extends AbstractFindBugsTest {
     @BeforeClass

--- a/eclipsePlugin-test/src/de/tobject/findbugs/properties/test/DetectorConfigurationTabTestSubclass.java
+++ b/eclipsePlugin-test/src/de/tobject/findbugs/properties/test/DetectorConfigurationTabTestSubclass.java
@@ -1,6 +1,6 @@
 /*
  * Contributions to FindBugs
- * Copyright (C) 2009, Tom�s Pollak
+ * Copyright (C) 2009, Tomás Pollak
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -29,7 +29,7 @@ import edu.umd.cs.findbugs.DetectorFactory;
  * Test subclass of DetectorConfigurationTab that provides methods for testing
  * purposes.
  * 
- * @author Tom�s Pollak
+ * @author Tomás Pollak
  */
 public class DetectorConfigurationTabTestSubclass extends DetectorConfigurationTab {
 

--- a/eclipsePlugin-test/src/de/tobject/findbugs/properties/test/FilterFilesTabTestSubclass.java
+++ b/eclipsePlugin-test/src/de/tobject/findbugs/properties/test/FilterFilesTabTestSubclass.java
@@ -1,6 +1,6 @@
 /*
  * Contributions to FindBugs
- * Copyright (C) 2009, Tom�s Pollak
+ * Copyright (C) 2009, Tomás Pollak
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -32,7 +32,7 @@ import de.tobject.findbugs.properties.IPathElement;
 /**
  * Test subclass of FilterFilesTab that provides methods for testing purposes.
  *
- * @author Tom�s Pollak
+ * @author Tomás Pollak
  */
 public class FilterFilesTabTestSubclass extends FilterFilesTab {
 

--- a/eclipsePlugin-test/src/de/tobject/findbugs/properties/test/FindbugsPropertyPageTestSubclass.java
+++ b/eclipsePlugin-test/src/de/tobject/findbugs/properties/test/FindbugsPropertyPageTestSubclass.java
@@ -1,6 +1,6 @@
 /*
  * Contributions to FindBugs
- * Copyright (C) 2009, Tom·s Pollak
+ * Copyright (C) 2009, Tom√°s Pollak
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -31,7 +31,7 @@ import de.tobject.findbugs.properties.ReportConfigurationTab;
  * Test subclass of FindbugsPropertyPage that provides methods for handling the
  * properties page for testing purposes.
  * 
- * @author Tom·s Pollak
+ * @author Tom√°s Pollak
  */
 public class FindbugsPropertyPageTestSubclass extends FindbugsPropertyPage {
 

--- a/eclipsePlugin-test/src/de/tobject/findbugs/properties/test/PropertiesPageTest.java
+++ b/eclipsePlugin-test/src/de/tobject/findbugs/properties/test/PropertiesPageTest.java
@@ -1,6 +1,6 @@
 /*
  * Contributions to FindBugs
- * Copyright (C) 2009, Tom�s Pollak
+ * Copyright (C) 2009, Tomás Pollak
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -46,7 +46,7 @@ import edu.umd.cs.findbugs.config.UserPreferences;
 /**
  * This class tests the FindbugsPropertyPage and related classes.
  *
- * @author Tom�s Pollak
+ * @author Tomás Pollak
  */
 public class PropertiesPageTest extends AbstractFindBugsTest {
     @BeforeClass

--- a/eclipsePlugin-test/src/de/tobject/findbugs/properties/test/PropertiesTestDialog.java
+++ b/eclipsePlugin-test/src/de/tobject/findbugs/properties/test/PropertiesTestDialog.java
@@ -1,6 +1,6 @@
 /*
  * Contributions to FindBugs
- * Copyright (C) 2009, Tom·s Pollak
+ * Copyright (C) 2009, Tom√°s Pollak
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -27,7 +27,7 @@ import org.eclipse.ui.IWorkbenchPropertyPage;
 /**
  * Dialog class to open the properties page.
  * 
- * @author Tom·s Pollak
+ * @author Tom√°s Pollak
  */
 public class PropertiesTestDialog extends Dialog {
     private final IWorkbenchPropertyPage page;

--- a/eclipsePlugin-test/src/de/tobject/findbugs/properties/test/ReportConfigurationTabTestSubclass.java
+++ b/eclipsePlugin-test/src/de/tobject/findbugs/properties/test/ReportConfigurationTabTestSubclass.java
@@ -1,6 +1,6 @@
 /*
  * Contributions to FindBugs
- * Copyright (C) 2009, Tom·s Pollak
+ * Copyright (C) 2009, Tom√°s Pollak
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -28,7 +28,7 @@ import de.tobject.findbugs.properties.ReportConfigurationTab;
  * Test subclass of ReportConfigurationTab that provides methods for testing
  * purposes.
  * 
- * @author Tom·s Pollak
+ * @author Tom√°s Pollak
  */
 public class ReportConfigurationTabTestSubclass extends ReportConfigurationTab {
 

--- a/eclipsePlugin-test/src/de/tobject/findbugs/quickfix/test/QuickfixTest.java
+++ b/eclipsePlugin-test/src/de/tobject/findbugs/quickfix/test/QuickfixTest.java
@@ -1,6 +1,6 @@
 /*
  * Contributions to FindBugs
- * Copyright (C) 2009, Tom�s Pollak
+ * Copyright (C) 2009, Tomás Pollak
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -34,7 +34,7 @@ import org.junit.Test;
 /**
  * This class tests the quickfix resolutions.
  *
- * @author Tom�s Pollak
+ * @author Tomás Pollak
  */
 public class QuickfixTest extends AbstractQuickfixTest {
     @BeforeClass
@@ -140,7 +140,3 @@ public class QuickfixTest extends AbstractQuickfixTest {
 
 
 }
-
-
-
-

--- a/eclipsePlugin-test/src/de/tobject/findbugs/quickfix/test/QuickfixWithJUnitTest.java
+++ b/eclipsePlugin-test/src/de/tobject/findbugs/quickfix/test/QuickfixWithJUnitTest.java
@@ -1,6 +1,6 @@
 /*
  * Contributions to FindBugs
- * Copyright (C) 2009, Tom·s Pollak
+ * Copyright (C) 2009, Tom√°s Pollak
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -31,7 +31,7 @@ import org.junit.Test;
 /**
  * This class tests the quickfix resolutions for examples that use JUnit.
  *
- * @author Tom·s Pollak
+ * @author Tom√°s Pollak
  */
 public class QuickfixWithJUnitTest extends AbstractQuickfixTest {
     @BeforeClass

--- a/eclipsePlugin-test/src/de/tobject/findbugs/reporter/test/JdtUtilTest.java
+++ b/eclipsePlugin-test/src/de/tobject/findbugs/reporter/test/JdtUtilTest.java
@@ -1,6 +1,6 @@
 /*
  * Contributions to FindBugs
- * Copyright (C) 2009, Tom·s Pollak
+ * Copyright (C) 2009, Tom√°s Pollak
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -34,7 +34,7 @@ import de.tobject.findbugs.test.TestScenario;
 /**
  * This class tests the JdtUtil class.
  * 
- * @author Tom·s Pollak
+ * @author Tom√°s Pollak
  */
 public class JdtUtilTest extends AbstractPluginTest {
     @BeforeClass

--- a/eclipsePlugin-test/src/de/tobject/findbugs/reporter/test/MarkerUtilTest.java
+++ b/eclipsePlugin-test/src/de/tobject/findbugs/reporter/test/MarkerUtilTest.java
@@ -1,6 +1,6 @@
 /*
  * Contributions to FindBugs
- * Copyright (C) 2009, Tom·s Pollak
+ * Copyright (C) 2009, Tom√°s Pollak
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -38,7 +38,7 @@ import de.tobject.findbugs.test.TestScenario;
 /**
  * This class tests the MarkerUtil class.
  *
- * @author Tom·s Pollak
+ * @author Tom√°s Pollak
  */
 public class MarkerUtilTest extends AbstractFindBugsTest {
     @BeforeClass

--- a/eclipsePlugin-test/src/de/tobject/findbugs/test/AbstractFindBugsTest.java
+++ b/eclipsePlugin-test/src/de/tobject/findbugs/test/AbstractFindBugsTest.java
@@ -1,6 +1,6 @@
 /*
  * Contributions to FindBugs
- * Copyright (C) 2009, Tom�s Pollak
+ * Copyright (C) 2009, Tomás Pollak
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -33,7 +33,7 @@ import edu.umd.cs.findbugs.config.UserPreferences;
 /**
  * Base class for the default test scenario of the FindBugs UI tests.
  *
- * @author Tom�s Pollak
+ * @author Tomás Pollak
  */
 public abstract class AbstractFindBugsTest extends AbstractPluginTest {
 

--- a/eclipsePlugin-test/src/de/tobject/findbugs/test/AbstractPluginTest.java
+++ b/eclipsePlugin-test/src/de/tobject/findbugs/test/AbstractPluginTest.java
@@ -1,6 +1,6 @@
 /*
  * Contributions to FindBugs
- * Copyright (C) 2009, Tom�s Pollak
+ * Copyright (C) 2009, Tomás Pollak
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -82,7 +82,7 @@ import edu.umd.cs.findbugs.config.UserPreferences;
  * all tests in the same class, if the tests don't modify the project or are
  * independent from the modifications.</li>
  *
- * @author Tom�s Pollak
+ * @author Tomás Pollak
  */
 public abstract class AbstractPluginTest {
 

--- a/eclipsePlugin-test/src/de/tobject/findbugs/test/AbstractQuickfixTest.java
+++ b/eclipsePlugin-test/src/de/tobject/findbugs/test/AbstractQuickfixTest.java
@@ -1,6 +1,6 @@
 /*
  * Contributions to FindBugs
- * Copyright (C) 2009, Tom�s Pollak
+ * Copyright (C) 2009, Tomás Pollak
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -55,7 +55,7 @@ import org.junit.Before;
 /**
  * Base class for FindBugs quickfix tests.
  *
- * @author Tom�s Pollak
+ * @author Tomás Pollak
  */
 public abstract class AbstractQuickfixTest extends AbstractPluginTest {
 

--- a/eclipsePlugin-test/src/de/tobject/findbugs/test/TestScenario.java
+++ b/eclipsePlugin-test/src/de/tobject/findbugs/test/TestScenario.java
@@ -1,6 +1,6 @@
 /*
  * Contributions to FindBugs
- * Copyright (C) 2009, Tom�s Pollak
+ * Copyright (C) 2009, Tomás Pollak
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,7 +26,7 @@ import java.util.Set;
  * Enum for the different test scenarios in FindBugs. Each test scenario has
  * information of the input files, the expected bugs and markers, and so on.
  *
- * @author Tom�s Pollak
+ * @author Tomás Pollak
  */
 public enum TestScenario {
     DEFAULT(new String[] { "/defaultScenario" }, false, new String[] { "URF_UNREAD_FIELD", "DM_STRING_CTOR" }, 2),

--- a/eclipsePlugin-test/src/de/tobject/findbugs/view/explorer/test/FilterBugsDialogTest.java
+++ b/eclipsePlugin-test/src/de/tobject/findbugs/view/explorer/test/FilterBugsDialogTest.java
@@ -1,6 +1,6 @@
 /*
  * Contributions to FindBugs
- * Copyright (C) 2009, Tom�s Pollak
+ * Copyright (C) 2009, Tomás Pollak
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -42,7 +42,7 @@ import edu.umd.cs.findbugs.DetectorFactoryCollection;
 /**
  * This class tests the FilterBugsDialog and its related classes.
  *
- * @author Tom�s Pollak
+ * @author Tomás Pollak
  */
 public class FilterBugsDialogTest extends AbstractFindBugsTest {
     @BeforeClass

--- a/eclipsePlugin-test/src/de/tobject/findbugs/view/explorer/test/FilterBugsDialogTestSubclass.java
+++ b/eclipsePlugin-test/src/de/tobject/findbugs/view/explorer/test/FilterBugsDialogTestSubclass.java
@@ -1,6 +1,6 @@
 /*
  * Contributions to FindBugs
- * Copyright (C) 2009, Tom·s Pollak
+ * Copyright (C) 2009, Tom√°s Pollak
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -30,7 +30,7 @@ import edu.umd.cs.findbugs.BugPattern;
  * Test subclass of FilterBugsDialog that overrides the opening behaviour for
  * testing purposes.
  * 
- * @author Tom·s Pollak
+ * @author Tom√°s Pollak
  */
 public class FilterBugsDialogTestSubclass extends FilterBugsDialog {
 

--- a/eclipsePlugin-test/src/de/tobject/findbugs/view/test/AbstractBugExplorerViewTest.java
+++ b/eclipsePlugin-test/src/de/tobject/findbugs/view/test/AbstractBugExplorerViewTest.java
@@ -1,6 +1,6 @@
 /*
  * Contributions to FindBugs
- * Copyright (C) 2009, Tom·s Pollak
+ * Copyright (C) 2009, Tom√°s Pollak
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -41,7 +41,7 @@ import de.tobject.findbugs.view.explorer.Grouping;
 /**
  * This is an abstract class for tests that interact with the BugExplorerView.
  * 
- * @author Tom·s Pollak
+ * @author Tom√°s Pollak
  */
 public abstract class AbstractBugExplorerViewTest extends AbstractFindBugsTest {
 

--- a/eclipsePlugin-test/src/de/tobject/findbugs/view/test/BugExplorerViewTest.java
+++ b/eclipsePlugin-test/src/de/tobject/findbugs/view/test/BugExplorerViewTest.java
@@ -1,6 +1,6 @@
 /*
  * Contributions to FindBugs
- * Copyright (C) 2009, Tom·s Pollak
+ * Copyright (C) 2009, Tom√°s Pollak
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -35,7 +35,7 @@ import de.tobject.findbugs.view.explorer.GroupType;
 /**
  * This class tests the BugExplorerView and its related classes.
  * 
- * @author Tom·s Pollak
+ * @author Tom√°s Pollak
  */
 public class BugExplorerViewTest extends AbstractBugExplorerViewTest {
     @BeforeClass

--- a/eclipsePlugin-test/src/de/tobject/findbugs/view/test/BugExplorerViewTwoSrcFoldersTest.java
+++ b/eclipsePlugin-test/src/de/tobject/findbugs/view/test/BugExplorerViewTwoSrcFoldersTest.java
@@ -1,6 +1,6 @@
 /*
  * Contributions to FindBugs
- * Copyright (C) 2009, Tom·s Pollak
+ * Copyright (C) 2009, Tom√°s Pollak
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -33,7 +33,7 @@ import de.tobject.findbugs.view.explorer.GroupType;
  * This class tests the BugExplorerView and its related classes. This tests a
  * different scenario with two source folders.
  * 
- * @author Tom·s Pollak
+ * @author Tom√°s Pollak
  */
 public class BugExplorerViewTwoSrcFoldersTest extends AbstractBugExplorerViewTest {
     @BeforeClass

--- a/eclipsePlugin-test/src/de/tobject/findbugs/view/test/ExpectedViewBugGroup.java
+++ b/eclipsePlugin-test/src/de/tobject/findbugs/view/test/ExpectedViewBugGroup.java
@@ -1,6 +1,6 @@
 /*
  * Contributions to FindBugs
- * Copyright (C) 2009, Tom·s Pollak
+ * Copyright (C) 2009, Tom√°s Pollak
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -33,7 +33,7 @@ import de.tobject.findbugs.view.explorer.GroupType;
 /**
  * Expected object for a bug group.
  * 
- * @author Tom·s Pollak
+ * @author Tom√°s Pollak
  */
 public class ExpectedViewBugGroup implements ExpectedViewElement {
 

--- a/eclipsePlugin-test/src/de/tobject/findbugs/view/test/ExpectedViewElement.java
+++ b/eclipsePlugin-test/src/de/tobject/findbugs/view/test/ExpectedViewElement.java
@@ -1,6 +1,6 @@
 /*
  * Contributions to FindBugs
- * Copyright (C) 2009, Tom·s Pollak
+ * Copyright (C) 2009, Tom√°s Pollak
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,7 +26,7 @@ import org.eclipse.jface.viewers.ITreeContentProvider;
  * created by a test case that sets the expectations and compares itself to an
  * actual element, asserting some desired characteristics.
  * 
- * @author Tom·s Pollak
+ * @author Tom√°s Pollak
  */
 public interface ExpectedViewElement {
     void assertEquals(Object actual, ITreeContentProvider contentProvider) throws CoreException;

--- a/eclipsePlugin-test/src/de/tobject/findbugs/view/test/ExpectedViewMarker.java
+++ b/eclipsePlugin-test/src/de/tobject/findbugs/view/test/ExpectedViewMarker.java
@@ -1,6 +1,6 @@
 /*
  * Contributions to FindBugs
- * Copyright (C) 2009, Tom·s Pollak
+ * Copyright (C) 2009, Tom√°s Pollak
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -28,7 +28,7 @@ import de.tobject.findbugs.marker.FindBugsMarker;
 /**
  * Expected object for a FindBugs marker.
  * 
- * @author Tom·s Pollak
+ * @author Tom√°s Pollak
  */
 public class ExpectedViewMarker implements ExpectedViewElement {
 

--- a/eclipsePlugin-test/src/de/tobject/findbugs/view/test/FindBugsPerspectiveTest.java
+++ b/eclipsePlugin-test/src/de/tobject/findbugs/view/test/FindBugsPerspectiveTest.java
@@ -1,6 +1,6 @@
 /*
  * Contributions to FindBugs
- * Copyright (C) 2009, Tom·s Pollak
+ * Copyright (C) 2009, Tom√°s Pollak
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -37,7 +37,7 @@ import de.tobject.findbugs.test.TestScenario;
 /**
  * This class tests the FindBugsPerspectiveFactory.
  * 
- * @author Tom·s Pollak
+ * @author Tom√°s Pollak
  */
 public class FindBugsPerspectiveTest extends AbstractFindBugsTest {
     @BeforeClass


### PR DESCRIPTION
This change will eliminate warning at `:eclipsePlugin-test:compileJava`

```
:eclipsePlugin-test:compileJava/home/travis/build/spotbugs/spotbugs/eclipsePlugin-test/src/de/tobject/findbugs/properties/test/PropertiesTestDialog.java:3: error: unmappable character for encoding UTF8
 * Copyright (C) 2009, Tom�s Pollak
                          ^
/home/travis/build/spotbugs/spotbugs/eclipsePlugin-test/src/de/tobject/findbugs/properties/test/PropertiesTestDialog.java:30: error: unmappable character for encoding UTF8
 * @author Tom�s Pollak
              ^
/home/travis/build/spotbugs/spotbugs/eclipsePlugin-test/src/de/tobject/findbugs/properties/test/FindbugsPropertyPageTestSubclass.java:3: error: unmappable character for encoding UTF8
 * Copyright (C) 2009, Tom�s Pollak
                          ^
/home/travis/build/spotbugs/spotbugs/eclipsePlugin-test/src/de/tobject/findbugs/properties/test/FindbugsPropertyPageTestSubclass.java:34: error: unmappable character for encoding UTF8
 * @author Tom�s Pollak
              ^
/home/travis/build/spotbugs/spotbugs/eclipsePlugin-test/src/de/tobject/findbugs/properties/test/ReportConfigurationTabTestSubclass.java:3: error: unmappable character for encoding UTF8
 * Copyright (C) 2009, Tom�s Pollak
                          ^
/home/travis/build/spotbugs/spotbugs/eclipsePlugin-test/src/de/tobject/findbugs/properties/test/ReportConfigurationTabTestSubclass.java:31: error: unmappable character for encoding UTF8
 * @author Tom�s Pollak
              ^
/home/travis/build/spotbugs/spotbugs/eclipsePlugin-test/src/de/tobject/findbugs/decorator/test/LabelDecoratorTest.java:3: error: unmappable character for encoding UTF8
 * Copyright (C) 2009, Tom�s Pollak
                          ^
/home/travis/build/spotbugs/spotbugs/eclipsePlugin-test/src/de/tobject/findbugs/decorator/test/LabelDecoratorTest.java:36: error: unmappable character for encoding UTF8
 * @author Tom�s Pollak
              ^
/home/travis/build/spotbugs/spotbugs/eclipsePlugin-test/src/de/tobject/findbugs/view/explorer/test/FilterBugsDialogTestSubclass.java:3: error: unmappable character for encoding UTF8
 * Copyright (C) 2009, Tom�s Pollak
                          ^
/home/travis/build/spotbugs/spotbugs/eclipsePlugin-test/src/de/tobject/findbugs/view/explorer/test/FilterBugsDialogTestSubclass.java:33: error: unmappable character for encoding UTF8
 * @author Tom�s Pollak
              ^
/home/travis/build/spotbugs/spotbugs/eclipsePlugin-test/src/de/tobject/findbugs/view/test/AbstractBugExplorerViewTest.java:3: error: unmappable character for encoding UTF8
 * Copyright (C) 2009, Tom�s Pollak
                          ^
/home/travis/build/spotbugs/spotbugs/eclipsePlugin-test/src/de/tobject/findbugs/view/test/AbstractBugExplorerViewTest.java:44: error: unmappable character for encoding UTF8
 * @author Tom�s Pollak
              ^
/home/travis/build/spotbugs/spotbugs/eclipsePlugin-test/src/de/tobject/findbugs/view/test/BugExplorerViewTwoSrcFoldersTest.java:3: error: unmappable character for encoding UTF8
 * Copyright (C) 2009, Tom�s Pollak
                          ^
/home/travis/build/spotbugs/spotbugs/eclipsePlugin-test/src/de/tobject/findbugs/view/test/BugExplorerViewTwoSrcFoldersTest.java:36: error: unmappable character for encoding UTF8
 * @author Tom�s Pollak
              ^
/home/travis/build/spotbugs/spotbugs/eclipsePlugin-test/src/de/tobject/findbugs/view/test/ExpectedViewBugGroup.java:3: error: unmappable character for encoding UTF8
 * Copyright (C) 2009, Tom�s Pollak
                          ^
/home/travis/build/spotbugs/spotbugs/eclipsePlugin-test/src/de/tobject/findbugs/view/test/ExpectedViewBugGroup.java:36: error: unmappable character for encoding UTF8
 * @author Tom�s Pollak
              ^
/home/travis/build/spotbugs/spotbugs/eclipsePlugin-test/src/de/tobject/findbugs/view/test/ExpectedViewElement.java:3: error: unmappable character for encoding UTF8
 * Copyright (C) 2009, Tom�s Pollak
                          ^
/home/travis/build/spotbugs/spotbugs/eclipsePlugin-test/src/de/tobject/findbugs/view/test/ExpectedViewElement.java:29: error: unmappable character for encoding UTF8
 * @author Tom�s Pollak
              ^
/home/travis/build/spotbugs/spotbugs/eclipsePlugin-test/src/de/tobject/findbugs/view/test/ExpectedViewMarker.java:3: error: unmappable character for encoding UTF8
 * Copyright (C) 2009, Tom�s Pollak
                          ^
/home/travis/build/spotbugs/spotbugs/eclipsePlugin-test/src/de/tobject/findbugs/view/test/ExpectedViewMarker.java:31: error: unmappable character for encoding UTF8
 * @author Tom�s Pollak
              ^
/home/travis/build/spotbugs/spotbugs/eclipsePlugin-test/src/de/tobject/findbugs/view/test/BugExplorerViewTest.java:3: error: unmappable character for encoding UTF8
 * Copyright (C) 2009, Tom�s Pollak
                          ^
/home/travis/build/spotbugs/spotbugs/eclipsePlugin-test/src/de/tobject/findbugs/view/test/BugExplorerViewTest.java:38: error: unmappable character for encoding UTF8
 * @author Tom�s Pollak
              ^
/home/travis/build/spotbugs/spotbugs/eclipsePlugin-test/src/de/tobject/findbugs/view/test/FindBugsPerspectiveTest.java:3: error: unmappable character for encoding UTF8
 * Copyright (C) 2009, Tom�s Pollak
                          ^
/home/travis/build/spotbugs/spotbugs/eclipsePlugin-test/src/de/tobject/findbugs/view/test/FindBugsPerspectiveTest.java:40: error: unmappable character for encoding UTF8
 * @author Tom�s Pollak
              ^
/home/travis/build/spotbugs/spotbugs/eclipsePlugin-test/src/de/tobject/findbugs/actions/test/SaveXMLActionTestSubclass.java:3: error: unmappable character for encoding UTF8
 * Copyright (C) 2009, Tom�s Pollak
                          ^
/home/travis/build/spotbugs/spotbugs/eclipsePlugin-test/src/de/tobject/findbugs/actions/test/SaveXMLActionTestSubclass.java:29: error: unmappable character for encoding UTF8
 * @author Tom�s Pollak
              ^
/home/travis/build/spotbugs/spotbugs/eclipsePlugin-test/src/de/tobject/findbugs/actions/test/LoadXMLActionTestSubclass.java:3: error: unmappable character for encoding UTF8
 * Copyright (C) 2009, Tom�s Pollak
                          ^
/home/travis/build/spotbugs/spotbugs/eclipsePlugin-test/src/de/tobject/findbugs/actions/test/LoadXMLActionTestSubclass.java:29: error: unmappable character for encoding UTF8
 * @author Tom�s Pollak
              ^
/home/travis/build/spotbugs/spotbugs/eclipsePlugin-test/src/de/tobject/findbugs/builder/test/ResourceUtilsTest.java:3: error: unmappable character for encoding UTF8
 * Copyright (C) 2009, Tom�s Pollak
                          ^
/home/travis/build/spotbugs/spotbugs/eclipsePlugin-test/src/de/tobject/findbugs/builder/test/ResourceUtilsTest.java:45: error: unmappable character for encoding UTF8
 * @author Tom�s Pollak
              ^
/home/travis/build/spotbugs/spotbugs/eclipsePlugin-test/src/de/tobject/findbugs/reporter/test/MarkerUtilTest.java:3: error: unmappable character for encoding UTF8
 * Copyright (C) 2009, Tom�s Pollak
                          ^
/home/travis/build/spotbugs/spotbugs/eclipsePlugin-test/src/de/tobject/findbugs/reporter/test/MarkerUtilTest.java:41: error: unmappable character for encoding UTF8
 * @author Tom�s Pollak
              ^
/home/travis/build/spotbugs/spotbugs/eclipsePlugin-test/src/de/tobject/findbugs/reporter/test/JdtUtilTest.java:3: error: unmappable character for encoding UTF8
 * Copyright (C) 2009, Tom�s Pollak
                          ^
/home/travis/build/spotbugs/spotbugs/eclipsePlugin-test/src/de/tobject/findbugs/reporter/test/JdtUtilTest.java:37: error: unmappable character for encoding UTF8
 * @author Tom�s Pollak
              ^
/home/travis/build/spotbugs/spotbugs/eclipsePlugin-test/src/de/tobject/findbugs/quickfix/test/QuickfixWithJUnitTest.java:3: error: unmappable character for encoding UTF8
 * Copyright (C) 2009, Tom�s Pollak
                          ^
/home/travis/build/spotbugs/spotbugs/eclipsePlugin-test/src/de/tobject/findbugs/quickfix/test/QuickfixWithJUnitTest.java:34: error: unmappable character for encoding UTF8
 * @author Tom�s Pollak
              ^
```