### PR TITLE
Revert "refs #299: Replace deprecated API used by Gradle plugin"

### DIFF
--- a/gradlePlugin/src/main/java/com/github/spotbugs/SpotBugsPlugin.java
+++ b/gradlePlugin/src/main/java/com/github/spotbugs/SpotBugsPlugin.java
@@ -193,7 +193,7 @@ public class SpotBugsPlugin extends AbstractCodeQualityPlugin<SpotBugsTask> {
             public FileCollection call() {
                 // the simple "classes = sourceSet.output" may lead to non-existing resources directory
                 // being passed to SpotBugs Ant task, resulting in an error
-                return project.fileTree(sourceSet.getOutput().getClassesDirs()).builtBy(sourceSet.getOutput());
+                return project.fileTree(sourceSet.getOutput().getClassesDir()).builtBy(sourceSet.getOutput());
             }
         });
         taskMapping.map("classpath", new Callable<FileCollection>() {


### PR DESCRIPTION
This reverts commit 313ea5b65420e2c370ff5af6f82941622036d75e.

See #320 for details.