### PR TITLE
Fix broken command-line scripts (#323)

### DIFF
--- a/spotbugs/src/scripts/deprecated/bugHistory
+++ b/spotbugs/src/scripts/deprecated/bugHistory
@@ -1,11 +1,5 @@
 #! /bin/sh
 
-@GET_FBHOME@
+# Deprecated
 
-@SET_DEFAULT_JAVA@
-
-fb_mainclass=edu.umd.cs.findbugs.workflow.BugHistory
-
-@WRAP_JAVA@
-
-# vim:ts=3
+exec "$(dirname $0)/../fbwrap" edu.umd.cs.findbugs.workflow.BugHistory "$@"

--- a/spotbugs/src/scripts/deprecated/unionBugs
+++ b/spotbugs/src/scripts/deprecated/unionBugs
@@ -1,14 +1,5 @@
 #! /bin/sh
 
-# Create the union of two results files, preserving
-# annotations in both files in the result.
+# Deprecated
 
-@GET_FBHOME@
-
-@SET_DEFAULT_JAVA@
-
-fb_mainclass=edu.umd.cs.findbugs.UnionResults
-
-@WRAP_JAVA@
-
-# vim:ts=3
+exec "$(dirname $0)/../unionBugs" "$@"

--- a/spotbugs/src/scripts/deprecated/unionResults
+++ b/spotbugs/src/scripts/deprecated/unionResults
@@ -1,16 +1,5 @@
 #! /bin/sh
 
-# Deprecated
+# Deprecated (replaced by unionBugs)
 
-# Create the union of two results files, preserving
-# annotations in both files in the result.
-
-@GET_FBHOME@
-
-@SET_DEFAULT_JAVA@
-
-fb_mainclass=edu.umd.cs.findbugs.workflow.UnionResults
-
-@WRAP_JAVA@
-
-# vim:ts=3
+exec "$(dirname $0)/../unionBugs" "$@"

--- a/spotbugs/src/scripts/deprecated/updateBugs
+++ b/spotbugs/src/scripts/deprecated/updateBugs
@@ -1,14 +1,5 @@
 #! /bin/sh
 
-# Merge a historical bug collection and a bug collection, producing an updated
-# historical bug collection
+# Deprecated (replaced by computeBugHistory)
 
-@GET_FBHOME@
-
-@SET_DEFAULT_JAVA@
-
-fb_mainclass=edu.umd.cs.findbugs.workflow.Update
-
-@WRAP_JAVA@
-
-# vim:ts=3
+exec "$(dirname $0)/../computeBugHistory" "$@"

--- a/spotbugs/src/scripts/experimental/backdateHistoryUsingSource
+++ b/spotbugs/src/scripts/experimental/backdateHistoryUsingSource
@@ -1,3 +1,3 @@
 #! /bin/sh
 
-"$(dirname $0)/../fbwrap" edu.umd.cs.findbugs.workflow.BackdateHistoryUsingSource
+exec "$(dirname $0)/../fbwrap" edu.umd.cs.findbugs.workflow.BackdateHistoryUsingSource "$@"

--- a/spotbugs/src/scripts/experimental/churn
+++ b/spotbugs/src/scripts/experimental/churn
@@ -1,3 +1,3 @@
 #! /bin/sh
 
-"$(dirname $0)/../fbwrap" edu.umd.cs.findbugs.workflow.Churn
+exec "$(dirname $0)/../fbwrap" edu.umd.cs.findbugs.workflow.Churn "$@"

--- a/spotbugs/src/scripts/experimental/obfuscate
+++ b/spotbugs/src/scripts/experimental/obfuscate
@@ -1,3 +1,3 @@
 #! /bin/sh
 
-"$(dirname $0)/../fbwrap" edu.umd.cs.findbugs.workflow.ObfuscateBugs
+exec "$(dirname $0)/../fbwrap" edu.umd.cs.findbugs.workflow.ObfuscateBugs "$@"

--- a/spotbugs/src/scripts/experimental/treemapVisualization
+++ b/spotbugs/src/scripts/experimental/treemapVisualization
@@ -1,3 +1,3 @@
 #! /bin/sh
 
-"$(dirname $0)/../fbwrap" edu.umd.cs.findbugs.workflow.TreemapVisualization
+exec "$(dirname $0)/../fbwrap" edu.umd.cs.findbugs.workflow.TreemapVisualization "$@"

--- a/spotbugs/src/scripts/standard/addMessages
+++ b/spotbugs/src/scripts/standard/addMessages
@@ -1,3 +1,3 @@
 #! /bin/sh
 
-"$(dirname $0)/fbwrap" edu.umd.cs.findbugs.AddMessages
+exec "$(dirname $0)/fbwrap" edu.umd.cs.findbugs.AddMessages "$@"

--- a/spotbugs/src/scripts/standard/computeBugHistory
+++ b/spotbugs/src/scripts/standard/computeBugHistory
@@ -3,4 +3,4 @@
 # Merge a historical bug collection and a bug collection, producing an updated
 # historical bug collection
 
-"$(dirname $0)/fbwrap" edu.umd.cs.findbugs.workflow.Update
+exec "$(dirname $0)/fbwrap" edu.umd.cs.findbugs.workflow.Update "$@"

--- a/spotbugs/src/scripts/standard/convertXmlToText
+++ b/spotbugs/src/scripts/standard/convertXmlToText
@@ -1,3 +1,3 @@
 #! /bin/sh
 
-"$(dirname $0)/fbwrap" edu.umd.cs.findbugs.PrintingBugReporter
+exec "$(dirname $0)/fbwrap" edu.umd.cs.findbugs.PrintingBugReporter "$@"

--- a/spotbugs/src/scripts/standard/copyBuggySource
+++ b/spotbugs/src/scripts/standard/copyBuggySource
@@ -1,3 +1,3 @@
 #! /bin/sh
 
-"$(dirname $0)/fbwrap" edu.umd.cs.findbugs.workflow.CopyBuggySource
+exec "$(dirname $0)/fbwrap" edu.umd.cs.findbugs.workflow.CopyBuggySource "$@"

--- a/spotbugs/src/scripts/standard/defectDensity
+++ b/spotbugs/src/scripts/standard/defectDensity
@@ -2,4 +2,4 @@
 
 # Generate a defect density table from a bug collection
 
-"$(dirname $0)/fbwrap" edu.umd.cs.findbugs.workflow.DefectDensity
+exec "$(dirname $0)/fbwrap" edu.umd.cs.findbugs.workflow.DefectDensity "$@"

--- a/spotbugs/src/scripts/standard/filterBugs
+++ b/spotbugs/src/scripts/standard/filterBugs
@@ -1,6 +1,6 @@
 #! /bin/sh
 
-# General purpose utility for filtering/transforming
-# bug collection and/or historical bug collections
+# General purpose utility for filtering/transforming bug collection and/or
+# historical bug collections
 
-"$(dirname $0)/fbwrap" edu.umd.cs.findbugs.workflow.Filter
+exec "$(dirname $0)/fbwrap" edu.umd.cs.findbugs.workflow.Filter "$@"

--- a/spotbugs/src/scripts/standard/findbugs-msv
+++ b/spotbugs/src/scripts/standard/findbugs-msv
@@ -1,3 +1,3 @@
 #! /bin/sh
 
-"$(dirname $0)/fbwrap" edu.umd.cs.findbugs.workflow.MergeSummarizeAndView
+exec "$(dirname $0)/fbwrap" edu.umd.cs.findbugs.workflow.MergeSummarizeAndView "$@"

--- a/spotbugs/src/scripts/standard/listBugDatabaseInfo
+++ b/spotbugs/src/scripts/standard/listBugDatabaseInfo
@@ -1,3 +1,3 @@
 #! /bin/sh
 
-"$(dirname $0)/fbwrap" edu.umd.cs.findbugs.workflow.ListBugDatabaseInfo
+exec "$(dirname $0)/fbwrap" edu.umd.cs.findbugs.workflow.ListBugDatabaseInfo "$@"

--- a/spotbugs/src/scripts/standard/mineBugHistory
+++ b/spotbugs/src/scripts/standard/mineBugHistory
@@ -1,3 +1,3 @@
 #! /bin/sh
 
-"$(dirname $0)/fbwrap" edu.umd.cs.findbugs.workflow.MineBugHistory
+exec "$(dirname $0)/fbwrap" edu.umd.cs.findbugs.workflow.MineBugHistory "$@"

--- a/spotbugs/src/scripts/standard/printAppVersion
+++ b/spotbugs/src/scripts/standard/printAppVersion
@@ -1,3 +1,3 @@
 #! /bin/sh
 
-"$(dirname $0)/fbwrap" edu.umd.cs.findbugs.workflow.PrintAppVersion
+exec "$(dirname $0)/fbwrap" edu.umd.cs.findbugs.workflow.PrintAppVersion "$@"

--- a/spotbugs/src/scripts/standard/printClass
+++ b/spotbugs/src/scripts/standard/printClass
@@ -1,3 +1,3 @@
 #! /bin/sh
 
-"$(dirname $0)/fbwrap" edu.umd.cs.findbugs.visitclass.PrintClass
+exec "$(dirname $0)/fbwrap" edu.umd.cs.findbugs.visitclass.PrintClass "$@"

--- a/spotbugs/src/scripts/standard/rejarForAnalysis
+++ b/spotbugs/src/scripts/standard/rejarForAnalysis
@@ -1,3 +1,3 @@
 #! /bin/sh
 
-"$(dirname $0)/fbwrap" edu.umd.cs.findbugs.workflow.RejarClassesForAnalysis
+exec "$(dirname $0)/fbwrap" edu.umd.cs.findbugs.workflow.RejarClassesForAnalysis "$@"

--- a/spotbugs/src/scripts/standard/setBugDatabaseInfo
+++ b/spotbugs/src/scripts/standard/setBugDatabaseInfo
@@ -1,3 +1,3 @@
 #! /bin/sh
 
-"$(dirname $0)/fbwrap" edu.umd.cs.findbugs.workflow.SetBugDatabaseInfo
+exec "$(dirname $0)/fbwrap" edu.umd.cs.findbugs.workflow.SetBugDatabaseInfo "$@"

--- a/spotbugs/src/scripts/standard/unionBugs
+++ b/spotbugs/src/scripts/standard/unionBugs
@@ -2,7 +2,7 @@
 
 # Deprecated
 
-# Create the union of two results files, preserving
-# annotations in both files in the result.
+# Create the union of two results files, preserving annotations in both files
+# in the result.
 
-"$(dirname $0)/fbwrap" edu.umd.cs.findbugs.workflow.UnionResults
+exec "$(dirname $0)/fbwrap" edu.umd.cs.findbugs.workflow.UnionResults "$@"

--- a/spotbugs/src/scripts/standard/xpathFind
+++ b/spotbugs/src/scripts/standard/xpathFind
@@ -1,3 +1,3 @@
 #! /bin/sh
 
-"$(dirname $0)/fbwrap" edu.umd.cs.findbugs.xml.XPathFind
+exec "$(dirname $0)/fbwrap" edu.umd.cs.findbugs.xml.XPathFind "$@"


### PR DESCRIPTION
In addition to now correctly passing on argument lists, this change also further improves upon the scripts; they now `exec` the script they warp, thus saving an extra process. Also, a few scripts which are effectively synonyms of another script (`unionBugs`/`unionResults` and `updateBugs`/`computeBugHistory`) now `exec` canonical scripts.