### PR TITLE
use isolated account for GitHub automation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ env:
     - SONATYPE_USERNAME="eller86"
     - secure: "bNbHxR43FHIWX/im5GUZD52UF0FszM5kxhw/3DFqpaOWEpf3BtvSTDpHvOdbVmcD+HtC8cCaXViCQaSIsDWuP2LrxxGlULl/a9yF5FLq+BxyTx28+Xi6c+mXSeava82poWEbF6whiLrn8GIIC+z2xwpphT+bBXj/3UmOmPj/cxfsuzb6gH95Xk1OhQJjhJ0Lt6muO0YmxA4dAtNDJHHwTU/GVn25+41WiAO1P4tDHRnPdAZFXnbM5kPV41KmYw4/0YbPgr5aJuAyrUD86ufwJR0Zp+TR4JJB+miw9+XYUgjRMgPBSS3VChOnYugKClfwVq8MwxRpUpBjG5eszt64TxgeEX0sTLBv9JwxUu5R+uCYgQvSdVKduyQYVTdJnMqTsVFCeOQlF0XHXvRXK7+SSNjkpaV/TMlfZ0vY+BAUnBIUAsMjvpX9RNMvDYx5D/5/cqj9WiEsaBLBLuQX90bZA0B8xbA1IHj9pRSxm9N8VAWMTzxhZzuqqMAi2IszBRZicKKYd66z83T1k9SFcTY4mvg0W2uVvZsoaBMIYmhvBZXPOLEgwadTbeiqFW2vox16k6k8xRlKzH+IIYQAChFPqxDxBtP8b7LZDa6ahreBMKtp3xBPbbCgbrviE647CwyPwb+DxOihua5GNfgxXby4kxiXcuglUXZ5NWCmvks2KIE="
 
-    # GITHUB_TOKEN value to push changes to GitHub; Currently it is ued to update gh-pages branch of spotbugs/eclipse-latest.
-    - secure: "KkVP4lQg8tMTxlO8SlPaHY++wXjfr9SM8w0Ld694eMJ44LoowRvwVSxsHxZ5dr/xTdfl0lHuFZO/FYF6WYl6e5i/dO/HniQOykZWfxkpXpF5g4rILuSDW0QyDpMgowcf0xf+tuytUB5UJroEhQPCDbrg5xoxYZ4/DoAcDrGwPSE8JhxTfTpdxZyKgw599UZi468ICMoQZfiZpCsN0TOGrwuFvCX78Stb8SBDedpfgy15IOjfzOjto4nZFKZF42x+7xftSUkVoN4ELtTPXsDcFUxdyB8ZiBr/LK0GvZgnl7LriQUDAMB6OIGv/uUJyBzam7pdpyNTi/f3QQF74OZ9bBFu/JEXOwAX1XtJAkfH1rBYEzNz7Y5cvH83WcR4+nd0llLple0EhdYpj8uT30HhZNrf9aePQoAczrOkeZhdJJ1n3kV+9dPsP7lWbQi0kB1aXcUP3x1Q1/dIVPRaqFoOEkdD2inGe3LxsgT00NRAHzQrkeVb3a9b0qr9VXEeqGmE+dufsFpoWIOO8XSd+lmut2s9EZNfJm6fy2x7+vNCca/4+Mg/BN+q6qEmvSCQ1Vh8kcToOpJMXKimmiqw51+jCGPU5kCsl8xOOtlO7+eF/ti2DjRfN4w7XOJVQyNjkdR1Ey71iccnXyPk9CtkxOBeCjPGNQu92h8C4Dzrz7sRWrQ="
+    # GITHUB_TOKEN value to push changes to GitHub; Currently it is ued to update gh-pages branch of spotbugs/eclipse-latest etc.
+    - secure: "dFmNTEiYr0XHd2Zoj95j1xqoawNIrN63pgvHwKWf5ngNkncxLukKu1nGvvt9Fbw4/Embgzvz2GRwxWJBu5//yKrUHD9ILBS78Sn8nxpba7wHE6r8k6m+u7dOeN4jEH1fzyzsniSq939S6uB8gvfhhikddh9oZzwZnMq1YVyHQaWzbcaUnom+cwndKfK+YXg5mkt5Z92uXkJjGqd36FPA3GrlGJH7kXgWhVXI7Vds2hHsX/IBG0/2ZDhKNSZ8AiaDU4g2pSBlqA7F/noFW68hpohz9AAjku2COmpK0Ojd/iE0bVclXHYzs2aZq3lvYb3gv0dTEJrcIwPlDKQZWaEV/SxX9nIOqL5Q6XeVigTmnKkivQQ/b0hMPEpeHVvipMETYVzDvFT0qatLX/gUsiLgRPilWu0imFvNY4YAPZK3UPBSL5g+/8DzDPmTMZiOqJTMuMr+r/c7ch8qfjoaibc6LqUSJYLxyfk3NeturoviPLiBBtoadNsLPddtsNE8MZhr9lwRefNXY/VPBUxi7Bpxo7KfZ0BDSTzKeW7AEm/9E4CDmbd25eYGdvfVFeElGt5iTAfwIBYhj/GDkqnjesNCyDeNry/NywnEigkZQ4gzIvkHDkevUFs19nSspBmxiK82doY/j9Q0/TAK30mIdhg8VQwmkq5AYVIcN8kCu8WBhxw="
   matrix:
     - JDK_FOR_TEST=oraclejdk8
 #    - JDK_FOR_TEST=oraclejdk9
@@ -63,6 +63,7 @@ deploy:
     github_token: $GITHUB_TOKEN
     local_dir: $TRAVIS_BUILD_DIR/eclipsePlugin/build/site/eclipse-daily
     repo: spotbugs/eclipse-latest
+    email: skypencil+spotbugs-bot@gmail.com
     on:
       branch: master
       condition: "$JDK_FOR_TEST = oraclejdk8"
@@ -71,6 +72,7 @@ deploy:
     github_token: $GITHUB_TOKEN
     local_dir: $TRAVIS_BUILD_DIR/eclipsePlugin/build/site/eclipse-candidate
     repo: spotbugs/eclipse-candidate
+    email: skypencil+spotbugs-bot@gmail.com
     on:
       tags: true
       condition: "$JDK_FOR_TEST = oraclejdk8"
@@ -79,6 +81,7 @@ deploy:
     github_token: $GITHUB_TOKEN
     local_dir: $TRAVIS_BUILD_DIR/eclipsePlugin/build/site/eclipse
     repo: spotbugs/eclipse
+    email: skypencil+spotbugs-bot@gmail.com
     on:
       tags: true
       condition: "$JDK_FOR_TEST = oraclejdk8 && $TRAVIS_TAG != *'_RC'*"


### PR DESCRIPTION
Previously we use GitHub token generated by @kengotoda so post from SonarQube uses his icon.
It makes our communication complicated.

Now we've created @spotbugs-bot and this change will use new token generated by her.
