### PR TITLE
Don't package too many 3rd party jars into our plugin

### DIFF
--- a/eclipsePlugin/build.gradle
+++ b/eclipsePlugin/build.gradle
@@ -60,10 +60,15 @@ clean {
 
 task copyLibsForEclipse(type: Copy) {
     dependsOn configurations.compile
-    from configurations.compile.files
+    from configurations.compile.files {
+    	include "*.jar"
+    	exclude "*xml-apis*.jar"
+    	// Workaround due https://github.com/spotbugs/spotbugs/issues/327 
+    	// BCEL classes are already included into the main spotbugs.jar
+    	// Should be removed after #327 is fixed.
+    	exclude "bcel-*.jar"
+    }
     into "lib"
-    include "*.jar"
-    exclude "*xml-apis*.jar"
 }
 
 task distSrcZip(type:Exec) {
@@ -145,18 +150,7 @@ jar {
   // Make sure we always update the manifest when building
   dependsOn updateManifest
   includeEmptyDirs = false
-  from(configurations.compile.collect { zipTree(it) }) {
-    exclude 'edu/umd/cs/findbugs/gui/**/*.*'
-    exclude 'edu/umd/cs/findbugs/gui2/**/*.*'
-    exclude 'edu/umd/cs/findbugs/userAnnotations/ri/**/*.*'
-    exclude 'edu/umd/cs/findbugs/sourceViewer/**/*.*'
-    exclude 'edu/umd/cs/findbugs/anttask/**/*.*'
-    exclude 'edu/umd/cs/findbugs/tools/**/*.*'
-    exclude 'edu/umd/cs/findbugs/annotations/**/*.*'
-    exclude 'net/jcip/annotations/**/*.*'
-    exclude 'META-INF/**.*'
-  }
-  exclude 'de/tobject/findbugs/tools/**'
+  from sourceSets.main.output
   archiveName 'spotbugs-plugin.jar'
 }
 

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -108,7 +108,9 @@ task updateManifest {
 // Manually define what goes into the default jar, since it's not only main sourceset
 jar {
   from sourceSets.main.output
-  from project(':spotbugs-annotations').sourceSets.main.output
+  
+  // Workaround for missing released BCEL maven artifact, see https://github.com/spotbugs/spotbugs/issues/327
+  // Should be removed after #327 is fixed.
   from zipTree("$projectDir/lib/bcel-6.1-20161207.023659-9.jar").matching {
     exclude 'META-INF/**'
   }
@@ -116,7 +118,7 @@ jar {
   manifest {
     attributes 'Main-Class': 'edu.umd.cs.findbugs.LaunchAppropriateUI',
                'Bundle-Version': project.version,
-               'Class-Path': 'dom4j-1.6.1.jar jaxen-1.1.6.jar asm-debug-all-6.0_BETA.jar jsr305-3.0.1.jar jFormatString-3.0.0.jar commons-lang-2.6.jar'
+               'Class-Path': 'spotbugs-annotations.jar dom4j-1.6.1.jar jaxen-1.1.6.jar asm-debug-all-6.0_BETA.jar jsr305-3.0.1.jar jFormatString-3.0.0.jar commons-lang-2.6.jar'
   }
 }
 


### PR DESCRIPTION
 - Don't merge all jars we use into eclipse-plugin.jar.
 - Don't ship second copy of the BCEL library, because spotbugs.jar
includes it already (see # 327).

Fixes issue #326