### PR TITLE
Translate manual into Japanese

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -267,6 +267,7 @@ texinfo_documents = [
 # http://www.sphinx-doc.org/en/latest/intl.html
 locale_dirs = ['locale/']
 gettext_compact = False
+gettext_additional_targets = ['raw']
 
 def setup(app):
   app.add_stylesheet('custom.css')

--- a/docs/locale/ja/LC_MESSAGES/analysisprops.po
+++ b/docs/locale/ja/LC_MESSAGES/analysisprops.po
@@ -3,30 +3,28 @@
 # This file is distributed under the same license as the spotbugs package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
 #
-#, fuzzy
 msgid ""
-msgstr ""
-"Project-Id-Version: spotbugs 3.1\n"
+msgstr "Project-Id-Version: spotbugs 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-06-09 13:58+0000\n"
+"POT-Creation-Date: 2017-08-17 15:12+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
+"Generated-By: Babel 2.4.0\n"
 
 #: ../../analysisprops.rst:2
 msgid "Analysis Properties"
-msgstr ""
+msgstr "解析プロパティ"
 
 #: ../../analysisprops.rst:4
 msgid ""
 "SpotBugs allows several aspects of the analyses it performs to be "
 "customized. System properties are used to configure these options. This "
 "chapter describes the configurable analysis options."
-msgstr ""
+msgstr "SpotBugs は，実行する解析の観点をカスタマイズできます。システムプロパティがオプションを設定するために使用されます。この章では，設定可能な解析オプションについて説明します。"
 
 #: ../../analysisprops.rst:6
 msgid ""
@@ -37,29 +35,29 @@ msgid ""
 "performed. Reducing analysis precision can save memory and analysis time,"
 " at the expense of missing some real bugs, or producing more false "
 "warnings."
-msgstr ""
+msgstr "解析オプションには主に2つの目的があります。1つ目は，SpotBugs にアプリケーションのメソッドの意味を通知し，より正確な結果を生成したり，誤検出を少なくしたりできます。2つ目は，実行される解析の精度を設定できます。解析の精度を下げると，メモリと解析時間を節約できますが，本当のバグを見逃したり，より多くの誤検出を作り出したりします。"
 
 #: ../../analysisprops.rst:8
 msgid ""
 "The analysis options are set using the ``-property`` command line option."
 " For example:"
-msgstr ""
+msgstr "解析オプションは，``-property`` コマンドラインオプションを使用して設定します。たとえば:"
 
 #: ../../analysisprops.rst:14
 msgid "The list of configurable analysis properties is shown in following table:"
-msgstr ""
+msgstr "設定できる解析プロパティのリストを次の表に示します。"
 
 #: ../../analysisprops.rst:17
 msgid "Property Name"
-msgstr ""
+msgstr "プロパティ名"
 
 #: ../../analysisprops.rst:17
 msgid "Value"
-msgstr ""
+msgstr "値"
 
 #: ../../analysisprops.rst:17
 msgid "Meaning"
-msgstr ""
+msgstr "意味"
 
 #: ../../analysisprops.rst:19
 msgid "findbugs.assertionmethods"
@@ -69,7 +67,7 @@ msgstr ""
 msgid ""
 "Comma-separated list of fully qualified method names: e.g., "
 "\"com.foo.MyClass.checkAssertion\""
-msgstr ""
+msgstr "コンマ区切りの完全就職メソッド名のリスト (例，「com.foo.MyClass.checkAssertion」)"
 
 #: ../../analysisprops.rst:19
 msgid ""
@@ -77,7 +75,7 @@ msgid ""
 "program assertions. Specifying these methods allows the null pointer "
 "dereference bug detector to avoid reporting false warnings for values "
 "which are checked by assertion methods."
-msgstr ""
+msgstr "このプロパティは，プログラムのアサーションをチェックするために使用されるメソッドの名前を指定します。これらのメソッドを指定すると，null 間接参照バグディテクタは，アサーションメソッドによってチェックされる値に対する誤検出を回避できます。"
 
 #: ../../analysisprops.rst:21
 msgid "findbugs.de.comment"
@@ -87,13 +85,13 @@ msgstr ""
 #: ../../analysisprops.rst:25 ../../analysisprops.rst:27
 #: ../../analysisprops.rst:29
 msgid "true or false"
-msgstr ""
+msgstr "true または false"
 
 #: ../../analysisprops.rst:21
 msgid ""
 "If true, the DroppedException detector scans source code for empty catch "
 "blocks for a comment, and if one is found, does not report a warning."
-msgstr ""
+msgstr "true のときは，DroppedException ディテクタは空のキャッチブロックにコメントがないかスキャンし，見つかったときは警告を報告しません。"
 
 #: ../../analysisprops.rst:23
 msgid "findbugs.maskedfields.locals"
@@ -103,7 +101,7 @@ msgstr ""
 msgid ""
 "If true, emit low priority warnings for local variables which obscure "
 "fields. Default is false."
-msgstr ""
+msgstr "true のときは，フィールドを隠蔽するローカル変数に対する優先度の低い警告を発行します。デフォルトは false です。"
 
 #: ../../analysisprops.rst:25
 msgid "findbugs.nullderef.assumensp"
@@ -116,7 +114,7 @@ msgid ""
 "parameter might be null. Default is false. Note that enabling this "
 "property will very likely cause a large number of false warnings to be "
 "produced.)"
-msgstr ""
+msgstr "使わないでください (意図: trueのときは，null 間接参照ディテクタはメソッドから返された，またはメソッドに渡されたパラメータの参照値が null であるとみなします。デフォルトは false です。このプロパティを有効にすると，多数の誤った警告が生成されることに注意してください。)"
 
 #: ../../analysisprops.rst:27
 msgid "findbugs.refcomp.reportAll"
@@ -127,7 +125,7 @@ msgid ""
 "If true, all suspicious reference comparisons using the == and != "
 "operators are reported.,If false, only one such warning is issued per "
 "method.,Default is false."
-msgstr ""
+msgstr "true のときは，== と != 演算子を使用している疑わしい参照比較がすべて報告されます。false のときは，メソッドごとに警告が1つだけ発行されます。デフォルトは false です。"
 
 #: ../../analysisprops.rst:29
 msgid "findbugs.sf.comment"
@@ -140,5 +138,5 @@ msgid ""
 "\"fall\" or \"nobreak\". (An accurate source path must be used for this "
 "feature to work correctly.) This helps find cases where the switch "
 "fallthrough is likely to be unintentional."
-msgstr ""
+msgstr "true のときは，SwitchFallthrough ディテクタは，ソースコードに「fall」または「nobreak」という単語がコメントに含まれていないときに警告を報告します。(この機能を正しく動作させるためには，正確なソースパスを使用する必要があります。) これにより，意図的ではない switch 文のフォールスルーを見つけられます。"
 

--- a/docs/locale/ja/LC_MESSAGES/ant.po
+++ b/docs/locale/ja/LC_MESSAGES/ant.po
@@ -39,7 +39,7 @@ msgstr "Ant タスクのインストール"
 msgid ""
 "To install the Ant task, simply copy ``$SPOTBUGS_HOME/lib/spotbugs-"
 "ant.jar`` into the lib subdirectory of your Ant installation."
-msgstr "Ant タスクをインストールするには，Ant インストールの lib サブディレクトリに `$SPOTBUGS_HOME/lib/spotbugs-ant.jar`` をコピーします。"
+msgstr "Ant タスクをインストールするには，Ant インストールの lib サブディレクトリに ``$SPOTBUGS_HOME/lib/spotbugs-ant.jar`` をコピーします。"
 
 #: ../../ant.rst:16
 msgid ""
@@ -192,7 +192,7 @@ msgid ""
 " reporting issues. If set to ``low``, confidence is not used to filter "
 "bugs. If set to ``medium`` (the default), low confidence issues are "
 "supressed. If set to ``high``, only high confidence bugs are reported."
-msgstr "オプション属性です。問題を報告するための信頼度/優先度を指定します。``low`` に設定すると，信頼度はバグをフィルタリングするために使われません。``medium`` (デフォルト) に設定すると，信頼度 (低) の問題が抑制されます。``high`` に設定すると，信頼度 (高) のバグだけが報告されます。"
+msgstr "オプション属性です。問題を報告するための信頼度/優先度を指定します。``low`` に設定すると，信頼度はバグをフィルタリングするために使われません。``medium`` (デフォルト) に設定すると，信頼度が低い問題が抑制されます。``high`` に設定すると，信頼度が高いバグだけが報告されます。"
 
 #: ../../ant.rst:120
 msgid "output"
@@ -266,7 +266,7 @@ msgid ""
 "``min``, ``default``, or ``max``. See `Command-line Options <running.html"
 "#command-line-options>`: for more information about setting the analysis "
 "level."
-msgstr "分析の活動レベルを設定します。指定する値は，``min``，``default``，``max`` のいずれかでなければなりません。解析レベル設定の詳細については `コマンドラインオプション <running.html#command-line-options>`__ を参照してください。"
+msgstr "解析力を設定します。指定する値は，``min``，``default``，``max`` のいずれかでなければなりません。解析力の詳細については `コマンドラインオプション <running.html#command-line-options>`__ を参照してください。"
 
 #: ../../ant.rst:141
 msgid "conserveSpace"

--- a/docs/locale/ja/LC_MESSAGES/ant.po
+++ b/docs/locale/ja/LC_MESSAGES/ant.po
@@ -3,23 +3,21 @@
 # This file is distributed under the same license as the spotbugs package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
 #
-#, fuzzy
 msgid ""
-msgstr ""
-"Project-Id-Version: spotbugs 3.1\n"
+msgstr "Project-Id-Version: spotbugs 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-06-13 15:12+0000\n"
+"POT-Creation-Date: 2017-08-17 15:12+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
+"Generated-By: Babel 2.4.0\n"
 
 #: ../../ant.rst:2
 msgid "Using the SpotBugs Ant task"
-msgstr ""
+msgstr "SpotBugs Ant タスクの使い方"
 
 #: ../../ant.rst:4
 msgid ""
@@ -27,21 +25,21 @@ msgid ""
 "Ant, which is a popular Java build and deployment tool. Using the "
 "SpotBugs Ant task, your build script can automatically run SpotBugs on "
 "your Java code."
-msgstr ""
+msgstr "この章では，一般的な Java ビルドおよびデプロイメントツールである Ant のビルドスクリプトに SpotBugs を統合する方法について説明します。SpotBugs Ant タスクを使用するとビルドスクリプトは Java コードで SpotBugs を自動的に実行できます。"
 
 #: ../../ant.rst:7
 msgid "The Ant task was generously contributed by Mike Fagan."
-msgstr ""
+msgstr "Ant タスクは，Mike Fagan 氏の多大なる貢献によるものです。"
 
 #: ../../ant.rst:10
 msgid "Installing the Ant task"
-msgstr ""
+msgstr "Ant タスクのインストール"
 
 #: ../../ant.rst:12
 msgid ""
 "To install the Ant task, simply copy ``$SPOTBUGS_HOME/lib/spotbugs-"
 "ant.jar`` into the lib subdirectory of your Ant installation."
-msgstr ""
+msgstr "Ant タスクをインストールするには，Ant インストールの lib サブディレクトリに `$SPOTBUGS_HOME/lib/spotbugs-ant.jar`` をコピーします。"
 
 #: ../../ant.rst:16
 msgid ""
@@ -49,37 +47,37 @@ msgid ""
 "SpotBugs it was included with. We do not guarantee that the Ant task Jar "
 "file will work with any version of SpotBugs other than the one it was "
 "included with."
-msgstr ""
+msgstr "SpotBugs に含まれていたバージョンの Ant タスクを使用することを強くお勧めします。Ant タスクの Jar ファイルは SpotBugsに含まれていたバージョン以外のバージョンで動作することを保証しません。"
 
 #: ../../ant.rst:20
 msgid "Modifying build.xml"
-msgstr ""
+msgstr "build.xml の変更"
 
 #: ../../ant.rst:22
 msgid ""
 "To incorporate SpotBugs into build.xml (the build script for Ant), you "
 "first need to add a task definition. This should appear as follows:"
-msgstr ""
+msgstr "SpotBugs を build.xml (Ant のビルドスクリプト) に組み込むには，まず最初にタスク定義を追加する必要があります。これは次のように記述します。"
 
 #: ../../ant.rst:30
 msgid ""
 "The task definition specifies that when a spotbugs element is seen in "
 "``build.xml``, it should use the indicated class to execute the task."
-msgstr ""
+msgstr "タスク定義は， spotbugs 要素を ``build.xml`` に記述したとき，タスクの実行に使用されるクラスを指定します。"
 
 #: ../../ant.rst:32
 msgid ""
 "After you have added the task definition, you can define a target which "
 "uses the spotbugs task. Here is an example which could be added to the "
 "``build.xml`` for the Apache BCEL library."
-msgstr ""
+msgstr "タスク定義を追加したら，spotbugs タスクを使用するターゲットを定義できます。次の例は，``build.xml`` に追加した Apache BCEL ライブラリです。"
 
 #: ../../ant.rst:49
 msgid ""
 "The spotbugs element must have the home attribute set to the directory in"
 " which SpotBugs is installed; in other words, ``$SPOTBUGS_HOME``. See "
 ":doc:`installing`."
-msgstr ""
+msgstr "spotbugs 要素のhome 属性には，SpotBugsがインストールされているディレクトリが設定されている必要があります。つまり，``$SPOTBUGS_HOME`` です。:doc:`installing` を参照してください。"
 
 #: ../../ant.rst:51
 msgid ""
@@ -91,33 +89,33 @@ msgid ""
 "to the aux classpath, because it is referenced by the main BCEL library. "
 "A source path is specified so that the saved bug data will have accurate "
 "references to the BCEL source code."
-msgstr ""
+msgstr "このターゲットは，``bcel.jar`` に対して SpotBugs を実行します。これは，BCEL のビルドスクリプトによって生成された Jar ファイルです。(\"jar\" ターゲットに依存させることで，SpotBugs を実行する前にライブラリが完全にコンパイルされていることを保証します) SpotBugs の出力は，XML 形式で ``bcel-sb.xml`` というファイルに保存されます。補助 Jar ファイル Regex.jar を補助クラスパスに追加します。なぜなら，BCEL ライブラリによって参照されるからです。保存されるバグデータが BCEL ソースコードへの正確な参照を持つようにするためにソースパスが指定されています。"
 
 #: ../../ant.rst:57
 msgid "Executing the task"
-msgstr ""
+msgstr "タスクの実行"
 
 #: ../../ant.rst:59
 msgid ""
 "Here is an example of invoking Ant from the command line, using the "
 "spotbugs target defined above."
-msgstr ""
+msgstr "上記で定義した spotbugs ターゲットを使用して，コマンドラインから Ant を起動する例を示します。"
 
 #: ../../ant.rst:82
 msgid ""
 "In this case, because we saved the bug results in an XML file, we can use"
 " the SpotBugs GUI to view the results; see :doc:`running`."
-msgstr ""
+msgstr "この場合バグ結果を XML ファイルに保存したので SpotBugs GUI を使用して結果を表示できます。:doc:`running` を参照してください。"
 
 #: ../../ant.rst:85
 msgid "Parameters"
-msgstr ""
+msgstr "パラメータ"
 
 #: ../../ant.rst:87
 msgid ""
 "This section describes the parameters that may be specified when using "
 "the FindBugs task."
-msgstr ""
+msgstr "この節では，SpotBugs タスクの使用時に指定できるパラメータについて説明します。"
 
 #: ../../ant.rst:95
 msgid "class"
@@ -129,7 +127,7 @@ msgid ""
 "element must specify a location attribute which names the archive file "
 "(jar, zip, etc.), directory, or class file to be analyzed. Multiple class"
 " elements may be specified as children of a single spotbugs element."
-msgstr ""
+msgstr "オプションのネストされた要素です。解析するクラスを指定します。class 要素は，解析されるアーカイブファイル (jar，zip など)，ディレクトリ，クラスファイルの名前を location 属性に指定する必要があります。複数のクラス要素は，単一の spotbugs 要素の子要素として指定します。"
 
 #: ../../ant.rst:94
 msgid ""
@@ -137,7 +135,7 @@ msgid ""
 "task can contain one or more fileset element(s) that specify files to be "
 "analyzed. For example, you might use a fileset to specify that all of the"
 " jar files in a directory should be analyzed."
-msgstr ""
+msgstr "クラス要素の指定を追加する，または代わりに，SpotBugs タスクに解析するファイルを指定する 1 つまたは複数の fileset 要素を含めることができます。たとえば，fileset を使用して，ディレクトリ内のすべての jar ファイルを分析するように指定できます。"
 
 #: ../../ant.rst:99
 msgid "auxClasspath"
@@ -149,7 +147,7 @@ msgid ""
 "directories) containing classes used by the analyzed library or "
 "application, but which you don't want to analyze. It is specified the "
 "same way as Ant's classpath element for the Java task."
-msgstr ""
+msgstr "オプションのネストされた要素です。解析するライブラリまたはアプリケーションで使用されるが，解析したくはないクラスを含むクラスパス (jar ファイルまたはディレクトリ) を指定します。Ant のJava タスクの classpath 要素と同じ方法で指定します。"
 
 #: ../../ant.rst:103
 msgid "sourcePath"
@@ -161,7 +159,7 @@ msgid ""
 "containing source files used to compile the Java code being analyzed. By "
 "specifying a source path, any generated XML bug output will have complete"
 " source information, which allows later viewing in the GUI."
-msgstr ""
+msgstr "オプションのネストされた要素です。解析される Java コードをコンパイルするために使用されるソースファイルを含むソースディレクトリのパスを指定します。ソースパスを指定することにより生成された XML バグ出力に完全なソース情報が含まれ，後で GUI で見ることができます。"
 
 #: ../../ant.rst:106
 msgid "home"
@@ -171,7 +169,7 @@ msgstr ""
 msgid ""
 "A required attribute. It must be set to the name of the directory where "
 "SpotBugs is installed."
-msgstr ""
+msgstr "必須属性です。SpotBugs がインストールされているディレクトリの名前を設定する必要があります。"
 
 #: ../../ant.rst:109
 msgid "quietErrors"
@@ -182,7 +180,7 @@ msgid ""
 "An optional boolean attribute. If true, reports of serious analysis "
 "errors and missing classes will be suppressed in the SpotBugs output. "
 "Default is false."
-msgstr ""
+msgstr "オプションのブール値属性です。true のときは，SpotBugs の出力で深刻な解析エラーや見つからなかったクラスの報告が抑制されます。デフォルトは false です。"
 
 #: ../../ant.rst:115
 msgid "reportLevel"
@@ -194,7 +192,7 @@ msgid ""
 " reporting issues. If set to ``low``, confidence is not used to filter "
 "bugs. If set to ``medium`` (the default), low confidence issues are "
 "supressed. If set to ``high``, only high confidence bugs are reported."
-msgstr ""
+msgstr "オプション属性です。問題を報告するための信頼度/優先度を指定します。``low`` に設定すると，信頼度はバグをフィルタリングするために使われません。``medium`` (デフォルト) に設定すると，信頼度 (低) の問題が抑制されます。``high`` に設定すると，信頼度 (高) のバグだけが報告されます。"
 
 #: ../../ant.rst:120
 msgid "output"
@@ -210,7 +208,7 @@ msgid ""
 "stylesheet is default.xsl). If set to ``text``, output is in ad-hoc text "
 "format. If set to ``emacs``, output is in Emacs error message format. If "
 "set to ``xdocs``, output is xdoc XML for use with Apache Maven."
-msgstr ""
+msgstr "オプション属性です。出力形式を指定します。``xml`` (デフォルト) に設定すると，出力は XML 形式になります。「xml:withMessages」に設定されているときは，出力は人間が読めるメッセージで拡張された XML 形式になります。(XSL スタイルシートを使用してレポートを生成するときは，この形式を使用する必要があります。) 「HTML」に設定したときは，出力はHTML形式になります (デフォルトスタイルシートは default.xsl)。``text`` に設定すると，出力は特別なテキスト形式になります。``emacs`` に設定すると，出力は Emacs のエラーメッセージ形式になります。``xdocs`` に設定すると，出力は Apache Maven で使用する xdoc XML形式になります。"
 
 #: ../../ant.rst:124
 msgid "stylesheet"
@@ -223,7 +221,7 @@ msgid ""
 "FindBugs distribution include default.xsl, fancy.xsl, fancy-hist.xsl, "
 "plain.xsl, and summary.xsl. The default value, if no stylesheet attribute"
 " is provided, is default.xsl."
-msgstr ""
+msgstr "オプション属性です。出力が html に設定されているときに html 出力を生成するために使用するスタイルシートを設定します。SpotBugs 配布物に含まれるスタイルシートには，default.xsl，fancy.xsl，fancy-hist.xsl，plain.xsl，summary.xsl があります。stylesheet 属性が指定されていないときのデフォルト値は default.xsl です。"
 
 #: ../../ant.rst:127
 msgid "sort"
@@ -234,7 +232,7 @@ msgid ""
 "Optional attribute. If the output attribute is set to ``text``, then the "
 "sort attribute specifies whether or not reported bugs are sorted by "
 "class. Default is ``true``."
-msgstr ""
+msgstr "オプション属性です。output 属性が ``text`` に設定されているときは，sort 属性は報告されたバグをクラスごとにソートするかどうかを設定します。デフォルトは ``true`` です。"
 
 #: ../../ant.rst:131
 msgid "outputFile"
@@ -245,7 +243,7 @@ msgid ""
 "Optional attribute. If specified, names the output file in which the "
 "FindBugs output will be saved. By default, the output is displayed "
 "directly by Ant."
-msgstr ""
+msgstr "オプション属性です。SpotBugs 出力を保存する出力ファイルの名前を指定します。デフォルトでは，出力は Ant によって直接表示されます。"
 
 #: ../../ant.rst:134
 msgid "debug"
@@ -256,7 +254,7 @@ msgid ""
 "Optional boolean attribute. If set to ``true``, SpotBugs prints "
 "diagnostic information about which classes are being analyzed, and which "
 "bug pattern detectors are being run. Default is ``false``."
-msgstr ""
+msgstr "オプションのブール値属性です。``true`` に設定すると，SpotBugs はどのクラスが解析されているか，どのバグパターンディテクタが実行されているかに関する診断情報を出力します。デフォルトは ``false`` です。"
 
 #: ../../ant.rst:138
 msgid "effort"
@@ -268,7 +266,7 @@ msgid ""
 "``min``, ``default``, or ``max``. See `Command-line Options <running.html"
 "#command-line-options>`: for more information about setting the analysis "
 "level."
-msgstr ""
+msgstr "分析の活動レベルを設定します。指定する値は，``min``，``default``，``max`` のいずれかでなければなりません。解析レベル設定の詳細については `コマンドラインオプション <running.html#command-line-options>`__ を参照してください。"
 
 #: ../../ant.rst:141
 msgid "conserveSpace"
@@ -276,7 +274,7 @@ msgstr ""
 
 #: ../../ant.rst:141
 msgid "Synonym for ``effort=\"min\"``."
-msgstr ""
+msgstr "``effort=\"min\"`` と同義です。"
 
 #: ../../ant.rst:144
 msgid "workHard"
@@ -284,7 +282,7 @@ msgstr ""
 
 #: ../../ant.rst:144
 msgid "Synonym for ``effort=\"max\"``."
-msgstr ""
+msgstr "``effort=\"max\"`` と同義です。"
 
 #: ../../ant.rst:149
 msgid "visitors"
@@ -296,7 +294,7 @@ msgid ""
 "which should be run. The bug detectors are specified by their class "
 "names, without any package qualification. By default, all detectors which"
 " are not disabled by default are run."
-msgstr ""
+msgstr "オプション属性です。実行すべきバグディテクタのコンマ区切りリストを指定します。バグディテクタは，パッケージ名がないクラス名で指定します。デフォルトでは，デフォルトで無効にされていないすべてのディテクタが実行されます。"
 
 #: ../../ant.rst:153
 msgid "omitVisitors"
@@ -307,7 +305,7 @@ msgid ""
 "Optional attribute. It specifies a comma-separated list of bug detectors."
 " It is like the visitors attribute, except it specifies detectors which "
 "will not be run."
-msgstr ""
+msgstr "オプション属性です。コンマ区切りのバグディテクタのリストを指定します。visitors 属性と似ていますが，実行しないディテクタを設定します。"
 
 #: ../../ant.rst:156
 msgid "chooseVisitors"
@@ -317,7 +315,7 @@ msgstr ""
 msgid ""
 "Optional attribute. It specifies a comma-separated list of bug detectors "
 "prefixed with \"+\" or \"-\" to selectively enable/disable them."
-msgstr ""
+msgstr "オプション属性です。コンマ区切りのバグディテクタリストのバグディテクタの接頭辞に「+」または「 -」を設定して，選択的に有効/無効にします。"
 
 #: ../../ant.rst:159
 msgid "excludeFilter"
@@ -327,7 +325,7 @@ msgstr ""
 msgid ""
 "Optional attribute. It specifies the filename of a filter specifying bugs"
 " to exclude from being reported. See :doc:`filter`."
-msgstr ""
+msgstr "オプション属性です。レポートから除外するバグを指定するフィルタのファイル名を指定します。:doc:`filter` を参照してください。"
 
 #: ../../ant.rst:162
 msgid "includeFilter"
@@ -337,7 +335,7 @@ msgstr ""
 msgid ""
 "Optional attribute. It specifies the filename of a filter specifying "
 "which bugs are reported. See :doc:`filter`."
-msgstr ""
+msgstr "オプション属性です。報告するバグを指定するフィルタのファイル名を指定します。:doc:`filter` を参照してください。"
 
 #: ../../ant.rst:168
 msgid "projectFile"
@@ -351,7 +349,7 @@ msgid ""
 "specify any class elements, nor do you need to specify ``auxClasspath`` "
 "or ``sourcePath`` attributes. See :doc:`running` for how to create a "
 "project."
-msgstr ""
+msgstr "オプション属性です。プロジェクトファイルの名前を指定します。プロジェクトファイルは，SpotBugs GUI によって作成され，クラス，補助クラスパスエントリ，ソースディレクトリを指定します。プロジェクトに名前を付けることによって，class 要素や``auxClasspath`` または ``sourcePath`` 属性を設定する必要がありません。`プロジェクトの作成 <gui.html#creating-a-project>`__ を参照してください。"
 
 #: ../../ant.rst:172
 msgid "jvmargs"
@@ -363,7 +361,7 @@ msgid ""
 "the Java virtual machine used to run SpotBugs. You may need to use this "
 "attribute to specify flags to increase the amount of memory the JVM may "
 "use if you are analyzing a very large program."
-msgstr ""
+msgstr "オプション属性です。SpotBugs を実行するために使用する Java 仮想マシンに渡す必要がある引数を指定します。この属性を使用して，巨大なプログラムを解析するときに JVM が使用するメモリ量を増やすためのフラグを指定する必要があります。"
 
 #: ../../ant.rst:176
 msgid "systemProperty"
@@ -374,7 +372,7 @@ msgid ""
 "Optional nested element. If specified, defines a system property. The "
 "name attribute specifies the name of the system property, and the value "
 "attribute specifies the value of the system property."
-msgstr ""
+msgstr "オプションのネストされた要素です。システムプロパティを定義します。name 属性はシステムプロパティの名前を指定し，value 属性はシステムプロパティの値を指定します。"
 
 #: ../../ant.rst:180
 msgid "timeout"
@@ -387,7 +385,7 @@ msgid ""
 "be hung and is terminated. The default is 600,000 milliseconds, which is "
 "ten minutes. Note that for very large programs, SpotBugs may require more"
 " than ten minutes to complete its analysis."
-msgstr ""
+msgstr "オプション属性です。SpotBugs を実行している Java プロセスがハングアップして終了する前に実行される時間をミリ秒単位で指定します。デフォルトは 600,000 ミリ秒 (10 分) です。巨大なプログラムのときは，SpotBugs は解析を完了するのに 10 分以上かかることがあります。"
 
 #: ../../ant.rst:183
 msgid "failOnError"
@@ -397,7 +395,7 @@ msgstr ""
 msgid ""
 "Optional boolean attribute. Whether to abort the build process if there "
 "is an error running SpotBugs. Defaults to ``false``."
-msgstr ""
+msgstr "オプションのブール値属性です。SpotBugs を実行中にエラーが発生したときに，ビルドプロセスrを中断するかどうか指定します。デフォルトは ``false`` です。"
 
 #: ../../ant.rst:186
 msgid "errorProperty"
@@ -407,7 +405,7 @@ msgstr ""
 msgid ""
 "Optional attribute which specifies the name of a property that will be "
 "set to ``true`` if an error occurs while running SpotBugs."
-msgstr ""
+msgstr "オプション属性です。SpotBugs の実行中にエラーが発生したときに，``true`` に設定するプロパティの名前を指定します。"
 
 #: ../../ant.rst:189
 msgid "warningsProperty"
@@ -418,7 +416,7 @@ msgid ""
 "Optional attribute which specifies the name of a property that will be "
 "set to ``true`` if any warnings are reported by SpotBugs on the analyzed "
 "program."
-msgstr ""
+msgstr "オプション属性です。 SpotBugs によって解析されたプログラムの警告が報告されたときに， ``true`` に設定するプロパティの名前を指定します。"
 
 #: ../../ant.rst:194
 msgid "userPreferencesFile"
@@ -432,7 +430,7 @@ msgid ""
 "will override them, as last argument would mean they will override some "
 "previous options). This rationale behind this option is to reuse SpotBugs"
 " Eclipse project settings for command line execution."
-msgstr ""
+msgstr "オプション属性です。使用するユーザ設定ファイルを設定します。上記のオプションの一部が上書きされる可能性があります。最初の引数として ``userPreferencesFile`` を指定すると，後続のオプションで上書きすることを意味します。最後の引数として指定すると以前のオプションを上書きすることを意味します。このオプションの背後にある根拠は，コマンドライン実行で SpotBugs Eclipse プロジェクトの設定を再利用するためです。"
 
 #: ../../ant.rst:198
 msgid "nested"
@@ -443,7 +441,7 @@ msgid ""
 "Optional attribute which enables or disables scanning of nested jar and "
 "zip files found in the list of files and directories to be analyzed. By "
 "default, scanning of nested jar/zip files is enabled."
-msgstr ""
+msgstr "オプション属性です。解析されるファイルとディレクトリのリストにあるネストされた jar/zip ファイルのスキャンを有効また無効にします。デフォルトでは，ネストされた jar/zip ファイルのスキャンが有効になっています。"
 
 #: ../../ant.rst:200
 msgid "setExitCode"
@@ -453,53 +451,5 @@ msgstr ""
 msgid ""
 "Optional boolean attribute. Whether the exit code will be returned to the"
 " main ant job. Defaults to ``true``."
-msgstr ""
-
-#~ msgid ""
-#~ msgstr ""
-
-#~ msgid "conserveSpace Synonym for effort=\"min\"."
-#~ msgstr ""
-
-#~ msgid "workHard Synonym for effort=\"max\"."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "warningsProperty Optional attribute which "
-#~ "specifies the name of a property "
-#~ "that will be set to \"true\" if"
-#~ " any warnings are reported by "
-#~ "FindBugs on the analyzed program."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "userPreferencesFile Optional attribute. Set "
-#~ "the path of the user preferences "
-#~ "file to use, which might override "
-#~ "some of the options abobe. Specifying"
-#~ " userPreferencesFile as first argument "
-#~ "would mean some later options will "
-#~ "override them, as last argument would"
-#~ " mean they will override some "
-#~ "previous options). This rationale behind "
-#~ "this option is to reuse FindBugs "
-#~ "Eclipse project settings for command "
-#~ "line execution."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "nested Optional attribute which enables "
-#~ "or disables scanning of nested jar "
-#~ "and zip files found in the list"
-#~ " of files and directories to be "
-#~ "analyzed. By default, scanning of nested"
-#~ " jar/zip files is enabled."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "setExitCode Optional boolean attribute. "
-#~ "Whether the exit code will be "
-#~ "returned to the main ant job. "
-#~ "Defaults to \"true\"."
-#~ msgstr ""
+msgstr "オプションのブール値属性です。終了コードがメインの ant ジョブに戻されるかどうか指定します。デフォルトは ``true`` です。"
 

--- a/docs/locale/ja/LC_MESSAGES/eclipse.po
+++ b/docs/locale/ja/LC_MESSAGES/eclipse.po
@@ -3,23 +3,21 @@
 # This file is distributed under the same license as the spotbugs package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
 #
-#, fuzzy
 msgid ""
-msgstr ""
-"Project-Id-Version: spotbugs 3.1\n"
+msgstr "Project-Id-Version: spotbugs 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-06 19:57+0000\n"
+"POT-Creation-Date: 2017-08-17 15:12+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
+"Generated-By: Babel 2.4.0\n"
 
 #: ../../eclipse.rst:2
 msgid "Using the SpotBugs Eclipse plugin"
-msgstr ""
+msgstr "SpotBugs Eclipseプラグインの使い方"
 
 #: ../../eclipse.rst:4
 msgid ""
@@ -27,28 +25,28 @@ msgid ""
 " IDE. The SpotBugs Eclipse plugin was generously contributed by Peter "
 "Friese. Phil Crosby and Andrey Loskutov contributed major improvements to"
 " the plugin."
-msgstr ""
+msgstr "SpotBugs Eclipseプラグインを使用すると SpotBugs を Eclipse IDE 内で使用できます。SpotBugs Eclipseプラグインは，Peter Friese 氏の多大なる貢献によるものです。Phil Crosby 氏と Andrey Loskutov 氏は，プラグインの大幅な改善に貢献しました。"
 
 #: ../../eclipse.rst:9
 msgid "Requirements"
-msgstr ""
+msgstr "必要条件"
 
 #: ../../eclipse.rst:11
 msgid ""
 "To use the SpotdBugs Plugin for Eclipse, you need Eclipse Neon (4.6) or "
 "later."
-msgstr ""
+msgstr "SpotdBugs Eclipse プラグインを使用するためには，Eclipse Neon (4.6) 以降が必要です。"
 
 #: ../../eclipse.rst:14
 msgid "Installation"
-msgstr ""
+msgstr "インストール"
 
 #: ../../eclipse.rst:16
 msgid ""
 "We provide update sites that allow you to automatically install SpotBugs "
 "into Eclipse and also query and install updates. There are three "
 "different update sites:"
-msgstr ""
+msgstr "私たちは，SpotBugs を Eclipse に自動的にインストールしたり，アップデートを照会してインストールもできる更新サイトを提供しています。3 つの異なる更新サイトがあります。"
 
 #: ../../eclipse.rst:20
 msgid "https://spotbugs.github.io/eclipse/"
@@ -56,7 +54,7 @@ msgstr ""
 
 #: ../../eclipse.rst:20
 msgid "Only provides official releases of SpotBugs Eclipse plugin."
-msgstr ""
+msgstr "SpotBugs Eclipse プラグインの公式リリースだけを提供します。"
 
 #: ../../eclipse.rst:23
 msgid "https://spotbugs.github.io/eclipse-candidate/"
@@ -66,7 +64,7 @@ msgstr ""
 msgid ""
 "Provides official releases and release candidates of SpotBugs Eclipse "
 "plugin."
-msgstr ""
+msgstr "SpotBugs Eclipse プラグインの公式リリースとリリース候補を提供します。"
 
 #: ../../eclipse.rst:26
 msgid "https://spotbugs.github.io/eclipse-latest/"
@@ -74,17 +72,17 @@ msgstr ""
 
 #: ../../eclipse.rst:26
 msgid "Provides latest SpotBugs Eclipse plugin built from master branch."
-msgstr ""
+msgstr "最新の SpotBugs Eclipse プラグインをマスターブランチからビルドします。"
 
 #: ../../eclipse.rst:28
 msgid ""
 "Or just use `Eclipse marketplace <https://marketplace.eclipse.org/content"
 "/spotbugs-eclipse-plugin>`_ to install SpotBugs Eclipse plugin."
-msgstr ""
+msgstr "または `Eclipse marketplace <https://marketplace.eclipse.org/content/spotbugs-eclipse-plugin>`_ を使って SpotBugs Eclipse プラグインをインストールします。"
 
 #: ../../eclipse.rst:31
 msgid "Using the Plugin"
-msgstr ""
+msgstr "プラグインの使い方"
 
 #: ../../eclipse.rst:33
 msgid ""
@@ -93,7 +91,7 @@ msgid ""
 "markers (displayed in source windows, and also in the Eclipse Problems "
 "view) will point to locations in your code which have been identified as "
 "potential instances of bug patterns."
-msgstr ""
+msgstr "開始するには，パッケージエクスプローラで Java プロジェクトを右クリックして，「Spot Bugs」というラベルの付いたオプションを選択します。SpotBugs が実行され，問題マーカー (ソースウインドウと Eclipse の問題ビューに表示されます) は，バグパターンの潜在的なインスタンスとして識別されたコード内の場所を示します。"
 
 #: ../../eclipse.rst:36
 msgid ""
@@ -103,21 +101,21 @@ msgid ""
 "in Package Explorer and select the option labeled \"Spot Bugs\". If you "
 "additionally configure the source code locations for the binaries, "
 "SpotBugs will also link the generated warnings to the right source files."
-msgstr ""
+msgstr "既存の Java アーカイブ (jar，ear，zip，war など) で SpotBugs を実行できます。空の Java プロジェクトを作成し，プロジェクトのクラスパスにアーカイブを追加するだけです。これで，パッケージエクスプローラでアーカイブノードを右クリックして，「SpotBugs」というラベルの付いたオプションを選択できます。さらに，バイナリのソースコードの場所を設定すると，SpotBugs は生成された警告を正しいソースファイルにリンクします。"
 
 #: ../../eclipse.rst:41
 msgid ""
 "You may customize how SpotBugs runs by opening the Properties dialog for "
 "a Java project, and choosing the \"SpotBugs\" property page. Options you "
 "may choose include:"
-msgstr ""
+msgstr "SpotBugs の実行方法をカスタマイズするには，Java プロジェクトのプロパティダイアログを開き，「SpotBugs」プロパティページを選択します。選択できるオプションは次のとおりです。"
 
 #: ../../eclipse.rst:44
 msgid ""
 "Enable or disable the \"Run SpotBugs Automatically\" checkbox. When "
 "enabled, SpotBugs will run every time you modify a Java class within the "
 "project."
-msgstr ""
+msgstr "「Run SpotBugs Automatically」チェックボックスを有効または無効にします。有効にすると，プロジェクト内の Java クラスを変更するたびに SpotBugs が実行されます。"
 
 #: ../../eclipse.rst:46
 msgid ""
@@ -126,24 +124,24 @@ msgid ""
 "\"Medium\" warning priority, only Medium and High priority warnings will "
 "be shown. Similarly, if you uncheck the \"Style\" checkbox, no warnings "
 "in the Style category will be displayed."
-msgstr ""
+msgstr "最低限の優先度を選択し，バグカテゴリを有効にします。これらのオプションは，表示される警告を選択します。たとえば，優先度で「Medium」を選択すると，優先度 (中) と優先度 (高) の警告だけが表示されます同様に，「Style」チェックボックスのチェックを外すと，Style カテゴリの警告は表示されません。"
 
 #: ../../eclipse.rst:48
 msgid ""
 "Select detectors. The table allows you to select which detectors you want"
 " to enable for your project."
-msgstr ""
+msgstr "ディテクタの選択。この表では，プロジェクトで有効にするディテクタを選択できます。"
 
 #: ../../eclipse.rst:51
 msgid "Extending the Eclipse Plugin (since 2.0.0)"
-msgstr ""
+msgstr "Eclipse プラグインの拡張 (2.0.0 以降)"
 
 #: ../../eclipse.rst:53
 msgid ""
 "Eclipse plugin supports contribution of custom SpotBugs detectors (see "
 "also AddingDetectors.txt for more information). There are two ways to "
 "contribute custom plugins to the Eclipse:"
-msgstr ""
+msgstr "Eclipse プラグインは，カスタム SpotBugs ディテクタの寄贈をサポートします (詳細については AddingDetectors.txt も参照してください)。カスタムプラグインを Eclipse に提供するには 2 つの方法があります。"
 
 #: ../../eclipse.rst:55
 msgid ""
@@ -155,13 +153,13 @@ msgid ""
 "quality of third party detectors. The drawback is that you have to apply "
 "this settings in each new Eclipse workspace, and this settings can't be "
 "shared between team members."
-msgstr ""
+msgstr "既存の標準 SpotBugs ディテクタパッケージは，``Window → Preferences → Java → FindBugs → Misc. Settings → Custom Detectors`` で設定できます。追加のプラグインの場所を指定するだけです。このソリューションの利点は，既存のディテクタパッケージを「そのまま」使用でき，サードパーティのディテクタの品質を迅速に検証でくることです。欠点は，新しい Eclipse ワークスペースごとにこの設定を適用する必要があり，この設定をチームメンバ間で共有できないことです。"
 
 #: ../../eclipse.rst:58
 msgid ""
 "It is possible to contribute custom detectors via standard Eclipse "
 "extensions mechanism."
-msgstr ""
+msgstr "標準の Eclipse 拡張機構を用いてカスタムディテクタを提供できます。"
 
 #: ../../eclipse.rst:60
 msgid ""
@@ -172,7 +170,7 @@ msgid ""
 "Usually you only need to add ``META-INF/MANIFEST.MF`` and ``plugin.xml`` "
 "to the jar and update your build scripts to not to override the "
 "``MANIFEST.MF`` during the build."
-msgstr ""
+msgstr "``eclipsePlugin/schema/detectorPlugins.exsd`` 拡張ポイントのドキュメントを参照して，plugin.xml の更新方法を確認してください。既存の SpotBugs ディテクタプラグインは，完全に機能する SpotBugs ディテクタプラグインになるように簡単に「拡張」できます。通常は，``META-INF/MANIFEST.MF`` と ``plugin.xml`` を jar ファイルに追加し，ビルド時に ``MANIFEST.MF`` を上書きしないようにビルドスクリプトを更新するだけです。"
 
 #: ../../eclipse.rst:64
 msgid ""
@@ -184,31 +182,31 @@ msgid ""
 "Another major differentiator is the ability to extend the default "
 "SpotBugs classpath at runtime with required third party libraries (see "
 "AddingDetectors.txt for more information)."
-msgstr ""
+msgstr "このソリューションの利点は，Eclipse インストールが共有されていれば，それぞれのチームメンバが正確に同じディテクタセットを持ち，何も設定する必要がないことです。(本当に小さな) 前提条件は，既存のディテクタパッケージを有効な Eclipse プラグインに変換しておくことです。サードパーティのディテクタでもこれを行うことができます。もうひとつの大きな違いは，実行時に必要なサードパーティのライブラリでデフォルトの SpotBugs クラスパスを拡張する能力です (詳細については AddingDetectors.txt を参照してください)。"
 
 #: ../../eclipse.rst:69
 msgid "Troubleshooting"
-msgstr ""
+msgstr "トラブルシューティング"
 
 #: ../../eclipse.rst:71
 msgid ""
 "This section lists common problems with the plugin and (if known) how to "
 "resolve them."
-msgstr ""
+msgstr "この節では，プラグインの一般的な問題と (既知の) 問題を解決する方法について説明します。"
 
 #: ../../eclipse.rst:73
 msgid ""
 "If you see OutOfMemory error dialogs after starting SpotBugs analysis in "
 "Eclipse, please increase JVM available memory: change ``eclipse.ini`` and"
 " add the lines below to the end of the file:"
-msgstr ""
+msgstr "Eclipse で SpotBugs の解析を開始した後に OutOfMemory エラーダイアログが表示されるときは，JVM の使用可能なメモリを増やしてください。``eclipse.ini`` を変更し次の行をファイルの最後に追加してください。"
 
 #: ../../eclipse.rst:81
 msgid ""
 "Important: the configuration arguments starting with the line ``-vmargs``"
 " must be last lines in the ``eclipse.ini`` file, and only one argument "
 "per line is allowed!"
-msgstr ""
+msgstr "重要: ``-vmargs`` 行から始まる設定引数は ``eclipse.ini`` ファイルの最後でなければならず，1 行につき 1 つの引数しか許されません!"
 
 #: ../../eclipse.rst:83
 msgid ""
@@ -216,20 +214,5 @@ msgid ""
 " in the Problems View), you may need to change your ``Problems View`` "
 "filter settings. See `FAQ <faq.html#q6-the-eclipse-plugin-loads-but-"
 "doesn-t-work-correctly>`__ for more information."
-msgstr ""
-
-#~ msgid ""
-#~ msgstr ""
-
-#~ msgid "..code::"
-#~ msgstr ""
-
-#~ msgid "See http://findbugs.sourceforge.net/FAQ.html#q7 for more information."
-#~ msgstr ""
-
-#~ msgid "-vmargs -Xmx1000m"
-#~ msgstr ""
-
-#~ msgid ">    -vmargs >    -Xmx1000m"
-#~ msgstr ""
+msgstr "SpotBugs の問題マーカーが (ソースファイルや問題ビューに) 表示されないときは，``問題ビュー`` のフィルタ設定を変更する必要があります。詳細は `FAQ <faq.html#q6-the-eclipse-plugin-loads-but-doesn-t-work-correctly>`__ を参照してください。"
 

--- a/docs/locale/ja/LC_MESSAGES/faq.po
+++ b/docs/locale/ja/LC_MESSAGES/faq.po
@@ -3,19 +3,17 @@
 # This file is distributed under the same license as the spotbugs package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
 #
-#, fuzzy
 msgid ""
-msgstr ""
-"Project-Id-Version: spotbugs 3.1\n"
+msgstr "Project-Id-Version: spotbugs 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-06-13 14:39+0000\n"
+"POT-Creation-Date: 2017-08-17 15:12+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
+"Generated-By: Babel 2.4.0\n"
 
 #: ../../faq.rst:2
 msgid "SpotBugs FAQ"
@@ -26,19 +24,19 @@ msgid ""
 "This document contains answers to frequently asked questions about "
 "SpotBugs. If you just want general information about SpotBugs, have a "
 "look at the manual."
-msgstr ""
+msgstr "このドキュメントには，SpotBugs に関する FAQ が含まれています。SpotBugs に関する一般的な情報だけが必要なときは，マニュアルをご覧ください。"
 
 #: ../../faq.rst:8
 msgid ""
 "Q1: I'm getting java.lang.UnsupportedClassVersionError when I try to run "
 "SpotBugs"
-msgstr ""
+msgstr "Q1: SpotBugs を実行しようとすると java.lang.UnsupportedClassVersionError が発生します。"
 
 #: ../../faq.rst:10
 msgid ""
 "SpotBugs requires JRE8 or later to run. If you use an earlier version, "
 "you will see an exception error message similar to the following:"
-msgstr ""
+msgstr "SpotBugs を実行するためには JRE8 以降が必要です。以前のバージョンを使用しているときは，次のような例外エラーメッセージが表示されます。"
 
 #: ../../faq.rst:13
 msgid ""
@@ -49,51 +47,51 @@ msgstr ""
 
 #: ../../faq.rst:16
 msgid "The solution is to upgrade to JRE8 or later."
-msgstr ""
+msgstr "解決方法は，JRE8 以降にアップグレードすることです。"
 
 #: ../../faq.rst:19
 msgid "Q2: SpotBugs is running out of memory, or is taking a long time to finish"
-msgstr ""
+msgstr "Q2: SpotBugs を実行するメモリが不足している，または終了するのに時間がかかる。"
 
 #: ../../faq.rst:21
 msgid ""
 "In general, SpotBugs requires lots of memory and a relatively fast CPU. "
 "For large applications, 1024M or more of heap space may be required."
-msgstr ""
+msgstr "一般的に，SpotBugs には多くのメモリと比較的高速な CPU が必要です。大規模なアプリケーションでは，1024M 以上のヒープ領域が必用になることがあります。"
 
 #: ../../faq.rst:24
 msgid ""
 "By default, SpotBugs allocates 768M of heap space. You can increase this "
 "using the ``-maxHeap n`` option, where n is the number of megabytes of "
 "heap space to allocate."
-msgstr ""
+msgstr "デフォルトでは，SpotBugs は 768M のヒープ領域を割り当てます。``-maxHeap n`` オプションを使用してヒープ領域を増やせます。n は割り当てるヒープ領域のメガバイト数です。"
 
 #: ../../faq.rst:28
 msgid "Q3: What is the \"auxiliary classpath\"? Why should I specify it?"
-msgstr ""
+msgstr "Q3: 「補助クラスパス」とは何ですか?なぜそれを指定すべきか?"
 
 #: ../../faq.rst:30
 msgid ""
 "Many important facts about a Java class require information about the "
 "classes that it references.  For example:"
-msgstr ""
+msgstr "Java クラスに関する重要な事実は，それが参照するクラスに関する情報を必要とします。たとえば:"
 
 #: ../../faq.rst:32
 msgid "What other classes and interfaces the class inherits from"
-msgstr ""
+msgstr "クラスが継承する他のクラスとインタフェース"
 
 #: ../../faq.rst:33
 msgid ""
 "What exceptions can be thrown by methods in external classes and "
 "interfaces"
-msgstr ""
+msgstr "外部クラスとインタフェース内のメソッドによってスローされる例外"
 
 #: ../../faq.rst:35
 msgid ""
 "The \"auxiliary classpath\" is a list of Jar files, directories, and "
 "class files containing classes that are used by the code you want "
 "SpotBugs to analyze, but should not themselves be analyzed by SpotBugs."
-msgstr ""
+msgstr "「補助クラスパス」は，SpotBugs で解析するコードで使用されるクラスを含む Jar ファイル，ディレクトリ，クラスのリストですが，SpotBugs によって解析されるべきではありません。"
 
 #: ../../faq.rst:37
 msgid ""
@@ -105,7 +103,7 @@ msgid ""
 "some bug detectors (such as the suspicious reference comparison detector)"
 " rely on being able to perform type inference, which requires complete "
 "type hierarchy information."
-msgstr ""
+msgstr "SpotBugs に被参照クラスに関する完全な情報がない場合，可能なかぎり正確な結果を生成できません。たとえは，被参照クラスの完全なリポジトリを持つことで，SpotBugs は制御フロー情報を削減できるので，実行時に実現性が最も高いメソッドを通じてパスに集中できます。また，疑わしい参照比較ディテクタなどのバグディテクタの中には完全な型階層情報を必要とする型推論を実行できるものがあります。"
 
 #: ../../faq.rst:41
 msgid ""
@@ -113,7 +111,7 @@ msgid ""
 "auxiliary classpath when you run SpotBugs. You can do this by using the "
 "``-auxclasspath`` command line option, or the \"Classpath entries\" list "
 "in the GUI project editor dialog."
-msgstr ""
+msgstr "これらの理由から，SpotBugs の実行時に補助クラスパスを完全に指定することを強くお勧めします。``-auxclasspath`` コマンドラインオプション，または GUI プロジェクトエディタダイアログの \"Classpath entries\" リストを使って設定できます。"
 
 #: ../../faq.rst:44
 msgid ""
@@ -121,17 +119,17 @@ msgid ""
 "print out a message when the analysis completes, specifying the classes "
 "that were missing. You should modify the auxiliary classpath to specify "
 "how to find the missing classes, and then run SpotBugs again."
-msgstr ""
+msgstr "SpotBugs がアプリケーションによって参照されるクラスを見つけられない場合，SpotBugs は解析が完了したときに見つからなかったクラスを指定してメッセージを出力します。補助クラスパスを変更して見つからなかったクラスを見つける方法を指定し，SpotBugs を再度実行する必要があります。"
 
 #: ../../faq.rst:49
 msgid "Q4: The Eclipse plugin doesn't load"
-msgstr ""
+msgstr "Q4: Eclipse プラグインがロードされない"
 
 #: ../../faq.rst:51
 msgid ""
 "The symptom of this problem is that Eclipse fails to load the SpotBugs UI"
 " plugin with the message:"
-msgstr ""
+msgstr "この問題の症状は，次のようなメッセージで Eclipse が SpotBugs UI プラグインをロードできないことです。"
 
 #: ../../faq.rst:53
 msgid ""
@@ -144,11 +142,11 @@ msgid ""
 "The reason for this problem is that the Eclipse plugin distributed with "
 "SpotBugs does not work with older 3.x versions of Eclipse. Please use "
 "Eclipse Neon (version 4.6) or newer."
-msgstr ""
+msgstr "この問題の原因は，SpotBugs で配布されている Eclipse プラグインが Eclipse の古い 3.x バージョンでは動作しないためです。Eclipse Neon (バージョン 4.6) 以降を使用してください。"
 
 #: ../../faq.rst:59
 msgid "Q5: I'm getting a lot of false \"OS\" and \"ODR\" warnings"
-msgstr ""
+msgstr "Q5: 多くの誤った \"OS\" と \"ODR\" 警告を受けています。"
 
 #: ../../faq.rst:61
 msgid ""
@@ -156,7 +154,7 @@ msgid ""
 "unchecked runtime exception. As a result, it may assume that an unchecked"
 " exception thrown out of the method could bypass a call to a ``close()`` "
 "method for a stream or database resource."
-msgstr ""
+msgstr "デフォルトでは，SpotBugs はメソッド呼び出しが非検査例外をスローする可能性があるとみなします。その結果，メソッドからスローされた非検査例外が，ストリームまたはデータベースリソースの ``close()`` メソッドへの呼び出しをバイパスできたと仮定するかもしれません。"
 
 #: ../../faq.rst:64
 msgid ""
@@ -164,31 +162,31 @@ msgid ""
 "``findbugs.workHard`` boolean analysis property to make SpotBugs work "
 "harder to prune unlikely exception edges. This generally reduces the "
 "number of false warnings, at the expense of slowing down the analysis."
-msgstr ""
+msgstr "``-workHard`` コマンドライン引数や ``findbugs.workHard`` ブール解析プロパティを使用して SpotBugs を動作させて，例外ではないエッジを削減できます。ほとんどの場合，誤った警告の数を減らせますが，解析を遅くするという犠牲を払います。"
 
 #: ../../faq.rst:68
 msgid "Q6: The Eclipse plugin loads, but doesn't work correctly"
-msgstr ""
+msgstr "Q6: Eclipse プラグインはロードされるが，正しく動作しません"
 
 #: ../../faq.rst:70
 msgid ""
 "Make sure the Java code you trying to analyze is built properly and has "
 "no classpath or compile errors."
-msgstr ""
+msgstr "解析しようしとている Java コードが正しく構築され，クラスパスやコンパイルエラーがないことを確認してください。"
 
 #: ../../faq.rst:71
 msgid ""
 "Make sure the project and workspace SpotBugs settings are valid - in "
 "doubt, revert them to defaults."
-msgstr ""
+msgstr "プロジェクトとワークスペースの SpotBugs 設定が有効であることを確認します。疑わしいときはデフォルトに戻してください。"
 
 #: ../../faq.rst:72
 msgid "Make sure the Error log view does not show errors."
-msgstr ""
+msgstr "エラーログビューにエラーが表示されていないことを確認します。"
 
 #: ../../faq.rst:75
 msgid "Q7: Where is the Maven plugin for SpotBugs?"
-msgstr ""
+msgstr "Q7: SpotBugs の Maven プラグインはどこにありますか?"
 
 #: ../../faq.rst:77
 msgid ""
@@ -196,5 +194,5 @@ msgid ""
 "<https://github.com/gleclaire/findbugs-maven-plugin/>`_. Please note that"
 " the Maven plugin is not maintained by the SpotBugs developers, so we "
 "can't answer questions about it."
-msgstr ""
+msgstr "SpotBugs の Maven プラグインは `ここ <https://github.com/gleclaire/findbugs-maven-plugin/>`_ にあります。Maven プラグインは，SpotBugs の開発者によって管理されていないので，私たちは質問に答えられません。"
 

--- a/docs/locale/ja/LC_MESSAGES/filter.po
+++ b/docs/locale/ja/LC_MESSAGES/filter.po
@@ -60,7 +60,7 @@ msgstr "``Match`` 要素には，述語を結合した子要素が含まれま�
 
 #: ../../filter.rst:26
 msgid "Types of Match clauses"
-msgstr "Match節の種類"
+msgstr "マッチング条件の種類"
 
 #: ../../filter.rst:29
 msgid "<Bug>"
@@ -97,7 +97,7 @@ msgid ""
 " may be used instead of <Bug> element. Each of these uses a name "
 "attribute for specifying accepted values list. Support for these elements"
 " may be removed in a future release."
-msgstr "下位互換の対策として，<Bug> 要素の代わりに <BugPattern> と <BugCode> 要素を使用できます。それぞれの要素は，受け入れられた値のリストを指定するための ``name`` 属性を使用します。\n"
+msgstr "下位互換性のために，<Bug> 要素の代わりに <BugPattern> と <BugCode> 要素を使用できます。それぞれの要素は，受け入れられた値のリストを指定するための ``name`` 属性を使用します。\n"
 "これらの要素のサポートは，将来のリリースで削除される可能性があります。"
 
 #: ../../filter.rst:41
@@ -111,7 +111,7 @@ msgid ""
 "confidence warnings, 2 to match normal-confidence warnings, or 3 to match"
 " low-confidence warnings. ``<Confidence>`` replaced ``<Priority>`` in "
 "2.0.0 release."
-msgstr "この要素は，警告を特定のバグ信頼度と照合します。``value`` 属性は，整数値でなければなりません。1 は信頼度 (高)，2 は信頼度 (中)，3 は信頼度 (低) の警告と一致します。2.0.0 リリースで，``<Confidence>`` は ``<Priority>`` に換えられました。"
+msgstr "この要素は，警告を特定のバグ信頼度と照合します。``value`` 属性は，整数値でなければなりません。1 は信頼度 (High)，2 は信頼度 (Medium)，3 は信頼度 (Low) の警告と一致します。2.0.0 リリースで，``<Confidence>`` は ``<Priority>`` に換えられました。"
 
 #: ../../filter.rst:46
 msgid "<Priority>"
@@ -119,7 +119,7 @@ msgstr ""
 
 #: ../../filter.rst:48
 msgid "Same as ``<Confidence>``, exists for backward compatibility."
-msgstr "``<Confidence>`` と同じですが，下位互換のために存在します。"
+msgstr "``<Confidence>`` と同じです。下位互換性を保つために残されています。"
 
 #: ../../filter.rst:51
 msgid "<Rank>"
@@ -130,7 +130,7 @@ msgid ""
 "This element matches warnings with a particular bug rank. The ``value`` "
 "attribute should be an integer value between 1 and 20, where 1 to 4 are "
 "scariest, 5 to 9 scary, 10 to 14 troubling, and 15 to 20 of concern bugs."
-msgstr "この要素は，警告を特定のバグランクと照合します。``value`` 属性は，1 から 20 までの整数値でなければなりません。1 から 4 は最も恐ろしいバグ， 5 から 9 は恐ろしいバグ， 10 から 14 は厄介なバグ， 15 から 20 は不安なバグを表します。"
+msgstr "この要素は，警告を特定のバグランクと照合します。``value`` 属性は，1 から 20 までの整数値でなければなりません。1 から 4 は恐るべきバグ， 5 から 9 は恐ろしいバグ， 10 から 14 は厄介なバグ， 15 から 20 は心配なバグを表します。"
 
 #: ../../filter.rst:56
 msgid "<Package>"
@@ -161,7 +161,7 @@ msgid ""
 " can use ``class`` attribute on a ``Match`` element to specify exact an "
 "class name or ``classregex`` attribute to specify a regular expression to"
 " match the class name against."
-msgstr "下位互換の対策として，この型の要素ではなく，``Match`` 要素の ``class`` 属性を使用して厳密なクラス名を指定したり，``classregex`` 属性を使用してクラス名と一致する正規表現を指定することもできます。"
+msgstr "下位互換性のために，<Class> 要素の代わりに ``Match`` 要素の ``class`` 属性を使用して厳密なクラス名を指定できます。また， ``classregex`` 属性を使用してクラス名と一致する正規表現を指定することもできます。"
 
 #: ../../filter.rst:67
 msgid ""
@@ -251,7 +251,7 @@ msgid ""
 "This element combines ``Match`` clauses as disjuncts. I.e., you can put "
 "two ``Method`` elements in an ``Or`` clause in order to match either "
 "method."
-msgstr "この要素は，``Match`` 節を論理和として組み合わせます。つまり，いずれかのメソッドと照合させるために 2 つの ``Method`` 要素を ``Or`` 節に入れられます。"
+msgstr "この要素は，マッチング条件を論理和として組み合わせます。つまり，いずれかのメソッドと照合させるために 2 つの ``Method`` 要素を ``Or`` 要素に入れられます。"
 
 #: ../../filter.rst:100
 msgid "<And>"
@@ -263,7 +263,7 @@ msgid ""
 "``true``. I.e., you can put ``Bug`` and ``Confidence`` elements in an "
 "``And`` clause in order to match specific bugs with given confidence "
 "only."
-msgstr "この要素は，``Match`` 節を論理積として組み合わせます。つまり特定のバグに与えられた信頼度だけと照合させるために  ``Bug`` と ``Confidence`` 要素を ``And`` 節に入れられます。"
+msgstr "この要素は，マッチング条件を論理積として組み合わせます。つまり，特定のバグに与えられた信頼度だけと照合させるために  ``Bug`` 要素と ``Confidence`` 要素を ``And`` 要素に入れられます。"
 
 #: ../../filter.rst:105
 msgid "<Not>"
@@ -274,7 +274,7 @@ msgid ""
 "This element inverts the included child ``Match``. I.e., you can put a "
 "``Bug`` element in a ``Not`` clause in order to match any bug excluding "
 "the given one."
-msgstr "この要素は，含まれている子要素の ``Match`` を反転させます。つまり与えられたバグ以外のバグと照合させるために ``Bug`` 要素を ``Not`` 節に入れられます。"
+msgstr "この要素は，含まれている子要素の ``Match`` を反転させます。つまり，与えられたバグ以外のバグと照合させるために ``Bug`` 要素を ``Not`` 要素に入れられます。"
 
 #: ../../filter.rst:110
 msgid "Java element name matching"
@@ -293,7 +293,7 @@ msgid ""
 "Note that the pattern is matched against whole element name and therefore"
 " ``.*`` clauses need to be used at pattern beginning and/or end to "
 "perform substring matching."
-msgstr "パターンは，要素名全体と照合されるので，部分文字列で照合をしたいときは，パターンの先頭や最後に ``.*`` 節を使用する必要があることに注意してください。"
+msgstr "パターンは，要素名全体と照合されるので，部分文字列で照合をしたいときは，パターンの先頭や最後に ``.*`` を使用する必要があることに注意してください。"
 
 #: ../../filter.rst:116
 msgid ""
@@ -323,7 +323,7 @@ msgid ""
 "suppress IC (initialization circularity) reports for classes "
 "\"com.foobar.A\" and \"com.foobar.B\", you would use two ``Match`` "
 "clauses:"
-msgstr "幾つかのバグインスタンスは 2 つか，それ以上のクラスを持っています。たとえば，DE (無視された例外) バグは，無視された例外が発生するメソッドを含むクラスと無視された例外の型を表すクラスの両方を報告します。*一番目* (主) のクラスだけが ``Match`` 節とマッチします。たとえば，クラス 「com.foobar.A」と「com.foobar.B」の IC (初期化時の循環) レポートを抑制したいときは，2 つの ``Match`` 節を使います。clauses:"
+msgstr "いくつかのバグインスタンスは 2 つか，それ以上のクラスを持っています。たとえば，DE (無視された例外) バグは，無視された例外が発生するメソッドを含むクラスと無視された例外の型を表すクラスの両方を報告します。*一番目* (主) のクラスだけがマッチング条件とマッチします。たとえば，クラス 「com.foobar.A」と「com.foobar.B」の IC (初期化時の循環) レポートを抑制したいときは，2 つの ``Match`` 要素を使用してマッチング条件を指定します。"
 
 #: ../../filter.rst:140
 msgid ""

--- a/docs/locale/ja/LC_MESSAGES/filter.po
+++ b/docs/locale/ja/LC_MESSAGES/filter.po
@@ -3,40 +3,38 @@
 # This file is distributed under the same license as the spotbugs package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
 #
-#, fuzzy
 msgid ""
-msgstr ""
-"Project-Id-Version: spotbugs 3.1\n"
+msgstr "Project-Id-Version: spotbugs 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-12 17:29+0000\n"
+"POT-Creation-Date: 2017-08-17 15:12+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
+"Generated-By: Babel 2.4.0\n"
 
 #: ../../filter.rst:2
 msgid "Filter file"
-msgstr ""
+msgstr "フィルタファイル"
 
 #: ../../filter.rst:4
 msgid ""
 "Filter files may be used to include or exclude bug reports for particular"
 " classes and methods. This chapter explains how to use filter files."
-msgstr ""
+msgstr "フィルタファイルを使用して，特定のクラスやメソッドのバグレポートに含めたり除外したりできます。この章では，フィルタファイルの使用方法について説明します。"
 
 #: ../../filter.rst:7
 msgid "Introduction to Filter Files"
-msgstr ""
+msgstr "フィルタファイルの概要"
 
 #: ../../filter.rst:9
 msgid ""
 "Conceptually, a filter matches bug instances against a set of criteria. "
 "By defining a filter, you can select bug instances for special treatment;"
 " for example, to exclude or include them in a report."
-msgstr ""
+msgstr "概念的には，フィルタはバグインスタンスを基準のセットと照合します。フィルタを定義することで，特別扱いのバグインスタンスを選択できます。たとえば，レポートに含めたり除外したりできます。"
 
 #: ../../filter.rst:12
 msgid ""
@@ -45,24 +43,24 @@ msgid ""
 "element represents a predicate which is applied to generated bug "
 "instances. Usually, a filter will be used to exclude bug instances. For "
 "example::"
-msgstr ""
+msgstr "フィルタファイルは，最上位の ``FindBugsFilter`` 要素を持つ XML 文書で，いくつかの ``Match`` 要素が子要素として含まれています。それぞれの ``Match`` 要素は，生成されたバグインスタンスに適用される述語を表します。通常，バグインスタンスを除外するためにフィルタが使用されます。たとえば::"
 
 #: ../../filter.rst:18
 msgid ""
 "However, a filter could also be used to select bug instances to "
 "specifically report::"
-msgstr ""
+msgstr "また一方で，具体的に報告するバグインスタンスを選択するためにフィルタを使用することもできます。"
 
 #: ../../filter.rst:22
 msgid ""
 "``Match`` elements contain children, which are conjuncts of the "
 "predicate. In other words, each of the children must be ``true`` for the "
 "predicate to be ``true``."
-msgstr ""
+msgstr "``Match`` 要素には，述語を結合した子要素が含まれます。言い換えれば，述語が ``真`` であるためには，それぞれの子要素も ``真`` でなければなりません。"
 
 #: ../../filter.rst:26
 msgid "Types of Match clauses"
-msgstr ""
+msgstr "Match節の種類"
 
 #: ../../filter.rst:29
 msgid "<Bug>"
@@ -75,7 +73,7 @@ msgid ""
 " You can find the bug pattern types for particular warnings by looking at"
 " the output produced by the **-xml** output option (the type attribute of"
 " BugInstance elements), or from the :doc:`bugDescriptions`."
-msgstr ""
+msgstr "この要素は，特定のバグパターンまたは一致するパターンを指定します。``pattern`` 属性は，コンマ区切りのバグパターンタイプのリストです。特定の警告のバグパターンタイプは **-xml** 出力オプション (BugInstance 要素の type 属性) によって生成された出力を調べることで見つけられます。または，:doc:`bugDescriptions` を参照してください。"
 
 #: ../../filter.rst:34
 msgid ""
@@ -84,14 +82,14 @@ msgid ""
 "matching use ``category`` attriute, that takes a comma separated list of "
 "bug category names: ``CORRECTNESS``, ``MT_CORRECTNESS``, "
 "``BAD_PRACTICICE``, ``PERFORMANCE``, ``STYLE``."
-msgstr ""
+msgstr "もっと粒度の粗い照合をしたいときは，``code`` 属性を使用します。コンマ区切りのバグ略語のリストを指定します。粒度の粗い照合では，``category`` 属性を使用してコンマ区切りのバグカテゴリのリストを指定します。バグカテゴリ名は，``CORRECTNESS``，``MT_CORRECTNESS``，``BAD_PRACTICICE``，``PERFORMANCE``，``STYLE`` です。"
 
 #: ../../filter.rst:36
 msgid ""
 "If more than one of the attributes mentioned above are specified on the "
 "same <Bug> element, all bug patterns that match either one of specified "
 "pattern names, or abreviations, or categories will be matched."
-msgstr ""
+msgstr "同じ <Bug> 要素に上記の属性が複数指定されていたときは，指定されたパターン名，略語，カテゴリのいずれかと一致するすべてのバグパターンが一致します。"
 
 #: ../../filter.rst:38
 msgid ""
@@ -99,7 +97,8 @@ msgid ""
 " may be used instead of <Bug> element. Each of these uses a name "
 "attribute for specifying accepted values list. Support for these elements"
 " may be removed in a future release."
-msgstr ""
+msgstr "下位互換の対策として，<Bug> 要素の代わりに <BugPattern> と <BugCode> 要素を使用できます。それぞれの要素は，受け入れられた値のリストを指定するための ``name`` 属性を使用します。\n"
+"これらの要素のサポートは，将来のリリースで削除される可能性があります。"
 
 #: ../../filter.rst:41
 msgid "<Confidence>"
@@ -112,7 +111,7 @@ msgid ""
 "confidence warnings, 2 to match normal-confidence warnings, or 3 to match"
 " low-confidence warnings. ``<Confidence>`` replaced ``<Priority>`` in "
 "2.0.0 release."
-msgstr ""
+msgstr "この要素は，警告を特定のバグ信頼度と照合します。``value`` 属性は，整数値でなければなりません。1 は信頼度 (高)，2 は信頼度 (中)，3 は信頼度 (低) の警告と一致します。2.0.0 リリースで，``<Confidence>`` は ``<Priority>`` に換えられました。"
 
 #: ../../filter.rst:46
 msgid "<Priority>"
@@ -120,7 +119,7 @@ msgstr ""
 
 #: ../../filter.rst:48
 msgid "Same as ``<Confidence>``, exists for backward compatibility."
-msgstr ""
+msgstr "``<Confidence>`` と同じですが，下位互換のために存在します。"
 
 #: ../../filter.rst:51
 msgid "<Rank>"
@@ -131,7 +130,7 @@ msgid ""
 "This element matches warnings with a particular bug rank. The ``value`` "
 "attribute should be an integer value between 1 and 20, where 1 to 4 are "
 "scariest, 5 to 9 scary, 10 to 14 troubling, and 15 to 20 of concern bugs."
-msgstr ""
+msgstr "この要素は，警告を特定のバグランクと照合します。``value`` 属性は，1 から 20 までの整数値でなければなりません。1 から 4 は最も恐ろしいバグ， 5 から 9 は恐ろしいバグ， 10 から 14 は厄介なバグ， 15 から 20 は不安なバグを表します。"
 
 #: ../../filter.rst:56
 msgid "<Package>"
@@ -143,7 +142,7 @@ msgid ""
 "specified using ``name`` attribute. Nested packages are not included "
 "(along the lines of Java import statement). However matching multiple "
 "packages can be achieved easily using regex name match."
-msgstr ""
+msgstr "この要素は，``name`` 属性で指定されたパッケージ内のクラスに関連した警告と照合します。ネストしたパッケージは含まれていません (Java import 文に従っています)。しかし，正規表現を使用すると複数のパッケージに一致させることが簡単に実現できます。"
 
 #: ../../filter.rst:61
 msgid "<Class>"
@@ -154,7 +153,7 @@ msgid ""
 "This element matches warnings associated with a particular class. The "
 "``name`` attribute is used to specify the exact or regex match pattern "
 "for the class name. The ``role`` attribute is the class role."
-msgstr ""
+msgstr "この要素は，特定のクラスに関連した警告と照合します。``name`` 属性は，クラス名の正確な正規表現パターンを指定するために使用されます。``role`` 属性はクラスの役割です。"
 
 #: ../../filter.rst:65
 msgid ""
@@ -162,7 +161,7 @@ msgid ""
 " can use ``class`` attribute on a ``Match`` element to specify exact an "
 "class name or ``classregex`` attribute to specify a regular expression to"
 " match the class name against."
-msgstr ""
+msgstr "下位互換の対策として，この型の要素ではなく，``Match`` 要素の ``class`` 属性を使用して厳密なクラス名を指定したり，``classregex`` 属性を使用してクラス名と一致する正規表現を指定することもできます。"
 
 #: ../../filter.rst:67
 msgid ""
@@ -171,7 +170,7 @@ msgid ""
 "classes. Such predicate is likely to match more bug instances than you "
 "want, unless it is refined further down with appropriate method or field "
 "predicates."
-msgstr ""
+msgstr "``Match`` 要素に ``Class`` 要素も ``class`` / ``classregex`` 属性も含まれていないときは，述語は全てのクラスに適用されます。そのような述語は適切なメソッドやフィールド述語を使用してさらに細かく分類されないかぎり，必要以上のバグインスタンスに一致する可能性があります。"
 
 #: ../../filter.rst:70
 msgid "<Source>"
@@ -182,7 +181,7 @@ msgid ""
 "This element matches warnings associated with a particular source file. "
 "The ``name`` attribute is used to specify the exact or regex match "
 "pattern for the source file name."
-msgstr ""
+msgstr "この要素は，特定のソースファイルに関連した警告と照合します。``name`` 属性は，ソースファイル名の正確な正規表現パターンを指定するために使用されます。"
 
 #: ../../filter.rst:75
 msgid "<Method>"
@@ -201,7 +200,7 @@ msgid ""
 "method signature. Note that you can provide either ``name`` attribute or "
 "``params`` and ``returns`` attributes or all three of them. This way you "
 "can provide various kinds of name and signature based matches."
-msgstr ""
+msgstr "この要素は，メソッドを指定します。``name`` 属性は，メソッド名の正確な正規表現パターンを指定するために使用されます。``params`` 属性は，メソッドパラメータの型のコンマ区切りリストです。``returns`` 属性は，メソッドの戻り値の型です。``role`` 属性は，メソッドの役割です。``params`` と ``returns`` はクラスの完全修飾名でなければなりません。(たとえば ``\"String\"`` ではなく ``\"java.lang.String\"`` を使用します。) 後者の属性のいずれかが指定されているときは，もう一方がメソッドシグネチャを作成するために必要です。``name`` 属性，``params`` と ``returns`` 属性，あるいはすべての属性を指定できます。このように，さまざまな種類の名前とシグネチャに基づく照合条件を指定できます。"
 
 #: ../../filter.rst:80
 msgid "<Field>"
@@ -215,7 +214,7 @@ msgid ""
 "fully qualified type of the field. You can specify either or both of "
 "these attributes in order to perform name / signature based matches. The "
 "``role`` attribute is the field role."
-msgstr ""
+msgstr "この要素は，フィールドを指定します。``name`` 属性は，フィールド名の正確な正規表現パターンを指定するために使用されます。シグネチャに基づいてフィールドをフィルタリングすることもできます。フィールドの完全修飾型を指定するためには ``type`` 属性を使用します。名前やシグネチャに基づいた照合を実行するために，これらの属性の一方または両方を指定できます。``role`` 属性はフィールドの役割です。"
 
 #: ../../filter.rst:85
 msgid "<Local>"
@@ -226,7 +225,7 @@ msgid ""
 "This element specifies a local variable. The ``name`` attribute is used "
 "to specify the exact or regex match pattern for the local variable name. "
 "Local variables are variables defined within a method."
-msgstr ""
+msgstr "この要素は，ローカル変数を指定します。``name`` 属性は，ローカル変数名の正確な正規表現パターンを指定するために使用されます。ローカル変数は，メソッド内で定義される変数です。"
 
 #: ../../filter.rst:90
 msgid "<Type>"
@@ -241,7 +240,7 @@ msgid ""
 "expression. The ``role`` attribute is the class role, and the "
 "``typeParameters`` is the type parameters. Both of ``role`` and "
 "``typeParameters`` are optional attributes."
-msgstr ""
+msgstr "この要素は，特定の型に関連した警告と照合します。``descriptor`` 属性は，型修飾子の正確な正規表現パターンを指定するために使用されます。ディスクリプタが ~ 文字で始まるときは，残りの属性コンテンツはJavaの正規表現として解釈されます。``role`` 属性は，クラスの役割です。``typeParameters`` 属性は，型パラメータです。``role`` と ``typeParameters`` はオプション属性です。"
 
 #: ../../filter.rst:95
 msgid "<Or>"
@@ -252,7 +251,7 @@ msgid ""
 "This element combines ``Match`` clauses as disjuncts. I.e., you can put "
 "two ``Method`` elements in an ``Or`` clause in order to match either "
 "method."
-msgstr ""
+msgstr "この要素は，``Match`` 節を論理和として組み合わせます。つまり，いずれかのメソッドと照合させるために 2 つの ``Method`` 要素を ``Or`` 節に入れられます。"
 
 #: ../../filter.rst:100
 msgid "<And>"
@@ -264,7 +263,7 @@ msgid ""
 "``true``. I.e., you can put ``Bug`` and ``Confidence`` elements in an "
 "``And`` clause in order to match specific bugs with given confidence "
 "only."
-msgstr ""
+msgstr "この要素は，``Match`` 節を論理積として組み合わせます。つまり特定のバグに与えられた信頼度だけと照合させるために  ``Bug`` と ``Confidence`` 要素を ``And`` 節に入れられます。"
 
 #: ../../filter.rst:105
 msgid "<Not>"
@@ -275,11 +274,11 @@ msgid ""
 "This element inverts the included child ``Match``. I.e., you can put a "
 "``Bug`` element in a ``Not`` clause in order to match any bug excluding "
 "the given one."
-msgstr ""
+msgstr "この要素は，含まれている子要素の ``Match``を反転させます。つまり与えられたバグ以外のバグと照合させるために ``Bug`` 要素を ``Not`` 節に入れられます。"
 
 #: ../../filter.rst:110
 msgid "Java element name matching"
-msgstr ""
+msgstr "Java 要素名との一致"
 
 #: ../../filter.rst:112
 msgid ""
@@ -287,32 +286,32 @@ msgid ""
 "``Field`` starts with the ``~`` character the rest of attribute content "
 "is interpreted as a Java regular expression that is matched against the "
 "names of the Java element in question."
-msgstr ""
+msgstr "``Class``，``Source``，``Method``，``Field`` の ``name`` 属性が ~ 文字で始まるときは，残りの属性コンテンツはJava要素名と照合されるJavaの正規表現として解釈されます。"
 
 #: ../../filter.rst:114
 msgid ""
 "Note that the pattern is matched against whole element name and therefore"
 " ``.*`` clauses need to be used at pattern beginning and/or end to "
 "perform substring matching."
-msgstr ""
+msgstr "パターンは，要素名全体と照合されるので，部分文字列で照合をしたいときは，パターンの先頭や最後に ``.*`` 節を使用する必要があることに注意してください。"
 
 #: ../../filter.rst:116
 msgid ""
 "See `java.util.regex.Pattern "
 "<https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html>`_"
 " documentation for pattern syntax."
-msgstr ""
+msgstr "パターン構文については `java.util.regex.Pattern <https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html>`_ を参照してください。"
 
 #: ../../filter.rst:119
 msgid "Caveats"
-msgstr ""
+msgstr "注意事項"
 
 #: ../../filter.rst:121
 msgid ""
 "``Match`` clauses can only match information that is actually contained "
 "in the bug instances. Every bug instance has a class, so in general, "
 "excluding bugs by class will work."
-msgstr ""
+msgstr "``Match`` 節は実際にバグインスタンスに含まれている情報にしかマッチできません。すべてのバグインスタンスにはクラスがあるので，一般的にクラスによるバグの除外はうまくいきます。"
 
 #: ../../filter.rst:124
 msgid ""
@@ -324,7 +323,7 @@ msgid ""
 "suppress IC (initialization circularity) reports for classes "
 "\"com.foobar.A\" and \"com.foobar.B\", you would use two ``Match`` "
 "clauses:"
-msgstr ""
+msgstr "幾つかのバグインスタンスは 2 つか，それ以上のクラスを持っています。たとえば，DE (無視された例外) バグは，無視された例外が発生するメソッドを含むクラスと無視された例外の型を表すクラスの両方を報告します。*一番目* (主) のクラスだけが ``Match`` 節とマッチします。たとえば，クラス 「com.foobar.A」と「com.foobar.B」の IC (初期化時の循環) レポートを抑制したいときは，2 つの ``Match`` 節を使います。clauses:"
 
 #: ../../filter.rst:140
 msgid ""
@@ -333,102 +332,74 @@ msgid ""
 "happens to be listed first in the bug instance. (Of course, this approach"
 " might accidentally supress circularities involving \"com.foobar.A\" or "
 "\"com.foobar.B\" and a third class.)"
-msgstr ""
+msgstr "両方のクラスを明示的に照合することで，循環に関与しているクラスがバグインスタンスで最初にリストされたとしても IC バグインスタンスがマッチすることを保証します。(もちろん，このアプローチでは，「com.foobar.A」または「com.foobar.B」と第 3 のクラスを含む循環が誤って抑制される可能性があります。)"
 
 #: ../../filter.rst:142
 msgid ""
 "Many kinds of bugs report what method they occur in. For those bug "
 "instances, you can put Method clauses in the Match element and they "
 "should work as expected."
-msgstr ""
+msgstr "さまざまな種類のバグは，どのようなメソッドで発生するかを報告します。これらのバグインスタンスに対しては，``Method`` 節を ``Match`` 要素に入れられるので，期待どおりに動作するはずです。"
 
 #: ../../filter.rst:145
 msgid "Examples"
-msgstr ""
+msgstr "例"
 
 #: ../../filter.rst:148
 msgid "Match all bug reports for a class"
-msgstr ""
+msgstr "特定のクラスに対するすべてのバグレポートと一致させる"
 
 #: ../../filter.rst:157
 msgid "Match certain tests from a class by specifying their abbreviations"
-msgstr ""
+msgstr "略語を指定してクラスから特定のテストと一致させる"
 
 #: ../../filter.rst:167
 msgid "Match certain tests from all classes by specifying their abbreviations"
-msgstr ""
+msgstr "略語を指定して，全てのクラスの特定のテストと一致させる"
 
 #: ../../filter.rst:176
 msgid "Match certain tests from all classes by specifying their category"
-msgstr ""
+msgstr "カテゴリを指定して，全てのクラスの特定のテストと一致させる"
 
 #: ../../filter.rst:185
 msgid "Match bug types from specified methods of a class by their abbreviations"
-msgstr ""
+msgstr "クラスのメソッドの略称を指定して，バグタイプと一致させる"
 
 #: ../../filter.rst:199
 msgid "Match a particular bug pattern in a particular method"
-msgstr ""
+msgstr "特定のメソッドで特定のバグパターンと一致させる"
 
 #: ../../filter.rst:211
 msgid ""
 "Match a particular bug pattern with a given priority in a particular "
 "method"
-msgstr ""
+msgstr "特定のメソッドで特定のバグパターンと優先度で一致させる"
 
 #: ../../filter.rst:224
 msgid ""
 "Match minor bugs introduced by AspectJ compiler (you are probably not "
 "interested in these unless you are an AspectJ developer)"
-msgstr ""
+msgstr "AspectJ コンパイラによって導入されたマイナーなバグに一致させる (AspectJ 開発者でないかぎり，おそらく関心がない)"
 
 #: ../../filter.rst:239
 msgid "Match bugs in specific parts of the code base"
-msgstr ""
+msgstr "コードベースの特定の部分と一致させる"
 
 #: ../../filter.rst:260
 msgid "Match bugs on fields or methods with specific signatures"
-msgstr ""
+msgstr "特定のシグネチャを持つフィールドやメソッドのバグに一致させる"
 
 #: ../../filter.rst:276
 msgid "Match bugs using the Not filter operator"
-msgstr ""
+msgstr "Not フィルタ演算子を使用してバグと一致させる"
 
 #: ../../filter.rst:294
 msgid ""
 "Full exclusion filter file to match all classes generated from Groovy "
 "source files"
-msgstr ""
+msgstr "Groovy ソースファイルから生成されたすべてのクラスに一致する完全除外フィルタファイル"
 
 #: ../../filter.rst:306
 msgid "Complete Example"
-msgstr ""
-
-#~ msgid ""
-#~ msgstr ""
-
-#~ msgid "<Match>"
-#~ msgstr ""
-
-#~ msgid "<Class name=\"com.foobar.A\" /> <Bug code=\"IC\" />"
-#~ msgstr ""
-
-#~ msgid "</Match>"
-#~ msgstr ""
-
-#~ msgid "<Class name=\"com.foobar.B\" /> <Bug code=\"IC\" />"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This element specifies a particular bug"
-#~ " ``pattern or patterns to match. The"
-#~ " ``pattern`` attribute is a comma-"
-#~ "separated list of bug pattern types. "
-#~ "You can find the bug pattern types"
-#~ " for particular warnings by looking "
-#~ "at the output produced by the "
-#~ "**-xml** output option (the type "
-#~ "attribute of BugInstance elements), or "
-#~ "from the :doc:`bugDescriotions`."
-#~ msgstr ""
+msgstr "完全な例"
 

--- a/docs/locale/ja/LC_MESSAGES/filter.po
+++ b/docs/locale/ja/LC_MESSAGES/filter.po
@@ -274,7 +274,7 @@ msgid ""
 "This element inverts the included child ``Match``. I.e., you can put a "
 "``Bug`` element in a ``Not`` clause in order to match any bug excluding "
 "the given one."
-msgstr "この要素は，含まれている子要素の ``Match``を反転させます。つまり与えられたバグ以外のバグと照合させるために ``Bug`` 要素を ``Not`` 節に入れられます。"
+msgstr "この要素は，含まれている子要素の ``Match`` を反転させます。つまり与えられたバグ以外のバグと照合させるために ``Bug`` 要素を ``Not`` 節に入れられます。"
 
 #: ../../filter.rst:110
 msgid "Java element name matching"

--- a/docs/locale/ja/LC_MESSAGES/gui.po
+++ b/docs/locale/ja/LC_MESSAGES/gui.po
@@ -3,47 +3,45 @@
 # This file is distributed under the same license as the spotbugs package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
 #
-#, fuzzy
 msgid ""
-msgstr ""
-"Project-Id-Version: spotbugs 3.1\n"
+msgstr "Project-Id-Version: spotbugs 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-06-09 13:58+0000\n"
+"POT-Creation-Date: 2017-08-17 15:12+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
+"Generated-By: Babel 2.4.0\n"
 
 #: ../../gui.rst:2
 msgid "Using the SpotBugs GUI"
-msgstr ""
+msgstr "SpotBugs GUI の使い方"
 
 #: ../../gui.rst:4
 msgid ""
 "This chapter describes how to use the SpotBugs graphical user interface "
 "(GUI)."
-msgstr ""
+msgstr "この章では，SpotBugs グラフィカルユーザインタフェース (GUI) の使い方について説明します。"
 
 #: ../../gui.rst:7
 msgid "Creating a Project"
-msgstr ""
+msgstr "プロジェクトの作成"
 
 #: ../../gui.rst:9
 msgid ""
 "After you have started SpotBugs using the ``spotbugs`` command, choose "
 "the ``File → New Project`` menu item. You will see a dialog which looks "
 "like this:"
-msgstr ""
+msgstr "``spotbugs`` コマンドを使って SpotBugs を起動したら，``File → New Project`` メニュー項目を選択します。次のようなダイアログが表示されます。"
 
 #: ../../gui.rst:14
 msgid ""
 "Use the \"Add\" button next to \"Classpath to analyze\" to select a Java "
 "archive file (zip, jar, ear, or war file) or directory containing java "
 "classes to analyze for bugs. You may add multiple archives/directories."
-msgstr ""
+msgstr "「Classpath to analyze」の横にある「Add」ボタンを使用して，バグを解析する Java アーカイブファイル (zip，jar，ear，war ファイル) または Java クラスを含むディレクトリを選択します。複数のアーカイブ/ディレクトリを追加できます。"
 
 #: ../../gui.rst:16
 msgid ""
@@ -54,7 +52,7 @@ msgid ""
 "For example, if your application is contained in the ``org.foobar.myapp``"
 " package, you should add the parent directory of the org directory to the"
 " source directory list for the project."
-msgstr ""
+msgstr "また，解析をする Java アーカイブのソースコードを含むディレクトリを追加することもできます。そうすると，SpotBugs は発生する可能性があるエラーを含むソースコードを強調表示できます。追加するソースディレクトリは，Java パッケージ階層のルートにする必要があります。たとえば，アプリケーションが ``org.foobar.myapp`` パッケージに含まれているときは，org ディレクトリの親ディレクトリをプロジェクトのソースディレクトリに追加する必要があります。"
 
 #: ../../gui.rst:18
 msgid ""
@@ -66,11 +64,11 @@ msgid ""
 "detectors in FindBugs make use of class hierarchy information, so you "
 "will get more accurate results if the entire class hierarchy is available"
 " which FindBugs performs its analysis."
-msgstr ""
+msgstr "もうひとつのオプションの手順は，追加する jar ファイルやディレクトリを「Auxiliary classpath locations」エントリとして追加することです。解析するアーカイブ/ディレクトリにも標準のランタイムクラスパスにも含まれていないクラスをアーカイブ/ディレクトリが参照しているときは追加する必要があります。SpotBugs のバグパターンディテクタの中には，クラス階層情報を利用するものがあるため，SpotBugs が解析を行うクラス階層全体が利用可能なら，より正確な結果が得られます。"
 
 #: ../../gui.rst:21
 msgid "Running the Analysis"
-msgstr ""
+msgstr "解析の実行"
 
 #: ../../gui.rst:23
 msgid ""
@@ -80,22 +78,22 @@ msgid ""
 "older computer, this may take quite a while (tens of minutes). A recent "
 "computer with ample memory will typically be able to analyze a large "
 "program in only a few minutes."
-msgstr ""
+msgstr "すべてのアーカイブ，ディレクトリ，ソースディレクトリを追加したら，「Analyze」ボタンをクリックして jar ファイルに含まれるクラスを解析します。古いコンピュータ上の巨大プロジェクトでは，かなりの時間 (数 10 分) かかることに注意してください。十分なメモリを備えた最近のコンピュータなら，大きなプログラムを数分で解析できます。"
 
 #: ../../gui.rst:26
 msgid "Browsing Results"
-msgstr ""
+msgstr "結果の閲覧"
 
 #: ../../gui.rst:28
 msgid "When the analysis completes, you will see a screen like the following:"
-msgstr ""
+msgstr "解析が完了すると，次のような画面が表示されます。"
 
 #: ../../gui.rst:32
 msgid ""
 "The upper left-hand pane of the window shows the bug tree; this is a "
 "hierarchical representation of all of the potential bugs detected in the "
 "analyzed Jar files."
-msgstr ""
+msgstr "ウィンドウの左上のペインにバグツリーが表示されます。これは，解析された jar ファイルで検出されたすべての潜在的なバグを階層的に表したものです。"
 
 #: ../../gui.rst:34
 msgid ""
@@ -106,7 +104,7 @@ msgid ""
 "the above example, the bug is a stream object that is not closed. The "
 "source code window highlights the line where the stream object is "
 "created."
-msgstr ""
+msgstr "上部ペインで特定のバグインスタンスを選択すると，下部ペインの「Details」タブにバグの説明が表示されます。さらに，右上のソースコードペインには，ソースが利用可能であれば，潜在的なバグが発生する場所のプログラムソースコードが表示されます。上記の例では，バグはクローズされていないストリームオブジェクトです。ソースコードウィンドウは，ストリームオブジェクトが作成された行を強調表示します。"
 
 #: ../../gui.rst:36
 msgid ""
@@ -114,11 +112,11 @@ msgid ""
 "into the text box just below the hierarchical view. You can type any "
 "information which you would like to record. When you load and save bug "
 "results files, the annotations are preserved."
-msgstr ""
+msgstr "バグインスタンスにテキストで注釈を追加できます。階層ビューのすぐ下にあるテキストボックスに注釈を入力します。記録しておきたい情報を入力できます。バグ結果ファイルをロード，保存したときに，注釈も保存されます。"
 
 #: ../../gui.rst:39
 msgid "Saving and Opening"
-msgstr ""
+msgstr "保存と開く"
 
 #: ../../gui.rst:41
 msgid ""
@@ -129,5 +127,5 @@ msgid ""
 " the jar file lists (\"FindBugs project file (.fbp)\") or just the "
 "results (\"FindBugs analysis file (.fba)\"). A saved file may be loaded "
 "with the ``File → Open...`` menu option."
-msgstr ""
+msgstr "``File → Save as...`` メニューオプションを使用するとユーザ作業を保存できます。指定した jar ファイルリストとすべてのバグ結果を含むユーザ作業を保存したいときは「Save as...」ダイアログのドロップダウンリストから「SpotBugs analysis results (.xml)」を選択します。jar ファイルリストだけを保存する (「FindBugs project file (.fbp)」)，結果だけを保存する (「FindBugs analysis file (.fba)」) オプションもあります。保存されたファイルは ``File → Open...`` メニューオプションでロードできます。"
 

--- a/docs/locale/ja/LC_MESSAGES/implement-plugin.po
+++ b/docs/locale/ja/LC_MESSAGES/implement-plugin.po
@@ -3,27 +3,25 @@
 # This file is distributed under the same license as the spotbugs package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
 #
-#, fuzzy
 msgid ""
-msgstr ""
-"Project-Id-Version: spotbugs 3.1\n"
+msgstr "Project-Id-Version: spotbugs 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-07-02 06:48+0000\n"
+"POT-Creation-Date: 2017-08-17 15:12+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
+"Generated-By: Babel 2.4.0\n"
 
 #: ../../implement-plugin.rst:2
 msgid "Implement SpotBugs plugin"
-msgstr ""
+msgstr "SpotBugs プラグインの実装"
 
 #: ../../implement-plugin.rst:5
 msgid "Create Maven project"
-msgstr ""
+msgstr "Maven プロジェクトの作成"
 
 #: ../../implement-plugin.rst:7
 msgid ""
@@ -31,11 +29,11 @@ msgid ""
 "archetype>`_ to create Maven project. Then Maven archetype plugin will "
 "ask you to decide plugin's groupId, artifactId, package and initial "
 "version."
-msgstr ""
+msgstr "`spotbugs-archetype <https://github.com/spotbugs/spotbugs-archetype>`_ を使って Maven プロジェクトを作成してください。Maven archetype プラグインは，プラグインの groupId，artifactId，package，initial version を決定するように求めます。"
 
 #: ../../implement-plugin.rst:18
 msgid "Write java code to represent bug to find"
-msgstr ""
+msgstr "見つけたいバグを表すコードを書く"
 
 #: ../../implement-plugin.rst:20
 msgid ""
@@ -44,17 +42,17 @@ msgid ""
 "archetype-0.1.0/src/main/resources/archetype-"
 "resources/src/test/java/BadCase.java>`_. Update this file to represent "
 "the target bug to find."
-msgstr ""
+msgstr "生成されたプロジェクトでは  `BadCase.java <https://github.com/spotbugs/spotbugs-archetype/blob/spotbugs-archetype-0.1.0/src/main/resources/archetype-resources/src/test/java/BadCase.java>`_ という名前のファイルを見つけられます。見つけたい対象のバグを表すようにこのファイルを更新します。"
 
 #: ../../implement-plugin.rst:23 ../../implement-plugin.rst:45
 msgid ""
 "If you have multiple patterns to represent, add more classes into "
 "``src/test/java`` directory."
-msgstr ""
+msgstr "表現するパターンが複数あるときは，``src/test/java`` ディレクトリにクラスを追加してください。"
 
 #: ../../implement-plugin.rst:27
 msgid "Write test case to ensure your detector can find bug"
-msgstr ""
+msgstr "ディテクタがバグを見つけられるようにテストケースを書く"
 
 #: ../../implement-plugin.rst:29
 msgid ""
@@ -65,7 +63,7 @@ msgid ""
 "``spotbugs.performAnalysis(Path)`` in this test runs SpotBugs with your "
 "plugin, and return all found bugs (here 1st argument of this method is a "
 "path of class file compiled from ``BadCase.java``)."
-msgstr ""
+msgstr "生成されたプロジェクトでは `MyDetectorTest.java <https://github.com/spotbugs/spotbugs-archetype/blob/spotbugs-archetype-0.1.0/src/main/resources/archetype-resources/src/test/java/MyDetectorTest.java>`_ という名前の別のファイルを見つけられます。このテストの ``spotbugs.performAnalysis(Path)`` はプラグインがある SpotBugs を実行し，見つかったバグをすべて返します (このメソッドの第 1 引数は ``BadCase.java`` からコンパイルされたクラスファイルのパスです)。"
 
 #: ../../implement-plugin.rst:32
 msgid ""
@@ -73,23 +71,23 @@ msgid ""
 "<https://github.com/spotbugs/spotbugs/blob/master/test-"
 "harness/src/main/java/edu/umd/cs/findbugs/test/matcher/BugInstanceMatcher.java>`_"
 " to verify that your plugin can find bug as expected."
-msgstr ""
+msgstr "`BugInstanceMatcher <https://github.com/spotbugs/spotbugs/blob/master/test-harness/src/main/java/edu/umd/cs/findbugs/test/matcher/BugInstanceMatcher.java>`_ でプラグインが期待したとおりにバグを見つけられることを確認します。"
 
 #: ../../implement-plugin.rst:34
 msgid ""
 "Currently this test should fail, because we've not updated detector "
 "itself yet."
-msgstr ""
+msgstr "現在このテストは失敗するはずです。なぜなら，まだディテクタを更新していないからです。"
 
 #: ../../implement-plugin.rst:38
 msgid "Write java code to avoid false-positive"
-msgstr ""
+msgstr "誤検出を回避するためのコードを書く"
 
 #: ../../implement-plugin.rst:40
 msgid ""
 "To avoid false-positive, it is good to ensure that in which case detector"
 " should NOT find bug."
-msgstr ""
+msgstr "誤検出を回避するために，どのようなときにディテクタがバグを見つけるべきでないかを確認することは良いことです。"
 
 #: ../../implement-plugin.rst:42
 msgid ""
@@ -98,15 +96,15 @@ msgid ""
 "resources/src/test/java/GoodCase.java>`_ in your project, and represent "
 "such cases. After that, add a test method into ``MyDetectorTest.java`` "
 "which verify that no bug found from this ``GoodCase`` class."
-msgstr ""
+msgstr "プロジェクトの `GoodCase.java <https://github.com/spotbugs/spotbugs-archetype/blob/spotbugs-archetype-0.1.0/src/main/resources/archetype-resources/src/test/java/GoodCase.java>`_ を更新して，そのような例を表します。その後，``MyDetectorTest.java`` にテストメソッドを追加して，この ``GoodCase`` クラスからバグが見つからないことを確認します。"
 
 #: ../../implement-plugin.rst:49
 msgid "Update detector to pass all unit tests"
-msgstr ""
+msgstr "すべての単体試験に合格するようにディテクタを更新する"
 
 #: ../../implement-plugin.rst:51
 msgid "Now you have tests to ensure that your detector can work as expected."
-msgstr ""
+msgstr "これで，ディテクタが期待どおりに動作することを確認するテストが実施されました。"
 
 #: ../../implement-plugin.rst:55
 msgid "TBU"
@@ -114,7 +112,7 @@ msgstr ""
 
 #: ../../implement-plugin.rst:59
 msgid "Which super class you should choose"
-msgstr ""
+msgstr "選ぶべきスーパークラス"
 
 #: ../../implement-plugin.rst:62
 msgid ""
@@ -126,7 +124,7 @@ msgstr ""
 msgid ""
 "Base detector which analyzes annotations on classes, fields, methods, and"
 " method parameters."
-msgstr ""
+msgstr "クラス，フィールド，メソッド，メソッドパラメータに関するアノテーションを解析するベースディテクタです。"
 
 #: ../../implement-plugin.rst:65
 msgid ""
@@ -136,7 +134,7 @@ msgstr ""
 
 #: ../../implement-plugin.rst:65
 msgid "Base detector which analyzes java bytecode in class files."
-msgstr ""
+msgstr "クラスファイル内の Java バイトコードを解析するベースディテクタです。"
 
 #: ../../implement-plugin.rst:69
 msgid ""
@@ -149,34 +147,34 @@ msgid ""
 "Sub class of ``BytecodeScanningDetector``, which can scan the bytecode of"
 " a method and use an `operand stack "
 "<https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-2.html#jvms-2.6.2>`_."
-msgstr ""
+msgstr "``BytecodeScanningDetector`` のサブクラスです。メソッドのバイトコードをスキャンし，`operand stack <https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-2.html#jvms-2.6.2>`_ を使用できます。"
 
 #: ../../implement-plugin.rst:72
 msgid "Update findbugs.xml"
-msgstr ""
+msgstr "findbugs.xml の更新"
 
 #: ../../implement-plugin.rst:74
 msgid ""
 "SpotBugs reads ``findbugs.xml`` in each plugin to find detectors and "
 "bugs. So when you add new detector, you need to add new ``<Detector>`` "
 "element like below:"
-msgstr ""
+msgstr "SpotBugs は，それぞれのプラグインで ``findbugs.xml`` を読み出してディテクタとバグを見つけます。したがって，新しいディテクタを追加するときは，次のように新しい ``<Detector>`` 要素を追加する必要があります。"
 
 #: ../../implement-plugin.rst:81
 msgid ""
 "It is also necessary to add ``<BugPattern>``, to describe type and "
 "category of your bug pattern."
-msgstr ""
+msgstr "また，バグパターンのタイプとカテゴリを記述するために ``<BugPattern>`` を追加する必要があります。"
 
 #: ../../implement-plugin.rst:87
 msgid ""
 "You can find ``findbugs.xml`` in ``src/main/resources`` directory of "
 "generated Maven project."
-msgstr ""
+msgstr "生成された Maven プロジェクトの ``src/main/resources`` ディレクトリに ``findbugs.xml`` があります。"
 
 #: ../../implement-plugin.rst:92
 msgid "Update messages.xml"
-msgstr ""
+msgstr "messages.xml の更新"
 
 #: ../../implement-plugin.rst:94
 msgid ""
@@ -184,33 +182,33 @@ msgid ""
 "readable message to report detected bug. It also supports reading "
 "localized messages from ``messages_ja.xml``, ``messages_fr.xml`` and so "
 "on."
-msgstr ""
+msgstr "SpotBugs は，それぞれのプラグインで ``messages.xml`` を読み出し，検出されたバグを報告するための人間が読めるメッセージを作成します。また，``messages_ja.xml``，``messages_fr.xml`` などローカライズされたメッセージを読み出すこともサポートしています。"
 
 #: ../../implement-plugin.rst:97
 msgid ""
 "You can find ``messages.xml`` in ``src/main/resources`` directory of "
 "generated Maven project."
-msgstr ""
+msgstr "生成された Maven プロジェクトの ``src/main/resources`` ディレクトリに ``messages.xml`` があります。"
 
 #: ../../implement-plugin.rst:100
 msgid "Update message of Detector"
-msgstr ""
+msgstr "ディテクタのメッセージの更新"
 
 #: ../../implement-plugin.rst:102
 msgid ""
 "In ``<Detector>`` element, you can add detector's description message. "
 "Note that it should be plain text, HTML is not supported."
-msgstr ""
+msgstr "``<Detector>`` 要素には，ディテクタを説明するメッセージを追加できます。メッセージはプレーンテキストでなければならず，HTMLはサポートされていないので注意してください。"
 
 #: ../../implement-plugin.rst:113
 msgid "Update message of Bug Pattern"
-msgstr ""
+msgstr "バグパターンのメッセージの更新"
 
 #: ../../implement-plugin.rst:115
 msgid ""
 "In ``<BugPattern>`` element, you can add bug pattern's description "
 "message. There are three kinds of messages:"
-msgstr ""
+msgstr "``<BugPattern>`` 要素には，バグパターンを説明するメッセージを追加できます。3 種類のメッセージがります。"
 
 #: ../../implement-plugin.rst:120
 msgid "ShortDescription"
@@ -220,7 +218,7 @@ msgstr ""
 msgid ""
 "Short description for bug pattern. Useful to tell its intent and "
 "character for users. It should be plain text, HTML is not supported."
-msgstr ""
+msgstr "バグパターンの簡単な説明です。ユーザの意図やキャラクタを伝えるのに便利です。プレーンテキストでなければならず，HTMLはサポートされていません。"
 
 #: ../../implement-plugin.rst:127
 msgid "LongDescription"
@@ -233,11 +231,11 @@ msgid ""
 "<https://javadoc.io/page/com.github.spotbugs/spotbugs/latest/edu/umd/cs/findbugs/BugInstance.html>`_"
 " will be inserted at there. So this ``LongDescription`` is useful to tell"
 " detailed information about detected bug."
-msgstr ""
+msgstr "バグパターンのより長い説明です。``{0}`` (0 はインデックス) のようなプレースホルダを使うことができ，`BugInstance <https://javadoc.io/page/com.github.spotbugs/spotbugs/latest/edu/umd/cs/findbugs/BugInstance.html>`_ がそこに挿入されます。この ``LongDescription`` は検出されたバグの詳細情報を伝えるのに便利です。"
 
 #: ../../implement-plugin.rst:127
 msgid "It should be plain text, HTML is not supported."
-msgstr ""
+msgstr "プレーンテキストでなければならず，HTMLはサポートされていません。"
 
 #: ../../implement-plugin.rst:130
 msgid "Details"
@@ -248,17 +246,5 @@ msgid ""
 "Detailed description for bug pattern. It should be HTML format, so this "
 "is useful to tell detailed specs/examples with table, list and code "
 "snippets."
-msgstr ""
-
-#~ msgid ""
-#~ msgstr ""
-
-#~ msgid "Update findbugs.xml and messages.xml"
-#~ msgstr ""
-
-#~ msgid "Write java codes to represent bug to find"
-#~ msgstr ""
-
-#~ msgid "Write java codes to avoid false-positive"
-#~ msgstr ""
+msgstr "バグパターンの詳細な説明です。HTML 形式でなければなりません。詳細な仕様/例を表，リスト，コードスニペットで伝えるのに便利です。"
 

--- a/docs/locale/ja/LC_MESSAGES/index.po
+++ b/docs/locale/ja/LC_MESSAGES/index.po
@@ -1,25 +1,23 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2016, spotbugs community
+# Copyright (C) 2016-2017, spotbugs community
 # This file is distributed under the same license as the spotbugs package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2016.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
 #
-#, fuzzy
 msgid ""
-msgstr ""
-"Project-Id-Version: spotbugs 3.1\n"
+msgstr "Project-Id-Version: spotbugs 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-06-28 18:11+0000\n"
+"POT-Creation-Date: 2017-08-17 15:12+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
+"Generated-By: Babel 2.4.0\n"
 
 #: ../../index.rst:7
 msgid "SpotBugs manual"
-msgstr ""
+msgstr "SpotBugs マニュアル"
 
 #: ../../index.rst:9
 msgid ""
@@ -27,17 +25,17 @@ msgid ""
 "NonCommercial-ShareAlike License. To view a copy of this license, visit "
 "http://creativecommons.org/licenses/by-nc-sa/1.0/ or send a letter to "
 "Creative Commons, 559 Nathan Abbott Way, Stanford, California 94305, USA."
-msgstr ""
+msgstr "このマニュアルは Creative Commons Attribution-NonCommercial-ShareAlike License の下で使用許諾されています。この使用許諾のコピーを見るためには http://creativecommons.org/licenses/by-nc-sa/1.0/ を参照するか Creative Commons, 559 Nathan Abbott Way, Stanford, California 94305, USA に書簡を送付してください。"
 
 #: ../../index.rst:12
 msgid ""
 "The name FindBugs and the FindBugs logo are trademarked by the University"
 " of Maryland."
-msgstr ""
+msgstr "FindBugs という名称と FindBugs のロゴはメリーランド大学の商標です。"
 
 #: ../../index.rst:15
 msgid "Indices and tables"
-msgstr ""
+msgstr "索引とテーブル"
 
 #: ../../index.rst:17
 msgid ":ref:`search`"
@@ -45,8 +43,5 @@ msgstr ""
 
 #: ../../index.rst:20
 msgid "Contents"
-msgstr ""
-
-#~ msgid ":ref:`genindex`"
-#~ msgstr ""
+msgstr "目次"
 

--- a/docs/locale/ja/LC_MESSAGES/installing.po
+++ b/docs/locale/ja/LC_MESSAGES/installing.po
@@ -1,21 +1,19 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2016, spotbugs community
+# Copyright (C) 2016-2017, spotbugs community
 # This file is distributed under the same license as the spotbugs package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2016.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
 #
-#, fuzzy
 msgid ""
-msgstr ""
-"Project-Id-Version: spotbugs 3.1\n"
+msgstr "Project-Id-Version: spotbugs 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-16 03:44+0000\n"
+"POT-Creation-Date: 2017-08-17 15:12+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
+"Generated-By: Babel 2.4.0\n"
 
 #: ../../installing.rst:2
 msgid "Installing"
@@ -23,11 +21,11 @@ msgstr "インストール"
 
 #: ../../installing.rst:4
 msgid "This chapter explains how to install SpotBugs."
-msgstr "この章ではSpotBugsのインストール方法を説明します。"
+msgstr "この章では，SpotBugs のインストール方法を説明します。"
 
 #: ../../installing.rst:7
 msgid "Extracting the Distribution"
-msgstr "配布パッケージの展開"
+msgstr "配布物の展開"
 
 #: ../../installing.rst:9
 msgid ""
@@ -38,20 +36,17 @@ msgid ""
 "<http://repo.maven.apache.org/maven2/com/github/spotbugs/spotbugs/3.1.0-RC5/spotbugs-3.1.0-RC5.zip>`_."
 " Once you have downloaded a binary distribution, extract it into a "
 "directory of your choice."
-msgstr ""
+msgstr "SpotBugs をインストールする最も簡単な方法は，バイナリ配布物をダウンロードすることです。バイナリ配布物は `gzipped tar 形式 <http://repo.maven.apache.org/maven2/com/github/spotbugs/spotbugs/3.1.0-RC5/spotbugs-3.1.0-RC5.tgz>`_ と `zip 形式 <http://repo.maven.apache.org/maven2/com/github/spotbugs/spotbugs/3.1.0-RC5/spotbugs-3.1.0-RC5.zip>`_ がそれぞれ入手可能です。バイナリ配布物をダウンロードしたら，任意のディレクトリに展開します。"
 
 #: ../../installing.rst:13
-#, fuzzy
 msgid "Extracting a gzipped tar format distribution::"
-msgstr "gzipped tar の展開方法例："
+msgstr "gzipped tar 形式の展開方法例::"
 
 #: ../../installing.rst:17
-#, fuzzy
 msgid "Extracting a zip format distribution::"
-msgstr "zipフォーマットの展開方法例："
+msgstr "zip 形式の展開方法例::"
 
 #: ../../installing.rst:21
-#, fuzzy
 msgid ""
 "Usually, extracting a binary distribution will create a directory ending "
 "in ``spotbugs-3.1.0-RC5``. For example, if you extracted the binary "
@@ -60,26 +55,5 @@ msgid ""
 "``C:\\Software\\spotbugs-3.1.0-RC5``. This directory is the SpotBugs home"
 " directory. We'll refer to it as ``$SPOTBUGS_HOME`` (or "
 "``%SPOTBUGS_HOME%`` for Windows) throughout this manual."
-msgstr ""
-"バイナリ配布物の展開すると、通常は spotbugs-3.1.0-dev-20161105-d07b50f "
-"ディレクトリーが作成されます。例えば、ディレクトリー C:\\Software でバイナリ配布物を展開すると、ディレクトリー "
-"C:\\Software\\findbugs-3.1.0-dev-20161105-d07b50f に FindBugs "
-"は展開されます。このディレクトリーが FindBugs のホームディレクトリーになります。このマニュアルでは、このホームディレクトリーを "
-"$FINDBUGS_HOME (Windowsでは %FINDBUGS_HOME%) を用いて参照します。"
-
-#~ msgid ""
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The easiest way to install SpotBugs "
-#~ "is to download a binary distribution."
-#~ " Binary distributions are available in "
-#~ "`gzipped tar format "
-#~ "<http://repo.maven.apache.org/maven2/com/github/spotbugs/spotbugs/3.1.0-RC4/spotbugs-3.1.0-RC4.tgz>`_"
-#~ " and `zip format "
-#~ "<http://repo.maven.apache.org/maven2/com/github/spotbugs/spotbugs/3.1.0-RC4/spotbugs-3.1.0-RC4.zip>`_."
-#~ " Once you have downloaded a binary"
-#~ " distribution, extract it into a "
-#~ "directory of your choice."
-#~ msgstr ""
+msgstr "バイナリ配布物を展開すると，通常は ``spotbugs-3.1.0-RC5`` で終わるディレクトリが作成されます。たとえば，``C:\\Software`` ディレクトリでバイナリ配布物を展開すると，SpotBugs ソフトウェアは ``C:\\Software\\spotbugs-3.1.0-RC5`` ディレクトリに展開されます。このディテクトリが SpotBugs のホームディレクトリになります。このマニュアルでは，``$SPOTBUGS_HOME`` (Windows では ``%SPOTBUGS_HOME%``) と呼びます。"
 

--- a/docs/locale/ja/LC_MESSAGES/introduction.po
+++ b/docs/locale/ja/LC_MESSAGES/introduction.po
@@ -1,21 +1,19 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2016, spotbugs community
+# Copyright (C) 2016-2017, spotbugs community
 # This file is distributed under the same license as the spotbugs package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2016.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
 #
-#, fuzzy
 msgid ""
-msgstr ""
-"Project-Id-Version: spotbugs 3.1\n"
+msgstr "Project-Id-Version: spotbugs 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-16 03:44+0000\n"
+"POT-Creation-Date: 2017-08-17 15:12+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
+"Generated-By: Babel 2.4.0\n"
 
 #: ../../introduction.rst:2
 msgid "Introduction"
@@ -26,22 +24,16 @@ msgid ""
 "SpotBugs is a program to find bugs in Java programs. It looks for "
 "instances of \"bug patterns\" --- code instances that are likely to be "
 "errors."
-msgstr ""
-"SpotBugs は、Java プログラムの中のバグを見つけるプログラムです。このプログラムは、「バグ パターン」の実例を探します。「バグ "
-"パターン」とは、エラーとなる可能性の高いコードの事例です。"
+msgstr "SpotBugs は，Java プログラムの中のバグを見つけるプログラムです。このプログラムは「バグパターン」のインスタンスを探します。「バグパターン」とは，エラーとなる可能性の高いコードのインスタンスです。"
 
 #: ../../introduction.rst:7
-#, fuzzy
 msgid ""
 "This document describes version 3.1.0-RC5 of SpotBugs. We are very "
 "interested in getting your feedback on SpotBugs. Please visit the "
 "SpotBugs web page for the latest information on SpotBugs, contact "
 "information, and support resources such as information about the SpotBugs"
 " GitHub organization."
-msgstr ""
-"この文書は、SpotBugs バージョン 3.1.0-dev-20161105-d07b50f について説明してます。私たちは、 SpotBugs"
-" に対するフィードバックを心待ちにしています。どうぞ、 SpotBugs Web ページ にアクセスしてください。SpotBugs "
-"についての最新情報、連絡先および SpotBugs GitHub Organizationなどのサポート情報を入手することができます。"
+msgstr "この文書では，SpotBugs のバージョン 3.1.0-RC5 について説明します。私たちは，SpotBugs に対するフィードバックを心待ちにしています。SpotBugs の最新情報，連絡先，SpotBugs GitHub 組織に関する情報などのサポートリソースは SpotBugs のウェブページを参照してください。"
 
 #: ../../introduction.rst:12
 msgid "Requirements"
@@ -52,15 +44,11 @@ msgid ""
 "To use SpotBugs, you need a runtime environment compatible with Java "
 "version 1.8 or later. SpotBugs is platform independent, and is known to "
 "run on GNU/Linux, Windows, and MacOS X platforms."
-msgstr ""
-"SpotBugs を使用するには、 Java バージョン 1.8 以降のバージョンと互換性のあるランタイム環境が必要です。SpotBugs "
-"は、プラットフォーム非依存であり、 GNU/Linux 、 Windows 、 MacOS X プラットフォーム上で動作することが知られています。"
+msgstr "SpotBugs を使うためには，Java バージョン 1.8 以降のバージョンと互換性のあるランタイム環境が必要です。SpotBugs は，プラットフォームに依存せず，GNU/Linux，Windows，MacOS X で動作することが知られています。"
 
 #: ../../introduction.rst:17
 msgid ""
 "You should have at least 512 MB of memory to use SpotBugs. To analyze "
 "very large projects, more memory may be needed."
-msgstr ""
-"SpotBugs を使用するためには、少なくとも 512 MB "
-"のメモリが必要です。巨大なプロジェクトを解析するためには、それより多くのメモリが必要とされることがあります。"
+msgstr "SpotBugs を使うためには，少なくとも 512MB のメモリが必要です。巨大なプロジェクトを解析するためには，より多くのメモリが必要になることがあります。"
 

--- a/docs/locale/ja/LC_MESSAGES/links.po
+++ b/docs/locale/ja/LC_MESSAGES/links.po
@@ -3,33 +3,31 @@
 # This file is distributed under the same license as the spotbugs package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
 #
-#, fuzzy
 msgid ""
-msgstr ""
-"Project-Id-Version: spotbugs 3.1\n"
+msgstr "Project-Id-Version: spotbugs 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-06-28 18:09+0000\n"
+"POT-Creation-Date: 2017-08-17 15:12+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
+"Generated-By: Babel 2.4.0\n"
 
 #: ../../links.rst:2
 msgid "SpotBugs Links"
-msgstr ""
+msgstr "SpotBugs リンク"
 
 #: ../../links.rst:4
 msgid ""
 "This page contains links to related projects, including tools that are "
 "similar to SpotBugs."
-msgstr ""
+msgstr "このページには，SpotBugs に似たツールを含む関連プロジェクトへのリンクが含まれています。."
 
 #: ../../links.rst:7
 msgid "SpotBugs Plugins"
-msgstr ""
+msgstr "SpotBugs プラグイン"
 
 #: ../../links.rst:10
 msgid "`fb-contrib <http://fb-contrib.sourceforge.net/>`_"
@@ -39,7 +37,7 @@ msgstr ""
 msgid ""
 "A FindBugs/SpotBugs plugin for doing static code analysis on java byte "
 "code."
-msgstr ""
+msgstr "Java バイトコードの静的コード解析を行う FindBugs/SpotBugs プラグインです。"
 
 #: ../../links.rst:13
 msgid "`Find Security Bugs <http://find-sec-bugs.github.io/>`_"
@@ -47,7 +45,7 @@ msgstr ""
 
 #: ../../links.rst:13
 msgid "A FindBugs/SpotBugs plugin for security audits of Java web applications."
-msgstr ""
+msgstr "Java ウェブアプリケーションのセキュリティ監査用のFindBugs/SpotBugs プラグインです。"
 
 #: ../../links.rst:16
 msgid "`findbugs-slf4j <https://github.com/KengoTODA/findbugs-slf4j>`_"
@@ -57,11 +55,11 @@ msgstr ""
 msgid ""
 "A FindBugs/SpotBugs plugin to verify usage of `SLF4J "
 "<https://www.slf4j.org/>`_."
-msgstr ""
+msgstr "`SLF4J <https://www.slf4j.org/>`_ の使い方を検証するためのFindBugs/SpotBugs プラグインです。"
 
 #: ../../links.rst:19
 msgid "Similar/Related Tools"
-msgstr ""
+msgstr "類似/関連ツール"
 
 #: ../../links.rst:22
 msgid "`FindBugs-IDEA <https://plugins.jetbrains.com/plugin/3847-findbugs-idea>`_"
@@ -71,7 +69,7 @@ msgstr ""
 msgid ""
 "The FindBugs plugin for `IntelliJ IDEA "
 "<https://www.jetbrains.com/idea/>`_."
-msgstr ""
+msgstr "`IntelliJ IDEA <https://www.jetbrains.com/idea/>`_ のための FindBugs プラグインです。"
 
 #: ../../links.rst:25
 msgid "`sonar-findbugs <https://github.com/SonarQubeCommunity/sonar-findbugs>`_"
@@ -81,7 +79,7 @@ msgstr ""
 msgid ""
 "A `SonarQube <https://www.sonarqube.org/>`_ plugin which provides rules "
 "based on SpotBugs and its major plugins."
-msgstr ""
+msgstr "SpotBugs とその主要なプラグインに基づいたルールを提供する `SonarQube <https://www.sonarqube.org/>`_ プラグインです。"
 
 #: ../../links.rst:28
 msgid "`Checkstyle <http://checkstyle.sourceforge.net/>`_"
@@ -89,7 +87,7 @@ msgstr ""
 
 #: ../../links.rst:28
 msgid "A style checker for Java."
-msgstr ""
+msgstr "Java 用のスタイルチェッカーです。"
 
 #: ../../links.rst:31
 msgid "`PMD <https://pmd.github.io/>`_"
@@ -97,7 +95,7 @@ msgstr ""
 
 #: ../../links.rst:31
 msgid "An extensible cross-language static code analyzer."
-msgstr ""
+msgstr "拡張可能な言語間静的コード解析ツールです。"
 
 #: ../../links.rst:34
 msgid "`huntbugs <https://github.com/amaembo/huntbugs>`_"
@@ -108,7 +106,7 @@ msgid ""
 "New Java bytecode static analyzer tool based on `Procyon Compiler Tools "
 "<https://bitbucket.org/mstrobel/procyon/overview>`_ aimed to supersede "
 "the FindBugs."
-msgstr ""
+msgstr "`Procyon Compiler Tools <https://bitbucket.org/mstrobel/procyon/overview>`_ に基づいた新しいバイトコード静的解析ツールで，FindBugs を置き換えることを目指しています。"
 
 #: ../../links.rst:37
 msgid "`Google Error Prone <http://errorprone.info/>`_"
@@ -118,7 +116,7 @@ msgstr ""
 msgid ""
 "A static analysis tool for Java that catches common programming mistakes "
 "at compile-time."
-msgstr ""
+msgstr "コンパイル時に一般的なプログラミングミスをキャッチする Java 用静的解析ツールです。"
 
 #: ../../links.rst:39
 msgid "`Checker Framework <https://checkerframework.org/>`_"
@@ -126,29 +124,5 @@ msgstr ""
 
 #: ../../links.rst:40
 msgid "A pluggable type-checking for Java."
-msgstr ""
-
-#~ msgid "`huntbugs <https://github.com/amaembo/huntbugs>`_`"
-#~ msgstr ""
-
-#~ msgid "Similar Tools"
-#~ msgstr ""
-
-#~ msgid "A FindBugs/SpotBugs plugin to verify usage of SLF4J."
-#~ msgstr ""
-
-#~ msgid "The FindBugs plugin for IntelliJ IDEA."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "A SonarQube plugin which provides rules"
-#~ " based on SpotBugs and its major "
-#~ "plugins."
-#~ msgstr ""
-
-#~ msgid "`SonarQube <https://www.sonarqube.org/>`_"
-#~ msgstr ""
-
-#~ msgid "The leading product for continuous code quality."
-#~ msgstr ""
+msgstr "プラグイン可能な Java の型チェックツールです。"
 

--- a/docs/locale/ja/LC_MESSAGES/migration.po
+++ b/docs/locale/ja/LC_MESSAGES/migration.po
@@ -1,25 +1,23 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2016, spotbugs community
+# Copyright (C) 2016-2017, spotbugs community
 # This file is distributed under the same license as the spotbugs package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
 #
-#, fuzzy
 msgid ""
-msgstr ""
-"Project-Id-Version: spotbugs 3.1\n"
+msgstr "Project-Id-Version: spotbugs 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-06 19:57+0000\n"
+"POT-Creation-Date: 2017-08-17 15:12+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
+"Generated-By: Babel 2.4.0\n"
 
 #: ../../migration.rst:2
 msgid "Guide for migration from FindBugs 3.0 to SpotBugs 3.1"
-msgstr ""
+msgstr "FindBugs 3.0 から SpotBugs 3.1 への移行ガイド"
 
 #: ../../migration.rst:5
 msgid "com.google.code.findbugs:findbugs"
@@ -29,7 +27,7 @@ msgstr ""
 msgid ""
 "Simply replace ``com.google.code.findbugs:findbugs`` with "
 "``com.github.spotbugs:spotbugs``."
-msgstr ""
+msgstr "``com.google.code.findbugs:findbugs`` を ``com.github.spotbugs:spotbugs`` に換えてください。"
 
 #: ../../migration.rst:24
 msgid "com.google.code.findbugs:jsr305"
@@ -39,7 +37,7 @@ msgstr ""
 msgid ""
 "JSR305 is already Dormant status, so SpotBugs does not release ``jsr305``"
 " jar file. Please continue using findbugs' one."
-msgstr ""
+msgstr "JSR305 は，すでに休止状態なので，SpotBugs は ``jsr305`` jarファイルをリリースしません。FindBugs のものを使い続けてください。"
 
 #: ../../migration.rst:30
 msgid "com.google.code.findbugs:findbugs-annotations"
@@ -47,7 +45,7 @@ msgstr ""
 
 #: ../../migration.rst:32
 msgid "Please depend on ``spotbugs-annotations`` instead."
-msgstr ""
+msgstr "代わりに ``spotbugs-annotations`` に依存してください。"
 
 #: ../../migration.rst:50
 msgid "com.google.code.findbugs:annotations"
@@ -57,71 +55,53 @@ msgstr ""
 msgid ""
 "Please depend on both of ``spotbugs-annotations`` and ``net.jcip:jcip-"
 "annotations:1.0`` instead."
-msgstr ""
+msgstr "代わりに ``spotbugs-annotations`` と ``net.jcip:jcip-annotations:1.0`` の両方に依存してください。"
 
 #: ../../migration.rst:77
 msgid "FindBugs Ant task"
-msgstr ""
+msgstr "FindBugs Ant タスク"
 
 #: ../../migration.rst:79
 msgid "Please replace ``findbugs-ant.jar`` with ``spotbugs-ant.jar``."
-msgstr ""
+msgstr "``findbugs-ant.jar`` を ``spotbugs-ant.jar`` に換えてください。"
 
 #: ../../migration.rst:99
 msgid "FindBugs Maven plugin"
-msgstr ""
+msgstr "FindBugs Maven プラグイン"
 
 #: ../../migration.rst:101
 msgid ""
 "Please use `com.github.hazendaz.spotbugs:spotbugs-maven-plugin` instead "
 "of `org.codehaus.mojo:findbugs-maven-plugin`."
-msgstr ""
+msgstr "``org.codehaus.mojo:findbugs-maven-plugin`` の代わりに ``com.github.hazendaz.spotbugs:spotbugs-maven-plugin`` を使用してください。"
 
 #: ../../migration.rst:120
 msgid "FindBugs Gradle plugin"
-msgstr ""
+msgstr "FindBugs Gradle プラグイン"
 
 #: ../../migration.rst:122
 msgid ""
 "Please use spotbugs plugin found on "
 "https://plugins.gradle.org/plugin/com.github.spotbugs"
-msgstr ""
+msgstr "https://plugins.gradle.org/plugin/com.github.spotbugs にある spotbugs プラグインを使用してください。"
 
 #: ../../migration.rst:142
 msgid "FindBugs Eclipse plugin"
-msgstr ""
+msgstr "FindBugs Eclipse プラグイン"
 
 #: ../../migration.rst:144
 msgid "Please use following update site instead."
-msgstr ""
+msgstr "代わりに次の更新サイトをご利用ください。"
 
 #: ../../migration.rst:146
 msgid "https://spotbugs.github.io/eclipse/ (to use stable version, not ready yet)"
-msgstr ""
+msgstr "https://spotbugs.github.io/eclipse/ (まだ安定していないバージョンを使用する)"
 
 #: ../../migration.rst:147
 msgid "https://spotbugs.github.io/eclipse-candidate/ (to use candidate version)"
-msgstr ""
+msgstr "https://spotbugs.github.io/eclipse-candidate/ (候補バージョンを使用する)"
 
 #: ../../migration.rst:148
 msgid "https://spotbugs.github.io/eclipse-latest/ (to use latest build)"
-msgstr ""
-
-#~ msgid ""
-#~ msgstr ""
-
-#~ msgid "Migration from FindBugs 3.0 to SpotBugs 3.1"
-#~ msgstr ""
-
-#~ msgid "TBU"
-#~ msgstr ""
-
-#~ msgid "In near future we release SpotBugs Gradle plugin."
-#~ msgstr ""
-
-#~ msgid "Please use spotbugs plugin found on https://plugins.gradle.org"
-#~ msgstr ""
-
-#~ msgid "Currently the update site for daily built plugin isn't ready."
-#~ msgstr ""
+msgstr "https://spotbugs.github.io/eclipse-latest/ (最新のビルドを使用する)"
 

--- a/docs/locale/ja/LC_MESSAGES/migration.po
+++ b/docs/locale/ja/LC_MESSAGES/migration.po
@@ -95,7 +95,7 @@ msgstr "代わりに次の更新サイトをご利用ください。"
 
 #: ../../migration.rst:146
 msgid "https://spotbugs.github.io/eclipse/ (to use stable version, not ready yet)"
-msgstr "https://spotbugs.github.io/eclipse/ (まだ安定していないバージョンを使用する)"
+msgstr "https://spotbugs.github.io/eclipse/ (安定バージョンを使用する (まだ利用できない))"
 
 #: ../../migration.rst:147
 msgid "https://spotbugs.github.io/eclipse-candidate/ (to use candidate version)"

--- a/docs/locale/ja/LC_MESSAGES/running.po
+++ b/docs/locale/ja/LC_MESSAGES/running.po
@@ -67,7 +67,7 @@ msgid ""
 "``$SPOTBUGS_HOME/lib/spotbugs.jar`` using the -jar command line switch of"
 " the JVM (java) executable. (Versions of SpotBugs prior to 1.3.5 required"
 " a wrapper script to invoke SpotBugs.)"
-msgstr "SpotBugs を実行するための推奨方法は，JVM (Java) 実行可能ファイルの -jar コマンドラインスイッチを使用して ``$SPOTBUGS_HOME/lib/spotbugs.jar`` を直接実行することです。(バージョン 1.3.5 以前の SpotBugs では，SpotBugs を起動するためのラッパースクリプトが必要でした。)"
+msgstr "SpotBugs を実行するためには，JVM (Java) 実行可能ファイルの -jar コマンドラインスイッチを使用して ``$SPOTBUGS_HOME/lib/spotbugs.jar`` を直接実行する方法を推奨します。(バージョン 1.3.5 以前の SpotBugs では，SpotBugs を起動するためのラッパースクリプトが必要でした。)"
 
 #: ../../running.rst:28
 msgid "The general syntax of invoking SpotBugs directly is the following:"

--- a/docs/locale/ja/LC_MESSAGES/running.po
+++ b/docs/locale/ja/LC_MESSAGES/running.po
@@ -3,65 +3,63 @@
 # This file is distributed under the same license as the spotbugs package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
 #
-#, fuzzy
 msgid ""
-msgstr ""
-"Project-Id-Version: spotbugs 3.1\n"
+msgstr "Project-Id-Version: spotbugs 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-06-09 13:58+0000\n"
+"POT-Creation-Date: 2017-08-17 15:12+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
+"Generated-By: Babel 2.4.0\n"
 
 #: ../../running.rst:2
 msgid "Running SpotBugs"
-msgstr ""
+msgstr "SpotBugs の実行"
 
 #: ../../running.rst:4
 msgid ""
 "SpotBugs has two user interfaces: a graphical user interface (GUI) and a "
 "command line user interface. This chapter describes how to run each of "
 "these user interfaces."
-msgstr ""
+msgstr "SpotBugs には，グラフィカルユーザインターフェイス (GUI) とコマンドラインユーザインターフェイスの2つのユーザインターフェイスがあります。この章では，それぞれのユーザインタフェースを実行する方法について説明します。"
 
 #: ../../running.rst:8
 msgid "Quick Start"
-msgstr ""
+msgstr "クイックスタート"
 
 #: ../../running.rst:10
 msgid ""
 "If you are running SpotBugs on a Windows system, double-click on the file"
 " ``%SPOTBUGS_HOME%\\lib\\spotbugs.jar`` to start the SpotBugs GUI."
-msgstr ""
+msgstr "Windows で SpotBugs を実行するときは，``%SPOTBUGS_HOME%\\lib\\spotbugs.jar`` ファイルをダブルクリックして SpotBugs GUI を起動します。"
 
 #: ../../running.rst:12
 msgid ""
 "On a Unix, Linux, or macOS system, run the "
 "``$SPOTBUGS_HOME/bin/spotbugs`` script, or run the command ``java -jar "
 "$SPOTBUGS_HOME/lib/spotbugs.jar`` to run the SpotBugs GUI."
-msgstr ""
+msgstr "Unix，Linux，macOS では，  ``$SPOTBUGS_HOME/bin/spotbugs`` スクリプト，または ``java -jar $SPOTBUGS_HOME/lib/spotbugs.jar`` コマンドで SpotBugs GUI を実行します。"
 
 #: ../../running.rst:14
 msgid "Refer to :doc:`gui` for information on how to use the GUI."
-msgstr ""
+msgstr "GUI の使い方は :doc:`gui` を参照してください。"
 
 #: ../../running.rst:17
 msgid "Executing SpotBugs"
-msgstr ""
+msgstr "SpotBugs の実行"
 
 #: ../../running.rst:19
 msgid ""
 "This section describes how to invoke the SpotBugs program. There are two "
 "ways to invoke SpotBugs: directly, or using a wrapper script."
-msgstr ""
+msgstr "この節では，SpotBugs プログラムを起動する方法について説明します。SpotBugs を起動するためには，直接，またはラッパースクリプトを使用する2つの方法があります。"
 
 #: ../../running.rst:23
 msgid "Direct invocation of SpotBugs"
-msgstr ""
+msgstr "SpotBugs の直接起動"
 
 #: ../../running.rst:25
 msgid ""
@@ -69,21 +67,21 @@ msgid ""
 "``$SPOTBUGS_HOME/lib/spotbugs.jar`` using the -jar command line switch of"
 " the JVM (java) executable. (Versions of SpotBugs prior to 1.3.5 required"
 " a wrapper script to invoke SpotBugs.)"
-msgstr ""
+msgstr "SpotBugs を実行するための推奨方法は，JVM (Java) 実行可能ファイルの -jar コマンドラインスイッチを使用して ``$SPOTBUGS_HOME/lib/spotbugs.jar`` を直接実行することです。(バージョン 1.3.5 以前の SpotBugs では，SpotBugs を起動するためのラッパースクリプトが必要でした。)"
 
 #: ../../running.rst:28
 msgid "The general syntax of invoking SpotBugs directly is the following:"
-msgstr ""
+msgstr "SpotBugs を直接起動する一般的な構文は次のようになります。"
 
 #: ../../running.rst:35
 msgid "Choosing the User Interface"
-msgstr ""
+msgstr "ユーザインタフェースの選択"
 
 #: ../../running.rst:37
 msgid ""
 "The first command line option chooses the SpotBugs user interface to "
 "execute. Possible values are:"
-msgstr ""
+msgstr "最初のコマンドラインオプションは，実行する SpotBugs ユーザインタフェースの選択です。指定可能な値は次のとおりです。"
 
 #: ../../running.rst:40
 msgid "-gui:"
@@ -91,7 +89,7 @@ msgstr ""
 
 #: ../../running.rst:40
 msgid "runs the graphical user interface (GUI)"
-msgstr ""
+msgstr "グラフィカルユーザインタフェース (GUI) の実行"
 
 #: ../../running.rst:43
 msgid "-textui:"
@@ -99,7 +97,7 @@ msgstr ""
 
 #: ../../running.rst:43
 msgid "runs the command line user interface"
-msgstr ""
+msgstr "コマンドラインユーザインタフェースの実行"
 
 #: ../../running.rst:46
 msgid "-version:"
@@ -107,7 +105,7 @@ msgstr ""
 
 #: ../../running.rst:46
 msgid "displays the SpotBugs version number"
-msgstr ""
+msgstr "SpotBugs のバージョン番号の表示"
 
 #: ../../running.rst:49
 msgid "-help:"
@@ -115,7 +113,7 @@ msgstr ""
 
 #: ../../running.rst:49
 msgid "displays help information for the SpotBugs command line user interface"
-msgstr ""
+msgstr "SpotBugs コマンドラインユーザインタフェースに関するヘルプ情報の表示"
 
 #: ../../running.rst:52
 msgid "-gui1:"
@@ -123,15 +121,15 @@ msgstr ""
 
 #: ../../running.rst:52
 msgid "executes the original (obsolete) SpotBugs graphical user interface"
-msgstr ""
+msgstr "オリジナル SpotBugs グラフィカルユーザインタフェース (廃止されている) の実行"
 
 #: ../../running.rst:55
 msgid "Java Virtual Machine (JVM) arguments"
-msgstr ""
+msgstr "Java 仮想マシン (JVM) の引数"
 
 #: ../../running.rst:57
 msgid "Several Java Virtual Machine arguments are useful when invoking SpotBugs."
-msgstr ""
+msgstr "Java 仮想マシンのいくつかの引数は，SpotBugs を起動するときに役立ちます。"
 
 #: ../../running.rst:62
 msgid "-XmxNNm:"
@@ -142,7 +140,7 @@ msgid ""
 "Set the maximum Java heap size to NN megabytes. SpotBugs generally "
 "requires a large amount of memory. For a very large project, using 1500 "
 "megabytes is not unusual."
-msgstr ""
+msgstr "Java ヒープサイズの最大値を NN メガバイトに設定します。SpotBugs は，通常大量のメモリを必要とします。巨大なプロジェクトでは，1500メガバイトを使用することは珍しいことではありません。"
 
 #: ../../running.rst:66
 msgid "-Dname=value:"
@@ -152,43 +150,43 @@ msgstr ""
 msgid ""
 "Set a Java system property. For example, you might use the argument "
 "``-Duser.language=ja`` to display GUI messages in Japanese."
-msgstr ""
+msgstr "Java システムプロパティを設定します。たとえば，GUI メッセージを日本語で表示したいときは ``-Duser.language=ja`` 引数を使用します。"
 
 #: ../../running.rst:69
 msgid "Invocation of SpotBugs using a wrapper script"
-msgstr ""
+msgstr "ラッパースクリプトを使用した SpotBugs の起動"
 
 #: ../../running.rst:71
 msgid "Another way to run SpotBugs is to use a wrapper script."
-msgstr ""
+msgstr "SpotBugs を実行するもう一つの方法は，ラッパースクリプトを使うことです。"
 
 #: ../../running.rst:73
 msgid ""
 "On Unix-like systems, use the following command to invoke the wrapper "
 "script:"
-msgstr ""
+msgstr "Unix 系システムでは，次のコマンドを使用してラッパースクリプトを起動します。"
 
 #: ../../running.rst:79
 msgid "On Windows systems, the command to invoke the wrapper script is"
-msgstr ""
+msgstr "Windows では，次のコマンドを使用してラッパースクリプトを起動します。"
 
 #: ../../running.rst:85
 msgid ""
 "On both Unix-like and Windows systems, you can simply add the "
 "``$SPOTBUGS_HOME/bin`` directory to your ``PATH`` environment variable "
 "and then invoke SpotBugs using the ``spotbugs`` command."
-msgstr ""
+msgstr "Unix 系システムと Windows のどちらでも，``$SPOTBUGS_HOME/bin`` ディレクトリを環境変数 ``PATH`` に追加するだけで，``spotbugs`` コマンドを使用して SpotBugs を起動できます。"
 
 #: ../../running.rst:88
 msgid "Wrapper script command line options"
-msgstr ""
+msgstr "ラッパースクリプトのコマンドラインオプション"
 
 #: ../../running.rst:90
 msgid ""
 "The SpotBugs wrapper scripts support the following command-line options. "
 "Note that these command line options are not handled by the SpotBugs "
 "program per se; rather, they are handled by the wrapper script."
-msgstr ""
+msgstr "SpotBugs ラッパースクリプトは，次のようなコマンドラインオプションをサポートしています。留意すべきは，これらのコマンドラインオプションは，SpotBugs プログラム自体では処理されません。それらはラッパースクリプトによって処理されます。"
 
 #: ../../running.rst:98
 msgid "-jvmArgs *args*:"
@@ -198,7 +196,7 @@ msgstr ""
 msgid ""
 "Specifies arguments to pass to the JVM. For example, you might want to "
 "set a JVM property:"
-msgstr ""
+msgstr "JVM に渡す引数を指定します。たとえは，JVM プロパティを設定したいとします。"
 
 #: ../../running.rst:101
 msgid "-javahome *directory*:"
@@ -208,7 +206,7 @@ msgstr ""
 msgid ""
 "Specifies the directory containing the JRE (Java Runtime Environment) to "
 "use to execute FindBugs."
-msgstr ""
+msgstr "SpotBugs の実行に使用する JRE(Javaランタイム環境) があるディテクトリを指定します。"
 
 #: ../../running.rst:105
 msgid "-maxHeap *size*:"
@@ -218,7 +216,7 @@ msgstr ""
 msgid ""
 "Specifies the maximum Java heap size in megabytes. The default is 256. "
 "More memory may be required to analyze very large programs or libraries."
-msgstr ""
+msgstr "Java ヒープサイズの最大値をメガバイトで指定します。デフォルトは256です。巨大なプログラムやライブラリを解析するためには，より多くのメモリが必要になることがあります。"
 
 #: ../../running.rst:109
 msgid "-debug:"
@@ -228,7 +226,7 @@ msgstr ""
 msgid ""
 "Prints a trace of detectors run and classes analyzed to standard output. "
 "Useful for troubleshooting unexpected analysis failures."
-msgstr ""
+msgstr "ディテクタの実行トレースと解析したクラスを標準出力に出力します。予期しない解析エラーのトラブルシューティングに役立ちます。"
 
 #: ../../running.rst:116
 msgid "-property *name=value*:"
@@ -240,26 +238,26 @@ msgid ""
 "configure analysis options. See :doc:`analysisprops`. You can use this "
 "option multiple times in order to set multiple properties. Note: In most "
 "versions of Windows, the name=value string must be in quotes."
-msgstr ""
+msgstr "このオプションはシステムプロパティを設定します。SpotBugs は，システムプロパティを使用して解析オプションを設定します。:doc:`analysisprops` を参照してください。複数のプロパティを設定したいときは，このオプションを複数回使用します。注:ほとんどの Windows のバージョンでは，name=value 文字列を引用符で囲む必要があります。"
 
 #: ../../running.rst:119
 msgid "Command-line Options"
-msgstr ""
+msgstr "コマンドラインオプション"
 
 #: ../../running.rst:121
 msgid ""
 "This section describes the command line options supported by SpotBugs. "
 "These command line options may be used when invoking SpotBugs directly, "
 "or when using a wrapper script."
-msgstr ""
+msgstr "この節では，SpotBugs でサポートされているコマンドラインオプションについて説明します。これらのコマンドラインオプションは，SpotBugs を直接起動するとき，またはラッパースクリプトを使用するときに使えます。"
 
 #: ../../running.rst:125
 msgid "Common command-line options"
-msgstr ""
+msgstr "共通のコマンドラインオプション"
 
 #: ../../running.rst:127
 msgid "These options may be used with both the GUI and command-line interfaces."
-msgstr ""
+msgstr "これらのオプションは，GUI とコマンドラインユーザインタフェースの両方で使えます。"
 
 #: ../../running.rst:131
 msgid "-effort:min:"
@@ -271,7 +269,7 @@ msgid ""
 "memory consumption. You may want to try this option if you find that "
 "SpotBugs runs out of memory, or takes an unusually long time to complete "
 "its analysis."
-msgstr ""
+msgstr "このオプションは，精度を向上させるがメモリ消費量も増やす解析を無効にします。SpotBugs を実行するためのメモリが不足したり，解析が完了するまでに異常に長い時間がかかるときは，このオプションを試してみると良いでしょう。"
 
 #: ../../running.rst:134
 msgid "-effort:max:"
@@ -281,7 +279,7 @@ msgstr ""
 msgid ""
 "Enable analyses which increase precision and find more bugs, but which "
 "may require more memory and take more time to complete."
-msgstr ""
+msgstr "精度を向上させ，より多くのバグを見つける解析を有効にします。しかし，より多くのメモリが必要になり，完了までに時間がかかることがあります。"
 
 #: ../../running.rst:138
 msgid "-project *project*:"
@@ -292,15 +290,15 @@ msgid ""
 "Specify a project to be analyzed. The project file you specify should be "
 "one that was created using the GUI interface. It will typically end in "
 "the extension .fb or .fbp."
-msgstr ""
+msgstr "解析するプロジェクトを指定します。指定するプロジェクトファイルは，GUI インタフェースを使用して作成したものでなければなりません。拡張子は，通常 .fb または .fbp です。"
 
 #: ../../running.rst:141
 msgid "GUI Options"
-msgstr ""
+msgstr "GUI オプション"
 
 #: ../../running.rst:143
 msgid "These options are only accepted by the Graphical User Interface."
-msgstr ""
+msgstr "これらのオプションは，グラフィカルユーザインタフェースだけで受け入れられます。"
 
 #: ../../running.rst:146
 msgid "-look:plastic|gtk|native:"
@@ -308,15 +306,15 @@ msgstr ""
 
 #: ../../running.rst:146
 msgid "Set Swing look and feel."
-msgstr ""
+msgstr "Swing のルック & フィールを設定します。"
 
 #: ../../running.rst:149
 msgid "Text UI Options"
-msgstr ""
+msgstr "テキスト UI オプション"
 
 #: ../../running.rst:151
 msgid "These options are only accepted by the Text User Interface."
-msgstr ""
+msgstr "これらのオプションは，テキストユーザインタフェースだけで受け入れられます。"
 
 #: ../../running.rst:154
 msgid "-sortByClass:"
@@ -324,7 +322,7 @@ msgstr ""
 
 #: ../../running.rst:154
 msgid "Sort reported bug instances by class name."
-msgstr ""
+msgstr "報告されたバグインスタンスをクラス名でソートします。"
 
 #: ../../running.rst:158
 msgid "-include *filterFile.xml*:"
@@ -334,7 +332,7 @@ msgstr ""
 msgid ""
 "Only report bug instances that match the filter specified by "
 "filterFile.xml. See :doc:`filter`."
-msgstr ""
+msgstr "filterFile.xml で指定したフィルタと一致するバグインスタンスだけを報告します。:doc:`filter` を参照してください。"
 
 #: ../../running.rst:162
 msgid "-exclude *filterFile.xml*:"
@@ -344,7 +342,7 @@ msgstr ""
 msgid ""
 "Report all bug instances except those matching the filter specified by "
 "filterFile.xml. See :doc:`filter`."
-msgstr ""
+msgstr "filterFile.xml で指定したフィルタと一致するもの以外のすべてのバグインスタンスを報告します。:doc:`filter` を参照してください。"
 
 #: ../../running.rst:169
 msgid "-onlyAnalyze *com.foobar.MyClass,com.foobar.mypkg.**:"
@@ -362,7 +360,7 @@ msgid ""
 "the same way they would in a Java import statement to import all classes "
 "in the package (i.e., add .* to the full name of the package). Replace .*"
 " with .- to also analyze all subpackages."
-msgstr ""
+msgstr "与えられたコンマ区切りのクラスとパッケージでバグを見つけるための解析を制限します。フィルタリングとは異なり，このオプションは明示的に一致しないクラスやパッケージの解析を回避します。大規模なプロジェクトの場合，解析を実行するために必要な時間が大幅に短縮されます。(しかしながら，アプリケーション全体でディテクタを実行していないので不正確な結果を返してしまうかもしれません。) クラスは，パッケージも含んだ完全なクラス名を使用して指定する必要があります。パッケージは，パッケージの中のすべてのクラスをインポートする Java import 文と同じ方法で指定する必要があります (つまり，パッケージの完全な名前に .* を追加します)。 .* を .- に換えるとすべてのサブパッケージも解析できます。"
 
 #: ../../running.rst:172
 msgid "-low:"
@@ -370,7 +368,7 @@ msgstr ""
 
 #: ../../running.rst:172
 msgid "Report all bugs."
-msgstr ""
+msgstr "すべてのバグを報告します。"
 
 #: ../../running.rst:175
 msgid "-medium:"
@@ -378,7 +376,7 @@ msgstr ""
 
 #: ../../running.rst:175
 msgid "Report medium and high priority bugs. This is the default setting."
-msgstr ""
+msgstr "優先度が中・高のバグを報告します。デフォルトの設定です。"
 
 #: ../../running.rst:178
 msgid "-high:"
@@ -386,7 +384,7 @@ msgstr ""
 
 #: ../../running.rst:178
 msgid "Report only high priority bugs."
-msgstr ""
+msgstr "優先度が高のバグを報告します。"
 
 #: ../../running.rst:182
 msgid "-relaxed:"
@@ -396,7 +394,7 @@ msgstr ""
 msgid ""
 "Relaxed reporting mode. For many detectors, this option suppresses the "
 "heuristics used to avoid reporting false positives."
-msgstr ""
+msgstr "ざっくりとした報告をするモードです。多くのディテクタにおいて，このオプションは誤検出を回避するために使用されるヒューリスティックを抑制します。"
 
 #: ../../running.rst:188
 msgid "-xml:"
@@ -410,7 +408,7 @@ msgid ""
 "output will contain human-readable messages describing the warnings "
 "contained in the file. XML files generated this way are easy to transform"
 " into reports."
-msgstr ""
+msgstr "バグレポートを XML として生成します。生成された XML データは，後で GUI で見ることができます。。このオプションは ``-xml:withMessages`` として指定することもできます。このオプションを使用すると出力された XML ファイルには人間が読める警告を説明するメッセージが含まれるようになります。この方法で生成された XML ファイルは簡単にレポートに変換できます。"
 
 #: ../../running.rst:197
 msgid "-html:"
@@ -428,7 +426,7 @@ msgid ""
 "for visual presentation. The ``fancy-hist.xsl`` an evolution of "
 "``fancy.xsl`` stylesheet. It makes an extensive use of DOM and Javascript"
 " for dynamically filtering the lists of bugs."
-msgstr ""
+msgstr "HTML 出力を生成します。デフォルトでは，SpotBugs は default.xsl XSLT スタイルシートを使用して HTML を生成します。このファイルは，spotbugs.jar，SpotBugs ソース，バイナリ配布物で見つけられます。このオプションのバリエーションには ``-html:plain.xsl``，``-html:fancy.xsl``，``-html:fancy-hist.xsl`` が含まれます。``plain.xsl`` スタイルシートは Javascript や DOM を使用していません。古いウェブブラウザや印刷のためにうまく動作するかもしれません。``fancy.xsl`` スタイルシートはナビゲーションのための DOM と Javascript，視覚的表現のための CSS を使用します。``fancy-hist.xsl`` は，``fancy.xsl`` スタイルシートが進化したものです。バグのリストを動的にフィルタリングするために DOM と Javascript をフル活用します。"
 
 #: ../../running.rst:197
 msgid ""
@@ -436,7 +434,7 @@ msgid ""
 "transformation to HTML, specify the option as ``-html:myStylesheet.xsl``,"
 " where ``myStylesheet.xsl`` is the filename of the stylesheet you want to"
 " use."
-msgstr ""
+msgstr "独自の XSLT スタイルシートを指定して HTML への変換を実行したいときは，``-html:myStylesheet.xsl`` としてオプションを指定します。ここで ``myStylesheet.xsl`` は使用するスタイルシートのファイル名です。"
 
 #: ../../running.rst:200
 msgid "-emacs:"
@@ -444,7 +442,7 @@ msgstr ""
 
 #: ../../running.rst:200
 msgid "Produce the bug reports in Emacs format."
-msgstr ""
+msgstr "バグレポートを Emacs 形式として生成します。"
 
 #: ../../running.rst:203
 msgid "-xdocs:"
@@ -452,7 +450,7 @@ msgstr ""
 
 #: ../../running.rst:203
 msgid "Produce the bug reports in xdoc XML format for use with Apache Maven."
-msgstr ""
+msgstr "Apache Maven で使用するための xdoc XML 形式のバグレポートを生成します。"
 
 #: ../../running.rst:206
 msgid "-output *filename*:"
@@ -460,7 +458,7 @@ msgstr ""
 
 #: ../../running.rst:206
 msgid "Produce the output in the specified file."
-msgstr ""
+msgstr "指定されたファイルに出力を生成します。"
 
 #: ../../running.rst:209
 msgid "-outputFile *filename*:"
@@ -468,7 +466,7 @@ msgstr ""
 
 #: ../../running.rst:209
 msgid "This argument is deprecated. Use ``-output`` instead."
-msgstr ""
+msgstr "この引数は推奨されません。代わりに ``-output`` を使用してください。"
 
 #: ../../running.rst:213
 msgid "-nested[:true|false]:"
@@ -480,7 +478,7 @@ msgid ""
 "found in the list of files and directories to be analyzed. By default, "
 "scanning of nested jar/zip files is enabled. To disable it, add "
 "``-nested:false`` to the command line arguments."
-msgstr ""
+msgstr "このオプションは，解析されるファイルとディレクトリのリストにあるネストされた jar/zip ファイルのスキャンを有効また無効にします。デフォルトでは，ネストされた jar/zip ファイルのスキャンが有効になっています。無効にしたいときは，コマンドライン引数に ``-nested:false`` を追加します。"
 
 #: ../../running.rst:217
 msgid "-auxclasspath *classpath*:"
@@ -491,7 +489,7 @@ msgid ""
 "Set the auxiliary classpath for analysis. This classpath should include "
 "all jar files and directories containing classes that are part of the "
 "program being analyzed but you do not want to have analyzed for bugs."
-msgstr ""
+msgstr "解析のための補助クラスパスを設定します。補助クラスパスには解析するプログラムで使用するクラスを含むディテクトリと jar ファイルをすべて指定します。バグの解析対象にはなりません。"
 
 #: ../../running.rst:220
 msgid "-auxclasspathFromInput:"
@@ -501,7 +499,7 @@ msgstr ""
 msgid ""
 "Read the auxiliary classpath for analysis from standard input, each line "
 "adds new entry to the auxiliary classpath for analysis."
-msgstr ""
+msgstr "標準入力から解析のための補助クラスパスを読み，それぞれの行を解析のための補助クラスパスに新規登録します。"
 
 #: ../../running.rst:223
 msgid "-auxclasspathFromFile *filepath*:"
@@ -511,7 +509,7 @@ msgstr ""
 msgid ""
 "Read the auxiliary classpath for analysis from file, each line adds new "
 "entry to the auxiliary classpath for analysis."
-msgstr ""
+msgstr "ファイルから解析のための補助クラスパスを読み，それぞれの行を解析のための補助クラスパスに新規登録します。"
 
 #: ../../running.rst:226
 msgid "-analyzeFromFile *filepath*:"
@@ -521,7 +519,7 @@ msgstr ""
 msgid ""
 "Read the files to analyze from file, each line adds new entry to the "
 "classpath for analysis."
-msgstr ""
+msgstr "ファイルから解析するファイルを読み，それぞれの行を解析のためのクラスパスに新規登録します。"
 
 #: ../../running.rst:230
 msgid "-userPrefs *edu.umd.cs.findbugs.core.prefs*:"
@@ -535,85 +533,5 @@ msgid ""
 "they will override some previous options). This rationale behind this "
 "option is to reuse SpotBugs Eclipse project settings for command line "
 "execution."
-msgstr ""
-
-#~ msgid "-Dname=value"
-#~ msgstr ""
-
-#~ msgid "-jvmArgs args"
-#~ msgstr ""
-
-#~ msgid "-javahome directory"
-#~ msgstr ""
-
-#~ msgid "-maxHeap size"
-#~ msgstr ""
-
-#~ msgid "-property name=value"
-#~ msgstr ""
-
-#~ msgid ""
-#~ msgstr ""
-
-#~ msgid "-low Report all bugs."
-#~ msgstr ""
-
-#~ msgid "-high Report only high priority bugs."
-#~ msgstr ""
-
-#~ msgid "-emacs Produce the bug reports in Emacs format."
-#~ msgstr ""
-
-#~ msgid "-output filename Produce the output in the specified file."
-#~ msgstr ""
-
-#~ msgid "-outputFile filename This argument is deprecated. Use -output instead."
-#~ msgstr ""
-
-#~ msgid "-include filterFile.xml:"
-#~ msgstr ""
-
-#~ msgid "-exclude filterFile.xml:"
-#~ msgstr ""
-
-#~ msgid "-onlyAnalyze com.foobar.MyClass,com.foobar.mypkg.*:"
-#~ msgstr ""
-
-#~ msgid "-output filename:"
-#~ msgstr ""
-
-#~ msgid "-outputFile filename:"
-#~ msgstr ""
-
-#~ msgid "-auxclasspath classpath:"
-#~ msgstr ""
-
-#~ msgid "-jvmArgs args:"
-#~ msgstr ""
-
-#~ msgid "-javahome directory:"
-#~ msgstr ""
-
-#~ msgid "-maxHeap size:"
-#~ msgstr ""
-
-#~ msgid "-property name=value:"
-#~ msgstr ""
-
-#~ msgid "-project project:"
-#~ msgstr ""
-
-#~ msgid "-sortByClass:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This option sets a system property. "
-#~ "SpotBugs uses system properties to "
-#~ "configure analysis options. See "
-#~ ":doc:`analysisProperties`. You can use this"
-#~ " option multiple times in order to"
-#~ " set multiple properties. Note: In "
-#~ "most versions of Windows, the name=value"
-#~ " string must be in quotes."
-#~ msgstr ""
+msgstr "使用するユーザ設定ファイルを設定します。上記のオプションの一部が上書きされる可能性があります。最初の引数として userPrefs を指定すると，後続のオプションで上書きすることになります。最後の引数として指定すると以前のオプションを上書きすることになります。このオプションの背後にある根拠は，コマンドライン実行で SpotBugs Eclipse プロジェクトの設定を再利用するためです。"
 


### PR DESCRIPTION
I translated the manual into Japanese with reference to the Japanese manual of FindBugs.

Tools.
- OmegaT (handling of PO files)
- Google翻訳 (translation)
- 英辞郎 (translation)
- Tomarigi (Calibration support tool)

Build step (Windows).
make gettext
sphinx-intl update -p .build/locale  -l ja
make -e SPHINXOPTS="-D language='ja'" html