### PR TITLE
Fix timing to delete files for eclipse sites

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,9 +43,6 @@ script:
 
 after_success:
   - if [[ $JDK_FOR_TEST == "oraclejdk8" ]]; then ./gradlew coveralls; fi
-  # Coveralls task above deletes generated site data, so we should re-generate it
-  # to deploy the daily build on the update site, see "deploy" task below
-  - ./gradlew eclipsePlugin:eclipseSite
 
 before_cache:
   - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/eclipsePlugin/build.gradle
+++ b/eclipsePlugin/build.gradle
@@ -268,6 +268,10 @@ task siteXml(type:Copy) {
   from 'plugin_site.xml'
   destinationDir = file("${buildDir}/site/eclipse")
   rename { 'site.xml' }
+  outputs.upToDateWhen {
+    // even if we have generated file, we should rerun this task to overwrite it.
+    false
+  }
 }
 
 task siteCandidateXml(type:Copy) {
@@ -275,6 +279,10 @@ task siteCandidateXml(type:Copy) {
   from 'plugin_site-candidate.xml'
   destinationDir = file("${buildDir}/site/eclipse-candidate")
   rename { 'site.xml' }
+  outputs.upToDateWhen {
+    // even if we have generated file, we should rerun this task to overwrite it.
+    false
+  }
 }
 
 task siteDailyXml(type:Copy) {
@@ -282,10 +290,17 @@ task siteDailyXml(type:Copy) {
   from 'plugin_site-daily.xml'
   destinationDir = file("${buildDir}/site/eclipse-daily")
   rename { 'site.xml' }
+  outputs.upToDateWhen {
+    // even if we have generated file, we should rerun this task to overwrite it.
+    false
+  }
 }
 
 task generateP2Metadata(type:Exec) {
-  project.delete 'build/site/eclipse'
+  doFirst {
+    project.delete "${buildDir}/site/eclipse/artifacts.xml"
+    project.delete "${buildDir}/site/eclipse/content.xml"
+  }
   inputs.file 'local.properties'
   dependsOn pluginJar, featureJar, siteXml
   commandLine "${eclipseExecutable}", '-nosplash',
@@ -296,7 +311,10 @@ task generateP2Metadata(type:Exec) {
 }
 
 task generateCandidateP2Metadata(type:Exec) {
-  project.delete "build/site/eclipse-candidate"
+  doFirst {
+    project.delete "${buildDir}/site/eclipse-candidate/artifacts.xml"
+    project.delete "${buildDir}/site/eclipse-candidate/content.xml"
+  }
   inputs.file 'local.properties'
   dependsOn pluginCandidateJar, featureCandidateJar, siteCandidateXml
   commandLine "${eclipseExecutable}", '-nosplash',
@@ -307,7 +325,10 @@ task generateCandidateP2Metadata(type:Exec) {
 }
 
 task generateP2MetadataDaily(type:Exec) {
-  project.delete "build/site/eclipse-daily"
+  doFirst {
+    project.delete "${buildDir}/site/eclipse-daily/artifacts.xml"
+    project.delete "${buildDir}/site/eclipse-daily/content.xml"
+  }
   inputs.file 'local.properties'
   dependsOn pluginDailyJar, featureDailyJar, siteDailyXml
   commandLine "${eclipseExecutable}", '-nosplash',


### PR DESCRIPTION
To solve #287, we introduced `project.delete` to build script by #294. But it runs when build script is parsed (not when the target task is actually called) so we needed workaround #310.

This change will wrap `project.delete` by `doFirst { ... }` to make sure we delete files only before we invoke Eclipse to generate `artifacts.xml` and `content.xml`. We also need to edit `Copy` tasks which generates `site.xml`, to ensure that it always runs.