### PR TITLE
stop listing deprecated bugs in docs

### DIFF
--- a/docs/extensions/generate_bug_description.py
+++ b/docs/extensions/generate_bug_description.py
@@ -34,6 +34,8 @@ def generate_bug_description(language):
             bug_description_page.write('\n\n')
 
             for bug_pattern in findbugs.findall(".//BugPattern[@category='%s']" % category):
+                if (bug_pattern.get('deprecated') == 'true'):
+                    continue
                 type = bug_pattern.get('type')
                 message = messages.find(".//BugPattern[@type='%s']" % type)
                 pattern_title = generate_pattern_title(bug_pattern, message)


### PR DESCRIPTION
This change will remove deprecated bugs such as `TLW_TWO_LOCK_NOTIFY` from bug descriptor list.

staging site: http://spotbugs-in-kengo-toda.readthedocs.io/en/remove-deprecated-bug-descriptions-from-docs/bugDescriptions.html

refs #343, cc: @orihalcon128 