### PR TITLE
Automate deployment of gradle plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ env:
 
     # GITHUB_TOKEN value to push changes to GitHub; Currently it is ued to update gh-pages branch of spotbugs/eclipse-latest etc.
     - secure: "dFmNTEiYr0XHd2Zoj95j1xqoawNIrN63pgvHwKWf5ngNkncxLukKu1nGvvt9Fbw4/Embgzvz2GRwxWJBu5//yKrUHD9ILBS78Sn8nxpba7wHE6r8k6m+u7dOeN4jEH1fzyzsniSq939S6uB8gvfhhikddh9oZzwZnMq1YVyHQaWzbcaUnom+cwndKfK+YXg5mkt5Z92uXkJjGqd36FPA3GrlGJH7kXgWhVXI7Vds2hHsX/IBG0/2ZDhKNSZ8AiaDU4g2pSBlqA7F/noFW68hpohz9AAjku2COmpK0Ojd/iE0bVclXHYzs2aZq3lvYb3gv0dTEJrcIwPlDKQZWaEV/SxX9nIOqL5Q6XeVigTmnKkivQQ/b0hMPEpeHVvipMETYVzDvFT0qatLX/gUsiLgRPilWu0imFvNY4YAPZK3UPBSL5g+/8DzDPmTMZiOqJTMuMr+r/c7ch8qfjoaibc6LqUSJYLxyfk3NeturoviPLiBBtoadNsLPddtsNE8MZhr9lwRefNXY/VPBUxi7Bpxo7KfZ0BDSTzKeW7AEm/9E4CDmbd25eYGdvfVFeElGt5iTAfwIBYhj/GDkqnjesNCyDeNry/NywnEigkZQ4gzIvkHDkevUFs19nSspBmxiK82doY/j9Q0/TAK30mIdhg8VQwmkq5AYVIcN8kCu8WBhxw="
+    # GRADLE_PUBLISH_KEY value
+    - secure: "lZc3FKJlHOKrtYJp2Tc+SDLTye5vip0Hp2jpLj9GwxyP74DgmfzdABeptcvbfbxAHP7+emAyV7en0jdfS6iK9YWDTKpu4FKH/WrH4b03ArdkowJTYQI1pi2TLBlUNg64xaP/eeao1oWg44jCqp/sbU414zlA3+9gynnGED3mpsRQieRF3niBIt2bnzIeIusWxIqMWCXSzRnxC4RvlYpV7lhhJQb+2nJRets/KykhGs4RZj+bZB2I/WqgorzVN8GXBKevjAvR6HCaVClfa9A5boA4qsxb1P7UEurcMT4dJUXJHCW1tMBXpGDxtyNAhJgbKr4cVL7skzVsDaqSE1szLNwnDf9P5+a23EZeaT7juVsf7kXpR4KZ1JRWbss6Md035Px0KrbNFGtiojdtqRHBkAYnNNB1AwfeD4ZmsRip7oKU7mnwXOK5yUtuFnssZaIVIQHeGeNJOmtL69ELhEju07fmellIf5+fpBYwJVj62t/MvTEt9I1NbXCNPHpeHOVq6HY8OhMQ0Gzpzy8OfM/F6Nu8lowFV9LK/G3NZ7Uh206xZ+ArGDJ59a3mjsJ0eIVbkar1XxoJDZkQrrUx3GSN19o4Jw8y62V9E5A486nA3zjRSl5uOUhbnPTNO9RsxcIvwFx1dHYTTXkZMLqZarvhSjj+Pi0mCLxKjcoUyvtWZMk="
+    # GRADLE_PUBLISH_SECRET value
+    - secure: "mfFuR4+xh23Q71jdwv43hL4LnwNPE3m3zH4h+q5XkNeKbdEQMb+Sn5nXmhgR/vJ9zFTchmlmyg4bjEdV4Dc65g2kNPSu0CvSgn+ypURhPwvN+5JAeplh+XBqtE8gVh8qxCXAR4ZCVsEEUg4KyW+Rb9U0Uuy04b+45f1RfjqO5dayYvob0DQg3c5OrqyQ6pD88Y2LGUjfVAB+/8RZvvLJeEQTvBvISNceBCTxQrRt00y8f9p2VqqLG5lVZD1mnceIRgLWIkTiK/nxUqOh5IBpeyUF6Y9/uLKNeNn/5U11RnYL4O3XMICReBD/HcwW4hVTT+gAg8vNVVTuANbyG8AcsWGTF0Yck52W8DK9j07vGIeqgqDetvmh+a+hvCwsfpM9Wl0sv5lx7iim9VSE2DappFDaWKRF8ixGvjndL8Up8yCsfdJPYVafH81Ybv+Fd5GQX59Q5GIQs2IYFZ7312wzRswFfy5j1Hn74cnQWInxtbn7SXVaRj5CswEFearua38KDjkrx0GY1pt3ypbjf//kkgPmjRj8PRtPe/SEuZvCWlqBOym8QkZ2mIhiPn+pz6RO+mNRll5bmAaOtHLLkcIziMuFD7fi1YrCtCuY3PKiW0Xt7NHQQlD+y6X3RK2qsV8txPGXZz3F2Cnk9GvJepQv14hbc8OKPtJdJG/2uaLUuDg="
   matrix:
     - JDK_FOR_TEST=oraclejdk8
 #    - JDK_FOR_TEST=oraclejdk9
@@ -87,4 +91,10 @@ deploy:
     script: ./gradlew uploadArchives -PossrhUsername="$SONATYPE_USERNAME" -PossrhPassword="$SONATYPE_PASSWORD"
     on:
       branch: master
+      condition: "$JDK_FOR_TEST = oraclejdk8"
+  - provider: script
+    skip_cleanup: true
+    script: ./gradlew publishPlugins -Pgradle.publish.key="$GRADLE_PUBLISH_KEY" -Pgradle.publish.secret="$GRADLE_PUBLISH_SECRET"
+    on:
+      tags: true
       condition: "$JDK_FOR_TEST = oraclejdk8"

--- a/RELEASE_PROCEDURE.md
+++ b/RELEASE_PROCEDURE.md
@@ -31,7 +31,9 @@ If you need to update [entry at Eclipse Marketplace](https://marketplace.eclipse
 
 ## Release to Gradle Plugin Portal
 
-Add necessary properties to `~/.gradle/gradle.properties` and run `./gradlew publishPlugins`.
+No action necessary. When we push tag, the build result on Travis CI will be deployed to Gradle Plugin Portal.
+
+See `deploy` phase in `.travis.yml` for detail.
 
 ## Update installation manual
 

--- a/gradlePlugin/build.gradle
+++ b/gradlePlugin/build.gradle
@@ -39,9 +39,19 @@ pluginBundle {
   }
 }
 
+def spotBugsVersion = project(':spotbugs').version
 task processVersionFile(type: WriteProperties) {
   outputFile file('src/main/resources/spotbugs-gradle-plugin.properties')
 
-  property 'spotbugs-version', project(':spotbugs').version
+  property 'spotbugs-version', spotBugsVersion
 }
 tasks.processResources.dependsOn processVersionFile
+
+tasks.publishPlugins.doFirst {
+  if (version.endsWith('-SNAPSHOT')) {
+    throw new StopExecutionException("Skip publishing Gradle plugin because its version is not stable: ${version}")
+  }
+  if (spotBugsVersion.endsWith('-SNAPSHOT')) {
+    throw new StopExecutionException("Skip publishing Gradle plugin because SpotBugs version is not stable: ${spotBugsVersion}")
+  }
+}


### PR DESCRIPTION
This change helps us to publish SpotBugs Gradle Plugin automatically.

Refs: https://guides.gradle.org/publishing-plugins-to-gradle-plugin-portal/#publish_your_plugin