### PR TITLE
gitignore bin directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ classesEclipse
 .DS_Store
 deps/
 eclipse/
+bin/
 
 # generated manifest files
 spotbugs/META-INF/MANIFEST.MF


### PR DESCRIPTION
Some documentation appears again and again as modified in this directory
when working on the Eclipse plugin. Therefore gitignore the complete bin
directory.