### PR TITLE
Use new style filter tree

### DIFF
--- a/eclipsePlugin/src/de/tobject/findbugs/view/explorer/FilterBugsDialog.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/view/explorer/FilterBugsDialog.java
@@ -183,7 +183,7 @@ public class FilterBugsDialog extends SelectionDialog {
 
     class PatternFilteredTree extends FilteredTree {
         PatternFilteredTree(Composite parent, int treeStyle, PatternFilter filter) {
-            super(parent, treeStyle, filter);
+            super(parent, treeStyle, filter, true);
         }
 
         @Override


### PR DESCRIPTION
Since Eclipse 3.5 filter text controls can embed the "clear" button
directly into the text control instead of showing a separate button.
This also removes a deprecation warning.