### PR TITLE
Fix hyperlinks in messages_ja.xml

### DIFF
--- a/spotbugs/etc/messages_ja.xml
+++ b/spotbugs/etc/messages_ja.xml
@@ -4004,7 +4004,7 @@ Web サーバは，一般的にサーブレットや JSP クラスのインス�
 これは効率が悪く，右辺の評価でエラーが発生するケースを左辺でガードしているなら，結果としてエラーになる可能性があります。
 </p>
 <p>
-詳細については， <a href="https://docs.oracle.com/javase/specs/jls/se7/html/jls-15.html#jls-15.22.2"> を参照してください。
+詳細については， <a href="https://docs.oracle.com/javase/specs/jls/se7/html/jls-15.html#jls-15.22.2">The Java Language Specification</a> を参照してください。
 </p>
 ]]>
     </Details>
@@ -4020,7 +4020,7 @@ Web サーバは，一般的にサーブレットや JSP クラスのインス�
 これは効率が悪く，右辺の評価でエラーが発生するケースを左辺でガードしているなら，結果としてエラーになる可能性があります。
 </p>
 <p>
-詳細については， <a href="https://docs.oracle.com/javase/specs/jls/se7/html/jls-15.html#jls-15.22.2"> を参照してください。
+詳細については， <a href="https://docs.oracle.com/javase/specs/jls/se7/html/jls-15.html#jls-15.22.2">The Java Language Specification</a> を参照してください。
 </p>
 ]]>
     </Details>


### PR DESCRIPTION
Hyperlinks in NS_NON_SHORT_CIRCUIT and NS_DANGEROUS_NON_SHORT_CIRCUIT in messages_ja.xml is broken, fix them.