### PR TITLE
Minimum Eclipse SDK version for SpotBugs plugin is 4.6

### DIFF
--- a/eclipsePlugin/META-INF/MANIFEST-TEMPLATE.MF
+++ b/eclipsePlugin/META-INF/MANIFEST-TEMPLATE.MF
@@ -4,9 +4,9 @@ Bundle-Name: SpotBugs
 Bundle-Activator: de.tobject.findbugs.FindbugsPlugin
 Bundle-Vendor: SpotBugs Project
 Require-Bundle: org.eclipse.ui.workbench.texteditor,
- org.eclipse.ui;bundle-version="3.6.0",
+ org.eclipse.ui,
  org.eclipse.ant.core,
- org.eclipse.core.runtime,
+ org.eclipse.core.runtime;bundle-version="3.12.0",
  org.eclipse.core.resources,
  org.eclipse.ui.ide,
  org.eclipse.ui.editors,

--- a/eclipsePlugin/plugin_feature-candidate.xml
+++ b/eclipsePlugin/plugin_feature-candidate.xml
@@ -26,7 +26,7 @@ http://www.gnu.org/licenses/lgpl.html
 
    <requires>
       <import plugin="org.eclipse.core.resources"/>
-      <import plugin="org.eclipse.core.runtime" version="3.6.0" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.core.runtime" version="3.12.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.jdt"/>
       <import plugin="org.eclipse.jdt.core"/>
       <import plugin="org.eclipse.jdt.launching"/>

--- a/eclipsePlugin/plugin_feature-daily.xml
+++ b/eclipsePlugin/plugin_feature-daily.xml
@@ -26,7 +26,7 @@ http://www.gnu.org/licenses/lgpl.html
 
    <requires>
       <import plugin="org.eclipse.core.resources"/>
-      <import plugin="org.eclipse.core.runtime" version="3.6.0" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.core.runtime" version="3.12.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.jdt"/>
       <import plugin="org.eclipse.jdt.core"/>
       <import plugin="org.eclipse.jdt.launching"/>

--- a/eclipsePlugin/plugin_feature.xml
+++ b/eclipsePlugin/plugin_feature.xml
@@ -26,7 +26,7 @@ http://www.gnu.org/licenses/lgpl.html
 
    <requires>
       <import plugin="org.eclipse.core.resources"/>
-      <import plugin="org.eclipse.core.runtime" version="3.6.0" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.core.runtime" version="3.12.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.jdt"/>
       <import plugin="org.eclipse.jdt.core"/>
       <import plugin="org.eclipse.jdt.launching"/>


### PR DESCRIPTION
Set restriction on lower version bound for org.eclipse.core.runtime to 3.12.0 which corresponds to the bundle version from Eclipse 4.6.0 SDK.

This fixes #354.