### PR TITLE
Stop including resources to main source

### DIFF
--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -5,6 +5,10 @@ sourceSets {
   main {
     java {
       srcDirs = ['src/main/java', 'src/gui']
+      exclude '**/*.properties'
+      exclude '**/*.db'
+      exclude '**/*.html'
+      exclude '**/*.png'
     }
     resources {
       /*
@@ -108,7 +112,7 @@ task updateManifest {
 // Manually define what goes into the default jar, since it's not only main sourceset
 jar {
   from sourceSets.main.output
-  
+
   // Workaround for missing released BCEL maven artifact, see https://github.com/spotbugs/spotbugs/issues/327
   // Should be removed after #327 is fixed.
   from zipTree("$projectDir/lib/bcel-6.1-20161207.023659-9.jar").matching {


### PR DESCRIPTION
This change eliminates duplicated resources in *-sources.jar, which is reported at #329.
I confirmed that this change reduces size of sources .jar file from 2,746,646 bytes to 2,545,922 bytes.

```bash
$ jar tf spotbugs/build/libs/spotbugs-3.1.0-SNAPSHOT-sources.jar | sort | uniq -c | awk '$1 > 1'
// no output
```