### PR TITLE
GitHub 82

### DIFF
--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -1,3 +1,4 @@
+apply plugin: 'findbugs'
 apply from: "$rootDir/gradle/jacoco.gradle"
 apply from: "$rootDir/gradle/maven.gradle"
 
@@ -47,6 +48,14 @@ dependencies {
 
   // TODO : Some of these can be extracted to actual dependencies
   compile fileTree(dir: 'lib', include: '*.jar')
+}
+
+findbugs {
+  effort = "max"
+  reportLevel = "high"
+  dependencies {
+    findbugs 'com.google.code.findbugs:findbugs:3.0.1'
+  }
 }
 
 clean {
@@ -108,7 +117,7 @@ task updateManifest {
 // Manually define what goes into the default jar, since it's not only main sourceset
 jar {
   from sourceSets.main.output
-  
+
   // Workaround for missing released BCEL maven artifact, see https://github.com/spotbugs/spotbugs/issues/327
   // Should be removed after #327 is fixed.
   from zipTree("$projectDir/lib/bcel-6.1-20161207.023659-9.jar").matching {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DroppedException.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DroppedException.java
@@ -104,6 +104,7 @@ public class DroppedException extends PreorderVisitor implements Detector {
         return asUnsignedByte(a[i]) << 8 | asUnsignedByte(a[i + 1]);
     }
 
+    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(value = "UC_USELESS_CONDITION", justification = "To be fixed in SpotBugs 4.0.0, see https://github.com/spotbugs/spotbugs/issues/84")
     @Override
     public void visit(Code obj) {
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DumbMethods.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DumbMethods.java
@@ -643,6 +643,7 @@ public class DumbMethods extends OpcodeStackDetector {
 
     MethodDescriptor previousMethodCall = null;
 
+    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(value = "TQ_COMPARING_VALUES_WITH_INCOMPATIBLE_TYPE_QUALIFIERS", justification = "False positive, see https://github.com/spotbugs/spotbugs/issues/87")
     @Override
     public void sawOpcode(int seen) {
 

--- a/spotbugs/src/test/java/edu/umd/cs/findbugs/ba/npe/IsNullValueTest.java
+++ b/spotbugs/src/test/java/edu/umd/cs/findbugs/ba/npe/IsNullValueTest.java
@@ -37,6 +37,7 @@ public class IsNullValueTest {
         assertFalse(nsp.isException());
     }
 
+    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(value = "NP_NONNULL_PARAM_VIOLATION", justification = "Test is disabled, would need to be fixed anyway")
     @Ignore
     @Test
     public void testMerge4() {

--- a/spotbugs/src/test/java/edu/umd/cs/findbugs/filter/NotMatcherTest.java
+++ b/spotbugs/src/test/java/edu/umd/cs/findbugs/filter/NotMatcherTest.java
@@ -26,6 +26,7 @@ import static org.junit.matchers.JUnitMatchers.containsString;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import org.junit.Test;
 
@@ -90,8 +91,7 @@ public class NotMatcherTest {
         notMatcher.writeXML(xmlOutput, false);
         xmlOutput.finish();
 
-        String xmlOutputCreated = outputStream.toString();
-        return xmlOutputCreated;
+        return outputStream.toString(StandardCharsets.UTF_8.name());
     }
 
     private static class TestMatcher implements Matcher {

--- a/spotbugs/src/test/java/edu/umd/cs/findbugs/filter/SourceMatcherTest.java
+++ b/spotbugs/src/test/java/edu/umd/cs/findbugs/filter/SourceMatcherTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.*;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.tools.ant.filters.StringInputStream;
 import org.junit.Before;
@@ -122,7 +123,7 @@ public class SourceMatcherTest {
         matcher.writeXML(xmlOutput, disabled);
         xmlOutput.finish();
 
-        return outputStream.toString().trim();
+        return outputStream.toString(StandardCharsets.UTF_8.name()).trim();
     }
 
 

--- a/spotbugs/src/test/java/edu/umd/cs/findbugs/gui2/SaveTypeTest.java
+++ b/spotbugs/src/test/java/edu/umd/cs/findbugs/gui2/SaveTypeTest.java
@@ -33,6 +33,7 @@ public class SaveTypeTest {
         assertEquals(type, SaveType.forFile(new File(file)));
     }
 
+    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(value = "DMI_HARDCODED_ABSOLUTE_FILENAME", justification = "No actual disk access, just fake paths for testing")
     @Test
     public void testSaveTypes() {
         check(SaveType.HTML_OUTPUT, "/home/pugh/bugs.html");


### PR DESCRIPTION
This enables FindBugs checks on the core Spotbugs submodule.

Going forward, we'll want to migrate this to use Spotbugs, once we have an appropriate Gradle plugin.