### PR TITLE
[docs] Update docs to tell how to use SpotBugs Plugin by SpotBugs Gradle Plugin

### DIFF
--- a/docs/gradle.rst
+++ b/docs/gradle.rst
@@ -8,6 +8,8 @@ Use SpotBugs Gradle Plugin
 
 Please follow instruction found on `official Gradle Plugin page <https://plugins.gradle.org/plugin/com.github.spotbugs>`_.
 
+Note that SpotBugs Gradle Plugin does not support Gradle v3, you need to use v4 or later.
+
 Tasks introduced by this Gradle Plugin
 --------------------------------------
 
@@ -29,4 +31,15 @@ For instance, to specify the version of SpotBugs, you can configure like below:
 
   spotbugs {
     toolVersion = '3.1.0-RC5'
+  }
+
+Introduce SpotBugs Plugin
+-------------------------
+
+To introduce SpotBugs Plugin, please declare dependency in ``dependencies`` like below:
+
+.. code-block:: groovy
+
+  dependencies {
+    spotbugsPlugins 'com.h3xstream.findsecbugs:findsecbugs-plugin:1.7.1'
   }

--- a/docs/gradle.rst
+++ b/docs/gradle.rst
@@ -21,7 +21,7 @@ SpotBugs Gradle Plugin adds task dependency from `check` to these these tasks, s
 Configure Gradle Plugin
 -----------------------
 
-Current version of SpotBugs Gradle Plugin uses the same way to configure. Please check the document for `FindBugsExtension <http://gradle.monochromeroad.com/docs/dsl/org.gradle.api.plugins.quality.FindBugsExtension.html>`_.
+Current version of SpotBugs Gradle Plugin uses the same way with FindBugs Gradle Plugin to configure. Please check the document for `FindBugsExtension <http://gradle.monochromeroad.com/docs/dsl/org.gradle.api.plugins.quality.FindBugsExtension.html>`_.
 
 For instance, to specify the version of SpotBugs, you can configure like below:
 

--- a/docs/locale/ja/LC_MESSAGES/gradle.po
+++ b/docs/locale/ja/LC_MESSAGES/gradle.po
@@ -4,16 +4,17 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
 #
 msgid ""
-msgstr "Project-Id-Version: spotbugs 3.1\n"
+msgstr ""
+"Project-Id-Version: spotbugs 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-31 14:07+0900\n"
+"POT-Creation-Date: 2017-09-03 12:32+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.4.0\n"
+"Generated-By: Babel 1.3\n"
 
 #: ../../gradle.rst:2
 msgid "Using the SpotBugs Gradle Plugin"
@@ -33,7 +34,9 @@ msgstr "SpotBugs Gradle プラグインを使う"
 msgid ""
 "Please follow instruction found on `official Gradle Plugin page "
 "<https://plugins.gradle.org/plugin/com.github.spotbugs>`_."
-msgstr "`Gradle プラグインの公式ページ <https://plugins.gradle.org/plugin/com.github.spotbugs>`_ の指示に従ってください。"
+msgstr ""
+"`Gradle プラグインの公式ページ "
+"<https://plugins.gradle.org/plugin/com.github.spotbugs>`_ の指示に従ってください。"
 
 #: ../../gradle.rst:12
 msgid "Tasks introduced by this Gradle Plugin"
@@ -50,13 +53,18 @@ msgid ""
 "`spotbugsMain` task runs SpotBugs for your production Java source files. "
 "This task depends on `classes` task. `spotbugsTest` task runs SpotBugs "
 "for your test Java source files. This task depends on `testClasses` task."
-msgstr "`spotbugsMain` タスクは，製品 Java ソースファイル用の SpotBugs を実行します。このタスクは `classes` タスクに依存します。`spotbugsTest` タスクは，テスト Java ソースファイル用の SpotBugs を実行します。このタスクは `testClasses` タスクに依存します。"
+msgstr ""
+"`spotbugsMain` タスクは，製品 Java ソースファイル用の SpotBugs を実行します。このタスクは `classes` "
+"タスクに依存します。`spotbugsTest` タスクは，テスト Java ソースファイル用の SpotBugs を実行します。このタスクは "
+"`testClasses` タスクに依存します。"
 
 #: ../../gradle.rst:19
 msgid ""
 "SpotBugs Gradle Plugin adds task dependency from `check` to these these "
 "tasks, so you can simply run ``./gradlew check`` to run SpotBugs."
-msgstr "SpotBugs Gradle プラグインは，`check` タスクからこれらのタスクにタスク依存関係を追加するので，単に ``./gradlew check`` を実行すれば SpotBugs を実行できます。"
+msgstr ""
+"SpotBugs Gradle プラグインは，`check` タスクからこれらのタスクにタスク依存関係を追加するので，単に ``./gradlew"
+" check`` を実行すれば SpotBugs を実行できます。"
 
 #: ../../gradle.rst:22
 msgid "Configure Gradle Plugin"
@@ -64,10 +72,14 @@ msgstr "Gradle プラグインの設定"
 
 #: ../../gradle.rst:24
 msgid ""
-"Current version of SpotBugs Gradle Plugin uses the same way to configure."
-" Please check the document for `FindBugsExtension "
+"Current version of SpotBugs Gradle Plugin uses the same way with FindBugs"
+" Gradle Plugin to configure. Please check the document for "
+"`FindBugsExtension "
 "<http://gradle.monochromeroad.com/docs/dsl/org.gradle.api.plugins.quality.FindBugsExtension.html>`_."
-msgstr "現バージョンの SpotBugs Gradle プラグインは同じ方法で設定します。`FindBugsExtension <http://gradle.monochromeroad.com/docs/dsl/org.gradle.api.plugins.quality.FindBugsExtension.html>`_ のドキュメントを参照してください。"
+msgstr ""
+"現バージョンの SpotBugs Gradle プラグインは FindBugs Gradle プラグインと同じ方法で設定します。`FindBugsExtension "
+"<http://gradle.monochromeroad.com/docs/dsl/org.gradle.api.plugins.quality.FindBugsExtension.html>`_"
+" のドキュメントを参照してください。"
 
 #: ../../gradle.rst:26
 msgid ""
@@ -76,14 +88,4 @@ msgid ""
 msgstr "たとえば，SpotBugs のバージョンを指定したいときは，次のように設定します。"
 
 #~ msgid ""
-#~ "This Gradle Plugin introduces two tasks:"
-#~ " `spotbugsMain and `spotbugsTest."
 #~ msgstr ""
-
-#~ msgid ""
-#~ "SpotBugs Gradle Plugin adds task "
-#~ "dependency from `check` to these these"
-#~ " tasks, so you can simly run "
-#~ "``./gradlew check`` to run SpotBugs."
-#~ msgstr ""
-

--- a/docs/locale/ja/LC_MESSAGES/gradle.po
+++ b/docs/locale/ja/LC_MESSAGES/gradle.po
@@ -38,17 +38,23 @@ msgstr ""
 "`Gradle プラグインの公式ページ "
 "<https://plugins.gradle.org/plugin/com.github.spotbugs>`_ の指示に従ってください。"
 
-#: ../../gradle.rst:12
+#: ../../gradle.rst:11
+msgid ""
+"Note that SpotBugs Gradle Plugin does not support Gradle v3, you need to "
+"use v4 or later."
+msgstr "SpotBugs PluginはGradleバージョン3をサポートしません。バージョン4以降を使用してください。"
+
+#: ../../gradle.rst:14
 msgid "Tasks introduced by this Gradle Plugin"
 msgstr "Gradle プラグインによって導入されたタスク"
 
-#: ../../gradle.rst:14
+#: ../../gradle.rst:16
 msgid ""
 "This Gradle Plugin introduces two tasks: `spotbugsMain` and "
 "`spotbugsTest`."
 msgstr "Gradle プラグインには，`spotbugsMain` と `spotbugsTest` という2つのタスクが導入されています。"
 
-#: ../../gradle.rst:16
+#: ../../gradle.rst:18
 msgid ""
 "`spotbugsMain` task runs SpotBugs for your production Java source files. "
 "This task depends on `classes` task. `spotbugsTest` task runs SpotBugs "
@@ -58,7 +64,7 @@ msgstr ""
 "タスクに依存します。`spotbugsTest` タスクは，テスト Java ソースファイル用の SpotBugs を実行します。このタスクは "
 "`testClasses` タスクに依存します。"
 
-#: ../../gradle.rst:19
+#: ../../gradle.rst:21
 msgid ""
 "SpotBugs Gradle Plugin adds task dependency from `check` to these these "
 "tasks, so you can simply run ``./gradlew check`` to run SpotBugs."
@@ -66,11 +72,11 @@ msgstr ""
 "SpotBugs Gradle プラグインは，`check` タスクからこれらのタスクにタスク依存関係を追加するので，単に ``./gradlew"
 " check`` を実行すれば SpotBugs を実行できます。"
 
-#: ../../gradle.rst:22
+#: ../../gradle.rst:24
 msgid "Configure Gradle Plugin"
 msgstr "Gradle プラグインの設定"
 
-#: ../../gradle.rst:24
+#: ../../gradle.rst:26
 msgid ""
 "Current version of SpotBugs Gradle Plugin uses the same way with FindBugs"
 " Gradle Plugin to configure. Please check the document for "
@@ -81,11 +87,21 @@ msgstr ""
 "<http://gradle.monochromeroad.com/docs/dsl/org.gradle.api.plugins.quality.FindBugsExtension.html>`_"
 " のドキュメントを参照してください。"
 
-#: ../../gradle.rst:26
+#: ../../gradle.rst:28
 msgid ""
 "For instance, to specify the version of SpotBugs, you can configure like "
 "below:"
 msgstr "たとえば，SpotBugs のバージョンを指定したいときは，次のように設定します。"
+
+#: ../../gradle.rst:37
+msgid "Introduce SpotBugs Plugin"
+msgstr "SpotBugs Pluginを利用する"
+
+#: ../../gradle.rst:39
+msgid ""
+"To introduce SpotBugs Plugin, please declare dependency in "
+"``dependencies`` like below:"
+msgstr "SpotBugs Pluginを利用するには、プラグインへの依存を以下のように ``dependencies`` 内に記載してください:"
 
 #~ msgid ""
 #~ msgstr ""


### PR DESCRIPTION
This also contains commit to fix broken description in both of English and Japanese (#361).

staging site: [en](http://spotbugs-in-kengo-toda.readthedocs.io/en/docs-how-to-use-plugin/gradle.html), [ja](http://spotbugs-in-kengo-toda.readthedocs.io/ja/docs-how-to-use-plugin/gradle.html)