### PR TITLE
Install spotbugs packages before testing gradle plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,8 +45,6 @@ install:
   - rm -rf eclipse
   - tar xzvf deps/eclipse-SDK-4.6.3-linux-gtk-x86_64.tar.gz eclipse
   - echo eclipseRoot.dir=$(pwd)/eclipse > eclipsePlugin/local.properties
-  # To run gradlePlugin:test, we need to install spotbugs and its dependencies into local repository
-  - ./gradlew install -x test
 
 script:
   # Manually switch to JDK9 if needed

--- a/gradlePlugin/build.gradle
+++ b/gradlePlugin/build.gradle
@@ -18,7 +18,11 @@ dependencies {
     testCompile 'junit:junit:4.12'//, 'org.spockframework:spock-core:1.0-groovy-2.4'
 }
 
-test { //show test output
+test {
+  // SpotBugsPluginTest.java needs SpotBugs packages in Maven local
+  dependsOn ':spotbugs-annotations:install'
+  dependsOn ':spotbugs:install'
+  // show test output
   testLogging.showStandardStreams = true
 }
 


### PR DESCRIPTION
Refer discussion at: https://github.com/spotbugs/spotbugs/commit/f7a08d93d719319b6af260e7cce83d2806b05dd0

I confirmed that `./gradlew build` can pass even after `rm -rf ~/.m2/repository/com/github/spotbugs` in local.