### PR TITLE
Release 3.1.0 rc6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This is the changelog for SpotBugs. This follows [Keep a Changelog v0.3](http://keepachangelog.com/en/0.3.0/).
 
-## Unreleased (2017/??/??)
+## 3.1.0-RC6 (2017/Sep/11)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 This is the changelog for SpotBugs. This follows [Keep a Changelog v0.3](http://keepachangelog.com/en/0.3.0/).
 
+## Unreleased (2017/??/??)
+
 ## 3.1.0-RC6 (2017/Sep/11)
 
 ### Removed

--- a/RELEASE_PROCEDURE.md
+++ b/RELEASE_PROCEDURE.md
@@ -7,7 +7,7 @@ When you release fixed version of SpotBugs, please follow these procedures.
 * `version` in `build.gradle` and `gradlePlugin/build.gradle`
 * version number in `CHANGELOG.md` and `gradlePlugin/CHANGELOG.md`
 * `version` and `full_version` in `docs/conf.py`
-* version numbers in `docs/migration.rst` and `docs/introduction.rst`
+* version numbers in `docs/migration.rst`, `docs/introduction.rst` and `docs/installing.rst`
 
 ## Release to Maven Central
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
   id 'org.sonarqube' version '2.5'
 }
 
-version = '3.1.0-SNAPSHOT'
+version = '3.1.0-RC6'
 
 apply plugin: 'java'
 apply from: "$rootDir/gradle/jacoco.gradle"

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
   id 'org.sonarqube' version '2.5'
 }
 
-version = '3.1.0-RC6'
+version = '3.1.0-SNAPSHOT'
 
 apply plugin: 'java'
 apply from: "$rootDir/gradle/jacoco.gradle"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,7 @@ import os
 
 html_context = {
   'version' : '3.1',
-  'full_version' : '3.1.0-RC5'
+  'full_version' : '3.1.0-RC6'
 }
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -7,18 +7,18 @@ Extracting the Distribution
 ---------------------------
 
 The easiest way to install SpotBugs is to download a binary distribution.
-Binary distributions are available in `gzipped tar format <http://repo.maven.apache.org/maven2/com/github/spotbugs/spotbugs/3.1.0-RC5/spotbugs-3.1.0-RC5.tgz>`_ and `zip format <http://repo.maven.apache.org/maven2/com/github/spotbugs/spotbugs/3.1.0-RC5/spotbugs-3.1.0-RC5.zip>`_.
+Binary distributions are available in `gzipped tar format <http://repo.maven.apache.org/maven2/com/github/spotbugs/spotbugs/3.1.0-RC6/spotbugs-3.1.0-RC6.tgz>`_ and `zip format <http://repo.maven.apache.org/maven2/com/github/spotbugs/spotbugs/3.1.0-RC6/spotbugs-3.1.0-RC6.zip>`_.
 Once you have downloaded a binary distribution, extract it into a directory of your choice.
 
 Extracting a gzipped tar format distribution::
 
-    $ gunzip -c spotbugs-3.1.0-RC5.tgz | tar xvf -
+    $ gunzip -c spotbugs-3.1.0-RC6.tgz | tar xvf -
 
 Extracting a zip format distribution::
 
-    C:\Software> unzip spotbugs-3.1.0-RC5.zip
+    C:\Software> unzip spotbugs-3.1.0-RC6.zip
 
-Usually, extracting a binary distribution will create a directory ending in ``spotbugs-3.1.0-RC5``.
-For example, if you extracted the binary distribution from the ``C:\Software directory``, then the SpotBugs software will be extracted into the directory ``C:\Software\spotbugs-3.1.0-RC5``.
+Usually, extracting a binary distribution will create a directory ending in ``spotbugs-3.1.0-RC6``.
+For example, if you extracted the binary distribution from the ``C:\Software directory``, then the SpotBugs software will be extracted into the directory ``C:\Software\spotbugs-3.1.0-RC6``.
 This directory is the SpotBugs home directory.
 We'll refer to it as ``$SPOTBUGS_HOME`` (or ``%SPOTBUGS_HOME%`` for Windows) throughout this manual.

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -4,7 +4,7 @@ Introduction
 SpotBugs is a program to find bugs in Java programs.
 It looks for instances of "bug patterns" --- code instances that are likely to be errors.
 
-This document describes version 3.1.0-RC5 of SpotBugs.
+This document describes version 3.1.0-RC6 of SpotBugs.
 We are very interested in getting your feedback on SpotBugs.
 Please visit the SpotBugs web page for the latest information on SpotBugs, contact information, and support resources such as information about the SpotBugs GitHub organization.
 

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -12,13 +12,13 @@ Simply replace ``com.google.code.findbugs:findbugs`` with ``com.github.spotbugs:
   <dependency>
     <groupId>com.github.spotbugs</groupId>
     <artifactId>spotbugs</artifactId>
-    <version>3.1.0-RC5</version>
+    <version>3.1.0-RC6</version>
   </dependency>
 
 .. code-block:: groovy
 
   // for Gradle
-  compileOnly 'com.github.spotbugs:spotbugs:3.1.0-RC5'
+  compileOnly 'com.github.spotbugs:spotbugs:3.1.0-RC6'
 
 com.google.code.findbugs:jsr305
 -------------------------------
@@ -37,14 +37,14 @@ Please depend on ``spotbugs-annotations`` instead.
   <dependency>
     <groupId>com.github.spotbugs</groupId>
     <artifactId>spotbugs-annotations</artifactId>
-    <version>3.1.0-RC5</version>
+    <version>3.1.0-RC6</version>
     <optional>true</optional>
   </dependency>
 
 .. code-block:: groovy
 
   // for Gradle
-  compileOnly 'com.github.spotbugs:spotbugs-annotations:3.1.0-RC5'
+  compileOnly 'com.github.spotbugs:spotbugs-annotations:3.1.0-RC6'
 
 com.google.code.findbugs:annotations
 ------------------------------------
@@ -63,7 +63,7 @@ Please depend on both of ``spotbugs-annotations`` and ``net.jcip:jcip-annotation
   <dependency>
     <groupId>com.github.spotbugs</groupId>
     <artifactId>spotbugs-annotations</artifactId>
-    <version>3.1.0-RC5</version>
+    <version>3.1.0-RC6</version>
     <optional>true</optional>
   </dependency>
 
@@ -71,7 +71,7 @@ Please depend on both of ``spotbugs-annotations`` and ``net.jcip:jcip-annotation
 
   // for Gradle
   compileOnly 'net.jcip:jcip-annotations:1.0'
-  compileOnly 'com.github.spotbugs:spotbugs-annotations:3.1.0-RC5'
+  compileOnly 'com.github.spotbugs:spotbugs-annotations:3.1.0-RC6'
 
 FindBugs Ant task
 -----------------
@@ -111,7 +111,7 @@ Please use `com.github.hazendaz.spotbugs:spotbugs-maven-plugin` instead of `org.
       <dependency>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs</artifactId>
-        <version>3.1.0-RC5</version>
+        <version>3.1.0-RC6</version>
       </dependency>
     </dependencies>
   </plugin>
@@ -127,7 +127,7 @@ Please use spotbugs plugin found on https://plugins.gradle.org/plugin/com.github
     id  'com.github.spotbugs' version '1.3'
   }
   spotbugs {
-    toolVersion = '3.1.0-RC5'
+    toolVersion = '3.1.0-RC6'
   }
 
   // To generate an HTML report instead of XML

--- a/gradlePlugin/CHANGELOG.md
+++ b/gradlePlugin/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 This is the changelog for SpotBugs Gradle Plugin. This follows [Keep a Changelog v0.3](http://keepachangelog.com/en/0.3.0/).
 
+## Unreleased (2017/??/??)
+
 ## 1.4 (2017/Sep/11)
 
 * Fix "Cannot convert the provided notation to a File or URI: classesDirs" error ([#320](https://github.com/spotbugs/spotbugs/issues/320))

--- a/gradlePlugin/CHANGELOG.md
+++ b/gradlePlugin/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This is the changelog for SpotBugs Gradle Plugin. This follows [Keep a Changelog v0.3](http://keepachangelog.com/en/0.3.0/).
 
-## Unreleased (2017/??/??)
+## 1.4 (2017/Sep/11)
 
 * Fix "Cannot convert the provided notation to a File or URI: classesDirs" error ([#320](https://github.com/spotbugs/spotbugs/issues/320))
 * Support working with Android Gradle Plugin 2.3 ([#256](https://github.com/spotbugs/spotbugs/issues/256))

--- a/gradlePlugin/build.gradle
+++ b/gradlePlugin/build.gradle
@@ -6,7 +6,7 @@ plugins{
 
 apply from: "$rootDir/gradle/checkstyle.gradle"
 
-version = "1.4"
+version = "1.5-SNAPSHOT"
 group = "com.github.spotbugs"
 
 dependencies {

--- a/gradlePlugin/build.gradle
+++ b/gradlePlugin/build.gradle
@@ -6,7 +6,7 @@ plugins{
 
 apply from: "$rootDir/gradle/checkstyle.gradle"
 
-version = "1.4-SNAPSHOT"
+version = "1.4"
 group = "com.github.spotbugs"
 
 dependencies {


### PR DESCRIPTION
It seems that we need more time to use BCEL 6.1, so let's release RC6 without it.

After we merge this PR, we tag 2565477 or rebased commit then Travis CI will deploy artifacts to Sonatype Nexus, Gradle plugin repository and Eclipse Update Sites. This is the first version to use this deploy automation, I will recover if it fails.