### PR TITLE
replace Coveralls with SonarQube

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,9 +51,6 @@ script:
   - if [[ $JDK_FOR_TEST == "oraclejdk9" ]]; then remove_dir_from_path $JAVA_HOME/bin; export JAVA_HOME=/usr/lib/jvm/java-9-oracle; export JAVA_HOME=/usr/lib/jvm/java-9-oracle; fi
   - ./gradlew build smoketest sonarqube -S
 
-after_success:
-  - if [[ $JDK_FOR_TEST == "oraclejdk8" ]]; then ./gradlew coveralls; fi
-
 before_cache:
   - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -rf $HOME/.gradle/caches/*/plugin-resolution/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # ![SpotBugs](https://spotbugs.github.io/images/logos/spotbugs_logo_300px.png)
 
 [![Build Status](https://travis-ci.org/spotbugs/spotbugs.svg?branch=master)](https://travis-ci.org/spotbugs/spotbugs)
-[![Coverage Status](https://coveralls.io/repos/github/spotbugs/spotbugs/badge.svg?branch=master)](https://coveralls.io/github/spotbugs/spotbugs?branch=master)
+[![Coverage Status](https://sonarcloud.io/api/badges/measure?key=com.github.spotbugs.spotbugs&metric=coverage)](https://sonarcloud.io/component_measures?id=com.github.spotbugs.spotbugs&metric=coverage)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.spotbugs/spotbugs/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.github.spotbugs/spotbugs)
 [![Javadocs](http://javadoc.io/badge/com.github.spotbugs/spotbugs.svg)](http://javadoc.io/doc/com.github.spotbugs/spotbugs)
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,4 @@
 plugins {
-  id "com.github.kt3k.coveralls" version "2.7.1"
   id 'org.sonarqube' version '2.5'
 }
 
@@ -39,7 +38,7 @@ wrapper {
 
 // https://discuss.gradle.org/t/merge-jacoco-coverage-reports-for-multiproject-setups/12100/6
 task jacocoRootReport(type: JacocoReport) {
-  description = 'Merge all coverage reports before submit to coveralls'
+  description = 'Merge all coverage reports before submit to SonarQube'
 
   executionData project(':spotbugs').file('build/jacoco/test.exec')
   sourceDirectories = files(subprojects.sourceSets.main.allSource.srcDirs)
@@ -53,15 +52,4 @@ task jacocoRootReport(type: JacocoReport) {
     xml.enabled = true
   }
 }
-
-coveralls {
-  jacocoReportPath = "${buildDir}/reports/jacoco/jacocoRootReport/jacocoRootReport.xml"
-}
-
-tasks.coveralls {
-  dependsOn jacocoRootReport
-  doFirst {
-    // set lazily to relect subproject specific config in each build.groovy
-    coveralls.sourceDirs = subprojects.sourceSets.main.allSource.srcDirs.flatten()
-  }
-}
+tasks.sonarqube.dependsOn jacocoRootReport

--- a/gradle/jacoco.gradle
+++ b/gradle/jacoco.gradle
@@ -6,7 +6,6 @@ jacoco {
 
 jacocoTestReport {
   reports {
-    xml.enabled = true // coveralls plugin depends on xml format report
     html.enabled = true
   }
 }

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -261,10 +261,6 @@ task smokeTest {
   }
 }
 
-coveralls {
-  jacocoReportPath = "${buildDir}/reports/jacoco/test/jacocoTestReport.xml"
-}
-
 uploadArchives {
   repositories {
     mavenDeployer {


### PR DESCRIPTION
I think we do not have to use Coveralls any more.

SonarQube supports enough use cases, and coveralls recently not so stable. Sometimes it cannot display badge, and recently it report no coverage change in PR page.

@kzaikin can I ask you to review this change, because this is related with #217.