### PR TITLE
Avoid exceptions on processing INVOKEDYNAMIC instructions, see #371

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v0.3](http://
 
 * Fix broken command line script ([#323](https://github.com/spotbugs/spotbugs/issues/323))
 * Fix broken Eclipse classpath variables ([#379](https://github.com/spotbugs/spotbugs/issues/379))
+* Fix errors on processing INVOKEDYNAMIC instructions ([#371](https://github.com/spotbugs/spotbugs/issues/371))
 
 ## 3.1.0-RC5 (2017/Aug/16)
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue371Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue371Test.java
@@ -1,0 +1,22 @@
+package edu.umd.cs.findbugs.ba;
+
+import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
+
+public class Issue371Test extends AbstractIntegrationTest {
+
+    @Test
+    public void test() {
+        performAnalysis("lambdas/Issue371.class");
+        final BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
+                .bugType("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE").build();
+        assertThat(getBugCollection(), containsExactly(1, bugTypeMatcher));
+    }
+
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/Hierarchy.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/Hierarchy.java
@@ -734,6 +734,9 @@ public class Hierarchy {
             // the class specified by the instruction
             receiverType = ObjectTypeFactory.getInstance(invokeInstruction.getClassName(cpg));
             receiverTypeIsExact = false; // Doesn't actually matter
+        } else if (opcode == Const.INVOKEDYNAMIC) {
+            // XXX handle INVOKEDYNAMIC
+            return new HashSet<>();
         } else {
             // For invokevirtual and invokeinterface instructions, we have
             // virtual dispatch. By taking the receiver type (which may be a

--- a/spotbugsTestCases/src/java/lambdas/Issue371.java
+++ b/spotbugsTestCases/src/java/lambdas/Issue371.java
@@ -1,0 +1,14 @@
+package lambdas;
+import javax.annotation.CheckForNull;
+
+public class Issue371 {
+
+    @CheckForNull
+    private String returnsNull() {
+        return null;
+    }
+
+    public void dereferenceWithLambda() {
+        returnsNull().chars().map(x -> 42);
+    }
+}


### PR DESCRIPTION
The similar workaround was already applied to
Hierarchy2.resolveMethodCallTargets().