### PR TITLE
Update manifest before generate Eclipse projects

### DIFF
--- a/spotbugs-annotations/build.gradle
+++ b/spotbugs-annotations/build.gradle
@@ -19,6 +19,7 @@ task updateManifest {
     // write manifests
     manifestSpec.writeTo("$projectDir/META-INF/MANIFEST.MF")
 }
+tasks.eclipse.dependsOn(updateManifest)
 
 jar {
   manifest {

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -117,6 +117,7 @@ task updateManifest {
     manifestSpec.writeTo("$projectDir/META-INF/MANIFEST.MF")
   }
 }
+tasks.eclipse.dependsOn(updateManifest)
 
 // Manually define what goes into the default jar, since it's not only main sourceset
 jar {


### PR DESCRIPTION
We define this dependency in eclipsePlugin/build.gradle,
but it is possible to ignore this if developer has no local.properties.

So we need to have this dependency even in spotbugs/build.gradle
and spotbugs-annotation/build.gradle.