### PR TITLE
Remove redundant type arguments in spotbugs, fixes #386

### DIFF
--- a/eclipsePlugin/src/de/tobject/findbugs/DetectorsExtensionHelper.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/DetectorsExtensionHelper.java
@@ -59,16 +59,16 @@ public class DetectorsExtensionHelper {
     /** key is the plugin id, value is the plugin library path */
     public static synchronized SortedMap<String, String> getContributedDetectors() {
         if (contributedDetectors != null) {
-            return new TreeMap<String, String>(contributedDetectors);
+            return new TreeMap<>(contributedDetectors);
         }
-        TreeMap<String, String> set = new TreeMap<String, String>();
+        TreeMap<String, String> set = new TreeMap<>();
 
         IExtensionRegistry registry = Platform.getExtensionRegistry();
         for (IConfigurationElement configElt : registry.getConfigurationElementsFor(EXTENSION_POINT_ID)) {
             addContribution(set, configElt);
         }
         contributedDetectors = set;
-        return new TreeMap<String, String>(contributedDetectors);
+        return new TreeMap<>(contributedDetectors);
     }
 
     private static void addContribution(TreeMap<String, String> set, IConfigurationElement configElt) {

--- a/eclipsePlugin/src/de/tobject/findbugs/EclipseGuiCallback.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/EclipseGuiCallback.java
@@ -52,7 +52,7 @@ public class EclipseGuiCallback implements IGuiCallback {
 
     @Override
     public String showQuestionDialog(String message, String title, final String defaultValue) {
-        final AtomicReference<Text> textBoxRef = new AtomicReference<Text>();
+        final AtomicReference<Text> textBoxRef = new AtomicReference<>();
         MessageDialog dlg = new MessageDialog(FindbugsPlugin.getShell(), getDialogTitle(title), null, message, MessageDialog.QUESTION,
                 new String[] { "OK", "Cancel" }, 1) {
             @Override

--- a/eclipsePlugin/src/de/tobject/findbugs/FindbugsPlugin.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/FindbugsPlugin.java
@@ -141,7 +141,7 @@ public class FindbugsPlugin extends AbstractUIPlugin {
     public static final String BUG_CONTENT_PROVIDER_ID = "de.tobject.findbugs.view.explorer.BugContentProvider";
 
     /** Map containing preloaded ImageDescriptors */
-    private final Map<String, ImageDescriptor> imageDescriptors = new HashMap<String, ImageDescriptor>(13);
+    private final Map<String, ImageDescriptor> imageDescriptors = new HashMap<>(13);
 
     /** Controls debugging of the plugin */
     public static boolean DEBUG;
@@ -281,7 +281,7 @@ public class FindbugsPlugin extends AbstractUIPlugin {
         }
         customDetectorsInitialized = true;
         DetectorValidator validator = new DetectorValidator();
-        final SortedSet<String> detectorPaths = new TreeSet<String>();
+        final SortedSet<String> detectorPaths = new TreeSet<>();
         SortedMap<String, String> contributedDetectors = DetectorsExtensionHelper.getContributedDetectors();
         UserPreferences corePreferences = getCorePreferences(null, force);
         detectorPaths.addAll(corePreferences.getCustomPlugins(true));
@@ -319,7 +319,7 @@ public class FindbugsPlugin extends AbstractUIPlugin {
             }
         }
 
-        HashSet<Plugin> enabled = new HashSet<Plugin>();
+        HashSet<Plugin> enabled = new HashSet<>();
 
         // adding FindBugs *Eclipse* plugins, key plugin id, value is path
         for (Entry<String, String> entry : contributedDetectors.entrySet()) {
@@ -1127,7 +1127,7 @@ public class FindbugsPlugin extends AbstractUIPlugin {
     }
 
     public static Set<BugPattern> getKnownPatterns() {
-        Set<BugPattern> patterns = new TreeSet<BugPattern>();
+        Set<BugPattern> patterns = new TreeSet<>();
         Iterator<BugPattern> patternIterator = DetectorFactoryCollection.instance().bugPatternIterator();
         while (patternIterator.hasNext()) {
             patterns.add(patternIterator.next());
@@ -1136,7 +1136,7 @@ public class FindbugsPlugin extends AbstractUIPlugin {
     }
 
     public static Set<BugCode> getKnownPatternTypes() {
-        Set<BugCode> patterns = new TreeSet<BugCode>(DetectorFactoryCollection.instance().getBugCodes());
+        Set<BugCode> patterns = new TreeSet<>(DetectorFactoryCollection.instance().getBugCodes());
         return patterns;
     }
 
@@ -1148,7 +1148,7 @@ public class FindbugsPlugin extends AbstractUIPlugin {
 
     public static Set<BugPattern> getFilteredPatterns() {
         Iterator<BugPattern> patternIterator = DetectorFactoryCollection.instance().bugPatternIterator();
-        Set<BugPattern> set = new HashSet<BugPattern>();
+        Set<BugPattern> set = new HashSet<>();
         Set<String> patternTypes = getFilteredIds();
         while (patternIterator.hasNext()) {
             BugPattern next = patternIterator.next();
@@ -1162,7 +1162,7 @@ public class FindbugsPlugin extends AbstractUIPlugin {
     }
 
     public static Set<BugCode> getFilteredPatternTypes() {
-        Set<BugCode> set = new HashSet<BugCode>();
+        Set<BugCode> set = new HashSet<>();
         Set<String> patternTypes = getFilteredIds();
         for(BugCode next :  DetectorFactoryCollection.instance().getBugCodes()) {
             String type = next.getAbbrev();

--- a/eclipsePlugin/src/de/tobject/findbugs/actions/FindBugsEditorAction.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/actions/FindBugsEditorAction.java
@@ -52,7 +52,7 @@ public class FindBugsEditorAction extends FindBugsAction implements IEditorActio
     public final void run(final IAction action) {
         if (currentEditor != null) {
             IFile file = ((FileEditorInput) (currentEditor.getEditorInput())).getFile();
-            List<WorkItem> list = new ArrayList<WorkItem>();
+            List<WorkItem> list = new ArrayList<>();
             list.add(new WorkItem(file));
             work(currentEditor, file, list);
         }

--- a/eclipsePlugin/src/de/tobject/findbugs/actions/GroupByAction.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/actions/GroupByAction.java
@@ -69,7 +69,7 @@ public class GroupByAction implements IViewActionDelegate {
         }
         id = id.substring(ACTION_ID_PREFIX.length());
         String[] typesArr = id.split("\\.");
-        List<GroupType> types = new ArrayList<GroupType>();
+        List<GroupType> types = new ArrayList<>();
         for (String string : typesArr) {
             GroupType type = GroupType.valueOf(string);
             types.add(type);

--- a/eclipsePlugin/src/de/tobject/findbugs/actions/MarkerRulerAction.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/actions/MarkerRulerAction.java
@@ -78,7 +78,7 @@ public class MarkerRulerAction implements IEditorActionDelegate, IUpdate, MouseL
 
     public MarkerRulerAction() {
         super();
-        markers = new ArrayList<IMarker>();
+        markers = new ArrayList<>();
     }
 
     public void setActiveEditor(IAction callerAction, IEditorPart targetEditor) {

--- a/eclipsePlugin/src/de/tobject/findbugs/builder/FindBugs2Eclipse.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/builder/FindBugs2Eclipse.java
@@ -62,10 +62,10 @@ import edu.umd.cs.findbugs.log.Profiler.Profile;
 public class FindBugs2Eclipse extends FindBugs2 {
 
     private static WeakHashMap<IProject, SoftReference<List<String>>> auxClassPaths =
-        new WeakHashMap<IProject, SoftReference<List<String>>>();
+        new WeakHashMap<>();
 
     private static WeakHashMap<IProject, SoftReference<Map<ClassDescriptor, Object>>> classAnalysisCache =
-        new WeakHashMap<IProject, SoftReference<Map<ClassDescriptor, Object>>>();
+        new WeakHashMap<>();
 
     private AnalysisCache analysisCache;
     private final IProject project;
@@ -81,7 +81,7 @@ public class FindBugs2Eclipse extends FindBugs2 {
             } else if (event.getResource() instanceof IProject) {
                 cleanClassClache((IProject) event.getResource());
             } else if(event.getDelta() != null) {
-                final Set<IProject> affectedProjects = new HashSet<IProject>();
+                final Set<IProject> affectedProjects = new HashSet<>();
                 final IResourceDelta delta = event.getDelta();
                 try {
                     delta.accept(new IResourceDeltaVisitor() {
@@ -190,8 +190,8 @@ public class FindBugs2Eclipse extends FindBugs2 {
         }
         if(cacheClassData) {
             // create new reference not reachable to anyone except us
-            classAnalysis = new HashMap<ClassDescriptor, Object>(classAnalysis);
-            classAnalysisCache.put(project, new SoftReference<Map<ClassDescriptor, Object>>(classAnalysis));
+            classAnalysis = new HashMap<>(classAnalysis);
+            classAnalysisCache.put(project, new SoftReference<>(classAnalysis));
         }
         reportExtraData(data);
     }
@@ -256,10 +256,10 @@ public class FindBugs2Eclipse extends FindBugs2 {
         SoftReference<List<String>> wr = auxClassPaths.get(project);
         List<String> oldAuxCp = wr != null ? wr.get() : null;
         if(oldAuxCp != null && !oldAuxCp.equals(auxClassPath)) {
-            auxClassPaths.put(project, new SoftReference<List<String>>(new ArrayList<String>(auxClassPath)));
+            auxClassPaths.put(project, new SoftReference<List<String>>(new ArrayList<>(auxClassPath)));
             classAnalysisCache.remove(project);
         } else if(oldAuxCp == null){
-            auxClassPaths.put(project, new SoftReference<List<String>>(new ArrayList<String>(auxClassPath)));
+            auxClassPaths.put(project, new SoftReference<List<String>>(new ArrayList<>(auxClassPath)));
         }
     }
 }

--- a/eclipsePlugin/src/de/tobject/findbugs/builder/FindBugsBuilder.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/builder/FindBugsBuilder.java
@@ -130,7 +130,7 @@ public class FindBugsBuilder extends IncrementalProjectBuilder {
             IResourceDelta resourceDelta = getDelta(project);
             boolean configChanged = !isConfigUnchanged(resourceDelta);
             if (configChanged) {
-                files = new ArrayList<WorkItem>();
+                files = new ArrayList<>();
                 files.add(new WorkItem(project));
             } else {
                 files = ResourceUtils.collectIncremental(resourceDelta);
@@ -142,7 +142,7 @@ public class FindBugsBuilder extends IncrementalProjectBuilder {
                 }
             }
         } else {
-            files = new ArrayList<WorkItem>();
+            files = new ArrayList<>();
             files.add(new WorkItem(project));
         }
 

--- a/eclipsePlugin/src/de/tobject/findbugs/builder/FindBugsWorker.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/builder/FindBugsWorker.java
@@ -371,7 +371,7 @@ public class FindBugsWorker {
     }
 
     private Map<String, Boolean> relativeToAbsolute(Map<String, Boolean> map) {
-        Map<String, Boolean> resultMap = new TreeMap<String, Boolean>();
+        Map<String, Boolean> resultMap = new TreeMap<>();
         for (Entry<String, Boolean> entry : map.entrySet()) {
             if(!entry.getValue().booleanValue()) {
                 continue;
@@ -484,7 +484,7 @@ public class FindBugsWorker {
      */
     private Map<IPath, IPath> createOutputLocations() throws CoreException {
 
-        Map<IPath, IPath> srcToOutputMap = new HashMap<IPath, IPath>();
+        Map<IPath, IPath> srcToOutputMap = new HashMap<>();
 
         // get the default location => relative to wsp
         IPath defaultOutputLocation = ResourceUtils.relativeToAbsolute(javaProject.getOutputLocation());

--- a/eclipsePlugin/src/de/tobject/findbugs/builder/PDEClassPathGenerator.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/builder/PDEClassPathGenerator.java
@@ -85,7 +85,7 @@ public class PDEClassPathGenerator {
 
     @SuppressWarnings("restriction")
     private static Set<String> createJavaClasspath(IJavaProject javaProject, Set<IProject> projectOnCp) {
-        LinkedHashSet<String> classPath = new LinkedHashSet<String>();
+        LinkedHashSet<String> classPath = new LinkedHashSet<>();
         try {
             // doesn't return jre libraries
             String[] defaultClassPath = JavaRuntime.computeDefaultRuntimeClassPath(javaProject);
@@ -214,7 +214,7 @@ public class PDEClassPathGenerator {
 
         BundleDescription target = model.getBundleDescription();
 
-        Set<BundleDescription> bundles = new HashSet<BundleDescription>();
+        Set<BundleDescription> bundles = new HashSet<>();
         // target is null if plugin uses non OSGI format
         if (target != null) {
             addDependentBundles(target, bundles);
@@ -242,7 +242,7 @@ public class PDEClassPathGenerator {
         if(model == null) {
             return;
         }
-        ArrayList<IClasspathEntry> classpathEntries = new ArrayList<IClasspathEntry>();
+        ArrayList<IClasspathEntry> classpathEntries = new ArrayList<>();
         ClasspathUtilCore.addLibraries(model, classpathEntries);
 
         for (IClasspathEntry cpe : classpathEntries) {

--- a/eclipsePlugin/src/de/tobject/findbugs/builder/ResourceUtils.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/builder/ResourceUtils.java
@@ -132,8 +132,8 @@ public class ResourceUtils {
      */
     public static List<WorkItem> collectIncremental(IResourceDelta delta) {
         // XXX deleted packages should be considered to remove markers
-        List<WorkItem> result = new ArrayList<WorkItem>();
-        List<IResourceDelta> foldersDelta = new ArrayList<IResourceDelta>();
+        List<WorkItem> result = new ArrayList<>();
+        List<IResourceDelta> foldersDelta = new ArrayList<>();
         IResourceDelta affectedChildren[] = delta.getAffectedChildren();
         for (int i = 0; i < affectedChildren.length; i++) {
             IResourceDelta childDelta = affectedChildren[i];
@@ -190,7 +190,7 @@ public class ResourceUtils {
      *         If project itself was selected, then key is the same as value.
      */
     public static Map<IProject, List<WorkItem>> getResourcesPerProject(IStructuredSelection structuredSelection) {
-        Map<IProject, List<WorkItem>> projectsMap = new HashMap<IProject, List<WorkItem>>();
+        Map<IProject, List<WorkItem>> projectsMap = new HashMap<>();
         for (Iterator<?> iter = structuredSelection.iterator(); iter.hasNext();) {
             Object element = iter.next();
             WorkItem workItem = getWorkItem(element);
@@ -226,7 +226,7 @@ public class ResourceUtils {
      * @return non null set with work items, which may be empty
      */
     public static Set<WorkItem> getResources(IWorkingSet wset) {
-        Set<WorkItem> set = new HashSet<WorkItem>();
+        Set<WorkItem> set = new HashSet<>();
         boolean aggregateWorkingSet = wset.isAggregateWorkingSet();
         // IAggregateWorkingSet was introduced in Eclipse 3.5
         if (aggregateWorkingSet && wset instanceof IAggregateWorkingSet) {
@@ -262,7 +262,7 @@ public class ResourceUtils {
         }
         List<WorkItem> resources = projectsMap.get(project);
         if (resources == null) {
-            resources = new ArrayList<WorkItem>();
+            resources = new ArrayList<>();
             projectsMap.put(project, resources);
         }
         // do not need to check for duplicates, cause user cannot select
@@ -282,7 +282,7 @@ public class ResourceUtils {
     public static List<WorkItem> getResources(ChangeSet set) {
         if (set != null && !set.isEmpty()) {
             IResource[] resources = set.getResources();
-            List<WorkItem> filtered = new ArrayList<WorkItem>();
+            List<WorkItem> filtered = new ArrayList<>();
             for (IResource resource : resources) {
                 if (resource.getType() == IResource.FILE && !Util.isJavaArtifact(resource)) {
                     // Ignore non java files

--- a/eclipsePlugin/src/de/tobject/findbugs/builder/WorkItem.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/builder/WorkItem.java
@@ -296,7 +296,7 @@ public class WorkItem {
                 recursive = true;
             }
             IMarker[] markers = MarkerUtil.getMarkers(res, recursive ? IResource.DEPTH_INFINITE : IResource.DEPTH_ONE);
-            return new HashSet<IMarker>(Arrays.asList(markers));
+            return new HashSet<>(Arrays.asList(markers));
         }
         IResource markerTarget = getMarkerTarget();
         if(!markerTarget.isAccessible()) {

--- a/eclipsePlugin/src/de/tobject/findbugs/preferences/FindBugsConstants.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/preferences/FindBugsConstants.java
@@ -128,7 +128,7 @@ public final class FindBugsConstants {
     }
 
     public static Set<String> decodeIds(String text) {
-        Set<String> sortedIds = new TreeSet<String>();
+        Set<String> sortedIds = new TreeSet<>();
         if (text == null || text.trim().length() == 0) {
             return sortedIds;
         }

--- a/eclipsePlugin/src/de/tobject/findbugs/properties/DetectorConfigurationTab.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/properties/DetectorConfigurationTab.java
@@ -312,7 +312,7 @@ public class DetectorConfigurationTab extends Composite {
 
     public DetectorConfigurationTab(TabFolder tabFolder, final FindbugsPropertyPage page, int style) {
         super(tabFolder, style);
-        columnsMap = new HashMap<Integer, COLUMN>();
+        columnsMap = new HashMap<>();
         this.propertyPage = page;
         setLayout(new GridLayout());
 
@@ -456,7 +456,7 @@ public class DetectorConfigurationTab extends Composite {
     private String getBugsCategories(DetectorFactory factory) {
         Collection<BugPattern> patterns = factory.getReportedBugPatterns();
         String category = null;
-        Set<String> categories = new TreeSet<String>();
+        Set<String> categories = new TreeSet<>();
         for (BugPattern bugPattern : patterns) {
             String category2 = bugPattern.getCategory();
             if (category == null) {
@@ -628,8 +628,8 @@ public class DetectorConfigurationTab extends Composite {
      * Populate the rule table
      */
     private void populateAvailableRulesTable(IProject project) {
-        List<DetectorFactory> allAvailableList = new ArrayList<DetectorFactory>();
-        factoriesToBugAbbrev = new HashMap<DetectorFactory, String>();
+        List<DetectorFactory> allAvailableList = new ArrayList<>();
+        factoriesToBugAbbrev = new HashMap<>();
         Iterator<DetectorFactory> iterator = DetectorFactoryCollection.instance().factoryIterator();
         while (iterator.hasNext()) {
             DetectorFactory factory = iterator.next();
@@ -678,7 +678,7 @@ public class DetectorConfigurationTab extends Composite {
     private String createBugsAbbreviation(DetectorFactory factory) {
         StringBuffer sb = new StringBuffer();
         Collection<BugPattern> patterns = factory.getReportedBugPatterns();
-        LinkedHashSet<String> abbrs = new LinkedHashSet<String>();
+        LinkedHashSet<String> abbrs = new LinkedHashSet<>();
         for (Iterator<BugPattern> iter = patterns.iterator(); iter.hasNext();) {
             BugPattern pattern = iter.next();
             String abbr = pattern.getAbbrev();

--- a/eclipsePlugin/src/de/tobject/findbugs/properties/DetectorProvider.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/properties/DetectorProvider.java
@@ -61,11 +61,11 @@ public class DetectorProvider extends PathsProvider {
      */
     public static List<IPathElement> getPluginElements(UserPreferences userPreferences) {
         DetectorValidator validator = new DetectorValidator();
-        final List<IPathElement> newPaths = new ArrayList<IPathElement>();
+        final List<IPathElement> newPaths = new ArrayList<>();
         Map<String, Boolean> pluginPaths = userPreferences.getCustomPlugins();
 
-        Set<String> disabledSystemPlugins = new HashSet<String>();
-        Set<URI> customPlugins = new HashSet<URI>();
+        Set<String> disabledSystemPlugins = new HashSet<>();
+        Set<URI> customPlugins = new HashSet<>();
         Set<Entry<String,Boolean>> entrySet = pluginPaths.entrySet();
         for (Entry<String, Boolean> entry : entrySet) {
             String idOrPath = entry.getKey();

--- a/eclipsePlugin/src/de/tobject/findbugs/properties/FilterFilesTab.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/properties/FilterFilesTab.java
@@ -91,7 +91,7 @@ public class FilterFilesTab extends Composite {
 
         List<IPathElement> getFilterFiles(UserPreferences prefs) {
             IProject project = propertyPage.getProject();
-            final List<IPathElement> newPaths = new ArrayList<IPathElement>();
+            final List<IPathElement> newPaths = new ArrayList<>();
             Map<String, Boolean> filterPaths = kind.selectedPaths(prefs);
             if (filterPaths != null) {
                 for (Entry<String, Boolean> entry : filterPaths.entrySet()) {
@@ -219,7 +219,7 @@ public class FilterFilesTab extends Composite {
 
             @Override
             Map<String, Boolean> excludedPaths(UserPreferences u) {
-                Map<String, Boolean> excl = new TreeMap<String, Boolean>();
+                Map<String, Boolean> excl = new TreeMap<>();
                 excl.putAll(u.getExcludeFilterFiles());
                 excl.putAll(u.getExcludeBugsFiles());
                 return excl;
@@ -238,7 +238,7 @@ public class FilterFilesTab extends Composite {
 
             @Override
             Map<String, Boolean> excludedPaths(UserPreferences u) {
-                Map<String, Boolean> excl = new TreeMap<String, Boolean>();
+                Map<String, Boolean> excl = new TreeMap<>();
                 excl.putAll(u.getIncludeFilterFiles());
                 excl.putAll(u.getExcludeBugsFiles());
                 return excl;
@@ -257,7 +257,7 @@ public class FilterFilesTab extends Composite {
 
             @Override
             Map<String, Boolean> excludedPaths(UserPreferences u) {
-                Map<String, Boolean> excl = new TreeMap<String, Boolean>();
+                Map<String, Boolean> excl = new TreeMap<>();
                 excl.putAll(u.getIncludeFilterFiles());
                 excl.putAll(u.getExcludeFilterFiles());
                 return excl;

--- a/eclipsePlugin/src/de/tobject/findbugs/properties/FindbugsPropertyPage.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/properties/FindbugsPropertyPage.java
@@ -148,7 +148,7 @@ public class FindbugsPropertyPage extends PropertyPage implements IWorkbenchPref
      */
     public FindbugsPropertyPage() {
         super();
-        visibleDetectors = new HashMap<DetectorFactory, Boolean>();
+        visibleDetectors = new HashMap<>();
     }
 
     @Override

--- a/eclipsePlugin/src/de/tobject/findbugs/properties/PathsProvider.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/properties/PathsProvider.java
@@ -65,7 +65,7 @@ abstract class PathsProvider extends SelectionAdapter implements IStructuredCont
 
     protected PathsProvider(TableViewer viewer, FindbugsPropertyPage propertyPage) {
         this.propertyPage = propertyPage;
-        this.paths = new ArrayList<IPathElement>();
+        this.paths = new ArrayList<>();
         this.viewer = viewer;
         if(viewer instanceof CheckboxTableViewer) {
             CheckboxTableViewer tv = (CheckboxTableViewer) viewer;
@@ -99,7 +99,7 @@ abstract class PathsProvider extends SelectionAdapter implements IStructuredCont
         paths.addAll(filterFiles);
         if(viewer instanceof CheckboxTableViewer) {
             CheckboxTableViewer tv = (CheckboxTableViewer) viewer;
-            List<IPathElement> checked = new ArrayList<IPathElement>();
+            List<IPathElement> checked = new ArrayList<>();
             for (IPathElement pe : paths) {
                 if(pe.isEnabled()) {
                     checked.add(pe);
@@ -250,7 +250,7 @@ abstract class PathsProvider extends SelectionAdapter implements IStructuredCont
 
     protected Map<String, Boolean> pathsToStrings() {
         IProject project = propertyPage.getProject();
-        Map<String, Boolean> result = new TreeMap<String, Boolean>();
+        Map<String, Boolean> result = new TreeMap<>();
         for (IPathElement path : paths) {
             if(path.isSystem()) {
                 if (!path.isEnabled()) {

--- a/eclipsePlugin/src/de/tobject/findbugs/properties/ReportConfigurationTab.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/properties/ReportConfigurationTab.java
@@ -247,8 +247,8 @@ public class ReportConfigurationTab extends Composite {
         checkBoxGroup.setLayout(new GridLayout(1, true));
         checkBoxGroup.setLayoutData(new GridData(SWT.BEGINNING, SWT.TOP, true, true));
 
-        List<String> bugCategoryList = new LinkedList<String>(DetectorFactoryCollection.instance().getBugCategories());
-        chkEnableBugCategoryList = new LinkedList<Button>();
+        List<String> bugCategoryList = new LinkedList<>(DetectorFactoryCollection.instance().getBugCategories());
+        chkEnableBugCategoryList = new LinkedList<>();
         ProjectFilterSettings origFilterSettings = propertyPage.getOriginalUserPreferences().getFilterSettings();
         for (String category : bugCategoryList) {
             Button checkBox = new Button(checkBoxGroup, SWT.CHECK);

--- a/eclipsePlugin/src/de/tobject/findbugs/reporter/JdtUtils.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/reporter/JdtUtils.java
@@ -65,7 +65,7 @@ public class JdtUtils {
             this.sourceComparator = sourceComparator;
             is50OrHigher = is50OrHigher(javaElement);
             topAncestorType = (IType) getLastAncestor(javaElement, IJavaElement.TYPE);
-            map = new IdentityHashMap<IType, Integer>();
+            map = new IdentityHashMap<>();
         }
 
         /**
@@ -267,7 +267,7 @@ public class JdtUtils {
             return null;
         }
 
-        List<IType> list = new ArrayList<IType>();
+        List<IType> list = new ArrayList<>();
         /*
          * For JDK >= 1.5 in Eclipse 3.1+ the naming schema for nested anonymous
          * classes was changed from A$1, A$2, A$3, A$4, ..., A$n to A$1, A$1$1,

--- a/eclipsePlugin/src/de/tobject/findbugs/reporter/MarkerReporter.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/reporter/MarkerReporter.java
@@ -151,7 +151,7 @@ public class MarkerReporter implements IWorkspaceRunnable {
      */
     @Nonnull
     private Map<String, Object> createMarkerAttributes(MarkerParameter mp) {
-        Map<String, Object> attributes = new HashMap<String, Object>(23);
+        Map<String, Object> attributes = new HashMap<>(23);
         attributes.put(IMarker.LINE_NUMBER, mp.startLine);
         attributes.put(PRIMARY_LINE, mp.primaryLine);
         attributes.put(BUG_TYPE, mp.bug.getType());

--- a/eclipsePlugin/src/de/tobject/findbugs/reporter/MarkerUtil.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/reporter/MarkerUtil.java
@@ -154,7 +154,7 @@ public final class MarkerUtil {
      */
     public static List<MarkerParameter> createBugParameters(IJavaProject project, BugCollection theCollection,
             IProgressMonitor monitor) {
-        List<MarkerParameter> bugParameters = new ArrayList<MarkerParameter>();
+        List<MarkerParameter> bugParameters = new ArrayList<>();
         if (project == null) {
             FindbugsPlugin.getDefault().logException(new NullPointerException("project is null"), "project is null");
             return bugParameters;
@@ -648,7 +648,7 @@ public final class MarkerUtil {
 
     public static Set<IMarker> findMarkerForJavaElement(IJavaElement elt, IMarker[] possibleCandidates, boolean recursive) {
         String id = elt.getHandleIdentifier();
-        Set<IMarker> markers = new HashSet<IMarker>();
+        Set<IMarker> markers = new HashSet<>();
         for (IMarker marker : possibleCandidates) {
             try {
                 Object elementId = marker.getAttribute(FindBugsMarker.UNIQUE_JAVA_ID);
@@ -821,7 +821,7 @@ public final class MarkerUtil {
      *         selection
      */
     public static Set<IMarker> getMarkerFromSelection(ISelection selection) {
-        Set<IMarker> markers = new HashSet<IMarker>();
+        Set<IMarker> markers = new HashSet<>();
         if (!(selection instanceof IStructuredSelection)) {
             return markers;
         }
@@ -834,7 +834,7 @@ public final class MarkerUtil {
     }
 
     public static Set<IMarker> getMarkers(Object obj) {
-        Set<IMarker> markers = new HashSet<IMarker>();
+        Set<IMarker> markers = new HashSet<>();
         if (obj instanceof IMarker) {
             IMarker marker = (IMarker) obj;
             if (isFindBugsMarker(marker)) {

--- a/eclipsePlugin/src/de/tobject/findbugs/reporter/Reporter.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/reporter/Reporter.java
@@ -139,7 +139,7 @@ public class Reporter extends AbstractBugReporter implements FindBugsProgress {
     @Override
     public void reportQueuedErrors() {
         // Report unique errors in order of their sequence
-        List<Error> errorList = new ArrayList<Error>(getQueuedErrors());
+        List<Error> errorList = new ArrayList<>(getQueuedErrors());
         if (errorList.size() > 0) {
             Collections.sort(errorList, new Comparator<Error>() {
                 @Override
@@ -289,7 +289,7 @@ public class Reporter extends AbstractBugReporter implements FindBugsProgress {
     @Override
     public void reportNumberOfArchives(int numArchives) {
         printToStream("\nStarting SpotBugs analysis on file(s) from: " + project.getElementName());
-        List<String> classpathEntryList = new ArrayList<String>(bugCollection.getProject().getAuxClasspathEntryList());
+        List<String> classpathEntryList = new ArrayList<>(bugCollection.getProject().getAuxClasspathEntryList());
         printToStream("\nResolved auxiliary classpath (" + classpathEntryList.size() + " entries):");
         for (String path : classpathEntryList) {
             printToStream("\t " + path);

--- a/eclipsePlugin/src/de/tobject/findbugs/util/ProjectUtilities.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/util/ProjectUtilities.java
@@ -100,7 +100,7 @@ public class ProjectUtilities {
     @Nonnull
     public static List<IProject> getFindBugsProjects(){
         IProject[] projects = ResourcesPlugin.getWorkspace().getRoot().getProjects();
-        List<IProject> fbProj = new ArrayList<IProject>();
+        List<IProject> fbProj = new ArrayList<>();
         for (IProject aProject : projects) {
             if (aProject.isAccessible() && ProjectUtilities.hasFindBugsNature(aProject)) {
                 fbProj.add(aProject);
@@ -124,7 +124,7 @@ public class ProjectUtilities {
         }
         IProjectDescription description = project.getDescription();
         String[] prevNatures = description.getNatureIds();
-        ArrayList<String> newNaturesList = new ArrayList<String>();
+        ArrayList<String> newNaturesList = new ArrayList<>();
         for (int i = 0; i < prevNatures.length; i++) {
             if (!FindbugsPlugin.NATURE_ID.equals(prevNatures[i])) {
                 newNaturesList.add(prevNatures[i]);

--- a/eclipsePlugin/src/de/tobject/findbugs/util/Util.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/util/Util.java
@@ -139,7 +139,7 @@ public class Util {
      * the results ascending with the overall time.
      */
     public static class StopTimer {
-        TreeMap<Long, String> stopTimes = new TreeMap<Long, String>();
+        TreeMap<Long, String> stopTimes = new TreeMap<>();
 
         public synchronized void newPoint(String name) {
             Long time = Long.valueOf(System.currentTimeMillis());

--- a/eclipsePlugin/src/de/tobject/findbugs/view/BugExplorerView.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/view/BugExplorerView.java
@@ -185,7 +185,7 @@ public class BugExplorerView extends CommonNavigator implements IMarkerSelection
 
     private ISelection adaptSelection(IStructuredSelection selection) {
         BugContentProvider provider = BugContentProvider.getProvider(getNavigatorContentService());
-        Set<Object> accepted = new HashSet<Object>();
+        Set<Object> accepted = new HashSet<>();
         Iterator<?> iter = selection.iterator();
         while (iter.hasNext()) {
             Object object = iter.next();

--- a/eclipsePlugin/src/de/tobject/findbugs/view/explorer/BugContentProvider.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/view/explorer/BugContentProvider.java
@@ -96,8 +96,8 @@ public class BugContentProvider implements ICommonContentProvider {
 
     public BugContentProvider() {
         super();
-        filteredMarkersMap = new HashMap<BugGroup, Integer>();
-        filteredMarkers = new HashSet<IMarker>();
+        filteredMarkersMap = new HashMap<>();
+        filteredMarkers = new HashSet<>();
         resourceFilter = new WorkingSetsFilter();
         rootElement = new BugGroup(null, null, GroupType.Undefined);
         refreshJob = new RefreshJob("Updating bugs in bug explorer", this);
@@ -148,7 +148,7 @@ public class BugContentProvider implements ICommonContentProvider {
     }
 
     private Set<IResource> getResources(Object parent) {
-        Set<IResource> resources = new HashSet<IResource>();
+        Set<IResource> resources = new HashSet<>();
         if (parent instanceof IWorkingSet) {
             IWorkingSet workingSet = (IWorkingSet) parent;
             IAdaptable[] elements = workingSet.getElements();
@@ -322,7 +322,7 @@ public class BugContentProvider implements ICommonContentProvider {
      * @return
      */
     private synchronized Object[] createChildren(GroupType desiredType, Set<IResource> parents, BugGroup parent) {
-        Set<IMarker> markerSet = new HashSet<IMarker>();
+        Set<IMarker> markerSet = new HashSet<>();
         boolean filterActive = isBugFilterActive();
         Set<String> patternFilter = getPatternFilter();
         for (IResource resource : parents) {
@@ -350,12 +350,12 @@ public class BugContentProvider implements ICommonContentProvider {
         }
         Set<IMarker> allMarkers = parent.getAllMarkers();
         GroupType childType = grouping.getChildType(mapper.getType());
-        Map<Identifier, Set<IMarker>> groupIds = new HashMap<Identifier, Set<IMarker>>();
+        Map<Identifier, Set<IMarker>> groupIds = new HashMap<>();
         UserPreferences prefs = FindbugsPlugin.getCorePreferences(null, false);
         Set<String> disabledPlugins = prefs.getCustomPlugins(false);
 
         // first, sort all bugs to the sets with same identifier type
-        Set<String> errorMessages = new HashSet<String>();
+        Set<String> errorMessages = new HashSet<>();
         for (IMarker marker : allMarkers) {
             Identifier id = mapper.getIdentifier(marker);
             if (id == null) {
@@ -471,7 +471,7 @@ public class BugContentProvider implements ICommonContentProvider {
      */
     public synchronized Set<BugGroup> updateContent(List<DeltaInfo> deltas) {
         int oldRootSize = rootElement.getChildren().length;
-        Set<BugGroup> changedParents = new HashSet<BugGroup>();
+        Set<BugGroup> changedParents = new HashSet<>();
         bugFilterActive = isBugFilterActive();
         Set<String> patternFilter = getPatternFilter();
         for (DeltaInfo delta : deltas) {
@@ -654,7 +654,7 @@ public class BugContentProvider implements ICommonContentProvider {
     }
 
     private List<BugGroup> getSelfAndParents(BugGroup child) {
-        List<BugGroup> parents = new ArrayList<BugGroup>();
+        List<BugGroup> parents = new ArrayList<>();
         parents.add(child);
         while (child.getParent() instanceof BugGroup) {
             child = (BugGroup) child.getParent();
@@ -724,7 +724,7 @@ public class BugContentProvider implements ICommonContentProvider {
     }
 
     public Set<Object> getShowInTargets(Object obj) {
-        Set<Object> supported = new HashSet<Object>();
+        Set<Object> supported = new HashSet<>();
         if (obj instanceof BugGroup) {
             supported.add(obj);
         } else if (obj instanceof IMarker) {

--- a/eclipsePlugin/src/de/tobject/findbugs/view/explorer/BugGroup.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/view/explorer/BugGroup.java
@@ -56,8 +56,8 @@ public class BugGroup implements IAdaptable, IActionFilter, Comparable<BugGroup>
         Assert.isNotNull(type, "Group type cannot be null");
         this.type = type;
         this.identifier = identifier;
-        this.children = new HashSet<Object>();
-        this.allMarkers = new HashSet<IMarker>();
+        this.children = new HashSet<>();
+        this.allMarkers = new HashSet<>();
         if (parent instanceof BugGroup) {
             BugGroup bugGroup = (BugGroup) parent;
             bugGroup.addChild(this);

--- a/eclipsePlugin/src/de/tobject/findbugs/view/explorer/BugLabelProvider.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/view/explorer/BugLabelProvider.java
@@ -170,8 +170,8 @@ public class BugLabelProvider implements /* IStyledLabelProvider, */ ICommonLabe
     }
 
     private int getBugCountsSum(Object[] objects) {
-        List<BugGroup> groups = new ArrayList<BugGroup>();
-        List<IMarker> markers = new ArrayList<IMarker>();
+        List<BugGroup> groups = new ArrayList<>();
+        List<IMarker> markers = new ArrayList<>();
         for (Object object : objects) {
             if (object instanceof BugGroup) {
                 groups.add((BugGroup) object);
@@ -189,7 +189,7 @@ public class BugLabelProvider implements /* IStyledLabelProvider, */ ICommonLabe
 
             });
         }
-        Set<BugGroup> finalGroups = new HashSet<BugGroup>();
+        Set<BugGroup> finalGroups = new HashSet<>();
         int count = 0;
         while (!groups.isEmpty()) {
             BugGroup g1 = groups.remove(groups.size() - 1);

--- a/eclipsePlugin/src/de/tobject/findbugs/view/explorer/FilterBugsDialog.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/view/explorer/FilterBugsDialog.java
@@ -251,9 +251,9 @@ public class FilterBugsDialog extends SelectionDialog {
 
     public FilterBugsDialog(Shell parentShell, Set<BugPattern> filteredPatterns, Set<BugCode> filteredTypes) {
         super(parentShell);
-        codeToPattern = new HashMap<BugCode, Set<BugPattern>>();
-        patternToFactory = new HashMap<BugPattern, Set<DetectorFactory>>();
-        patternToPlugin = new HashMap<BugPattern, Set<Plugin>>();
+        codeToPattern = new HashMap<>();
+        patternToFactory = new HashMap<>();
+        patternToPlugin = new HashMap<>();
         allowedPatterns = FindbugsPlugin.getKnownPatterns();
         allowedTypes = FindbugsPlugin.getKnownPatternTypes();
         preSelectedPatterns = filteredPatterns;
@@ -284,7 +284,7 @@ public class FilterBugsDialog extends SelectionDialog {
         }
 
         // merge types and the rest of patterns (without parent type)
-        List<Object> merged = new ArrayList<Object>();
+        List<Object> merged = new ArrayList<>();
         merged.addAll(preSelectedTypes);
         merged.addAll(preSelectedPatterns);
 
@@ -307,7 +307,7 @@ public class FilterBugsDialog extends SelectionDialog {
             for (BugPattern pattern : patterns) {
                 Set<DetectorFactory> set = patternToFactory.get(pattern);
                 if (set == null) {
-                    set = new TreeSet<DetectorFactory>(new Comparator<DetectorFactory>() {
+                    set = new TreeSet<>(new Comparator<DetectorFactory>() {
                         @Override
                         public int compare(DetectorFactory f1, DetectorFactory f2) {
                             return f1.getFullName().compareTo(f2.getFullName());
@@ -319,7 +319,7 @@ public class FilterBugsDialog extends SelectionDialog {
 
                 Set<Plugin> pset = patternToPlugin.get(pattern);
                 if (pset == null) {
-                    pset = new TreeSet<Plugin>(new Comparator<Plugin>() {
+                    pset = new TreeSet<>(new Comparator<Plugin>() {
                         @Override
                         public int compare(Plugin f1, Plugin f2) {
                             return f1.getPluginId().compareTo(f2.getPluginId());
@@ -518,7 +518,7 @@ public class FilterBugsDialog extends SelectionDialog {
     }
 
     private Object[] getPreselected() {
-        List<Object> all = new ArrayList<Object>(preSelectedPatterns);
+        List<Object> all = new ArrayList<>(preSelectedPatterns);
         all.addAll(preSelectedTypes);
         return all.toArray();
     }
@@ -538,7 +538,7 @@ public class FilterBugsDialog extends SelectionDialog {
         if (set != null) {
             return set;
         }
-        set = new HashSet<BugPattern>();
+        set = new HashSet<>();
         codeToPattern.put(bugCode, set);
         return set;
     }
@@ -565,7 +565,7 @@ public class FilterBugsDialog extends SelectionDialog {
     }
 
     protected void elementChecked(Object element, boolean checked) {
-        Set<Object> selected = new HashSet<Object>();
+        Set<Object> selected = new HashSet<>();
         selected.addAll(Arrays.asList(checkedElements));
         toggleElement(checked, element, selected);
         if (element instanceof BugCode) {
@@ -663,7 +663,7 @@ public class FilterBugsDialog extends SelectionDialog {
             sb.append(bugPattern.getType()).append("<br>");
         }
         // add reported by...
-        Set<DetectorFactory> allFactories = new TreeSet<DetectorFactory>(new Comparator<DetectorFactory>() {
+        Set<DetectorFactory> allFactories = new TreeSet<>(new Comparator<DetectorFactory>() {
             @Override
             public int compare(DetectorFactory f1, DetectorFactory f2) {
                 return f1.getFullName().compareTo(f2.getFullName());

--- a/eclipsePlugin/src/de/tobject/findbugs/view/explorer/GroupSelectionDialog.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/view/explorer/GroupSelectionDialog.java
@@ -67,7 +67,7 @@ public class GroupSelectionDialog extends SelectionDialog {
         super(parentShell);
         this.preSelectedGroups = selectedGroups;
         this.allowedGroups = GroupType.getVisible();
-        selectionMap = new HashMap<GroupType, Boolean>();
+        selectionMap = new HashMap<>();
 
         initSelections();
     }
@@ -228,7 +228,7 @@ public class GroupSelectionDialog extends SelectionDialog {
     }
 
     public List<GroupType> getGroups() {
-        List<GroupType> selected = new ArrayList<GroupType>();
+        List<GroupType> selected = new ArrayList<>();
         for (GroupType groupType : allowedGroups) {
             if (selectionMap.get(groupType).booleanValue()) {
                 selected.add(groupType);

--- a/eclipsePlugin/src/de/tobject/findbugs/view/explorer/GroupType.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/view/explorer/GroupType.java
@@ -270,7 +270,7 @@ public enum GroupType {
     }
 
     public static List<GroupType> getVisible() {
-        List<GroupType> visible = new ArrayList<GroupType>();
+        List<GroupType> visible = new ArrayList<>();
         GroupType[] values = values();
         for (GroupType type : values) {
             if (type.isVisible()) {

--- a/eclipsePlugin/src/de/tobject/findbugs/view/explorer/Grouping.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/view/explorer/Grouping.java
@@ -31,7 +31,7 @@ public class Grouping {
     private final LinkedList<GroupType> groupOrder;
 
     private Grouping(List<GroupType> types) {
-        groupOrder = new LinkedList<GroupType>(types);
+        groupOrder = new LinkedList<>(types);
         // at least marker should be shown
         if (!groupOrder.contains(GroupType.Marker)) {
             groupOrder.add(GroupType.Marker);
@@ -39,7 +39,7 @@ public class Grouping {
     }
 
     private static Grouping createDefault() {
-        List<GroupType> order = new ArrayList<GroupType>();
+        List<GroupType> order = new ArrayList<>();
         order.add(GroupType.Project);
         order.add(GroupType.BugRank);
         order.add(GroupType.Confidence);
@@ -55,7 +55,7 @@ public class Grouping {
 
     @Nonnull
     public List<GroupType> asList() {
-        return new LinkedList<GroupType>(groupOrder);
+        return new LinkedList<>(groupOrder);
     }
 
     @Nonnull
@@ -94,7 +94,7 @@ public class Grouping {
             return createDefault();
         }
         StringTokenizer st = new StringTokenizer(saved, "[] ,", false);
-        List<GroupType> types = new ArrayList<GroupType>();
+        List<GroupType> types = new ArrayList<>();
         while (st.hasMoreTokens()) {
             GroupType type = GroupType.getType(st.nextToken());
             types.add(type);

--- a/eclipsePlugin/src/de/tobject/findbugs/view/explorer/RefreshJob.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/view/explorer/RefreshJob.java
@@ -57,7 +57,7 @@ class RefreshJob extends Job implements IViewerRefreshJob {
         setPriority(Job.DECORATE);
         contentProvider = provider;
         deltaComparator = new RemovedFirstComparator();
-        deltaToRefresh = new ArrayList<DeltaInfo>();
+        deltaToRefresh = new ArrayList<>();
         resourceListener = new ResourceChangeListener(this);
     }
 
@@ -143,7 +143,7 @@ class RefreshJob extends Job implements IViewerRefreshJob {
     }
 
     private List<DeltaInfo> fetchDeltas() {
-        final List<DeltaInfo> deltas = new ArrayList<DeltaInfo>();
+        final List<DeltaInfo> deltas = new ArrayList<>();
         synchronized (deltaToRefresh) {
             if (deltaToRefresh.isEmpty()) {
                 return deltas;

--- a/eclipsePlugin/src/de/tobject/findbugs/view/properties/PropertyPageAdapterFactory.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/view/properties/PropertyPageAdapterFactory.java
@@ -64,7 +64,7 @@ public class PropertyPageAdapterFactory implements IAdapterFactory {
 
         public PropertySource(Object object) {
             this.object = object;
-            List<IPropertyDescriptor> props = new ArrayList<IPropertyDescriptor>();
+            List<IPropertyDescriptor> props = new ArrayList<>();
             List<Method> getters = getGetters(object);
             for (Method method : getters) {
                 props.add(new PropertyDescriptor(method, getReadableName(method)));
@@ -123,7 +123,7 @@ public class PropertyPageAdapterFactory implements IAdapterFactory {
 
         public ArrayPropertySource(Object[] object) {
             this.array = object;
-            List<IPropertyDescriptor> props = new ArrayList<IPropertyDescriptor>();
+            List<IPropertyDescriptor> props = new ArrayList<>();
             for (Object obj : array) {
                 props.add(new PropertyDescriptor(obj, getDisplayName(obj)));
             }
@@ -163,7 +163,7 @@ public class PropertyPageAdapterFactory implements IAdapterFactory {
     }
 
     static List<Method> getGetters(Object obj) {
-        List<Method> methodList = new ArrayList<Method>();
+        List<Method> methodList = new ArrayList<>();
         Method[] methods = obj.getClass().getMethods();
         for (Method method : methods) {
             if (method.getParameterTypes().length == 0) {
@@ -195,7 +195,7 @@ public class PropertyPageAdapterFactory implements IAdapterFactory {
 
         public MarkerPropertySource(IMarker marker) {
             this.marker = marker;
-            List<IPropertyDescriptor> props = new ArrayList<IPropertyDescriptor>();
+            List<IPropertyDescriptor> props = new ArrayList<>();
             try {
                 Map<?, ?> attributes = marker.getAttributes();
                 Set<?> keySet = new TreeSet<Object>(attributes.keySet());

--- a/eclipsePlugin/src/de/tobject/findbugs/wizards/ExportWizardPage.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/wizards/ExportWizardPage.java
@@ -204,7 +204,7 @@ public class ExportWizardPage extends WizardPage {
      */
     private String collectBugsData() {
         IProject[] projects = ResourcesPlugin.getWorkspace().getRoot().getProjects();
-        List<Record> lines = new ArrayList<Record>();
+        List<Record> lines = new ArrayList<>();
         for (IProject project : projects) {
             Record line = createProjectLine(project);
             if (line != null) {

--- a/eclipsePlugin/src/edu/umd/cs/findbugs/plugin/eclipse/quickfix/CreateDoPrivilegedBlockResolution.java
+++ b/eclipsePlugin/src/edu/umd/cs/findbugs/plugin/eclipse/quickfix/CreateDoPrivilegedBlockResolution.java
@@ -93,7 +93,7 @@ public class CreateDoPrivilegedBlockResolution extends BugResolution {
 
     private boolean staticImport = false;
 
-    private Comparator<ImportDeclaration> importComparator = new ImportDeclarationComparator<ImportDeclaration>();
+    private Comparator<ImportDeclaration> importComparator = new ImportDeclarationComparator<>();
 
     public CreateDoPrivilegedBlockResolution() {
         super();
@@ -243,7 +243,7 @@ public class CreateDoPrivilegedBlockResolution extends BugResolution {
 
         if (isUpdateImports()) {
             final AST ast = rewrite.getAST();
-            SortedSet<ImportDeclaration> imports = new TreeSet<ImportDeclaration>(importComparator);
+            SortedSet<ImportDeclaration> imports = new TreeSet<>(importComparator);
             imports.add(createImportDeclaration(ast, PrivilegedAction.class));
             if (!isStaticImport()) {
                 imports.add(createImportDeclaration(ast, AccessController.class));
@@ -392,7 +392,7 @@ public class CreateDoPrivilegedBlockResolution extends BugResolution {
     }
 
     private Set<String> findVariableReferences(List<?> arguments) {
-        final Set<String> refs = new HashSet<String>();
+        final Set<String> refs = new HashSet<>();
         for (Object argumentObj : arguments) {
             Expression argument = (Expression) argumentObj;
             argument.accept(new ASTVisitor() {

--- a/eclipsePlugin/src/edu/umd/cs/findbugs/plugin/eclipse/quickfix/QuickFixContribution.java
+++ b/eclipsePlugin/src/edu/umd/cs/findbugs/plugin/eclipse/quickfix/QuickFixContribution.java
@@ -49,7 +49,7 @@ public class QuickFixContribution {
     }
 
     private static Map<String, String> convertToMap(Set<String> args) {
-        Map<String, String> params = new HashMap<String, String>();
+        Map<String, String> params = new HashMap<>();
         for (String keyValue : args) {
             String[] keyValueArr = keyValue.split("\\s*=\\s*");
             if(keyValueArr.length > 1) {

--- a/eclipsePlugin/src/edu/umd/cs/findbugs/plugin/eclipse/quickfix/UseEqualsResolution.java
+++ b/eclipsePlugin/src/edu/umd/cs/findbugs/plugin/eclipse/quickfix/UseEqualsResolution.java
@@ -149,7 +149,7 @@ public class UseEqualsResolution extends BugResolution {
 
     static class StringEqualityCheckFinder extends ASTVisitor {
 
-        private final Set<InfixExpression> objectEqualityChecks = new HashSet<InfixExpression>();
+        private final Set<InfixExpression> objectEqualityChecks = new HashSet<>();
 
         @Override
         public boolean visit(InfixExpression node) {

--- a/eclipsePlugin/src/edu/umd/cs/findbugs/plugin/eclipse/quickfix/util/ASTUtil.java
+++ b/eclipsePlugin/src/edu/umd/cs/findbugs/plugin/eclipse/quickfix/util/ASTUtil.java
@@ -88,9 +88,9 @@ public class ASTUtil {
     private static Map<String, Class<?>> primitiveTypes;
 
     static {
-        defaultImportComparator = new ImportDeclarationComparator<ImportDeclaration>();
+        defaultImportComparator = new ImportDeclarationComparator<>();
 
-        primitiveTypes = new HashMap<String, Class<?>>();
+        primitiveTypes = new HashMap<>();
         primitiveTypes.put("B", byte.class);
         primitiveTypes.put("C", char.class);
         primitiveTypes.put("S", short.class);
@@ -119,7 +119,7 @@ public class ASTUtil {
         requireNonNull(imports, "imports");
 
         final AST ast = rewrite.getAST();
-        SortedSet<ImportDeclaration> importDeclarations = new TreeSet<ImportDeclaration>(comparator);
+        SortedSet<ImportDeclaration> importDeclarations = new TreeSet<>(comparator);
         for (String importName : imports) {
             ImportDeclaration importDeclaration = ast.newImportDeclaration();
             importDeclaration.setName(ast.newName(importName));

--- a/gradlePlugin/src/main/java/com/github/spotbugs/SpotBugsTask.java
+++ b/gradlePlugin/src/main/java/com/github/spotbugs/SpotBugsTask.java
@@ -70,9 +70,9 @@ public class SpotBugsTask extends SourceTask implements VerificationTask, Report
 
   private String maxHeapSize;
 
-  private Collection<String> visitors = new ArrayList<String>();
+  private Collection<String> visitors = new ArrayList<>();
 
-  private Collection<String> omitVisitors = new ArrayList<String>();
+  private Collection<String> omitVisitors = new ArrayList<>();
 
   private TextResource includeFilterConfig;
 
@@ -80,7 +80,7 @@ public class SpotBugsTask extends SourceTask implements VerificationTask, Report
 
   private TextResource excludeBugsFilterConfig;
 
-  private Collection<String> extraArgs = new ArrayList<String>();
+  private Collection<String> extraArgs = new ArrayList<>();
 
   @Nested
   private final SpotBugsReportsInternal reports;

--- a/gradlePlugin/src/main/java/com/github/spotbugs/internal/spotbugs/SpotBugsSpecBuilder.java
+++ b/gradlePlugin/src/main/java/com/github/spotbugs/internal/spotbugs/SpotBugsSpecBuilder.java
@@ -139,7 +139,7 @@ public class SpotBugsSpecBuilder {
     }
 
     public SpotBugsSpec build() {
-        ArrayList<String> args = new ArrayList<String>();
+        ArrayList<String> args = new ArrayList<>();
         args.add("-pluginList");
         args.add(pluginsList==null ? "" : pluginsList.getAsPath());
         args.add("-sortByClass");

--- a/spotbugs-ant/src/main/java/edu/umd/cs/findbugs/anttask/AbstractFindBugsTask.java
+++ b/spotbugs-ant/src/main/java/edu/umd/cs/findbugs/anttask/AbstractFindBugsTask.java
@@ -85,7 +85,7 @@ public abstract class AbstractFindBugsTask extends Task {
 
     protected String errorProperty = null;
 
-    private final List<SystemProperty> systemPropertyList = new ArrayList<SystemProperty>();
+    private final List<SystemProperty> systemPropertyList = new ArrayList<>();
 
     private Path classpath = null;
 

--- a/spotbugs-ant/src/main/java/edu/umd/cs/findbugs/anttask/ComputeBugHistoryTask.java
+++ b/spotbugs-ant/src/main/java/edu/umd/cs/findbugs/anttask/ComputeBugHistoryTask.java
@@ -50,7 +50,7 @@ public class ComputeBugHistoryTask extends AbstractFindBugsTask {
 
     public ComputeBugHistoryTask() {
         super("edu.umd.cs.findbugs.workflow.Update");
-        dataFileList = new LinkedList<DataFile>();
+        dataFileList = new LinkedList<>();
 
         setFailOnError(true);
     }

--- a/spotbugs-ant/src/main/java/edu/umd/cs/findbugs/anttask/FindBugsTask.java
+++ b/spotbugs-ant/src/main/java/edu/umd/cs/findbugs/anttask/FindBugsTask.java
@@ -161,7 +161,7 @@ public class FindBugsTask extends AbstractFindBugsTask {
 
     private String stylesheet;
 
-    private final List<ClassLocation> classLocations = new ArrayList<ClassLocation>();
+    private final List<ClassLocation> classLocations = new ArrayList<>();
 
     private String onlyAnalyze;
 
@@ -171,9 +171,9 @@ public class FindBugsTask extends AbstractFindBugsTask {
 
     private boolean setExitCode = true;
 
-    private final List<FileSet> filesets = new ArrayList<FileSet>();
+    private final List<FileSet> filesets = new ArrayList<>();
 
-    private final List<DirSet> dirsets = new ArrayList<DirSet>();
+    private final List<DirSet> dirsets = new ArrayList<>();
 
     public FindBugsTask() {
         super("edu.umd.cs.findbugs.FindBugs2");

--- a/spotbugs-ant/src/main/java/edu/umd/cs/findbugs/anttask/UnionBugs.java
+++ b/spotbugs-ant/src/main/java/edu/umd/cs/findbugs/anttask/UnionBugs.java
@@ -52,7 +52,7 @@ import edu.umd.cs.findbugs.workflow.UnionResults;
 @Deprecated
 public class UnionBugs extends Task {
 
-    private final List<FileSet> fileSets = new ArrayList<FileSet>();
+    private final List<FileSet> fileSets = new ArrayList<>();
 
     private String into;
 
@@ -109,7 +109,7 @@ public class UnionBugs extends Task {
     }
 
     private List<File> createListOfAllFilesToMerge() {
-        List<File> fileList = new ArrayList<File>();
+        List<File> fileList = new ArrayList<>();
         for (FileSet s : fileSets) {
             File fromDir = s.getDir(getProject());
             for (String file : s.getDirectoryScanner(getProject()).getIncludedFiles()) {
@@ -120,7 +120,7 @@ public class UnionBugs extends Task {
     }
 
     private String[] createCommandArgumentsArray(List<File> fileList) {
-        List<String> parts = new ArrayList<String>();
+        List<String> parts = new ArrayList<>();
         parts.add("-withMessages");
         parts.add("-output");
         parts.add(into);

--- a/spotbugs-ant/src/main/java/edu/umd/cs/findbugs/anttask/UnionBugs2.java
+++ b/spotbugs-ant/src/main/java/edu/umd/cs/findbugs/anttask/UnionBugs2.java
@@ -43,7 +43,7 @@ public class UnionBugs2 extends AbstractFindBugsTask {
 
     private String to;
 
-    private final ArrayList<FileSet> fileSets = new ArrayList<FileSet>();
+    private final ArrayList<FileSet> fileSets = new ArrayList<>();
 
     public UnionBugs2() {
         super("edu.umd.cs.findbugs.workflow.UnionResults");

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/DetectorsTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/DetectorsTest.java
@@ -129,7 +129,7 @@ public class DetectorsTest {
 
     @After
     public void checkForUnexpectedBugs() {
-        List<BugInstance> unexpectedBugs = new ArrayList<BugInstance>();
+        List<BugInstance> unexpectedBugs = new ArrayList<>();
         for (BugInstance bug : bugReporter.getBugCollection()) {
             if (isUnexpectedBug(bug) && bug.getPriority() == Priorities.HIGH_PRIORITY) {
                 unexpectedBugs.add(bug);

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/JUnitDetectorAdapter.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/JUnitDetectorAdapter.java
@@ -35,9 +35,9 @@ public class JUnitDetectorAdapter implements Detector2 {
 
     private boolean testExecuted;
 
-    private static InheritableThreadLocal<JUnitDetectorAdapter> instance = new InheritableThreadLocal<JUnitDetectorAdapter>();
+    private static InheritableThreadLocal<JUnitDetectorAdapter> instance = new InheritableThreadLocal<>();
 
-    private static InheritableThreadLocal<RunnableWithExceptions> runnableInstance = new InheritableThreadLocal<RunnableWithExceptions>();
+    private static InheritableThreadLocal<RunnableWithExceptions> runnableInstance = new InheritableThreadLocal<>();
 
     public JUnitDetectorAdapter(BugReporter bugReporter) {
         instance.set(this);

--- a/spotbugs/src/gui/edu/umd/cs/findbugs/gui2/AbstractSwingGuiCallback.java
+++ b/spotbugs/src/gui/edu/umd/cs/findbugs/gui2/AbstractSwingGuiCallback.java
@@ -114,7 +114,7 @@ public abstract class AbstractSwingGuiCallback implements IGuiCallback {
             return null;
         }
         updateFormItemsFromGui(items);
-        List<String> results = new ArrayList<String>();
+        List<String> results = new ArrayList<>();
         for (FormItem item : items) {
             results.add(item.getCurrentValue());
         }

--- a/spotbugs/src/gui/edu/umd/cs/findbugs/gui2/BugAspects.java
+++ b/spotbugs/src/gui/edu/umd/cs/findbugs/gui2/BugAspects.java
@@ -50,7 +50,7 @@ public class BugAspects implements Iterable<BugAspects.SortableValue> {
 
     private int count = -1;
 
-    private ArrayList<BugAspects.SortableValue> lst = new ArrayList<BugAspects.SortableValue>();
+    private ArrayList<BugAspects.SortableValue> lst = new ArrayList<>();
 
     public SortableValue last() {
         return lst.get(lst.size() - 1);
@@ -96,7 +96,7 @@ public class BugAspects implements Iterable<BugAspects.SortableValue> {
     }
 
     public BugAspects(BugAspects a) {
-        lst = new ArrayList<SortableValue>(a.lst);
+        lst = new ArrayList<>(a.lst);
         count = a.count;
     }
 

--- a/spotbugs/src/gui/edu/umd/cs/findbugs/gui2/BugSet.java
+++ b/spotbugs/src/gui/edu/umd/cs/findbugs/gui2/BugSet.java
@@ -100,9 +100,9 @@ public class BugSet implements Iterable<BugLeafNode> {
      * @param filteredSet
      */
     BugSet(Collection<? extends BugLeafNode> filteredSet) {
-        this.mainList = new ArrayList<BugLeafNode>(filteredSet);
-        doneMap = new HashMap<SortableValue, BugSet>();
-        doneContainsMap = new HashMap<SortableValue, Boolean>();
+        this.mainList = new ArrayList<>(filteredSet);
+        doneMap = new HashMap<>();
+        doneContainsMap = new HashMap<>();
         cacheSortables();
     }
 
@@ -137,7 +137,7 @@ public class BugSet implements Iterable<BugLeafNode> {
      * the results.
      */
     void cacheSortables() {
-        sortablesToStrings = new HashMap<Sortables, String[]>();
+        sortablesToStrings = new HashMap<>();
     }
 
     String[] getDistinctValues(Sortables key) {
@@ -157,7 +157,7 @@ public class BugSet implements Iterable<BugLeafNode> {
             return EMPTY_STRING_ARRAY;
         }
 
-        Collection<String> list = new HashSet<String>();
+        Collection<String> list = new HashSet<>();
 
         for (BugLeafNode p : mainList) {
             if (suppress(p)) {
@@ -198,8 +198,8 @@ public class BugSet implements Iterable<BugLeafNode> {
     // Note: THIS CLEARS THE CACHES OF DONE SETS!
     BugSet(BugSet copySet) {
         this.mainList = copySet.mainList;
-        doneMap = new HashMap<SortableValue, BugSet>();
-        doneContainsMap = new HashMap<SortableValue, Boolean>();
+        doneMap = new HashMap<>();
+        doneContainsMap = new HashMap<>();
         cacheSortables();
     }
 
@@ -219,7 +219,7 @@ public class BugSet implements Iterable<BugLeafNode> {
         if (doneMap.containsKey(keyValuePair)) {
             return doneMap.get(keyValuePair);
         }
-        ArrayList<BugLeafNode> bugs = new ArrayList<BugLeafNode>();
+        ArrayList<BugLeafNode> bugs = new ArrayList<>();
 
         for (BugLeafNode b : mainList) {
             if (b.matches(keyValuePair)) {
@@ -291,7 +291,7 @@ public class BugSet implements Iterable<BugLeafNode> {
 
             }
         };
-        ArrayList<BugLeafNode> copy = new ArrayList<BugLeafNode>(mainList);
+        ArrayList<BugLeafNode> copy = new ArrayList<>(mainList);
         Collections.sort(copy, comparator);
         mainList = copy;
 
@@ -367,9 +367,9 @@ public class BugSet implements Iterable<BugLeafNode> {
     // //////Filtered API
 
     BugSet(ArrayList<BugLeafNode> filteredSet, boolean cacheSortables) {
-        this.mainList = new ArrayList<BugLeafNode>(filteredSet);
-        doneMap = new HashMap<SortableValue, BugSet>();
-        doneContainsMap = new HashMap<SortableValue, Boolean>();
+        this.mainList = new ArrayList<>(filteredSet);
+        doneMap = new HashMap<>();
+        doneContainsMap = new HashMap<>();
         if (cacheSortables) {
             cacheSortables();
         }
@@ -377,7 +377,7 @@ public class BugSet implements Iterable<BugLeafNode> {
 
     private BugSet filteredBugsNoCache() {
 
-        ArrayList<BugLeafNode> people = new ArrayList<BugLeafNode>();
+        ArrayList<BugLeafNode> people = new ArrayList<>();
         for (BugLeafNode p : mainList) {
             if (!suppress(p)) {
                 people.add(p);
@@ -400,7 +400,7 @@ public class BugSet implements Iterable<BugLeafNode> {
     }
 
     public BugSet getBugsMatchingFilter(Matcher m) {
-        ArrayList<BugLeafNode> people = new ArrayList<BugLeafNode>();
+        ArrayList<BugLeafNode> people = new ArrayList<>();
         for (BugLeafNode p : mainList) {
             if (!(m.match(p.getBug()))) {
                 people.add(p);

--- a/spotbugs/src/gui/edu/umd/cs/findbugs/gui2/BugTreeModel.java
+++ b/spotbugs/src/gui/edu/umd/cs/findbugs/gui2/BugTreeModel.java
@@ -90,11 +90,11 @@ public class BugTreeModel implements TreeModel, TableColumnModelListener, TreeEx
 
     private BugSet bugSet;
 
-    private ArrayList<TreeModelListener> listeners = new ArrayList<TreeModelListener>();
+    private ArrayList<TreeModelListener> listeners = new ArrayList<>();
 
     private JTree tree;
 
-    static ArrayList<BugLeafNode> selectedBugLeafNodes = new ArrayList<BugLeafNode>();
+    static ArrayList<BugLeafNode> selectedBugLeafNodes = new ArrayList<>();
 
     private static final boolean DEBUG = false;
 
@@ -267,7 +267,7 @@ public class BugTreeModel implements TreeModel, TableColumnModelListener, TreeEx
         }
 
         String[] all = key.getAll(bugSet.query(a));
-        ArrayList<SortableValue> result = new ArrayList<SortableValue>(all.length);
+        ArrayList<SortableValue> result = new ArrayList<>(all.length);
         for (String i : all) {
             result.add(new SortableValue(key, i));
         }
@@ -399,7 +399,7 @@ public class BugTreeModel implements TreeModel, TableColumnModelListener, TreeEx
     public void crawl(final ArrayList<BugAspects> path, final int depth) {
         for (int i = 0; i < getChildCount(path.get(path.size() - 1)); i++) {
             if (depth > 0) {
-                ArrayList<BugAspects> newPath = new ArrayList<BugAspects>(path);
+                ArrayList<BugAspects> newPath = new ArrayList<>(path);
                 newPath.add((BugAspects) getChild(path.get(path.size() - 1), i));
                 crawl(newPath, depth - 1);
             } else {

--- a/spotbugs/src/gui/edu/umd/cs/findbugs/gui2/FilterActivity.java
+++ b/spotbugs/src/gui/edu/umd/cs/findbugs/gui2/FilterActivity.java
@@ -32,7 +32,7 @@ import javax.swing.tree.TreePath;
  */
 public class FilterActivity {
 
-    private static final HashSet<FilterListener> listeners = new HashSet<FilterListener>();
+    private static final HashSet<FilterListener> listeners = new HashSet<>();
 
     public static boolean addFilterListener(FilterListener newListener) {
         return listeners.add(newListener);
@@ -43,7 +43,7 @@ public class FilterActivity {
     }
 
     public static void notifyListeners(FilterListener.Action whatsGoingOnCode, @CheckForNull TreePath optionalPath) {
-        Collection<FilterListener> currentListeners = new ArrayList<FilterListener>(FilterActivity.listeners);
+        Collection<FilterListener> currentListeners = new ArrayList<>(FilterActivity.listeners);
         switch (whatsGoingOnCode) {
         case FILTERING:
         case UNFILTERING:

--- a/spotbugs/src/gui/edu/umd/cs/findbugs/gui2/FilterFromBugPicker.java
+++ b/spotbugs/src/gui/edu/umd/cs/findbugs/gui2/FilterFromBugPicker.java
@@ -45,7 +45,7 @@ import edu.umd.cs.findbugs.filter.NotMatcher;
  */
 final class FilterFromBugPicker {
 
-    private final HashMap<JCheckBox, Sortables> map = new HashMap<JCheckBox, Sortables>();
+    private final HashMap<JCheckBox, Sortables> map = new HashMap<>();
     private final BugInstance bug;
     private final List<Sortables> availableSortables;
     private final JPanel pickerPanel;
@@ -89,7 +89,7 @@ final class FilterFromBugPicker {
     }
 
     public Matcher makeMatcherFromSelection() {
-        HashSet<Sortables> set = new HashSet<Sortables>();
+        HashSet<Sortables> set = new HashSet<>();
         for (Map.Entry<JCheckBox, Sortables> e : map.entrySet()) {
             if (e.getKey().isSelected()) {
                 set.add(e.getValue());

--- a/spotbugs/src/gui/edu/umd/cs/findbugs/gui2/GUISaveState.java
+++ b/spotbugs/src/gui/edu/umd/cs/findbugs/gui2/GUISaveState.java
@@ -135,9 +135,9 @@ public class GUISaveState {
 
     private int packagePrefixSegments;
 
-    private List<String> enabledPlugins = new ArrayList<String>();
-    private List<String> disabledPlugins = new ArrayList<String>();
-    private final LinkedHashSet<URI> customPlugins = new LinkedHashSet<URI>();
+    private List<String> enabledPlugins = new ArrayList<>();
+    private List<String> disabledPlugins = new ArrayList<>();
+    private final LinkedHashSet<URI> customPlugins = new LinkedHashSet<>();
 
     private static String[] generateSorterKeys(int numSorters) {
         String[] result = new String[numSorters];
@@ -156,7 +156,7 @@ public class GUISaveState {
 
     public static void loadInstance() {
         GUISaveState newInstance = new GUISaveState();
-        newInstance.recentFiles = new ArrayList<File>();
+        newInstance.recentFiles = new ArrayList<>();
         Preferences p = Preferences.userNodeForPackage(GUISaveState.class);
 
         newInstance.tabSize = p.getInt(TAB_SIZE, 4);
@@ -180,7 +180,7 @@ public class GUISaveState {
 
         int sorterSize = p.getInt(GUISaveState.SORTERTABLELENGTH, -1);
         if (sorterSize != -1) {
-            ArrayList<Sortables> sortColumns = new ArrayList<Sortables>();
+            ArrayList<Sortables> sortColumns = new ArrayList<>();
             String[] sortKeys = GUISaveState.generateSorterKeys(sorterSize);
             for (int x = 0; x < sorterSize; x++) {
                 Sortables s = Sortables.getSortableByPrettyName(p.get(sortKeys[x], "*none*"));
@@ -196,7 +196,7 @@ public class GUISaveState {
             }
             if (!newInstance.useDefault) {
                 // add in default columns
-                Set<Sortables> missingSortColumns = new HashSet<Sortables>(Arrays.asList(DEFAULT_COLUMN_HEADERS));
+                Set<Sortables> missingSortColumns = new HashSet<>(Arrays.asList(DEFAULT_COLUMN_HEADERS));
                 missingSortColumns.removeAll(sortColumns);
                 sortColumns.addAll(missingSortColumns);
                 newInstance.sortColumns = sortColumns.toArray(new Sortables[sortColumns.size()]);
@@ -266,8 +266,8 @@ public class GUISaveState {
 
         String enabledPluginsString = p.get(ENABLED_PLUGINS, "");
         String disabledPluginsString = p.get(DISABLED_PLUGINS, "");
-        newInstance.enabledPlugins = new ArrayList<String>(Arrays.asList(enabledPluginsString.split(",")));
-        newInstance.disabledPlugins = new ArrayList<String>(Arrays.asList(disabledPluginsString.split(",")));
+        newInstance.enabledPlugins = new ArrayList<>(Arrays.asList(enabledPluginsString.split(",")));
+        newInstance.disabledPlugins = new ArrayList<>(Arrays.asList(disabledPluginsString.split(",")));
 
         instance = newInstance;
     }
@@ -283,8 +283,8 @@ public class GUISaveState {
     }
 
     private GUISaveState() {
-        recentFiles = new ArrayList<File>();
-        previousComments = new LinkedList<String>();
+        recentFiles = new ArrayList<>();
+        previousComments = new LinkedList<>();
     }
 
     public int getTabSize() {
@@ -529,8 +529,8 @@ public class GUISaveState {
     }
 
     public void setPluginsEnabled(List<String> enabledPlugins, List<String> disabledPlugins) {
-        this.enabledPlugins = new ArrayList<String>(enabledPlugins);
-        this.disabledPlugins = new ArrayList<String>(disabledPlugins);
+        this.enabledPlugins = new ArrayList<>(enabledPlugins);
+        this.disabledPlugins = new ArrayList<>(disabledPlugins);
     }
 
     public void setPluginEnabled(String url) {

--- a/spotbugs/src/gui/edu/umd/cs/findbugs/gui2/MainFrame.java
+++ b/spotbugs/src/gui/edu/umd/cs/findbugs/gui2/MainFrame.java
@@ -676,8 +676,8 @@ public class MainFrame extends FBFrame implements LogSync {
     }
 
     public void selectPackagePrefixByProject() {
-        TreeSet<String> projects = new TreeSet<String>(String.CASE_INSENSITIVE_ORDER);
-        Multiset<String> count = new Multiset<String>();
+        TreeSet<String> projects = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+        Multiset<String> count = new Multiset<>();
         int total = 0;
         for (BugInstance b : getBugCollection().getCollection()) {
             if (shouldDisplayIssueIgnoringPackagePrefixes(b)) {
@@ -691,7 +691,7 @@ public class MainFrame extends FBFrame implements LogSync {
             JOptionPane.showMessageDialog(this, "No issues in current view");
             return;
         }
-        ArrayList<ProjectSelector> selectors = new ArrayList<ProjectSelector>(projects.size() + 1);
+        ArrayList<ProjectSelector> selectors = new ArrayList<>(projects.size() + 1);
         ProjectSelector everything = new ProjectSelector("all projects", "", total);
         selectors.add(everything);
         for (String projectName : projects) {

--- a/spotbugs/src/gui/edu/umd/cs/findbugs/gui2/MainFrameTree.java
+++ b/spotbugs/src/gui/edu/umd/cs/findbugs/gui2/MainFrameTree.java
@@ -115,7 +115,7 @@ public class MainFrameTree {
 
     public Sortables[] getAvailableSortables() {
         Sortables[] sortables;
-        ArrayList<Sortables> a = new ArrayList<Sortables>(Sortables.values().length);
+        ArrayList<Sortables> a = new ArrayList<>(Sortables.values().length);
         for (Sortables s : Sortables.values()) {
             if (s.isAvailable(mainFrame)) {
                 a.add(s);

--- a/spotbugs/src/gui/edu/umd/cs/findbugs/gui2/NewFilterFrame.java
+++ b/spotbugs/src/gui/edu/umd/cs/findbugs/gui2/NewFilterFrame.java
@@ -145,7 +145,7 @@ public class NewFilterFrame extends FBDialog {
                 Sortables key = (Sortables) comboBox.getSelectedItem();
                 String[] values = key.getAllSorted();
 
-                ArrayList<SortableValue> filterMe = new ArrayList<SortableValue>();
+                ArrayList<SortableValue> filterMe = new ArrayList<>();
                 for (int i : list.getSelectedIndices()) {
                     filterMe.add(new BugAspects.SortableValue(key, values[i]));
                 }

--- a/spotbugs/src/gui/edu/umd/cs/findbugs/gui2/NewFilterFromBug.java
+++ b/spotbugs/src/gui/edu/umd/cs/findbugs/gui2/NewFilterFromBug.java
@@ -39,7 +39,7 @@ import edu.umd.cs.findbugs.filter.Matcher;
 @SuppressWarnings("serial")
 public class NewFilterFromBug extends FBDialog {
 
-    private static final List<NewFilterFromBug> listOfAllFrames = new ArrayList<NewFilterFromBug>();
+    private static final List<NewFilterFromBug> listOfAllFrames = new ArrayList<>();
 
     public NewFilterFromBug(final FilterFromBugPicker filterFromBugPicker, final ApplyNewFilter applyNewFilter) {
         this.setModal(true);

--- a/spotbugs/src/gui/edu/umd/cs/findbugs/gui2/NewProjectWizard.java
+++ b/spotbugs/src/gui/edu/umd/cs/findbugs/gui2/NewProjectWizard.java
@@ -91,19 +91,19 @@ public class NewProjectWizard extends FBDialog {
         }
     };
 
-    private final JList<String> analyzeList = new JList<String>();
+    private final JList<String> analyzeList = new JList<>();
 
-    private final DefaultListModel<String> analyzeModel = new DefaultListModel<String>();
+    private final DefaultListModel<String> analyzeModel = new DefaultListModel<>();
 
     private final JTextField projectName = new JTextField();
 
-    private final JList<String> auxList = new JList<String>();
+    private final JList<String> auxList = new JList<>();
 
-    private final DefaultListModel<String> auxModel = new DefaultListModel<String>();
+    private final DefaultListModel<String> auxModel = new DefaultListModel<>();
 
-    private final JList<String> sourceList = new JList<String>();
+    private final JList<String> sourceList = new JList<>();
 
-    private final DefaultListModel<String> sourceModel = new DefaultListModel<String>();
+    private final DefaultListModel<String> sourceModel = new DefaultListModel<>();
 
     private final JButton finishButton = new JButton();
 

--- a/spotbugs/src/gui/edu/umd/cs/findbugs/gui2/PreferencesFrame.java
+++ b/spotbugs/src/gui/edu/umd/cs/findbugs/gui2/PreferencesFrame.java
@@ -105,7 +105,7 @@ public class PreferencesFrame extends FBDialog {
 
     private JTextField packagePrefixLengthTextField;
 
-    private final Map<Plugin, EnabledSettings> pluginEnabledStatus = new HashMap<Plugin, EnabledSettings>();
+    private final Map<Plugin, EnabledSettings> pluginEnabledStatus = new HashMap<>();
     private JPanel pluginPanelCenter;
 
     private static class EnabledSettings {
@@ -199,8 +199,8 @@ public class PreferencesFrame extends FBDialog {
 
         boolean changed = pluginsAdded;
         pluginsAdded = false;
-        List<String> enabledPlugins = new ArrayList<String>();
-        List<String> disabledPlugins = new ArrayList<String>();
+        List<String> enabledPlugins = new ArrayList<>();
+        List<String> disabledPlugins = new ArrayList<>();
         for (Map.Entry<Plugin, EnabledSettings> entry : pluginEnabledStatus.entrySet()) {
             Plugin plugin = entry.getKey();
             EnabledSettings enabled = entry.getValue();
@@ -721,7 +721,7 @@ public class PreferencesFrame extends FBDialog {
     }
 
     void updateFilterPanel() {
-        ArrayList<MatchBox> boxes = new ArrayList<MatchBox>();
+        ArrayList<MatchBox> boxes = new ArrayList<>();
         final Filter f = MainFrame.getInstance().getProject().getSuppressionFilter();
 
         for (final Matcher m : f.getChildren()) {

--- a/spotbugs/src/gui/edu/umd/cs/findbugs/gui2/ProjectSettings.java
+++ b/spotbugs/src/gui/edu/umd/cs/findbugs/gui2/ProjectSettings.java
@@ -44,7 +44,7 @@ public class ProjectSettings implements Serializable {
     // Singleton
     private ProjectSettings() {
         allMatchers = new CompoundMatcher();
-        filters = new ArrayList<FilterMatcher>();
+        filters = new ArrayList<>();
     }
 
     private static ProjectSettings instance;
@@ -132,8 +132,8 @@ public class ProjectSettings implements Serializable {
             List<Sortables> sortablesToCheck = order.subList(0, sizeToCheck);
             Debug.println("Size to check" + sizeToCheck + " checking list" + sortablesToCheck);
             Debug.println("checking filters");
-            ArrayList<String> almostPath = new ArrayList<String>();
-            ArrayList<Sortables> almostPathSortables = new ArrayList<Sortables>();
+            ArrayList<String> almostPath = new ArrayList<>();
+            ArrayList<Sortables> almostPathSortables = new ArrayList<>();
             for (int x = 0; x < sortablesToCheck.size(); x++) {
                 Sortables s = sortablesToCheck.get(x);
                 for (FilterMatcher fm : filtersInStack) {
@@ -144,7 +144,7 @@ public class ProjectSettings implements Serializable {
                 }
             }
             if (almostPath.size() == filtersInStack.length) {
-                ArrayList<String> finalPath = new ArrayList<String>();
+                ArrayList<String> finalPath = new ArrayList<>();
                 for (int x = 0; x < almostPath.size(); x++) {
                     Sortables s = almostPathSortables.get(x);
                     if (MainFrame.getInstance().getSorter().getOrderBeforeDivider().contains(s)) {

--- a/spotbugs/src/gui/edu/umd/cs/findbugs/gui2/RecentMenu.java
+++ b/spotbugs/src/gui/edu/umd/cs/findbugs/gui2/RecentMenu.java
@@ -57,7 +57,7 @@ public class RecentMenu {
     JMenu recentMenu;
 
     public RecentMenu(JMenu menu) {
-        recentFiles = new LimitedArrayList<File>();
+        recentFiles = new LimitedArrayList<>();
         recentMenu = menu;
 
         for (File f : GUISaveState.getInstance().getRecentFiles()) {

--- a/spotbugs/src/gui/edu/umd/cs/findbugs/gui2/SorterDialog.java
+++ b/spotbugs/src/gui/edu/umd/cs/findbugs/gui2/SorterDialog.java
@@ -55,7 +55,7 @@ public class SorterDialog extends FBDialog {
 
     private JTableHeader preview;
 
-    private final ArrayList<SortableCheckBox> checkBoxSortList = new ArrayList<SortableCheckBox>();
+    private final ArrayList<SortableCheckBox> checkBoxSortList = new ArrayList<>();
 
     JButton sortApply;
 

--- a/spotbugs/src/gui/edu/umd/cs/findbugs/gui2/SorterTableColumnModel.java
+++ b/spotbugs/src/gui/edu/umd/cs/findbugs/gui2/SorterTableColumnModel.java
@@ -57,15 +57,15 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  */
 public class SorterTableColumnModel implements TableColumnModel {
 
-    private ArrayList<Sortables> order = new ArrayList<Sortables>();
+    private ArrayList<Sortables> order = new ArrayList<>();
 
-    private final Set<Sortables> shown = new HashSet<Sortables>();
+    private final Set<Sortables> shown = new HashSet<>();
 
-    private final ArrayList<TableColumn> columnList = new ArrayList<TableColumn>();
+    private final ArrayList<TableColumn> columnList = new ArrayList<>();
 
     private DefaultListSelectionModel dlsm;
 
-    private final ArrayList<TableColumnModelListener> watchers = new ArrayList<TableColumnModelListener>();
+    private final ArrayList<TableColumnModelListener> watchers = new ArrayList<>();
 
     private boolean frozen = false;
 
@@ -258,7 +258,7 @@ public class SorterTableColumnModel implements TableColumnModel {
 
         orderUpdate();
 
-        for (TableColumnModelListener w : new ArrayList<TableColumnModelListener>(watchers)) {
+        for (TableColumnModelListener w : new ArrayList<>(watchers)) {
             w.columnMoved(new TableColumnModelEvent(this, fromIndex, toIndex));
         }
     }
@@ -391,7 +391,7 @@ public class SorterTableColumnModel implements TableColumnModel {
 
     List<Sortables> getOrderAfterDivider() {
         if (!order.contains(Sortables.DIVIDER) || order.indexOf(Sortables.DIVIDER) == order.size() - 1) {
-            return new ArrayList<Sortables>();
+            return new ArrayList<>();
         }
 
         return order.subList(order.indexOf(Sortables.DIVIDER) + 1, order.size());
@@ -400,7 +400,7 @@ public class SorterTableColumnModel implements TableColumnModel {
     private void orderUpdate() {
         // order.clear();
         if (!frozen) {
-            order = new ArrayList<Sortables>();
+            order = new ArrayList<>();
             for (TableColumn c : columnList) {
                 order.add((Sortables) c.getIdentifier());
             }

--- a/spotbugs/src/gui/edu/umd/cs/findbugs/gui2/SourceCodeDisplay.java
+++ b/spotbugs/src/gui/edu/umd/cs/findbugs/gui2/SourceCodeDisplay.java
@@ -59,7 +59,7 @@ public final class SourceCodeDisplay implements Runnable {
 
     private int currentChar = -1; // for find
 
-    private final Map<String, SoftReference<JavaSourceDocument>> map = new HashMap<String, SoftReference<JavaSourceDocument>>();
+    private final Map<String, SoftReference<JavaSourceDocument>> map = new HashMap<>();
 
     SourceCodeDisplay(MainFrame frame) {
         this.frame = frame;
@@ -78,7 +78,7 @@ public final class SourceCodeDisplay implements Runnable {
         final SourceLineAnnotation source;
     }
 
-    final BlockingQueue<DisplayMe> queue = new   LinkedBlockingQueue<DisplayMe>();
+    final BlockingQueue<DisplayMe> queue = new   LinkedBlockingQueue<>();
 
     public  void displaySource(BugInstance bug, SourceLineAnnotation source) {
         queue.add(new DisplayMe(bug, source));
@@ -108,7 +108,7 @@ public final class SourceCodeDisplay implements Runnable {
                 result = JavaSourceDocument.UNKNOWNSOURCE;
                 Debug.println(e); // e.printStackTrace();
             }
-            map.put(fullFileName, new SoftReference<JavaSourceDocument>(result));
+            map.put(fullFileName, new SoftReference<>(result));
             return result;
         } catch (Exception e) {
             Debug.println(e); // e.printStackTrace();
@@ -192,7 +192,7 @@ public final class SourceCodeDisplay implements Runnable {
             frame.setSourceTab(sourceFile + " in " + mySourceLine.getPackageName(), myBug);
 
             int originLine = (startLine + endLine) / 2;
-            LinkedList<Integer> otherLines = new LinkedList<Integer>();
+            LinkedList<Integer> otherLines = new LinkedList<>();
             // show(frame.getSourceCodeTextPane(), document,
             // thisSource);
             for (Iterator<BugAnnotation> i = myBug.annotationIterator(); i.hasNext();) {

--- a/spotbugs/src/gui/edu/umd/cs/findbugs/gui2/SourceDirectoryWizard.java
+++ b/spotbugs/src/gui/edu/umd/cs/findbugs/gui2/SourceDirectoryWizard.java
@@ -73,8 +73,8 @@ public class SourceDirectoryWizard extends javax.swing.JDialog {
     // desc="Generated Code">//GEN-BEGIN:initComponents
     private void initComponents() {
 
-        foundModel = new DefaultListModel<String>();
-        progressModel = new DefaultListModel<String>();
+        foundModel = new DefaultListModel<>();
+        progressModel = new DefaultListModel<>();
         contentPanel = new javax.swing.JPanel();
         secondPanel = new javax.swing.JPanel();
         jScrollPane1 = new javax.swing.JScrollPane();

--- a/spotbugs/src/gui/edu/umd/cs/findbugs/gui2/StackedFilterMatcher.java
+++ b/spotbugs/src/gui/edu/umd/cs/findbugs/gui2/StackedFilterMatcher.java
@@ -81,8 +81,8 @@ public class StackedFilterMatcher extends FilterMatcher {
             List<Sortables> sortablesToCheck = order.subList(0, Math.min(sizeToCheck, order.size()));
             Debug.println("Size to check" + sizeToCheck + " checking list" + sortablesToCheck);
             Debug.println("checking filters");
-            ArrayList<String> almostPath = new ArrayList<String>();
-            ArrayList<Sortables> almostPathSortables = new ArrayList<Sortables>();
+            ArrayList<String> almostPath = new ArrayList<>();
+            ArrayList<Sortables> almostPathSortables = new ArrayList<>();
             for (int x = 0; x < sortablesToCheck.size(); x++) {
                 Sortables s = sortablesToCheck.get(x);
                 for (FilterMatcher fm : filtersInStack) {
@@ -92,7 +92,7 @@ public class StackedFilterMatcher extends FilterMatcher {
                     }
                 }
             }
-            ArrayList<String> finalPath = new ArrayList<String>();
+            ArrayList<String> finalPath = new ArrayList<>();
             for (int x = 0; x < almostPath.size(); x++) {
                 Sortables s = almostPathSortables.get(x);
                 if (MainFrame.getInstance().getSorter().getOrderBeforeDivider().contains(s)) {

--- a/spotbugs/src/gui/edu/umd/cs/findbugs/sourceViewer/HighlightInformation.java
+++ b/spotbugs/src/gui/edu/umd/cs/findbugs/sourceViewer/HighlightInformation.java
@@ -28,7 +28,7 @@ import javax.annotation.CheckForNull;
 
 public class HighlightInformation {
 
-    Map<Integer, Color> map = new HashMap<Integer, Color>();
+    Map<Integer, Color> map = new HashMap<>();
 
     private int foundLineNum = -1;
 

--- a/spotbugs/src/gui/edu/umd/cs/findbugs/sourceViewer/JavaScanner.java
+++ b/spotbugs/src/gui/edu/umd/cs/findbugs/sourceViewer/JavaScanner.java
@@ -38,7 +38,7 @@ public class JavaScanner {
     public final static int EOF = -1;
 
     @StaticConstant
-    private final static HashSet<String> KEYWORDS = new HashSet<String>();
+    private final static HashSet<String> KEYWORDS = new HashSet<>();
 
     private final static int MAX_KEYWORD_LENGTH;
 

--- a/spotbugs/src/gui/edu/umd/cs/findbugs/sourceViewer/NavigableTextPane.java
+++ b/spotbugs/src/gui/edu/umd/cs/findbugs/sourceViewer/NavigableTextPane.java
@@ -152,7 +152,7 @@ public class NavigableTextPane extends JTextPane {
             endY = startY + max;
         } else if (otherLines != null && otherLines.size() > 0) {
             int origin = startY + endY / 2;
-            PriorityQueue<Integer> pq = new PriorityQueue<Integer>(otherLines.size(), new DistanceComparator(origin));
+            PriorityQueue<Integer> pq = new PriorityQueue<>(otherLines.size(), new DistanceComparator(origin));
             for (int line : otherLines) {
                 int otherY;
                 try {

--- a/spotbugs/src/gui/edu/umd/cs/findbugs/sourceViewer/NumberedParagraphView.java
+++ b/spotbugs/src/gui/edu/umd/cs/findbugs/sourceViewer/NumberedParagraphView.java
@@ -95,7 +95,7 @@ class NumberedParagraphView extends ParagraphView {
         return lineCount;
     }
 
-    static WeakHashMap<Element, Integer> elementLineNumberCache = new WeakHashMap<Element, Integer>();
+    static WeakHashMap<Element, Integer> elementLineNumberCache = new WeakHashMap<>();
 
     public Integer getLineNumber() {
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/AbstractBugReporter.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/AbstractBugReporter.java
@@ -130,9 +130,9 @@ public abstract class AbstractBugReporter implements BugReporter {
     public AbstractBugReporter() {
         super();
         verbosityLevel = NORMAL;
-        missingClassMessageList = new LinkedHashSet<String>();
-        errorSet = new HashSet<Error>();
-        observerList = new LinkedList<BugReporterObserver>();
+        missingClassMessageList = new LinkedHashSet<>();
+        errorSet = new HashSet<>();
+        observerList = new LinkedList<>();
         projectStats = new ProjectStats();
         // bug 2815983: no bugs are reported anymore
         // there is no info which value should be default, so using the max

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/AddMessages.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/AddMessages.java
@@ -66,9 +66,9 @@ public class AddMessages {
         Iterator<?> elementIter = XMLUtil.selectNodes(document, "/BugCollection/BugInstance").iterator();
         Iterator<BugInstance> bugInstanceIter = bugCollection.iterator();
 
-        Set<String> bugTypeSet = new HashSet<String>();
-        Set<String> bugCategorySet = new HashSet<String>();
-        Set<String> bugCodeSet = new HashSet<String>();
+        Set<String> bugTypeSet = new HashSet<>();
+        Set<String> bugCategorySet = new HashSet<>();
+        Set<String> bugCodeSet = new HashSet<>();
 
         // Add short and long descriptions to BugInstance elements.
         // We rely on the Document and the BugCollection storing

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/AnalysisError.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/AnalysisError.java
@@ -112,7 +112,7 @@ public class AnalysisError {
 
     private String[] getStackTraceAsStringArray(Throwable exception) {
         StackTraceElement[] exceptionStackTrace = exception.getStackTrace();
-        ArrayList<String> arr = new ArrayList<String>();
+        ArrayList<String> arr = new ArrayList<>();
         for (StackTraceElement aExceptionStackTrace : exceptionStackTrace) {
             arr.add(aExceptionStackTrace.toString());
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/Analyze.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/Analyze.java
@@ -219,7 +219,7 @@ public class Analyze {
         }
 
         // exist classes that are both X and Y
-        Set<ClassDescriptor> xButNotY = new HashSet<ClassDescriptor>(subtypes2.getSubtypes(xDesc));
+        Set<ClassDescriptor> xButNotY = new HashSet<>(subtypes2.getSubtypes(xDesc));
         xButNotY.removeAll(transitiveCommonSubtypes);
         for (ClassDescriptor c : xButNotY) {
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/BugAccumulator.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/BugAccumulator.java
@@ -47,9 +47,9 @@ public class BugAccumulator {
 
     private final boolean performAccumulation;
 
-    private final Map<BugInstance, Data> map = new HashMap<BugInstance, Data>();
+    private final Map<BugInstance, Data> map = new HashMap<>();
 
-    private final HashMap<String, BugInstance> hashes = new HashMap<String, BugInstance>();
+    private final HashMap<String, BugInstance> hashes = new HashMap<>();
 
     private BugInstance lastBug;
     private SourceLineAnnotation lastSourceLine;
@@ -65,7 +65,7 @@ public class BugAccumulator {
 
         SourceLineAnnotation primarySource;
 
-        LinkedHashSet<SourceLineAnnotation> allSource = new LinkedHashSet<SourceLineAnnotation>();
+        LinkedHashSet<SourceLineAnnotation> allSource = new LinkedHashSet<>();
     }
 
     /**
@@ -186,7 +186,7 @@ public class BugAccumulator {
     public void reportBug(BugInstance bug, Data d) {
         bug.setPriority(d.priority);
         bug.addSourceLine(d.primarySource);
-        HashSet<Integer> lines = new HashSet<Integer>();
+        HashSet<Integer> lines = new HashSet<>();
         lines.add(d.primarySource.getStartLine());
         d.allSource.remove(d.primarySource);
         for (SourceLineAnnotation source : d.allSource) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/BugInstance.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/BugInstance.java
@@ -180,7 +180,7 @@ public class BugInstance implements Comparable<BugInstance>, XMLWriteable, Clone
         this.type = type.intern();
         this.priority = priority;
         lastVersion = -1;
-        annotationList = new ArrayList<BugAnnotation>(4);
+        annotationList = new ArrayList<>(4);
         cachedHashCode = INVALID_HASH_CODE;
 
         BugPattern p = DetectorFactoryCollection.instance().lookupBugPattern(type);
@@ -542,7 +542,7 @@ public class BugInstance implements Comparable<BugInstance>, XMLWriteable, Clone
 
     public Collection<? extends SourceLineAnnotation> getAnotherInstanceSourceLineAnnotations() {
         // Highest priority: return the first top level source line annotation
-        Collection<SourceLineAnnotation> result = new ArrayList<SourceLineAnnotation>();
+        Collection<SourceLineAnnotation> result = new ArrayList<>();
         for (BugAnnotation annotation : annotationList) {
             if (annotation instanceof SourceLineAnnotation
                     && SourceLineAnnotation.ROLE_ANOTHER_INSTANCE.equals(annotation.getDescription())
@@ -2036,7 +2036,7 @@ public class BugInstance implements Comparable<BugInstance>, XMLWriteable, Clone
         Map<BugAnnotation, Void> primaryAnnotations;
 
         if (addMessages) {
-            primaryAnnotations = new IdentityHashMap<BugAnnotation, Void>();
+            primaryAnnotations = new IdentityHashMap<>();
             primaryAnnotations.put(getPrimarySourceLineAnnotation(), null);
             primaryAnnotations.put(getPrimaryClass(), null);
             primaryAnnotations.put(getPrimaryField(), null);
@@ -2226,7 +2226,7 @@ public class BugInstance implements Comparable<BugInstance>, XMLWriteable, Clone
     }
 
     public BugInstance addOptionalUniqueAnnotations(BugAnnotation... annotations) {
-        HashSet<BugAnnotation> added = new HashSet<BugAnnotation>();
+        HashSet<BugAnnotation> added = new HashSet<>();
         for (BugAnnotation a : annotations) {
             if (a != null && added.add(a)) {
                 add(a);
@@ -2236,7 +2236,7 @@ public class BugInstance implements Comparable<BugInstance>, XMLWriteable, Clone
     }
 
     public boolean tryAddingOptionalUniqueAnnotations(BugAnnotation... annotations) {
-        HashSet<BugAnnotation> added = new HashSet<BugAnnotation>();
+        HashSet<BugAnnotation> added = new HashSet<>();
         for (BugAnnotation a : annotations) {
             if (a != null && added.add(a)) {
                 add(a);
@@ -2246,7 +2246,7 @@ public class BugInstance implements Comparable<BugInstance>, XMLWriteable, Clone
     }
 
     public BugInstance addOptionalUniqueAnnotationsWithFallback(BugAnnotation fallback, BugAnnotation... annotations) {
-        HashSet<BugAnnotation> added = new HashSet<BugAnnotation>();
+        HashSet<BugAnnotation> added = new HashSet<>();
         for (BugAnnotation a : annotations) {
             if (a != null && added.add(a)) {
                 add(a);
@@ -2493,9 +2493,9 @@ public class BugInstance implements Comparable<BugInstance>, XMLWriteable, Clone
     }
 
     public List<BugAnnotation> getAnnotationsForMessage(boolean showContext) {
-        ArrayList<BugAnnotation> result = new ArrayList<BugAnnotation>();
+        ArrayList<BugAnnotation> result = new ArrayList<>();
 
-        HashSet<BugAnnotation> primaryAnnotations = new HashSet<BugAnnotation>();
+        HashSet<BugAnnotation> primaryAnnotations = new HashSet<>();
 
         // This ensures the order of the primary annotations of the bug
         FieldAnnotation primeField = getPrimaryField();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/BugRanker.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/BugRanker.java
@@ -93,9 +93,9 @@ public class BugRanker {
     static final boolean PLUGIN_DEBUG = Boolean.getBoolean("bugranker.plugin.debug");
 
     static class Scorer {
-        private final HashMap<String, Integer> adjustment = new HashMap<String, Integer>();
+        private final HashMap<String, Integer> adjustment = new HashMap<>();
 
-        private final HashSet<String> isRelative = new HashSet<String>();
+        private final HashSet<String> isRelative = new HashSet<>();
 
         int get(String key) {
             Integer v = adjustment.get(key);
@@ -263,7 +263,7 @@ public class BugRanker {
     = new AnalysisLocal<HashMap<BugPattern, Integer>>() {
         @Override
         protected HashMap<BugPattern, Integer> initialValue() {
-            return new HashMap<BugPattern, Integer>();
+            return new HashMap<>();
         }
     };
 
@@ -299,7 +299,7 @@ public class BugRanker {
 
     private static int findRankUnknownPlugin(BugPattern pattern) {
 
-        List<BugRanker> rankers = new ArrayList<BugRanker>();
+        List<BugRanker> rankers = new ArrayList<>();
         pluginLoop: for (Plugin plugin : Plugin.getAllPlugins()) {
             if (plugin.isCorePlugin()) {
                 continue;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/CallGraph.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/CallGraph.java
@@ -29,7 +29,7 @@ public class CallGraph extends AbstractGraph<CallGraphEdge, CallGraphNode> {
     private final IdentityHashMap<Method, CallGraphNode> methodToNodeMap;
 
     public CallGraph() {
-        this.methodToNodeMap = new IdentityHashMap<Method, CallGraphNode>();
+        this.methodToNodeMap = new IdentityHashMap<>();
     }
 
     public CallGraphEdge createEdge(CallGraphNode source, CallGraphNode target, CallSite callSite) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ClassScreener.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ClassScreener.java
@@ -67,7 +67,7 @@ public class ClassScreener implements IClassScreener {
      * packages.
      */
     public ClassScreener() {
-        this.patternList = new LinkedList<Matcher>();
+        this.patternList = new LinkedList<>();
     }
 
     /**

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/DetectorFactory.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/DetectorFactory.java
@@ -340,7 +340,7 @@ public class DetectorFactory {
      * we don't know what kind of bug patterns might be reported.
      */
     public Set<BugPattern> getReportedBugPatterns() {
-        Set<BugPattern> result = new TreeSet<BugPattern>();
+        Set<BugPattern> result = new TreeSet<>();
         StringTokenizer tok = new StringTokenizer(reports, ",");
         while (tok.hasMoreTokens()) {
             String type = tok.nextToken();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/DetectorFactoryCollection.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/DetectorFactoryCollection.java
@@ -60,17 +60,17 @@ public class DetectorFactoryCollection {
     private static DetectorFactoryCollection theInstance;
     private static final Object lock = new Object();
 
-    private final Map<String, Plugin> pluginByIdMap = new LinkedHashMap<String, Plugin>();
+    private final Map<String, Plugin> pluginByIdMap = new LinkedHashMap<>();
     private Plugin corePlugin;
-    private final List<DetectorFactory> factoryList = new ArrayList<DetectorFactory>();
-    private final Map<String, DetectorFactory> factoriesByName = new HashMap<String, DetectorFactory>();
-    private final Map<String, DetectorFactory> factoriesByDetectorClassName = new HashMap<String, DetectorFactory>();
-    protected final Map<String, BugCategory> categoryDescriptionMap = new HashMap<String, BugCategory>();
-    protected final Map<String, BugPattern> bugPatternMap = new HashMap<String, BugPattern>();
-    protected final Map<String, BugCode> bugCodeMap = new HashMap<String, BugCode>();
+    private final List<DetectorFactory> factoryList = new ArrayList<>();
+    private final Map<String, DetectorFactory> factoriesByName = new HashMap<>();
+    private final Map<String, DetectorFactory> factoriesByDetectorClassName = new HashMap<>();
+    protected final Map<String, BugCategory> categoryDescriptionMap = new HashMap<>();
+    protected final Map<String, BugPattern> bugPatternMap = new HashMap<>();
+    protected final Map<String, BugCode> bugCodeMap = new HashMap<>();
 
-    final Map<String, String> globalOptions = new HashMap<String,String>();
-    final Map<String, Plugin> globalOptionsSetter = new HashMap<String,Plugin>();
+    final Map<String, String> globalOptions = new HashMap<>();
+    final Map<String, Plugin> globalOptionsSetter = new HashMap<>();
 
     public DetectorFactoryCollection() {
         this(true, false, Plugin.getAllPlugins(), new ArrayList<Plugin>());
@@ -537,7 +537,7 @@ public class DetectorFactoryCollection {
      * @return Collection of bug category keys.
      */
     public Collection<String> getBugCategories() {
-        ArrayList<String> result = new ArrayList<String>(categoryDescriptionMap.size());
+        ArrayList<String> result = new ArrayList<>(categoryDescriptionMap.size());
         for(BugCategory c : categoryDescriptionMap.values()) {
             if (!c.isHidden()) {
                 result.add(c.getCategory());

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/DiscoverSourceDirectories.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/DiscoverSourceDirectories.java
@@ -156,7 +156,7 @@ public class DiscoverSourceDirectories {
     public DiscoverSourceDirectories() {
         this.errorLogger = new NoOpErrorLogger();
         this.progress = new NoOpProgress();
-        this.discoveredSourceDirectoryList = new LinkedList<String>();
+        this.discoveredSourceDirectoryList = new LinkedList<>();
     }
 
     /**
@@ -331,7 +331,7 @@ public class DiscoverSourceDirectories {
 
         progress.startScanningClasses(appClassList.size());
 
-        List<String> fullyQualifiedSourceFileNameList = new LinkedList<String>();
+        List<String> fullyQualifiedSourceFileNameList = new LinkedList<>();
 
         for (ClassDescriptor classDesc : appClassList) {
             try {
@@ -352,7 +352,7 @@ public class DiscoverSourceDirectories {
     private void findSourceDirectoriesForAllSourceFiles(List<String> fullyQualifiedSourceFileNameList,
             List<String> candidateSourceDirList) {
 
-        Set<String> sourceDirsFound = new HashSet<String>();
+        Set<String> sourceDirsFound = new HashSet<>();
 
         // For each source file discovered, try to locate it in one of
         // the candidate source directories.

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/EmacsBugReporter.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/EmacsBugReporter.java
@@ -39,9 +39,9 @@ import edu.umd.cs.findbugs.classfile.ClassDescriptor;
  */
 public class EmacsBugReporter extends TextUIBugReporter {
 
-    private final HashSet<BugInstance> seenAlready = new HashSet<BugInstance>();
+    private final HashSet<BugInstance> seenAlready = new HashSet<>();
 
-    private final HashMap<String, String> sourceFileNameCache = new HashMap<String, String>();
+    private final HashMap<String, String> sourceFileNameCache = new HashMap<>();
 
     @Override
     public void observeClass(ClassDescriptor classDescriptor) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ErrorCountingBugReporter.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ErrorCountingBugReporter.java
@@ -28,9 +28,9 @@ import java.util.Set;
 public class ErrorCountingBugReporter extends DelegatingBugReporter {
     private int bugCount;
 
-    private final HashSet<String> errors = new HashSet<String>();
+    private final HashSet<String> errors = new HashSet<>();
 
-    private final Set<String> missingClassSet = new HashSet<String>();
+    private final Set<String> missingClassSet = new HashSet<>();
 
     public ErrorCountingBugReporter(BugReporter realBugReporter) {
         super(realBugReporter);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ExcludingHashesBugReporter.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ExcludingHashesBugReporter.java
@@ -32,7 +32,7 @@ import org.dom4j.DocumentException;
  */
 public class ExcludingHashesBugReporter extends DelegatingBugReporter {
 
-    Set<String> excludedHashes = new HashSet<String>();
+    Set<String> excludedHashes = new HashSet<>();
 
     /**
      * @param delegate

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/FindBugs.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/FindBugs.java
@@ -311,7 +311,7 @@ public abstract class FindBugs {
      */
     public static Set<String> handleBugCategories(String categories) {
         // Parse list of bug categories
-        Set<String> categorySet = new HashSet<String>();
+        Set<String> categorySet = new HashSet<>();
         StringTokenizer tok = new StringTokenizer(categories, ",");
         while (tok.hasMoreTokens()) {
             categorySet.add(tok.nextToken());

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/FindBugs2.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/FindBugs2.java
@@ -129,7 +129,7 @@ public class FindBugs2 implements IFindBugsEngine {
      * Constructor.
      */
     public FindBugs2() {
-        this.classObserverList = new LinkedList<IClassObserver>();
+        this.classObserverList = new LinkedList<>();
         this.analysisOptions.analysisFeatureSettingList = FindBugs.DEFAULT_EFFORT;
         this.progress = new NoOpFindBugsProgress();
 
@@ -656,7 +656,7 @@ public class FindBugs2 implements IFindBugsEngine {
         IClassPathBuilder builder = classFactory.createClassPathBuilder(bugReporter);
 
         {
-            HashSet<String> seen = new HashSet<String>();
+            HashSet<String> seen = new HashSet<>();
             for (String path : project.getFileArray()) {
                 if (seen.add(path)) {
                     builder.addCodeBase(classFactory.createFilesystemCodeBaseLocator(path), true);
@@ -706,19 +706,19 @@ public class FindBugs2 implements IFindBugsEngine {
         if (PROGRESS) {
             System.out.println("Adding referenced classes");
         }
-        Set<String> referencedPackageSet = new HashSet<String>();
+        Set<String> referencedPackageSet = new HashSet<>();
 
-        LinkedList<ClassDescriptor> workList = new LinkedList<ClassDescriptor>();
+        LinkedList<ClassDescriptor> workList = new LinkedList<>();
         workList.addAll(appClassList);
 
-        Set<ClassDescriptor> seen = new HashSet<ClassDescriptor>();
-        Set<ClassDescriptor> appClassSet = new HashSet<ClassDescriptor>(appClassList);
+        Set<ClassDescriptor> seen = new HashSet<>();
+        Set<ClassDescriptor> appClassSet = new HashSet<>(appClassList);
 
-        Set<ClassDescriptor> badAppClassSet = new HashSet<ClassDescriptor>();
-        HashSet<ClassDescriptor> knownDescriptors = new HashSet<ClassDescriptor>(DescriptorFactory.instance()
+        Set<ClassDescriptor> badAppClassSet = new HashSet<>();
+        HashSet<ClassDescriptor> knownDescriptors = new HashSet<>(DescriptorFactory.instance()
                 .getAllClassDescriptors());
         int count = 0;
-        Set<ClassDescriptor> addedToWorkList = new HashSet<ClassDescriptor>(appClassList);
+        Set<ClassDescriptor> addedToWorkList = new HashSet<>(appClassList);
 
         // add fields
         //noinspection ConstantIfStatement
@@ -815,7 +815,7 @@ public class FindBugs2 implements IFindBugsEngine {
         for (ClassDescriptor d : DescriptorFactory.instance().getAllClassDescriptors()) {
             referencedPackageSet.add(d.getPackageName());
         }
-        referencedClassSet = new ArrayList<ClassDescriptor>(DescriptorFactory.instance().getAllClassDescriptors());
+        referencedClassSet = new ArrayList<>(DescriptorFactory.instance().getAllClassDescriptors());
 
         // Based on referenced packages, add any resolvable package-info classes
         // to the set of referenced classes.
@@ -898,7 +898,7 @@ public class FindBugs2 implements IFindBugsEngine {
 
         // Use user preferences to decide which detectors are enabled.
         DetectorFactoryChooser detectorFactoryChooser = new DetectorFactoryChooser() {
-            HashSet<DetectorFactory> forcedEnabled = new HashSet<DetectorFactory>();
+            HashSet<DetectorFactory> forcedEnabled = new HashSet<>();
 
             @Override
             public boolean choose(DetectorFactory factory) {
@@ -961,7 +961,7 @@ public class FindBugs2 implements IFindBugsEngine {
             }
             progress.predictPassCount(classesPerPass);
             XFactory factory = AnalysisContext.currentXFactory();
-            Collection<ClassDescriptor> badClasses = new LinkedList<ClassDescriptor>();
+            Collection<ClassDescriptor> badClasses = new LinkedList<>();
             for (ClassDescriptor desc : referencedClassSet) {
                 try {
                     XClass info = Global.getAnalysisCache().getClassAnalysis(XClass.class, desc);
@@ -975,7 +975,7 @@ public class FindBugs2 implements IFindBugsEngine {
                 }
             }
             if (!badClasses.isEmpty()) {
-                referencedClassSet = new LinkedHashSet<ClassDescriptor>(referencedClassSet);
+                referencedClassSet = new LinkedHashSet<>(referencedClassSet);
                 referencedClassSet.removeAll(badClasses);
             }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/FuzzyBugComparator.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/FuzzyBugComparator.java
@@ -116,7 +116,7 @@ public class FuzzyBugComparator implements WarningComparator {
         if (DEBUG) {
             System.out.println("Created fuzzy comparator");
         }
-        this.bugCollectionMap = new IdentityHashMap<BugInstance, BugCollection>();
+        this.bugCollectionMap = new IdentityHashMap<>();
         // this.classHashToCanonicalClassNameMap = new TreeMap<ClassHash,
         // String>();
     }
@@ -312,7 +312,7 @@ public class FuzzyBugComparator implements WarningComparator {
 
     // See "FindBugsAnnotationDescriptions.properties"
     @StaticConstant
-    private static final HashSet<String> significantDescriptionSet = new HashSet<String>();
+    private static final HashSet<String> significantDescriptionSet = new HashSet<>();
     static {
         // Classes, methods, and fields are significant.
         significantDescriptionSet.add("CLASS_DEFAULT");

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/InstructionScannerDriver.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/InstructionScannerDriver.java
@@ -47,7 +47,7 @@ public class InstructionScannerDriver {
      */
     public InstructionScannerDriver(Iterator<Edge> edgeIter) {
         this.edgeIter = edgeIter;
-        scannerList = new LinkedList<InstructionScanner>();
+        scannerList = new LinkedList<>();
     }
 
     /**

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/IntAnnotation.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/IntAnnotation.java
@@ -128,7 +128,7 @@ public class IntAnnotation implements BugAnnotation {
         return base10;
     }
     private static int uniqueDigits(String value) {
-        Set<Character> used = new HashSet<Character>();
+        Set<Character> used = new HashSet<>();
         for(int i = 0; i < value.length(); i++) {
             used.add(value.charAt(i));
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/LaunchAppropriateUI.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/LaunchAppropriateUI.java
@@ -66,7 +66,7 @@ public class LaunchAppropriateUI {
     @StaticConstant
     public static final Map<String, Integer> uiNameToCodeMap;
     static {
-        uiNameToCodeMap = new HashMap<String, Integer>();
+        uiNameToCodeMap = new HashMap<>();
         uiNameToCodeMap.put("textui", TEXTUI);
         uiNameToCodeMap.put("gui", GUI2);
         uiNameToCodeMap.put("gui1", GUI1);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/OpcodeStack.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/OpcodeStack.java
@@ -127,7 +127,7 @@ public class OpcodeStack implements Constants2 {
     private static final boolean DEBUG2 = DEBUG;
 
     @StaticConstant
-    static final HashMap<String, String> boxedTypes = new HashMap<String, String>();
+    static final HashMap<String, String> boxedTypes = new HashMap<>();
 
     private List<Item> stack;
 
@@ -163,9 +163,9 @@ public class OpcodeStack implements Constants2 {
 
     private boolean jumpInfoChangedByNewTarget;
 
-    private Map<Integer, List<Item>> jumpEntries = new HashMap<Integer, List<Item>>();
+    private Map<Integer, List<Item>> jumpEntries = new HashMap<>();
 
-    private Map<Integer, List<Item>> jumpStackEntries = new HashMap<Integer, List<Item>>();
+    private Map<Integer, List<Item>> jumpStackEntries = new HashMap<>();
 
     private BitSet jumpEntryLocations = new BitSet();
 
@@ -278,7 +278,7 @@ public class OpcodeStack implements Constants2 {
          */
         @Deprecated
         @edu.umd.cs.findbugs.internalAnnotations.StaticConstant
-        public static final HashMap<Integer, String> specialKindNames = new HashMap<Integer, String>();
+        public static final HashMap<Integer, String> specialKindNames = new HashMap<>();
 
         private static @SpecialKind int nextSpecialKind = asSpecialKind(TYPE_ONLY + 1);
 
@@ -1118,9 +1118,9 @@ public class OpcodeStack implements Constants2 {
     }
 
     public OpcodeStack() {
-        stack = new ArrayList<Item>();
-        lvValues = new ArrayList<Item>();
-        lastUpdate = new ArrayList<Integer>();
+        stack = new ArrayList<>();
+        lvValues = new ArrayList<>();
+        lastUpdate = new ArrayList<>();
     }
 
     public boolean hasIncomingBranches(int pc) {
@@ -1202,9 +1202,9 @@ public class OpcodeStack implements Constants2 {
 
             }
             if (isTop()) {
-                lvValues = new ArrayList<Item>(jumpEntry);
+                lvValues = new ArrayList<>(jumpEntry);
                 if (jumpStackEntry != null) {
-                    stack = new ArrayList<Item>(jumpStackEntry);
+                    stack = new ArrayList<>(jumpStackEntry);
                 } else {
                     stack.clear();
                 }
@@ -1213,10 +1213,10 @@ public class OpcodeStack implements Constants2 {
             }
             if (isReachOnlyByBranch()) {
                 setTop(false);
-                lvValues = new ArrayList<Item>(jumpEntry);
+                lvValues = new ArrayList<>(jumpEntry);
                 if (!stackUpdated) {
                     if (jumpStackEntry != null) {
-                        stack = new ArrayList<Item>(jumpStackEntry);
+                        stack = new ArrayList<>(jumpStackEntry);
                     } else {
                         stack.clear();
                     }
@@ -2760,7 +2760,7 @@ public class OpcodeStack implements Constants2 {
 
             List<Item> mergeIntoCopy = null;
             if (DEBUG2) {
-                mergeIntoCopy = new ArrayList<Item>(mergeInto);
+                mergeIntoCopy = new ArrayList<>(mergeInto);
             }
             int common = Math.min(intoSize, fromSize);
             for (int i = 0; i < common; i++) {
@@ -2955,10 +2955,10 @@ public class OpcodeStack implements Constants2 {
         if (atTarget == null) {
             setJumpInfoChangedByBackwardBranch("new target", from, target);
             setJumpInfoChangedByNewTarget();
-            jumpEntries.put(Integer.valueOf(target), new ArrayList<Item>(lvValues));
+            jumpEntries.put(Integer.valueOf(target), new ArrayList<>(lvValues));
             jumpEntryLocations.set(target);
             if (stack.size() > 0) {
-                jumpStackEntries.put(Integer.valueOf(target), new ArrayList<Item>(stack));
+                jumpStackEntries.put(Integer.valueOf(target), new ArrayList<>(stack));
             }
         } else {
             if (mergeLists(atTarget, lvValues, false)) {
@@ -2982,8 +2982,8 @@ public class OpcodeStack implements Constants2 {
         if (info == null) {
             return;
         }
-        jumpEntries = new HashMap<Integer, List<Item>>(info.jumpEntries);
-        jumpStackEntries = new HashMap<Integer, List<Item>>(info.jumpStackEntries);
+        jumpEntries = new HashMap<>(info.jumpEntries);
+        jumpStackEntries = new HashMap<>(info.jumpStackEntries);
         jumpEntryLocations = (BitSet) info.jumpEntryLocations.clone();
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/PackageStats.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/PackageStats.java
@@ -194,7 +194,7 @@ public class PackageStats extends BugCounts implements XMLWriteable {
     // LinkedList<BugInstance>();
 
     // all classes and interfaces in this package
-    private final Map<String, ClassStats> packageMembers = new HashMap<String, ClassStats>(5);
+    private final Map<String, ClassStats> packageMembers = new HashMap<>(5);
 
     public PackageStats(String packageName) {
         this.packageName = packageName;
@@ -310,7 +310,7 @@ public class PackageStats extends BugCounts implements XMLWriteable {
     }
 
     public Collection<ClassStats> getSortedClassStats() {
-        SortedMap<String, ClassStats> sorted = new TreeMap<String, ClassStats>(packageMembers);
+        SortedMap<String, ClassStats> sorted = new TreeMap<>(packageMembers);
         return sorted.values();
 
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/Plugin.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/Plugin.java
@@ -57,7 +57,7 @@ public class Plugin {
 
 
     private static final String USE_FINDBUGS_VERSION = "USE_FINDBUGS_VERSION";
-    static Map<URI, Plugin> allPlugins = new LinkedHashMap<URI, Plugin>();
+    static Map<URI, Plugin> allPlugins = new LinkedHashMap<>();
     private final String pluginId;
 
     private final String version;
@@ -119,17 +119,17 @@ public class Plugin {
             version = Version.VERSION_STRING;
         }
         assert enabled || !cannotDisable;
-        myGlobalOptions = new HashMap<String, String>();
-        componentPlugins = new DualKeyHashMap<Class<?>, String, ComponentPlugin<?>> ();
+        myGlobalOptions = new HashMap<>();
+        componentPlugins = new DualKeyHashMap<> ();
         this.version = version;
         this.releaseDate = releaseDate;
-        this.detectorFactoryList = new ArrayList<DetectorFactory>();
-        this.bugPatterns = new LinkedHashSet<BugPattern>();
-        this.bugCodeList = new LinkedHashSet<BugCode>();
-        this.bugCategories = new LinkedHashMap<String,BugCategory>();
-        this.interPassConstraintList = new ArrayList<DetectorOrderingConstraint>();
-        this.intraPassConstraintList = new ArrayList<DetectorOrderingConstraint>();
-        this.mainPlugins = new HashMap<String, FindBugsMain>();
+        this.detectorFactoryList = new ArrayList<>();
+        this.bugPatterns = new LinkedHashSet<>();
+        this.bugCodeList = new LinkedHashSet<>();
+        this.bugCategories = new LinkedHashMap<>();
+        this.interPassConstraintList = new ArrayList<>();
+        this.intraPassConstraintList = new ArrayList<>();
+        this.mainPlugins = new HashMap<>();
         this.pluginLoader = pluginLoader;
         this.enabledByDefault = enabled;
         this.cannotDisable = cannotDisable;
@@ -509,11 +509,11 @@ public class Plugin {
      * @return a copy of the internal plugins collection
      */
     public static synchronized Collection<Plugin> getAllPlugins() {
-        return new ArrayList<Plugin>(allPlugins.values());
+        return new ArrayList<>(allPlugins.values());
     }
 
     public static synchronized Collection<String> getAllPluginIds() {
-        ArrayList<String> result = new ArrayList<String>();
+        ArrayList<String> result = new ArrayList<>();
         for(Plugin p : allPlugins.values()) {
             result.add(p.getPluginId());
         }
@@ -524,12 +524,12 @@ public class Plugin {
      * @return a copy of the internal plugins collection
      */
     public static synchronized Map<URI, Plugin> getAllPluginsMap() {
-        return new LinkedHashMap<URI, Plugin>(allPlugins);
+        return new LinkedHashMap<>(allPlugins);
     }
 
     public static synchronized Set<URI> getAllPluginsURIs() {
         Collection<Plugin> plugins = getAllPlugins();
-        Set<URI> uris = new HashSet<URI>();
+        Set<URI> uris = new HashSet<>();
         for (Plugin plugin : plugins) {
 
             try {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/PluginLoader.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/PluginLoader.java
@@ -109,7 +109,7 @@ public class PluginLoader {
 
     private static final boolean DEBUG = SystemProperties.getBoolean("findbugs.debug.PluginLoader");
     static boolean lazyInitialization = false;
-    static LinkedList<PluginLoader> partiallyInitialized = new LinkedList<PluginLoader>();
+    static LinkedList<PluginLoader> partiallyInitialized = new LinkedList<>();
 
 
     // Keep a count of how many plugins we've seen without a
@@ -141,7 +141,7 @@ public class PluginLoader {
     /** plugin Id for parent plugin */
     String parentId;
 
-    static HashSet<String> loadedPluginIds = new HashSet<String>();
+    static HashSet<String> loadedPluginIds = new HashSet<>();
     static {
         if (DEBUG) {
             System.out.println("Debugging plugin loading. SpotBugs version "
@@ -234,8 +234,8 @@ public class PluginLoader {
         }
         while (!partiallyInitialized.isEmpty()) {
             boolean changed = false;
-            LinkedList<String>  unresolved = new LinkedList<String>();
-            Set<String>  needed = new TreeSet<String>();
+            LinkedList<String>  unresolved = new LinkedList<>();
+            Set<String>  needed = new TreeSet<>();
 
             for (Iterator<PluginLoader> i = partiallyInitialized.iterator(); i.hasNext();) {
                 PluginLoader pluginLoader = i.next();
@@ -292,7 +292,7 @@ public class PluginLoader {
      * @throws PluginException
      */
     private static @Nonnull URL[] createClassloaderUrls(@Nonnull URL url) throws PluginException {
-        List<URL> urls = new ArrayList<URL>();
+        List<URL> urls = new ArrayList<>();
         urls.add(url);
 
         Manifest mf = null;
@@ -1004,7 +1004,7 @@ public class PluginLoader {
         }
 
         // Create BugCodes
-        Set<String> definedBugCodes = new HashSet<String>();
+        Set<String> definedBugCodes = new HashSet<>();
         for (Document messageCollection : messageCollectionList) {
             List<Node> bugCodeNodeList = XMLUtil.selectNodes(messageCollection, "/MessageCollection/BugCode");
             for (Node bugCodeNode : bugCodeNodeList) {
@@ -1209,7 +1209,7 @@ public class PluginLoader {
         String language = locale.getLanguage();
         String country = locale.getCountry();
 
-        List<String> potential = new ArrayList<String>(3);
+        List<String> potential = new ArrayList<>(3);
         if (country != null) {
             potential.add("messages_" + language + "_" + country + ".xml");
         }
@@ -1220,7 +1220,7 @@ public class PluginLoader {
 
     private List<Document> getMessageDocuments() throws PluginException {
         // List of message translation files in decreasing order of precedence
-        ArrayList<Document> messageCollectionList = new ArrayList<Document>();
+        ArrayList<Document> messageCollectionList = new ArrayList<>();
         PluginException caught = null;
         for (String m : getPotentialMessageFiles()) {
             try {
@@ -1249,7 +1249,7 @@ public class PluginLoader {
             componentClass = getClass(classLoader, componentClassname, componentKind);
         }
 
-        ComponentPlugin<T> componentPlugin = new ComponentPlugin<T>(plugin, filterId, classLoader, componentClass,
+        ComponentPlugin<T> componentPlugin = new ComponentPlugin<>(plugin, filterId, classLoader, componentClass,
                 properties, !disabled, description, details);
         plugin.addComponentPlugin(componentKind, componentPlugin);
     }
@@ -1607,7 +1607,7 @@ public class PluginLoader {
             String pluginId = pluginDocument.valueOf(XPATH_PLUGIN_PLUGINID).trim();
             String provider = pluginDocument.valueOf(XPATH_PLUGIN_PROVIDER).trim();
             String website = pluginDocument.valueOf(XPATH_PLUGIN_WEBSITE).trim();
-            List<Document> msgDocuments = new ArrayList<Document>(3);
+            List<Document> msgDocuments = new ArrayList<>(3);
             for (String msgFile : getPotentialMessageFiles()) {
                 ZipEntry msgEntry = zip.getEntry(msgFile);
                 if (msgEntry == null) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/PrintingBugReporter.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/PrintingBugReporter.java
@@ -40,7 +40,7 @@ import edu.umd.cs.findbugs.util.Bag;
  * stream.
  */
 public class PrintingBugReporter extends TextUIBugReporter {
-    private final HashSet<BugInstance> seenAlready = new HashSet<BugInstance>();
+    private final HashSet<BugInstance> seenAlready = new HashSet<>();
 
     @Override
     public void observeClass(ClassDescriptor classDescriptor) {
@@ -172,7 +172,7 @@ public class PrintingBugReporter extends TextUIBugReporter {
         boolean bugsReported = false;
         RuntimeException storedException = null;
         
-        Bag<String> lowRank = new Bag<String>(new TreeMap<String, Integer>());
+        Bag<String> lowRank = new Bag<>(new TreeMap<String, Integer>());
         for (BugInstance warning : bugCollection.getCollection()) {
             if (!reporter.isApplySuppressions() || !bugCollection.getProject().getSuppressionFilter().match(warning)) {
                 int rank = warning.getBugRank();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/Project.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/Project.java
@@ -154,13 +154,13 @@ public class Project implements XMLWriteable {
      * Create an anonymous project.
      */
     public Project() {
-        enabledPlugins = new HashMap<String,Boolean>();
+        enabledPlugins = new HashMap<>();
         configuration = UserPreferences.createDefaultUserPreferences();
-        analysisTargets = new LinkedList<String>();
-        srcDirList = new LinkedList<String>();
-        auxClasspathEntryList = new LinkedList<String>();
+        analysisTargets = new LinkedList<>();
+        srcDirList = new LinkedList<>();
+        auxClasspathEntryList = new LinkedList<>();
         isModified = false;
-        currentWorkingDirectoryList = new ArrayList<File>();
+        currentWorkingDirectoryList = new ArrayList<>();
     }
 
     /**
@@ -199,9 +199,9 @@ public class Project implements XMLWriteable {
     }
 
     public static <T> List<T> appendWithoutDuplicates(List<T> lst1, List<T> lst2) {
-        LinkedHashSet<T> joined = new LinkedHashSet<T>(lst1);
+        LinkedHashSet<T> joined = new LinkedHashSet<>(lst1);
         joined.addAll(lst2);
-        return new ArrayList<T>(joined);
+        return new ArrayList<>(joined);
 
     }
 
@@ -461,8 +461,8 @@ public class Project implements XMLWriteable {
          * Constructor. Creates an empty worklist.
          */
         public WorkList() {
-            this.itemList = new LinkedList<WorkListItem>();
-            this.addedSet = new HashSet<String>();
+            this.itemList = new LinkedList<>();
+            this.addedSet = new HashSet<>();
         }
 
         /**
@@ -535,7 +535,7 @@ public class Project implements XMLWriteable {
      */
     @Deprecated
     public List<String> getImplicitClasspathEntryList() {
-        final LinkedList<String> implicitClasspath = new LinkedList<String>();
+        final LinkedList<String> implicitClasspath = new LinkedList<>();
         WorkList workList = new WorkList();
 
         // Prime the worklist by adding the zip/jar files
@@ -821,7 +821,7 @@ public class Project implements XMLWriteable {
             writeElementList(xmlOutput, JAR_ELEMENT_NAME, convertToRelative(analysisTargets, base));
             writeElementList(xmlOutput, AUX_CLASSPATH_ENTRY_ELEMENT_NAME, convertToRelative(auxClasspathEntryList, base));
             writeElementList(xmlOutput, SRC_DIR_ELEMENT_NAME, convertToRelative(srcDirList, base));
-            List<String> cwdStrings = new ArrayList<String>();
+            List<String> cwdStrings = new ArrayList<>();
             for (File file : currentWorkingDirectoryList) {
                 cwdStrings.add(file.getPath());
             }
@@ -864,7 +864,7 @@ public class Project implements XMLWriteable {
     private static final boolean FILE_IGNORE_CASE = SystemProperties.getProperty("os.name", "unknown").startsWith("Windows");
 
     private Iterable<String> convertToRelative(List<String> paths, String base) {
-        List<String> newList = new ArrayList<String>(paths.size());
+        List<String> newList = new ArrayList<>(paths.size());
         for (String path : paths) {
             newList.add(convertToRelative(path, base));
         }
@@ -988,7 +988,7 @@ public class Project implements XMLWriteable {
      * @return A list of at least one candidate path for the given filename.
      */
     private List<String> makeAbsoluteCwdCandidates(String fileName) {
-        List<String> candidates = new ArrayList<String>();
+        List<String> candidates = new ArrayList<>();
 
         boolean hasProtocol = (URLClassPath.getURLProtocol(fileName) != null);
         if (hasProtocol) {
@@ -1095,7 +1095,7 @@ public class Project implements XMLWriteable {
     }
 
     public Iterable<String> getResolvedSourcePaths() {
-        List<String> result = new ArrayList<String>();
+        List<String> result = new ArrayList<>();
         for (String s : srcDirList) {
             boolean hasProtocol = (URLClassPath.getURLProtocol(s) != null);
             if (hasProtocol) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ProjectPackagePrefixes.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ProjectPackagePrefixes.java
@@ -78,13 +78,13 @@ public class ProjectPackagePrefixes {
         return map.size();
     }
 
-    Map<String, PrefixFilter> map = new HashMap<String, PrefixFilter>();
+    Map<String, PrefixFilter> map = new HashMap<>();
 
-    Map<Set<String>, Integer> count = new HashMap<Set<String>, Integer>();
+    Map<Set<String>, Integer> count = new HashMap<>();
 
-    Map<String, Integer> missingProjectCount = new TreeMap<String, Integer>();
+    Map<String, Integer> missingProjectCount = new TreeMap<>();
 
-    Map<String, Integer> rawPackageCount = new TreeMap<String, Integer>();
+    Map<String, Integer> rawPackageCount = new TreeMap<>();
 
     int totalCount = 0;
 
@@ -112,7 +112,7 @@ public class ProjectPackagePrefixes {
     }
 
     public TreeSet<String> getProjects(@DottedClassName String className) {
-        TreeSet<String> results = new TreeSet<String>();
+        TreeSet<String> results = new TreeSet<>();
         for (Map.Entry<String, PrefixFilter> e : map.entrySet()) {
             if (e.getValue().matches(className)) {
                 results.add(e.getKey());
@@ -160,7 +160,7 @@ public class ProjectPackagePrefixes {
 
         Set<String> packages = missingProjectCount.keySet();
         for (int count = 0; count < 3; count++) {
-            HashSet<String> extraSuperPackages = new HashSet<String>();
+            HashSet<String> extraSuperPackages = new HashSet<>();
 
             for (String p1 : packages) {
                 int num = missingProjectCount.get(p1);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ProjectStats.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ProjectStats.java
@@ -110,7 +110,7 @@ public class ProjectStats implements XMLWriteable, Cloneable {
      * Constructor. Creates an empty object.
      */
     public ProjectStats() {
-        this.packageStatsMap = new TreeMap<String, PackageStats>();
+        this.packageStatsMap = new TreeMap<>();
         this.totalClasses = 0;
         this.analysisTimestamp = new Date();
         this.baseFootprint = new Footprint();
@@ -436,7 +436,7 @@ public class ProjectStats implements XMLWriteable, Cloneable {
         xmlOutput.stopTag(false);
 
         if (withMessages && fileBugHashes != null) {
-            for (String sourceFile : new TreeSet<String>(fileBugHashes.getSourceFiles())) {
+            for (String sourceFile : new TreeSet<>(fileBugHashes.getSourceFiles())) {
                 xmlOutput.startTag("FileStats");
                 xmlOutput.addAttribute("path", sourceFile);
                 xmlOutput.addAttribute("bugCount", String.valueOf(fileBugHashes.getBugCount(sourceFile)));
@@ -470,7 +470,7 @@ public class ProjectStats implements XMLWriteable, Cloneable {
             computeFileStats(bugs);
         }
 
-        HashMap<String, String> result = new HashMap<String, String>();
+        HashMap<String, String> result = new HashMap<>();
         for (String sourceFile : fileBugHashes.getSourceFiles()) {
             result.put(sourceFile, fileBugHashes.getHash(sourceFile));
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/RecursiveFileSearch.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/RecursiveFileSearch.java
@@ -43,9 +43,9 @@ public class RecursiveFileSearch {
 
     private final LinkedList<File> directoryWorkList;
 
-    private final HashSet<String> directoriesScanned = new HashSet<String>();
+    private final HashSet<String> directoriesScanned = new HashSet<>();
 
-    private final List<String> directoriesScannedList = new LinkedList<String>();
+    private final List<String> directoriesScannedList = new LinkedList<>();
 
     private final ArrayList<String> resultList;
 
@@ -61,8 +61,8 @@ public class RecursiveFileSearch {
     public RecursiveFileSearch(String baseDir, FileFilter fileFilter) {
         this.baseDir = baseDir;
         this.fileFilter = fileFilter;
-        this.directoryWorkList = new LinkedList<File>();
-        this.resultList = new ArrayList<String>();
+        this.directoryWorkList = new LinkedList<>();
+        this.resultList = new ArrayList<>();
     }
 
     static String bestEffortCanonicalPath(File f) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ResourceCollection.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ResourceCollection.java
@@ -50,8 +50,8 @@ public class ResourceCollection<Resource> {
      * Constructor. Creates empty collection.
      */
     public ResourceCollection() {
-        this.resourceList = new LinkedList<Resource>();
-        this.locationToResourceMap = new HashMap<Location, Resource>();
+        this.resourceList = new LinkedList<>();
+        this.locationToResourceMap = new HashMap<>();
     }
 
     /**

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ResourceTrackingDetector.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ResourceTrackingDetector.java
@@ -125,7 +125,7 @@ Detector {
     private ResourceCollection<Resource> buildResourceCollection(ClassContext classContext, Method method,
             ResourceTrackerType resourceTracker) throws CFGBuilderException, DataflowAnalysisException {
 
-        ResourceCollection<Resource> resourceCollection = new ResourceCollection<Resource>();
+        ResourceCollection<Resource> resourceCollection = new ResourceCollection<>();
 
         CFG cfg = classContext.getCFG(method);
         ConstantPoolGen cpg = classContext.getConstantPoolGen();
@@ -176,9 +176,9 @@ Detector {
             for (Iterator<Resource> i = resourceCollection.resourceIterator(); i.hasNext();) {
                 Resource resource = i.next();
 
-                ResourceValueAnalysis<Resource> analysis = new ResourceValueAnalysis<Resource>(methodGen, cfg, dfs,
+                ResourceValueAnalysis<Resource> analysis = new ResourceValueAnalysis<>(methodGen, cfg, dfs,
                         resourceTracker, resource);
-                Dataflow<ResourceValueFrame, ResourceValueAnalysis<Resource>> dataflow = new Dataflow<ResourceValueFrame, ResourceValueAnalysis<Resource>>(
+                Dataflow<ResourceValueFrame, ResourceValueAnalysis<Resource>> dataflow = new Dataflow<>(
                         cfg, analysis);
 
                 Profiler profiler = Global.getAnalysisCache().getProfiler();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/SAXBugCollectionHandler.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/SAXBugCollectionHandler.java
@@ -81,11 +81,11 @@ public class SAXBugCollectionHandler extends DefaultHandler {
     @CheckForNull
     private final Project project;
 
-    private final Stack<CompoundMatcher> matcherStack = new Stack<CompoundMatcher>();
+    private final Stack<CompoundMatcher> matcherStack = new Stack<>();
 
     private Filter filter;
 
-    private final MapCache<String, String> cache = new MapCache<String, String>(2000);
+    private final MapCache<String, String> cache = new MapCache<>(2000);
 
     private final ArrayList<String> elementStack;
 
@@ -114,9 +114,9 @@ public class SAXBugCollectionHandler extends DefaultHandler {
         this.bugCollection = bugCollection;
         this.project = project;
 
-        this.elementStack = new ArrayList<String>();
+        this.elementStack = new ArrayList<>();
         this.textBuffer = new StringBuilder();
-        this.stackTrace = new ArrayList<String>();
+        this.stackTrace = new ArrayList<>();
         this.base = base;
 
     }
@@ -430,7 +430,7 @@ public class SAXBugCollectionHandler extends DefaultHandler {
     }
 
     boolean nextMatchedIsDisabled;
-    private final Set<String> outerElementTags = unmodifiableSet(new HashSet<String>(asList("And", "Match", "Or", "Not")));
+    private final Set<String> outerElementTags = unmodifiableSet(new HashSet<>(asList("And", "Match", "Or", "Not")));
 
     private void parseMatcher(String qName, Attributes attributes) throws SAXException {
         if (DEBUG) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/SelfCalls.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/SelfCalls.java
@@ -61,7 +61,7 @@ public class SelfCalls {
     public SelfCalls(ClassContext classContext) {
         this.classContext = classContext;
         this.callGraph = new CallGraph();
-        this.calledMethodSet = new HashSet<Method>();
+        this.calledMethodSet = new HashSet<>();
         this.hasSynchronization = false;
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ShowHelp.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ShowHelp.java
@@ -33,7 +33,7 @@ public class ShowHelp {
         DetectorFactoryCollection.instance();
         System.out.println("Command line options");
 
-        TreeSet<FindBugsMain> cmds = new TreeSet<FindBugsMain>();
+        TreeSet<FindBugsMain> cmds = new TreeSet<>();
         for(Plugin p : Plugin.getAllPlugins()) {
             for(FindBugsMain m : p.getAllFindBugsMain()) {
                 cmds.add(m);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/SortedBugCollection.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/SortedBugCollection.java
@@ -475,7 +475,7 @@ public class SortedBugCollection implements BugCollection {
             return;
         }
         invalidateHashes();
-        HashMap<String, Integer> seen = new HashMap<String, Integer>();
+        HashMap<String, Integer> seen = new HashMap<>();
 
         for (BugInstance bugInstance : getCollection()) {
             String hash = bugInstance.getInstanceHash();
@@ -616,7 +616,7 @@ public class SortedBugCollection implements BugCollection {
 
     private void writeBugPatterns(XMLOutput xmlOutput) throws IOException {
         // Find bug types reported
-        Set<String> bugTypeSet = new HashSet<String>();
+        Set<String> bugTypeSet = new HashSet<>();
         for (Iterator<BugInstance> i = iterator(); i.hasNext();) {
             BugInstance bugInstance = i.next();
             BugPattern bugPattern = bugInstance.getBugPattern();
@@ -652,7 +652,7 @@ public class SortedBugCollection implements BugCollection {
 
     private void writeBugCodes(XMLOutput xmlOutput) throws IOException {
         // Find bug codes reported
-        Set<String> bugCodeSet = new HashSet<String>();
+        Set<String> bugCodeSet = new HashSet<>();
         for (Iterator<BugInstance> i = iterator(); i.hasNext();) {
             BugInstance bugInstance = i.next();
             String bugCode = bugInstance.getAbbrev();
@@ -685,7 +685,7 @@ public class SortedBugCollection implements BugCollection {
 
     private void writeBugCategories(XMLOutput xmlOutput) throws IOException {
         // Find bug categories reported
-        Set<String> bugCatSet = new HashSet<String>();
+        Set<String> bugCatSet = new HashSet<>();
         for (Iterator<BugInstance> i = iterator(); i.hasNext();) {
             BugInstance bugInstance = i.next();
             BugPattern bugPattern = bugInstance.getBugPattern();
@@ -928,13 +928,13 @@ public class SortedBugCollection implements BugCollection {
         this.projectStats = projectStats;
         this.comparator = comparator;
         this.project = project;
-        bugSet = new TreeSet<BugInstance>(comparator);
+        bugSet = new TreeSet<>(comparator);
         errorList = new BoundedLinkedHashSet();
-        missingClassSet = new TreeSet<String>();
+        missingClassSet = new TreeSet<>();
         summaryHTML = null;
-        classFeatureSetMap = new TreeMap<String, ClassFeatureSet>();
+        classFeatureSetMap = new TreeMap<>();
         sequence = 0L;
-        appVersionList = new LinkedList<AppVersion>();
+        appVersionList = new LinkedList<>();
         releaseName = "";
         timestamp = -1L;
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/SourceLineAnnotation.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/SourceLineAnnotation.java
@@ -111,9 +111,9 @@ public class SourceLineAnnotation implements BugAnnotation {
 
     public static final String DESCRIPTION_LOOP_BOTTOM = "SOURCE_LINE_LOOP_BOTTOM";
 
-    static final ThreadLocal<Project> myProject = new ThreadLocal<Project>();
+    static final ThreadLocal<Project> myProject = new ThreadLocal<>();
 
-    static final ThreadLocal<String> relativeSourceBase = new ThreadLocal<String>();
+    static final ThreadLocal<String> relativeSourceBase = new ThreadLocal<>();
 
     private static final String ELEMENT_NAME = "SourceLine";
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/StackMapAnalyzer.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/StackMapAnalyzer.java
@@ -116,7 +116,7 @@ public  class StackMapAnalyzer {
     }
 
     static  List<Item>  getInitialLocals(MethodDescriptor descriptor) {
-        List<Item> locals = new ArrayList<Item>();
+        List<Item> locals = new ArrayList<>();
         Type[] argTypes = Type.getArgumentTypes(descriptor.getSignature());
         int reg = 0;
         if (!descriptor.isStatic()) {
@@ -201,12 +201,12 @@ public  class StackMapAnalyzer {
         if (stackMapTable == null) {
             return null;
         }
-        Map<Integer, List<Item>> jumpEntries = new HashMap<Integer, List<Item>>();
+        Map<Integer, List<Item>> jumpEntries = new HashMap<>();
 
-        Map<Integer, List<Item>> jumpStackEntries = new HashMap<Integer, List<Item>>();
+        Map<Integer, List<Item>> jumpStackEntries = new HashMap<>();
 
         List<Item> locals = getInitialLocals(descriptor);
-        List<Item> stack = new ArrayList<Item>();
+        List<Item> stack = new ArrayList<>();
         BitSet jumpEntryLocations = new BitSet();
         if (DEBUG) {
             System.out.println(descriptor);
@@ -258,9 +258,9 @@ public  class StackMapAnalyzer {
                 System.out.printf("     %s :: %s%n", stack, locals);
             }
             if (pc > 0) {
-                jumpEntries.put(pc, new ArrayList<Item>(locals));
+                jumpEntries.put(pc, new ArrayList<>(locals));
                 if (!stack.isEmpty()) {
-                    jumpStackEntries.put(pc, new ArrayList<Item>(stack));
+                    jumpStackEntries.put(pc, new ArrayList<>(stack));
                 }
                 jumpEntryLocations.set(pc);
             }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/SuppressionMatcher.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/SuppressionMatcher.java
@@ -29,9 +29,9 @@ import edu.umd.cs.findbugs.filter.Matcher;
 import edu.umd.cs.findbugs.xml.XMLOutput;
 
 public class SuppressionMatcher implements Matcher {
-    private final Map<ClassAnnotation, Collection<WarningSuppressor>> suppressedWarnings = new HashMap<ClassAnnotation, Collection<WarningSuppressor>>();
+    private final Map<ClassAnnotation, Collection<WarningSuppressor>> suppressedWarnings = new HashMap<>();
 
-    private final Map<String, Collection<WarningSuppressor>> suppressedPackageWarnings = new HashMap<String, Collection<WarningSuppressor>>();
+    private final Map<String, Collection<WarningSuppressor>> suppressedPackageWarnings = new HashMap<>();
 
     int count = 0;
 
@@ -40,7 +40,7 @@ public class SuppressionMatcher implements Matcher {
 
         Collection<WarningSuppressor> c = suppressedPackageWarnings.get(packageName);
         if (c == null) {
-            c = new LinkedList<WarningSuppressor>();
+            c = new LinkedList<>();
             suppressedPackageWarnings.put(packageName, c);
         }
         c.add(suppressor);
@@ -50,7 +50,7 @@ public class SuppressionMatcher implements Matcher {
         ClassAnnotation clazz = suppressor.getClassAnnotation().getTopLevelClass();
         Collection<WarningSuppressor> c = suppressedWarnings.get(clazz);
         if (c == null) {
-            c = new LinkedList<WarningSuppressor>();
+            c = new LinkedList<>();
             suppressedWarnings.put(clazz, c);
         }
         c.add(suppressor);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/SwitchHandler.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/SwitchHandler.java
@@ -34,7 +34,7 @@ public class SwitchHandler {
     private final List<SwitchDetails> switchOffsetStack;
 
     public SwitchHandler() {
-        switchOffsetStack = new ArrayList<SwitchDetails>();
+        switchOffsetStack = new ArrayList<>();
     }
 
     public int stackSize() {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/TextUICommandLine.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/TextUICommandLine.java
@@ -104,9 +104,9 @@ public class TextUICommandLine extends FindBugsCommandLine {
 
     private final ClassScreener classScreener = new ClassScreener();
 
-    private final Set<String> enabledBugReporterDecorators = new LinkedHashSet<String>();
+    private final Set<String> enabledBugReporterDecorators = new LinkedHashSet<>();
 
-    private final Set<String> disabledBugReporterDecorators = new LinkedHashSet<String>();
+    private final Set<String> disabledBugReporterDecorators = new LinkedHashSet<>();
 
     private boolean setExitCode = false;
 
@@ -252,7 +252,7 @@ public class TextUICommandLine extends FindBugsCommandLine {
         return printVersion;
     }
 
-    Map<String, String> parsedOptions = new LinkedHashMap<String, String>();
+    Map<String, String> parsedOptions = new LinkedHashMap<>();
 
     @SuppressFBWarnings("DM_EXIT")
     @Override

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/AbstractBlockOrder.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/AbstractBlockOrder.java
@@ -40,7 +40,7 @@ public abstract class AbstractBlockOrder implements BlockOrder {
 
         // Put the blocks in an array
         int numBlocks = cfg.getNumBasicBlocks();
-        blockList = new ArrayList<BasicBlock>(cfg.getNumBasicBlocks());
+        blockList = new ArrayList<>(cfg.getNumBasicBlocks());
         for (BasicBlock bb : cfg.blocks()) {
             blockList.add(bb);
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/AnalysisContext.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/AnalysisContext.java
@@ -961,9 +961,9 @@ public class AnalysisContext {
 
     public void setAppClassList(List<ClassDescriptor> appClassCollection) {
         // FIXME: we really should drive the progress callback here
-        HashSet<ClassDescriptor> appSet = new HashSet<ClassDescriptor>(appClassCollection);
+        HashSet<ClassDescriptor> appSet = new HashSet<>(appClassCollection);
 
-        Collection<ClassDescriptor> allClassDescriptors = new ArrayList<ClassDescriptor>(DescriptorFactory.instance()
+        Collection<ClassDescriptor> allClassDescriptors = new ArrayList<>(DescriptorFactory.instance()
                 .getAllClassDescriptors());
         for (ClassDescriptor appClass : allClassDescriptors) {
             try {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/AnnotationDatabase.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/AnnotationDatabase.java
@@ -58,9 +58,9 @@ public class AnnotationDatabase<AnnotationEnum extends AnnotationEnumeration<Ann
 
     //    private static final String DEFAULT_ANNOTATION_ANNOTATION_CLASS = "DefaultAnnotation";
 
-    private final Map<Object, AnnotationEnum> directAnnotations = new HashMap<Object, AnnotationEnum>();
+    private final Map<Object, AnnotationEnum> directAnnotations = new HashMap<>();
 
-    private final Map<AnnotationDatabase.Target, Map<String, AnnotationEnum>> defaultAnnotation = new EnumMap<AnnotationDatabase.Target, Map<String, AnnotationEnum>>(AnnotationDatabase.Target.class);
+    private final Map<AnnotationDatabase.Target, Map<String, AnnotationEnum>> defaultAnnotation = new EnumMap<>(AnnotationDatabase.Target.class);
 
     // private Subtypes subtypes;
     public AnnotationDatabase() {
@@ -78,7 +78,7 @@ public class AnnotationDatabase<AnnotationEnum extends AnnotationEnumeration<Ann
 
     }
 
-    private final Set<AnnotationEnum> seen = new HashSet<AnnotationEnum>();
+    private final Set<AnnotationEnum> seen = new HashSet<>();
 
     public void addDirectAnnotation(Object o, AnnotationEnum n) {
         directAnnotations.put(o, n);
@@ -101,9 +101,9 @@ public class AnnotationDatabase<AnnotationEnum extends AnnotationEnumeration<Ann
     }
 
     // TODO: Parameterize these values?
-    Map<Object, AnnotationEnum> cachedMinimal = new MapCache<Object, AnnotationEnum>(20000);
+    Map<Object, AnnotationEnum> cachedMinimal = new MapCache<>(20000);
 
-    Map<Object, AnnotationEnum> cachedMaximal = new MapCache<Object, AnnotationEnum>(20000);
+    Map<Object, AnnotationEnum> cachedMaximal = new MapCache<>(20000);
 
     @CheckForNull
     public AnnotationEnum getResolvedAnnotation(Object o, boolean getMinimal) {
@@ -186,7 +186,7 @@ public class AnnotationDatabase<AnnotationEnum extends AnnotationEnumeration<Ann
                 if (!m.isStatic() && !Const.CONSTRUCTOR_NAME.equals(m.getName())) {
                     JavaClass c = Repository.lookupClass(className);
                     // get inherited annotation
-                    TreeSet<AnnotationEnum> inheritedAnnotations = new TreeSet<AnnotationEnum>();
+                    TreeSet<AnnotationEnum> inheritedAnnotations = new TreeSet<>();
                     if (c.getSuperclassNameIndex() > 0) {
 
                         n = lookInOverriddenMethod(o, c.getSuperclassName(), m, getMinimal);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/AnnotationRetentionDatabase.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/AnnotationRetentionDatabase.java
@@ -22,7 +22,7 @@ package edu.umd.cs.findbugs.ba;
 import java.util.HashMap;
 
 public class AnnotationRetentionDatabase {
-    private final HashMap<String, Boolean> annotationRetention = new HashMap<String, Boolean>();
+    private final HashMap<String, Boolean> annotationRetention = new HashMap<>();
 
     public boolean hasRuntimeRetention(String dottedClassName) {
         Boolean result = annotationRetention.get(dottedClassName);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/AssertionMethods.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/AssertionMethods.java
@@ -79,7 +79,7 @@ public class AssertionMethods implements Constants {
     }
 
     @edu.umd.cs.findbugs.internalAnnotations.StaticConstant
-    private static final List<UserAssertionMethod> userAssertionMethodList = new ArrayList<UserAssertionMethod>();
+    private static final List<UserAssertionMethod> userAssertionMethodList = new ArrayList<>();
 
     static {
         String userProperty = SystemProperties.getProperty("findbugs.assertionmethods");

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/BasicAbstractDataflowAnalysis.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/BasicAbstractDataflowAnalysis.java
@@ -46,8 +46,8 @@ public abstract class BasicAbstractDataflowAnalysis<Fact> implements DataflowAna
      * Constructor.
      */
     public BasicAbstractDataflowAnalysis() {
-        this.startFactMap = new IdentityHashMap<BasicBlock, Fact>();
-        this.resultFactMap = new IdentityHashMap<BasicBlock, Fact>();
+        this.startFactMap = new IdentityHashMap<>();
+        this.resultFactMap = new IdentityHashMap<>();
     }
 
     /**

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/BetterCFGBuilder2.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/BetterCFGBuilder2.java
@@ -212,12 +212,12 @@ public class BetterCFGBuilder2 implements CFGBuilder, EdgeTypes, Debug {
             this.start = start;
             this.instructionSet = new BitSet();
             this.cfgSub = new CFG();
-            this.blockMap = new IdentityHashMap<InstructionHandle, BasicBlock>();
-            this.escapeTargetListMap = new IdentityHashMap<BasicBlock, List<EscapeTarget>>();
+            this.blockMap = new IdentityHashMap<>();
+            this.escapeTargetListMap = new IdentityHashMap<>();
             this.returnBlockSet = new BitSet();
             this.exitBlockSet = new BitSet();
             this.unhandledExceptionBlockSet = new BitSet();
-            this.workList = new LinkedList<WorkListItem>();
+            this.workList = new LinkedList<>();
         }
 
         /**
@@ -405,7 +405,7 @@ public class BetterCFGBuilder2 implements CFGBuilder, EdgeTypes, Debug {
                 // Control escapes this subroutine
                 List<EscapeTarget> escapeTargetList = escapeTargetListMap.get(sourceBlock);
                 if (escapeTargetList == null) {
-                    escapeTargetList = new LinkedList<EscapeTarget>();
+                    escapeTargetList = new LinkedList<>();
                     escapeTargetListMap.put(sourceBlock, escapeTargetList);
                 }
                 escapeTargetList.add(new EscapeTarget(target, edgeType));
@@ -483,8 +483,8 @@ public class BetterCFGBuilder2 implements CFGBuilder, EdgeTypes, Debug {
             this.caller = caller;
             this.subroutine = subroutine;
             this.result = result;
-            this.blockMap = new IdentityHashMap<BasicBlock, BasicBlock>();
-            this.workList = new LinkedList<BasicBlock>();
+            this.blockMap = new IdentityHashMap<>();
+            this.workList = new LinkedList<>();
         }
 
         /**
@@ -593,7 +593,7 @@ public class BetterCFGBuilder2 implements CFGBuilder, EdgeTypes, Debug {
 
     private final IdentityHashMap<InstructionHandle, Subroutine> jsrSubroutineMap;
 
-    private final Map<FieldDescriptor, Integer> addedFields = new HashMap<FieldDescriptor, Integer>();
+    private final Map<FieldDescriptor, Integer> addedFields = new HashMap<>();
     private Subroutine topLevelSubroutine;
 
     private CFG cfg;
@@ -627,8 +627,8 @@ public class BetterCFGBuilder2 implements CFGBuilder, EdgeTypes, Debug {
 
         this.exceptionHandlerMap = new ExceptionHandlerMap(methodGen, merger);
         this.usedInstructionSet = new BitSet();
-        this.jsrSubroutineMap = new IdentityHashMap<InstructionHandle, Subroutine>();
-        this.subroutineWorkList = new LinkedList<Subroutine>();
+        this.jsrSubroutineMap = new IdentityHashMap<>();
+        this.subroutineWorkList = new LinkedList<>();
     }
 
     public int getIndex(FieldDescriptor f) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/CFG.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/CFG.java
@@ -339,7 +339,7 @@ public class CFG extends AbstractGraph<Edge, BasicBlock> implements Debug {
      * @return collection of locations
      */
     public Collection<Location> orderedLocations() {
-        TreeSet<Location> tree = new TreeSet<Location>();
+        TreeSet<Location> tree = new TreeSet<>();
         for (Iterator<Location> locs = locationIterator(); locs.hasNext();) {
             Location loc = locs.next();
             tree.add(loc);
@@ -355,7 +355,7 @@ public class CFG extends AbstractGraph<Edge, BasicBlock> implements Debug {
      * @return a Collection containing the blocks whose IDs are given
      */
     public Collection<BasicBlock> getBlocks(BitSet labelSet) {
-        LinkedList<BasicBlock> result = new LinkedList<BasicBlock>();
+        LinkedList<BasicBlock> result = new LinkedList<>();
         for (Iterator<BasicBlock> i = blockIterator(); i.hasNext();) {
             BasicBlock block = i.next();
             if (labelSet.get(block.getLabel())) {
@@ -375,7 +375,7 @@ public class CFG extends AbstractGraph<Edge, BasicBlock> implements Debug {
      *         with that offset
      */
     public Collection<BasicBlock> getBlocksContainingInstructionWithOffset(int offset) {
-        LinkedList<BasicBlock> result = new LinkedList<BasicBlock>();
+        LinkedList<BasicBlock> result = new LinkedList<>();
         for (Iterator<BasicBlock> i = blockIterator(); i.hasNext();) {
             BasicBlock block = i.next();
             if (block.containsInstructionWithOffset(offset)) {
@@ -394,7 +394,7 @@ public class CFG extends AbstractGraph<Edge, BasicBlock> implements Debug {
      * @return all Locations referring to the instruction at that offset
      */
     public Collection<Location> getLocationsContainingInstructionWithOffset(int offset) {
-        LinkedList<Location> result = new LinkedList<Location>();
+        LinkedList<Location> result = new LinkedList<>();
         for (Iterator<Location> i = locationIterator(); i.hasNext();) {
             Location location = i.next();
             if (location.getHandle().getPosition() == offset) {
@@ -483,7 +483,7 @@ public class CFG extends AbstractGraph<Edge, BasicBlock> implements Debug {
      * @return Iterator over Edges removed from this CFG
      */
     public Iterator<Edge> removedEdgeIterator() {
-        return removedEdgeList != null ? removedEdgeList.iterator() : new NullIterator<Edge>();
+        return removedEdgeList != null ? removedEdgeList.iterator() : new NullIterator<>();
     }
 
     /**
@@ -582,7 +582,7 @@ public class CFG extends AbstractGraph<Edge, BasicBlock> implements Debug {
 
         // Keep track of removed edges.
         if (removedEdgeList == null) {
-            removedEdgeList = new LinkedList<Edge>();
+            removedEdgeList = new LinkedList<>();
         }
         removedEdgeList.add(edge);
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/ClassContext.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/ClassContext.java
@@ -115,7 +115,7 @@ public class ClassContext {
     public ClassContext(JavaClass jclass, AnalysisContext analysisContext) {
         this.jclass = jclass;
         this.analysisContext = analysisContext;
-        this.methodAnalysisObjectMap = new HashMap<Class<?>, Map<MethodDescriptor, Object>>();
+        this.methodAnalysisObjectMap = new HashMap<>();
         try {
             classInfo = (ClassInfo) Global.getAnalysisCache().getClassAnalysis(XClass.class,
                     DescriptorFactory.createClassDescriptor(jclass));
@@ -128,11 +128,11 @@ public class ClassContext {
         Map<MethodDescriptor, Object> objectMap = methodAnalysisObjectMap.get(analysisClass);
         if (objectMap == null) {
             if (analysisClass == ValueNumberDataflow.class) {
-                objectMap = new MapCache<MethodDescriptor, Object>(300);
+                objectMap = new MapCache<>(300);
             } else if (Dataflow.class.isAssignableFrom(analysisClass)) {
-                objectMap = new MapCache<MethodDescriptor, Object>(500);
+                objectMap = new MapCache<>(500);
             } else {
-                objectMap = new HashMap<MethodDescriptor, Object>();
+                objectMap = new HashMap<>();
             }
             methodAnalysisObjectMap.put(analysisClass, objectMap);
         }
@@ -241,13 +241,13 @@ public class ClassContext {
 
     public @Nonnull
     List<Method> getMethodsInCallOrder() {
-        Map<XMethod, Method> map = new HashMap<XMethod, Method>();
+        Map<XMethod, Method> map = new HashMap<>();
         for (Method m : getJavaClass().getMethods()) {
             XMethod xMethod = classInfo.findMethod(m.getName(), m.getSignature(), m.isStatic());
             map.put(xMethod, m);
         }
         List<? extends XMethod> xmethodsInCallOrder = classInfo.getXMethodsInCallOrder();
-        List<Method> methodsInCallOrder = new ArrayList<Method>(xmethodsInCallOrder.size());
+        List<Method> methodsInCallOrder = new ArrayList<>(xmethodsInCallOrder.size());
         for (XMethod x : xmethodsInCallOrder) {
             Method m = map.get(x);
             if (m != null) {
@@ -384,7 +384,7 @@ public class ClassContext {
             new AnalysisLocal<MapCache<XMethod, BitSet>>() {
         @Override
         protected MapCache<XMethod, BitSet> initialValue() {
-            return  new MapCache<XMethod, BitSet>(64);
+            return  new MapCache<>(64);
         }
     };
 
@@ -392,7 +392,7 @@ public class ClassContext {
             new AnalysisLocal<MapCache<XMethod, Set<Integer>>>() {
         @Override
         protected MapCache<XMethod, Set<Integer>> initialValue() {
-            return  new MapCache<XMethod, Set<Integer>>(13);
+            return  new MapCache<>(13);
         }
     };
 
@@ -481,7 +481,7 @@ public class ClassContext {
 
         byte[] instructionList = code.getCode();
 
-        Set<Integer> result = new HashSet<Integer>();
+        Set<Integer> result = new HashSet<>();
         for (int i = 0; i < instructionList.length; i++) {
             if (checkForBranchExit(instructionList, i)) {
                 result.add(i);
@@ -905,7 +905,7 @@ public class ClassContext {
             @CheckForNull UnconditionalValueDerefDataflow dataflow, @CheckForNull TypeDataflow typeDataflow)
                     throws DataflowAnalysisException {
         System.out.println("\n\n{ UnconditionalValueDerefAnalysis analysis for " + method.getName());
-        TreeSet<Location> tree = new TreeSet<Location>();
+        TreeSet<Location> tree = new TreeSet<>();
 
         for (Iterator<Location> locs = cfg.locationIterator(); locs.hasNext();) {
             Location loc = locs.next();
@@ -937,7 +937,7 @@ public class ClassContext {
     public static void dumpTypeDataflow(Method method, CFG cfg, TypeDataflow typeDataflow) throws DataflowAnalysisException {
         System.out.println("\n\n{ Type analysis for " + cfg.getMethodGen().getClassName() + "." + method.getName()
                 + method.getSignature());
-        TreeSet<Location> tree = new TreeSet<Location>();
+        TreeSet<Location> tree = new TreeSet<>();
 
         for (Iterator<Location> locs = cfg.locationIterator(); locs.hasNext();) {
             Location loc = locs.next();
@@ -954,7 +954,7 @@ public class ClassContext {
     public static void dumpLiveLocalStoreDataflow(MethodDescriptor method, CFG cfg, LiveLocalStoreDataflow dataflow)
             throws DataflowAnalysisException {
         System.out.println("\n\n{ LiveLocalStore analysis for " + method);
-        TreeSet<Location> tree = new TreeSet<Location>();
+        TreeSet<Location> tree = new TreeSet<>();
 
         for (Iterator<Location> locs = cfg.locationIterator(); locs.hasNext();) {
             Location loc = locs.next();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/ClassHash.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/ClassHash.java
@@ -67,7 +67,7 @@ public class ClassHash implements XMLWriteable, Comparable<ClassHash> {
      * Constructor.
      */
     public ClassHash() {
-        this.methodHashMap = new HashMap<XMethod, MethodHash>();
+        this.methodHashMap = new HashMap<>();
     }
 
     /**

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/ClassNotFoundExceptionParser.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/ClassNotFoundExceptionParser.java
@@ -48,7 +48,7 @@ public class ClassNotFoundExceptionParser {
     private static final Pattern[] patternList;
 
     static {
-        ArrayList<Pattern> list = new ArrayList<Pattern>();
+        ArrayList<Pattern> list = new ArrayList<>();
         list.add(BCEL_MISSING_CLASS_PATTERN);
         list.add(TYPE_REPOSITORY_MISSING_CLASS_PATTERN);
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/ClassSummary.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/ClassSummary.java
@@ -27,9 +27,9 @@ import java.util.Set;
 import edu.umd.cs.findbugs.classfile.ClassDescriptor;
 
 public class ClassSummary {
-    private final Map<ClassDescriptor, ClassDescriptor> map = new HashMap<ClassDescriptor, ClassDescriptor>();
+    private final Map<ClassDescriptor, ClassDescriptor> map = new HashMap<>();
 
-    private final Set<ClassDescriptor> veryFunky = new HashSet<ClassDescriptor>();
+    private final Set<ClassDescriptor> veryFunky = new HashSet<>();
 
     public boolean mightBeEqualTo(ClassDescriptor checker, ClassDescriptor checkee) {
         return checkee.equals(map.get(checker)) || veryFunky.contains(checker);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/CompactLocationNumbering.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/CompactLocationNumbering.java
@@ -40,8 +40,8 @@ public class CompactLocationNumbering {
      *            the CFG containing the Locations to number
      */
     public CompactLocationNumbering(CFG cfg) {
-        this.locationToNumberMap = new HashMap<Location, Integer>();
-        this.numberToLocationMap = new HashMap<Integer, Location>();
+        this.locationToNumberMap = new HashMap<>();
+        this.numberToLocationMap = new HashMap<>();
         build(cfg);
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/Dataflow.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/Dataflow.java
@@ -207,7 +207,7 @@ public class Dataflow<Fact, AnalysisType extends DataflowAnalysis<Fact>> {
                 if (DEBUG) {
                     System.out.println("Trying program order");
                 }
-                TreeSet<BasicBlock> bb = new TreeSet<BasicBlock>(new BackwardProgramOrder());
+                TreeSet<BasicBlock> bb = new TreeSet<>(new BackwardProgramOrder());
                 Iterator<BasicBlock> j = blockOrder.blockIterator();
                 while (j.hasNext()) {
                     BasicBlock block = j.next();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/DataflowCFGPrinter.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/DataflowCFGPrinter.java
@@ -106,7 +106,7 @@ public class DataflowCFGPrinter<Fact, AnalysisType extends DataflowAnalysis<Fact
      */
     public static <Fact, AnalysisType extends BasicAbstractDataflowAnalysis<Fact>> void printCFG(
             Dataflow<Fact, AnalysisType> dataflow, PrintStream out) {
-        DataflowCFGPrinter<Fact, AnalysisType> printer = new DataflowCFGPrinter<Fact, AnalysisType>(dataflow);
+        DataflowCFGPrinter<Fact, AnalysisType> printer = new DataflowCFGPrinter<>(dataflow);
         printer.print(out);
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/EqualsKindSummary.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/EqualsKindSummary.java
@@ -29,7 +29,7 @@ import edu.umd.cs.findbugs.ClassAnnotation;
  */
 public class EqualsKindSummary {
 
-    final Map<ClassAnnotation, EqualsKindSummary.KindOfEquals> kindMap = new HashMap<ClassAnnotation, EqualsKindSummary.KindOfEquals>();
+    final Map<ClassAnnotation, EqualsKindSummary.KindOfEquals> kindMap = new HashMap<>();
 
     public static enum KindOfEquals {
         OBJECT_EQUALS, ABSTRACT_INSTANCE_OF, INSTANCE_OF_EQUALS,INSTANCE_OF_SUPERCLASS_EQUALS, COMPARE_EQUALS, CHECKED_CAST_EQUALS, RETURNS_SUPER, GETCLASS_GOOD_EQUALS, ABSTRACT_GETCLASS_GOOD_EQUALS, GETCLASS_BAD_EQUALS, DELEGATE_EQUALS, TRIVIAL_EQUALS, INVOKES_SUPER, ALWAYS_TRUE, ALWAYS_FALSE, UNKNOWN

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/ExceptionHandlerMap.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/ExceptionHandlerMap.java
@@ -55,8 +55,8 @@ public class ExceptionHandlerMap {
      *            the method to build the map for
      */
     public ExceptionHandlerMap( MethodGen methodGen, TypeMerger merger) {
-        codeToHandlerMap = new IdentityHashMap<InstructionHandle, List<CodeExceptionGen>>();
-        startInstructionToHandlerMap = new IdentityHashMap<InstructionHandle, CodeExceptionGen>();
+        codeToHandlerMap = new IdentityHashMap<>();
+        startInstructionToHandlerMap = new IdentityHashMap<>();
         this.merger = merger;
         build(methodGen);
     }
@@ -162,7 +162,7 @@ public class ExceptionHandlerMap {
     private void addHandler(InstructionHandle handle, CodeExceptionGen exceptionHandler) {
         List<CodeExceptionGen> handlerList = codeToHandlerMap.get(handle);
         if (handlerList == null) {
-            handlerList = new LinkedList<CodeExceptionGen>();
+            handlerList = new LinkedList<>();
             codeToHandlerMap.put(handle, handlerList);
         }
         handlerList.add(exceptionHandler);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/FieldSummary.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/FieldSummary.java
@@ -49,17 +49,17 @@ import edu.umd.cs.findbugs.util.Util;
  * @author pugh
  */
 public class FieldSummary {
-    private final Set<XField> writtenOutsideOfConstructor = new HashSet<XField>();
+    private final Set<XField> writtenOutsideOfConstructor = new HashSet<>();
 
-    private final Map<XField, OpcodeStack.Item> summary = new HashMap<XField, OpcodeStack.Item>();
+    private final Map<XField, OpcodeStack.Item> summary = new HashMap<>();
 
-    private final Map<XMethod, Set<XField>> fieldsWritten = new HashMap<XMethod, Set<XField>>();
+    private final Map<XMethod, Set<XField>> fieldsWritten = new HashMap<>();
 
-    private final Map<XMethod, XMethod> nonVoidSuperConstructorsCalled = new HashMap<XMethod, XMethod>();
+    private final Map<XMethod, XMethod> nonVoidSuperConstructorsCalled = new HashMap<>();
 
-    private final Map<XMethod, Set<ProgramPoint>> selfMethodsCalledFromConstructor = new HashMap<XMethod, Set<ProgramPoint>>();
+    private final Map<XMethod, Set<ProgramPoint>> selfMethodsCalledFromConstructor = new HashMap<>();
 
-    private final Set<ClassDescriptor> callsOverriddenMethodsFromConstructor = new HashSet<ClassDescriptor>();
+    private final Set<ClassDescriptor> callsOverriddenMethodsFromConstructor = new HashSet<>();
 
     private boolean complete = false;
 
@@ -101,7 +101,7 @@ public class FieldSummary {
     public void setCalledFromSuperConstructor(ProgramPoint from, XMethod calledFromConstructor) {
         Set<ProgramPoint> set = selfMethodsCalledFromConstructor.get(calledFromConstructor);
         if (set == null) {
-            set = new HashSet<ProgramPoint>();
+            set = new HashSet<>();
             selfMethodsCalledFromConstructor.put(calledFromConstructor, set);
         }
         set.add(from);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/Frame.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/Frame.java
@@ -110,7 +110,7 @@ public abstract class Frame<ValueType> {
      */
     public Frame(int numLocals) {
         this.numLocals = numLocals;
-        this.slotList = new ArrayList<ValueType>(numLocals + DEFAULT_STACK_CAPACITY);
+        this.slotList = new ArrayList<>(numLocals + DEFAULT_STACK_CAPACITY);
         for (int i = 0; i < numLocals; ++i) {
             slotList.add(null);
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/Hierarchy.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/Hierarchy.java
@@ -714,7 +714,7 @@ public class Hierarchy {
         short opcode = invokeInstruction.getOpcode();
 
         if (opcode == Const.INVOKESTATIC) {
-            HashSet<JavaClassAndMethod> result = new HashSet<JavaClassAndMethod>();
+            HashSet<JavaClassAndMethod> result = new HashSet<>();
             JavaClassAndMethod targetMethod = findInvocationLeastUpperBound(invokeInstruction, cpg, CONCRETE_METHOD);
             if (targetMethod != null) {
                 result.add(targetMethod);
@@ -723,7 +723,7 @@ public class Hierarchy {
         }
 
         if (!typeFrame.isValid()) {
-            return new HashSet<JavaClassAndMethod>();
+            return new HashSet<>();
         }
 
         Type receiverType;
@@ -742,7 +742,7 @@ public class Hierarchy {
             int instanceStackLocation = typeFrame.getInstanceStackLocation(invokeInstruction, cpg);
             receiverType = typeFrame.getStackValue(instanceStackLocation);
             if (!(receiverType instanceof ReferenceType)) {
-                return new HashSet<JavaClassAndMethod>();
+                return new HashSet<>();
             }
             receiverTypeIsExact = typeFrame.isExact(instanceStackLocation);
         }
@@ -788,7 +788,7 @@ public class Hierarchy {
      */
     public static Set<JavaClassAndMethod> resolveMethodCallTargets(ReferenceType receiverType,
             InvokeInstruction invokeInstruction, ConstantPoolGen cpg, boolean receiverTypeIsExact) throws ClassNotFoundException {
-        HashSet<JavaClassAndMethod> result = new HashSet<JavaClassAndMethod>();
+        HashSet<JavaClassAndMethod> result = new HashSet<>();
 
         if (invokeInstruction.getOpcode() == Const.INVOKESTATIC) {
             throw new IllegalArgumentException();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/Hierarchy2.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/Hierarchy2.java
@@ -213,7 +213,7 @@ public class Hierarchy2 {
     }
 
     public static Set<XMethod> findSuperMethods(XMethod m) {
-        Set<XMethod> result = new HashSet<XMethod>();
+        Set<XMethod> result = new HashSet<>();
 
         findSuperMethods(m.getClassDescriptor(), m, result);
         result.remove(m);
@@ -439,7 +439,7 @@ public class Hierarchy2 {
             return Collections.<XMethod> emptySet();
         }
 
-        HashSet<XMethod> result = new LinkedHashSet<XMethod>();
+        HashSet<XMethod> result = new LinkedHashSet<>();
         XMethod upperBound = findMethod(receiverDesc, methodName, methodSig, false);
         if (upperBound == null) {
             upperBound = findInvocationLeastUpperBound(xClass, methodName, methodSig, false, false);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/InnerClassAccessMap.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/InnerClassAccessMap.java
@@ -133,7 +133,7 @@ public class InnerClassAccessMap {
      * Constructor.
      */
     private InnerClassAccessMap() {
-        this.classToAccessMap = new HashMap<String, Map<String, InnerClassAccess>>(3);
+        this.classToAccessMap = new HashMap<>(3);
     }
 
     /**
@@ -342,7 +342,7 @@ public class InnerClassAccessMap {
 
         Map<String, InnerClassAccess> map = classToAccessMap.get(className);
         if (map == null) {
-            map = new HashMap<String, InnerClassAccess>(3);
+            map = new HashMap<>(3);
 
             if (!className.startsWith("[")) {
                 JavaClass javaClass = Repository.lookupClass(className);
@@ -385,7 +385,7 @@ public class InnerClassAccessMap {
             if (map.size() == 0) {
                 map = Collections.emptyMap();
             } else {
-                map = new HashMap<String, InnerClassAccess>(map);
+                map = new HashMap<>(map);
             }
 
             classToAccessMap.put(className, map);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/JCIPAnnotationDatabase.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/JCIPAnnotationDatabase.java
@@ -29,9 +29,9 @@ import org.apache.bcel.classfile.ElementValue;
 import edu.umd.cs.findbugs.internalAnnotations.DottedClassName;
 
 public class JCIPAnnotationDatabase {
-    Map<ClassMember, Map<String, ElementValue>> memberAnnotations = new HashMap<ClassMember, Map<String, ElementValue>>();
+    Map<ClassMember, Map<String, ElementValue>> memberAnnotations = new HashMap<>();
 
-    Map<String, Map<String, ElementValue>> classAnnotations = new HashMap<String, Map<String, ElementValue>>();
+    Map<String, Map<String, ElementValue>> classAnnotations = new HashMap<>();
 
     @CheckForNull
     public ElementValue getClassAnnotation(@DottedClassName String dottedClassName, String annotationClass) {
@@ -76,7 +76,7 @@ public class JCIPAnnotationDatabase {
             String annotationClass, ElementValue value) {
         Map<String, ElementValue> map = memberAnnotations.get(member);
         if (map == null) {
-            map = new HashMap<String, ElementValue>();
+            map = new HashMap<>();
             memberAnnotations.put(member, map);
         }
         map.put(annotationClass, value);
@@ -92,7 +92,7 @@ public class JCIPAnnotationDatabase {
             String annotationClass, ElementValue value) {
         Map<String, ElementValue> map = getEntryForClass(dottedClassName);
         if (map == null) {
-            map = new HashMap<String, ElementValue>(3);
+            map = new HashMap<>(3);
             classAnnotations.put(dottedClassName, map);
         }
         map.put(annotationClass, value);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/LineNumberMap.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/LineNumberMap.java
@@ -57,7 +57,7 @@ public class LineNumberMap {
      */
     public LineNumberMap(MethodGen methodGen) {
         this.methodGen = methodGen;
-        lineNumberMap = new IdentityHashMap<InstructionHandle, LineNumber>();
+        lineNumberMap = new IdentityHashMap<>();
         hasLineNumbers = false;
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/LockChecker.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/LockChecker.java
@@ -62,7 +62,7 @@ public class LockChecker {
      * Constructor.
      */
     public LockChecker(MethodDescriptor methodDescriptor) {
-        this.cache = new HashMap<Location, LockSet>();
+        this.cache = new HashMap<>();
         this.methodDescriptor = methodDescriptor;
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/LockSet.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/LockSet.java
@@ -386,7 +386,7 @@ public final class LockSet {
         if (frame == null) {
             throw new IllegalArgumentException("Null Frame");
         }
-        HashSet<ValueNumber> result = new HashSet<ValueNumber>();
+        HashSet<ValueNumber> result = new HashSet<>();
         for (ValueNumber v : frame.allSlots()) {
             if (v != null && getLockCount(v.getNumber()) > 0) {
                 result.add(v);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/ObjectTypeFactory.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/ObjectTypeFactory.java
@@ -35,7 +35,7 @@ public class ObjectTypeFactory {
     private static ThreadLocal<Map<String, ObjectType>> instance = new ThreadLocal<Map<String, ObjectType>>() {
         @Override
         protected Map<String, ObjectType> initialValue() {
-            return new HashMap<String, ObjectType>();
+            return new HashMap<>();
         }
     };
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/PruneInfeasibleExceptionEdges.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/PruneInfeasibleExceptionEdges.java
@@ -119,8 +119,8 @@ public class PruneInfeasibleExceptionEdges implements EdgeTypes {
      */
     @SuppressFBWarnings("ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD")
     public void execute() throws ClassNotFoundException {
-        Set<Edge> deletedEdgeSet = new HashSet<Edge>();
-        List<MarkedEdge> markedEdgeList = new LinkedList<MarkedEdge>();
+        Set<Edge> deletedEdgeSet = new HashSet<>();
+        List<MarkedEdge> markedEdgeList = new LinkedList<>();
 
         // Mark edges to delete,
         // mark edges to set properties of

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/PruneUnconditionalExceptionThrowerEdges.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/PruneUnconditionalExceptionThrowerEdges.java
@@ -102,7 +102,7 @@ public class PruneUnconditionalExceptionThrowerEdges implements EdgeTypes {
             throw new IllegalStateException("This should not happen");
         }
         boolean foundInexact = false;
-        Set<Edge> deletedEdgeSet = new HashSet<Edge>();
+        Set<Edge> deletedEdgeSet = new HashSet<>();
         // TypeDataflow typeDataflow = classContext.getTypeDataflow(method);
 
         if (DEBUG) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/PutfieldScanner.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/PutfieldScanner.java
@@ -44,7 +44,7 @@ public class PutfieldScanner {
 
     static class Scanner extends OpcodeStackDetector {
 
-        Map<Integer, OpcodeStack.Item> putfields = new TreeMap<Integer, OpcodeStack.Item>();
+        Map<Integer, OpcodeStack.Item> putfields = new TreeMap<>();
 
         public Scanner(JavaClass theClass, Method targetMethod, XField target) {
             this.theClass = theClass;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/SignatureParser.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/SignatureParser.java
@@ -50,7 +50,7 @@ public class SignatureParser {
         if ( parameterOffset != null ) {
             return parameterOffset;
         }
-        ArrayList<Integer> offsets = new ArrayList<Integer>();
+        ArrayList<Integer> offsets = new ArrayList<>();
         Iterator<String> i = parameterSignatureIterator();
         int totalSize = 0;
 
@@ -164,7 +164,7 @@ public class SignatureParser {
     }
 
     public String[] getArguments() {
-        ArrayList<String> result = new ArrayList<String>();
+        ArrayList<String> result = new ArrayList<>();
         for (Iterator<String> i = parameterSignatureIterator(); i.hasNext();) {
             result.add(i.next());
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/SimplePathEnumerator.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/SimplePathEnumerator.java
@@ -74,7 +74,7 @@ public class SimplePathEnumerator implements EdgeTypes, DFSEdgeTypes {
         this.maxPaths = maxPaths;
         this.maxWork = maxWork;
         this.work = 0;
-        this.pathList = new LinkedList<List<Edge>>();
+        this.pathList = new LinkedList<>();
     }
 
     /**
@@ -101,7 +101,7 @@ public class SimplePathEnumerator implements EdgeTypes, DFSEdgeTypes {
         }
         Edge entryEdge = entryOut.next();
 
-        LinkedList<Edge> init = new LinkedList<Edge>();
+        LinkedList<Edge> init = new LinkedList<>();
         init.add(entryEdge);
 
         work(init);
@@ -128,7 +128,7 @@ public class SimplePathEnumerator implements EdgeTypes, DFSEdgeTypes {
 
         // Is this a complete path?
         if (last.getTarget() == cfg.getExit()) {
-            pathList.add(new LinkedList<Edge>(partialPath));
+            pathList.add(new LinkedList<>(partialPath));
             return;
         }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/SourceFinder.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/SourceFinder.java
@@ -135,8 +135,8 @@ public class SourceFinder {
 
     private static class InMemorySourceRepository implements SourceRepository {
 
-        Map<String, byte[]> contents = new HashMap<String, byte[]>();
-        Map<String, Long> lastModified = new HashMap<String, Long>();
+        Map<String, byte[]> contents = new HashMap<>();
+        Map<String, Long> lastModified = new HashMap<>();
 
         InMemorySourceRepository(@WillClose ZipInputStream in) throws IOException {
             try {
@@ -582,7 +582,7 @@ public class SourceFinder {
 
     private void setProject(Project project) {
         this.project = project;
-        repositoryList = new LinkedList<SourceRepository>();
+        repositoryList = new LinkedList<>();
         cache = new Cache();
         setSourceBaseList(project.getResolvedSourcePaths());
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/SourceInfoMap.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/SourceInfoMap.java
@@ -233,9 +233,9 @@ public class SourceInfoMap {
      * Constructor. Creates an empty object.
      */
     public SourceInfoMap() {
-        this.fieldLineMap = new HashMap<FieldDescriptor, SourceLineRange>();
-        this.methodLineMap = new HashMap<MethodDescriptor, SourceLineRange>();
-        this.classLineMap = new HashMap<String, SourceLineRange>();
+        this.fieldLineMap = new HashMap<>();
+        this.methodLineMap = new HashMap<>();
+        this.classLineMap = new HashMap<>();
     }
 
     /**

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/TargetEnumeratingVisitor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/TargetEnumeratingVisitor.java
@@ -60,7 +60,7 @@ public class TargetEnumeratingVisitor extends org.apache.bcel.generic.EmptyVisit
     public TargetEnumeratingVisitor(InstructionHandle handle, ConstantPoolGen constPoolGen) {
         this.handle = handle;
         this.constPoolGen = constPoolGen;
-        targetList = new LinkedList<Target>();
+        targetList = new LinkedList<>();
         isBranch = isReturn = isThrow = isExit = false;
 
         handle.getInstruction().accept(this);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/URLClassPath.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/URLClassPath.java
@@ -287,7 +287,7 @@ public class URLClassPath implements AutoCloseable, Serializable {
      * Constructor. Creates a classpath with no elements.
      */
     public URLClassPath() {
-        this.entryList = new LinkedList<Entry>();
+        this.entryList = new LinkedList<>();
     }
 
     /**
@@ -398,7 +398,7 @@ public class URLClassPath implements AutoCloseable, Serializable {
         return null;
     }
 
-    private final Set<String> classesThatCantBeFound = new HashSet<String>();
+    private final Set<String> classesThatCantBeFound = new HashSet<>();
 
     /**
      * Look up a class from the classpath.

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/URLClassPathRepository.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/URLClassPathRepository.java
@@ -56,7 +56,7 @@ public class URLClassPathRepository implements Repository {
     private final URLClassPath urlClassPath;
 
     public URLClassPathRepository() {
-        this.nameToClassMap = new HashMap<String, JavaClass>();
+        this.nameToClassMap = new HashMap<>();
         this.urlClassPath = new URLClassPath();
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/UnresolvedXMethod.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/UnresolvedXMethod.java
@@ -184,11 +184,11 @@ class UnresolvedXMethod extends AbstractMethod {
      */
     @Override
     public void addParameterAnnotation(int param, AnnotationValue annotationValue) {
-        HashMap<Integer, Map<ClassDescriptor, AnnotationValue>> updatedAnnotations = new HashMap<Integer, Map<ClassDescriptor, AnnotationValue>>(
+        HashMap<Integer, Map<ClassDescriptor, AnnotationValue>> updatedAnnotations = new HashMap<>(
                 methodParameterAnnotations);
         Map<ClassDescriptor, AnnotationValue> paramMap = updatedAnnotations.get(param);
         if (paramMap == null) {
-            paramMap = new HashMap<ClassDescriptor, AnnotationValue>();
+            paramMap = new HashMap<>();
             updatedAnnotations.put(param, paramMap);
         }
         paramMap.put(annotationValue.getAnnotationClass(), annotationValue);
@@ -241,7 +241,7 @@ class UnresolvedXMethod extends AbstractMethod {
      */
     @Override
     public void addAnnotation(AnnotationValue annotationValue) {
-        HashMap<ClassDescriptor, AnnotationValue> updatedAnnotations = new HashMap<ClassDescriptor, AnnotationValue>(
+        HashMap<ClassDescriptor, AnnotationValue> updatedAnnotations = new HashMap<>(
                 methodAnnotations);
         updatedAnnotations.put(annotationValue.getAnnotationClass(), annotationValue);
         methodAnnotations = updatedAnnotations;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/XFactory.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/XFactory.java
@@ -71,19 +71,19 @@ import edu.umd.cs.findbugs.visitclass.PreorderVisitor;
 public class XFactory {
     public static final boolean DEBUG_UNRESOLVED = SystemProperties.getBoolean("findbugs.xfactory.debugunresolved");
 
-    private final Set<ClassDescriptor> reflectiveClasses = new HashSet<ClassDescriptor>();
+    private final Set<ClassDescriptor> reflectiveClasses = new HashSet<>();
 
-    private final Map<MethodDescriptor, XMethod> methods = new HashMap<MethodDescriptor, XMethod>();
+    private final Map<MethodDescriptor, XMethod> methods = new HashMap<>();
 
-    private final Map<FieldDescriptor, XField> fields = new HashMap<FieldDescriptor, XField>();
+    private final Map<FieldDescriptor, XField> fields = new HashMap<>();
 
-    private final Set<XMethod> calledMethods = new HashSet<XMethod>();
+    private final Set<XMethod> calledMethods = new HashSet<>();
 
-    private final Set<XField> emptyArrays = new HashSet<XField>();
+    private final Set<XField> emptyArrays = new HashSet<>();
 
-    private final Set<String> calledMethodSignatures = new HashSet<String>();
+    private final Set<String> calledMethodSignatures = new HashSet<>();
 
-    private final Set<MethodDescriptor> functionsThatMightBeMistakenForProcedures = new HashSet<MethodDescriptor>();
+    private final Set<MethodDescriptor> functionsThatMightBeMistakenForProcedures = new HashSet<>();
 
     public void canonicalizeAll() {
         DescriptorFactory descriptorFactory = DescriptorFactory.instance();
@@ -566,7 +566,7 @@ public class XFactory {
 
     private XField resolveXField(FieldDescriptor originalDescriptor) {
         FieldDescriptor desc = originalDescriptor;
-        LinkedList<ClassDescriptor> worklist = new LinkedList<ClassDescriptor>();
+        LinkedList<ClassDescriptor> worklist = new LinkedList<>();
         ClassDescriptor originalClassDescriptor = desc.getClassDescriptor();
         worklist.add(originalClassDescriptor);
         try {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/bcp/ByteCodePatternMatch.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/bcp/ByteCodePatternMatch.java
@@ -34,7 +34,7 @@ public class ByteCodePatternMatch {
 
     @Override
     public String toString() {
-        ArrayList<Integer> lst = new ArrayList<Integer>();
+        ArrayList<Integer> lst = new ArrayList<>();
         for (PatternElementMatch m : patternElementMatchList) {
             lst.add(m.getMatchedInstructionInstructionHandle().getPosition());
         }
@@ -44,7 +44,7 @@ public class ByteCodePatternMatch {
     public ByteCodePatternMatch(BindingSet bindingSet, PatternElementMatch lastElementMatch) {
         this.bindingSet = bindingSet;
         this.lastElementMatch = lastElementMatch;
-        this.patternElementMatchList = new LinkedList<PatternElementMatch>();
+        this.patternElementMatchList = new LinkedList<>();
 
         // The PatternElementMatch objects are stored in reverse order.
         // So, put them in a LinkedList to get them in the right order.

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/bcp/PatternMatcher.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/bcp/PatternMatcher.java
@@ -96,9 +96,9 @@ public class PatternMatcher implements DFSEdgeTypes {
         this.dfs = classContext.getDepthFirstSearch(method);
         this.vnaDataflow = classContext.getValueNumberDataflow(method);
         this.domAnalysis = classContext.getNonExceptionDominatorsAnalysis(method);
-        this.workList = new LinkedList<BasicBlock>();
-        this.visitedBlockMap = new IdentityHashMap<BasicBlock, BasicBlock>();
-        this.resultList = new LinkedList<ByteCodePatternMatch>();
+        this.workList = new LinkedList<>();
+        this.visitedBlockMap = new IdentityHashMap<>();
+        this.resultList = new LinkedList<>();
     }
 
     /**
@@ -379,7 +379,7 @@ public class PatternMatcher implements DFSEdgeTypes {
             if (!lookForDominatedInstruction()) {
                 throw new IllegalStateException();
             }
-            LinkedList<State> stateList = new LinkedList<State>();
+            LinkedList<State> stateList = new LinkedList<>();
 
             State dup = this.duplicate();
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/ca/CallList.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/ca/CallList.java
@@ -27,7 +27,7 @@ public class CallList {
     private final ArrayList<Call> callList;
 
     public CallList() {
-        this.callList = new ArrayList<Call>();
+        this.callList = new ArrayList<>();
     }
 
     public boolean isValid() {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/ca/CallListAnalysis.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/ca/CallListAnalysis.java
@@ -50,7 +50,7 @@ public class CallListAnalysis extends AbstractDataflowAnalysis<CallList> {
     }
 
     private static Map<InstructionHandle, Call> buildCallMap(CFG cfg, ConstantPoolGen cpg) {
-        Map<InstructionHandle, Call> callMap = new HashMap<InstructionHandle, Call>();
+        Map<InstructionHandle, Call> callMap = new HashMap<>();
 
         for (Iterator<Location> i = cfg.locationIterator(); i.hasNext();) {
             InstructionHandle handle = i.next().getHandle();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/ch/InterproceduralCallGraph.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/ch/InterproceduralCallGraph.java
@@ -39,7 +39,7 @@ public class InterproceduralCallGraph extends AbstractGraph<InterproceduralCallG
      * Constructor.
      */
     public InterproceduralCallGraph() {
-        this.methodDescToVertexMap = new HashMap<MethodDescriptor, InterproceduralCallGraphVertex>();
+        this.methodDescToVertexMap = new HashMap<>();
     }
 
     /*

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/ch/Subtypes2.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/ch/Subtypes2.java
@@ -85,7 +85,7 @@ public class Subtypes2 {
      * Object to record the results of a supertype search.
      */
     private static class SupertypeQueryResults {
-        private final Set<ClassDescriptor> supertypeSet = new HashSet<ClassDescriptor>(4);
+        private final Set<ClassDescriptor> supertypeSet = new HashSet<>(4);
 
         private boolean encounteredMissingClasses = false;
 
@@ -115,13 +115,13 @@ public class Subtypes2 {
      */
     public Subtypes2() {
         this.graph = new InheritanceGraph();
-        this.classDescriptorToVertexMap = new HashMap<ClassDescriptor, ClassVertex>();
-        this.supertypeSetMap = new MapCache<ClassDescriptor, SupertypeQueryResults>(500);
-        this.subtypeSetMap = new MapCache<ClassDescriptor, Set<ClassDescriptor>>(500);
-        this.xclassSet = new HashSet<XClass>();
+        this.classDescriptorToVertexMap = new HashMap<>();
+        this.supertypeSetMap = new MapCache<>(500);
+        this.subtypeSetMap = new MapCache<>(500);
+        this.xclassSet = new HashSet<>();
         this.SERIALIZABLE = ObjectTypeFactory.getInstance("java.io.Serializable");
         this.CLONEABLE = ObjectTypeFactory.getInstance("java.lang.Cloneable");
-        this.firstCommonSuperclassQueryCache = new DualKeyHashMap<ReferenceType, ReferenceType, ReferenceType>();
+        this.firstCommonSuperclassQueryCache = new DualKeyHashMap<>();
     }
 
     /**
@@ -264,7 +264,7 @@ public class Subtypes2 {
             throw new IllegalStateException();
         }
 
-        LinkedList<XClass> workList = new LinkedList<XClass>();
+        LinkedList<XClass> workList = new LinkedList<>();
         workList.add(xclass);
 
         while (!workList.isEmpty()) {
@@ -800,7 +800,7 @@ public class Subtypes2 {
      * @return list of all superclass vertices in order
      */
     private ArrayList<ClassVertex> getAllSuperclassVertices(ClassVertex vertex) throws ClassNotFoundException {
-        ArrayList<ClassVertex> result = new ArrayList<ClassVertex>();
+        ArrayList<ClassVertex> result = new ArrayList<>();
         ClassVertex cur = vertex;
         while (cur != null) {
             if (!cur.isResolved()) {
@@ -858,7 +858,7 @@ public class Subtypes2 {
 
         ClassVertex startVertex = resolveClassVertex(classDescriptor);
 
-        Set<ClassDescriptor> result = new HashSet<ClassDescriptor>();
+        Set<ClassDescriptor> result = new HashSet<>();
         Iterator<InheritanceEdge> i = graph.incomingEdgeIterator(startVertex);
         while (i.hasNext()) {
             InheritanceEdge edge = i.next();
@@ -881,7 +881,7 @@ public class Subtypes2 {
     public Set<ClassDescriptor> getTransitiveCommonSubtypes(ClassDescriptor classDescriptor1, ClassDescriptor classDescriptor2)
             throws ClassNotFoundException {
         Set<ClassDescriptor> subtypes1 = getSubtypes(classDescriptor1);
-        Set<ClassDescriptor> result = new HashSet<ClassDescriptor>(subtypes1);
+        Set<ClassDescriptor> result = new HashSet<>(subtypes1);
         Set<ClassDescriptor> subtypes2 = getSubtypes(classDescriptor2);
         result.retainAll(subtypes2);
         return result;
@@ -908,7 +908,7 @@ public class Subtypes2 {
 
         public SupertypeTraversalPath(@CheckForNull ClassVertex next) {
             this.next = next;
-            this.seen = new HashSet<ClassDescriptor>();
+            this.seen = new HashSet<>();
         }
 
         @Override
@@ -956,7 +956,7 @@ public class Subtypes2 {
      *             if the start vertex cannot be resolved
      */
     public void traverseSupertypes(ClassDescriptor start, InheritanceGraphVisitor visitor) throws ClassNotFoundException {
-        LinkedList<SupertypeTraversalPath> workList = new LinkedList<SupertypeTraversalPath>();
+        LinkedList<SupertypeTraversalPath> workList = new LinkedList<>();
 
         ClassVertex startVertex = resolveClassVertex(start);
         workList.addLast(new SupertypeTraversalPath(startVertex));
@@ -1087,12 +1087,12 @@ public class Subtypes2 {
      * @throws ClassNotFoundException
      */
     private Set<ClassDescriptor> computeKnownSubtypes(ClassDescriptor classDescriptor) throws ClassNotFoundException {
-        LinkedList<ClassVertex> workList = new LinkedList<ClassVertex>();
+        LinkedList<ClassVertex> workList = new LinkedList<>();
 
         ClassVertex startVertex = resolveClassVertex(classDescriptor);
         workList.addLast(startVertex);
 
-        Set<ClassDescriptor> result = new HashSet<ClassDescriptor>();
+        Set<ClassDescriptor> result = new HashSet<>();
 
         while (!workList.isEmpty()) {
             ClassVertex current = workList.removeFirst();
@@ -1113,7 +1113,7 @@ public class Subtypes2 {
             }
         }
 
-        return new HashSet<ClassDescriptor>(result);
+        return new HashSet<>(result);
     }
 
 
@@ -1124,11 +1124,11 @@ public class Subtypes2 {
             return true;
         }
 
-        LinkedList<ClassVertex> workList = new LinkedList<ClassVertex>();
+        LinkedList<ClassVertex> workList = new LinkedList<>();
 
         workList.addLast(startVertex);
 
-        Set<ClassDescriptor> result = new HashSet<ClassDescriptor>();
+        Set<ClassDescriptor> result = new HashSet<>();
 
         while (!workList.isEmpty()) {
             ClassVertex current = workList.removeFirst();
@@ -1154,12 +1154,12 @@ public class Subtypes2 {
         return false;
     }
     private Set<ClassDescriptor> computeKnownSupertypes(ClassDescriptor classDescriptor) throws ClassNotFoundException {
-        LinkedList<ClassVertex> workList = new LinkedList<ClassVertex>();
+        LinkedList<ClassVertex> workList = new LinkedList<>();
 
         ClassVertex startVertex = resolveClassVertex(classDescriptor);
         workList.addLast(startVertex);
 
-        Set<ClassDescriptor> result = new HashSet<ClassDescriptor>();
+        Set<ClassDescriptor> result = new HashSet<>();
 
         while (!workList.isEmpty()) {
             ClassVertex current = workList.removeFirst();
@@ -1223,7 +1223,7 @@ public class Subtypes2 {
         // Add all known superclasses/superinterfaces.
         // The ClassVertexes for all of them should be in the
         // InheritanceGraph by now.
-        LinkedList<ClassVertex> workList = new LinkedList<ClassVertex>();
+        LinkedList<ClassVertex> workList = new LinkedList<>();
         workList.addLast(typeVertex);
         while (!workList.isEmpty()) {
             ClassVertex vertex = workList.removeFirst();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/deref/UnconditionalValueDerefAnalysis.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/deref/UnconditionalValueDerefAnalysis.java
@@ -413,7 +413,7 @@ public class UnconditionalValueDerefAnalysis extends BackwardDataflowAnalysis<Un
                 System.out.println("** Summary of call @ " + location.getHandle().getPosition() + ": " + derefParamSet);
             }
 
-            HashSet<ValueNumber> requiredToBeNonnull = new HashSet<ValueNumber>();
+            HashSet<ValueNumber> requiredToBeNonnull = new HashSet<>();
             for (int i = 0; i < numParams; i++) {
                 if (!derefParamSet.hasProperty(i)) {
                     continue;
@@ -559,7 +559,7 @@ public class UnconditionalValueDerefAnalysis extends BackwardDataflowAnalysis<Un
         SignatureParser sigParser = new SignatureParser(called.getSignature());
         int numParams = sigParser.getNumParameters();
 
-        Set<ValueNumber> result = new HashSet<ValueNumber>();
+        Set<ValueNumber> result = new HashSet<>();
         Iterator<String> parameterIterator = sigParser.parameterSignatureIterator();
         for (int i = 0; i < numParams; i++) {
             String parameterSignature = parameterIterator.next();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/deref/UnconditionalValueDerefSet.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/deref/UnconditionalValueDerefSet.java
@@ -67,7 +67,7 @@ public class UnconditionalValueDerefSet {
     public UnconditionalValueDerefSet(int numValueNumbersInMethod) {
         this.numValueNumbersInMethod = numValueNumbersInMethod;
         this.valueNumbersUnconditionallyDereferenced = new BitSet();
-        this.derefLocationSetMap = new HashMap<ValueNumber, Set<Location>>(3);
+        this.derefLocationSetMap = new HashMap<>(3);
 
     }
 
@@ -189,7 +189,7 @@ public class UnconditionalValueDerefSet {
                     // this value number.
                     Set<Location> derefLocationSet = derefLocationSetMap.get(vn);
                     if (derefLocationSet == null) {
-                        derefLocationSet = new HashSet<Location>();
+                        derefLocationSet = new HashSet<>();
                         derefLocationSetMap.put(vn, derefLocationSet);
                     }
                     derefLocationSet.addAll(fact.derefLocationSetMap.get(vn));
@@ -223,12 +223,12 @@ public class UnconditionalValueDerefSet {
                 // this value number.
                 Set<Location> derefLocationSet = derefLocationSetMap.get(vn);
                 if (derefLocationSet == null) {
-                    derefLocationSet = new HashSet<Location>();
+                    derefLocationSet = new HashSet<>();
                     derefLocationSetMap.put(vn, derefLocationSet);
                 }
                 derefLocationSet.addAll(fact.derefLocationSetMap.get(vn));
             } else {
-                derefLocationSetMap.put(vn, new HashSet<Location>(fact.getDerefLocationSet(vn)));
+                derefLocationSetMap.put(vn, new HashSet<>(fact.getDerefLocationSet(vn)));
             }
         }
     }
@@ -295,7 +295,7 @@ public class UnconditionalValueDerefSet {
     public Set<Location> getDerefLocationSet(ValueNumber vn) {
         Set<Location> derefLocationSet = derefLocationSetMap.get(vn);
         if (derefLocationSet == null) {
-            derefLocationSet = new HashSet<Location>();
+            derefLocationSet = new HashSet<>();
             derefLocationSetMap.put(vn, derefLocationSet);
         }
         return derefLocationSet;
@@ -315,7 +315,7 @@ public class UnconditionalValueDerefSet {
     }
 
     public Set<ValueNumber> getValueNumbersThatAreUnconditionallyDereferenced() {
-        HashSet<ValueNumber> result = new HashSet<ValueNumber>();
+        HashSet<ValueNumber> result = new HashSet<>();
         for (Map.Entry<ValueNumber, Set<Location>> e : derefLocationSetMap.entrySet()) {
             if (!e.getValue().isEmpty()) {
                 result.add(e.getKey());
@@ -385,7 +385,7 @@ public class UnconditionalValueDerefSet {
             } else {
                 buf.append('?');
             }
-            TreeSet<Location> derefLocationSet = new TreeSet<Location>();
+            TreeSet<Location> derefLocationSet = new TreeSet<>();
             derefLocationSet.addAll(getDerefLocationSet(i));
             boolean firstLoc = true;
             for (Location location : derefLocationSet) {
@@ -408,7 +408,7 @@ public class UnconditionalValueDerefSet {
                 return Collections.<Location> unmodifiableSet(entry.getValue());
             }
         }
-        return new HashSet<Location>();
+        return new HashSet<>();
     }
 
     /**
@@ -417,7 +417,7 @@ public class UnconditionalValueDerefSet {
      */
     public void cleanDerefSet(@CheckForNull Location location, ValueNumberFrame vnaFrame) {
 
-        Set<ValueNumber> valueNumbers = new HashSet<ValueNumber>(vnaFrame.allSlots());
+        Set<ValueNumber> valueNumbers = new HashSet<>(vnaFrame.allSlots());
 
         valueNumbers.addAll(vnaFrame.valueNumbersForLoads());
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/generic/GenericUtilities.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/generic/GenericUtilities.java
@@ -434,7 +434,7 @@ public class GenericUtilities {
     public static final @CheckForNull
     List<ReferenceType> getTypeParameters(String signature) {
         GenericSignatureParser parser = new GenericSignatureParser("(" + signature + ")V");
-        List<ReferenceType> types = new ArrayList<ReferenceType>();
+        List<ReferenceType> types = new ArrayList<>();
 
         Iterator<String> iter = parser.parameterSignatureIterator();
         while (iter.hasNext()) {
@@ -449,7 +449,7 @@ public class GenericUtilities {
     }
 
     public static final List<String> split(String signature, boolean skipInitialAngleBracket) {
-        List<String> result = new ArrayList<String>();
+        List<String> result = new ArrayList<>();
         if (signature.charAt(0) != '<') {
             skipInitialAngleBracket = false;
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/heap/FieldSet.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/heap/FieldSet.java
@@ -33,7 +33,7 @@ public class FieldSet {
     private final Set<XField> fieldSet;
 
     public FieldSet() {
-        fieldSet = new HashSet<XField>();
+        fieldSet = new HashSet<>();
     }
 
     public void setTop() {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/heap/FieldSetAnalysis.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/heap/FieldSetAnalysis.java
@@ -49,7 +49,7 @@ public abstract class FieldSetAnalysis extends ForwardDataflowAnalysis<FieldSet>
     public FieldSetAnalysis(DepthFirstSearch dfs, ConstantPoolGen cpg) {
         super(dfs);
         this.cpg = cpg;
-        this.instructionToFieldMap = new HashMap<InstructionHandle, XField>();
+        this.instructionToFieldMap = new HashMap<>();
     }
 
     public ConstantPoolGen getCPG() {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/interproc/PropertyDatabase.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/interproc/PropertyDatabase.java
@@ -59,7 +59,7 @@ public abstract class PropertyDatabase<KeyType extends FieldOrMethodDescriptor, 
      * Constructor. Creates an empty property database.
      */
     protected PropertyDatabase() {
-        this.propertyMap = new HashMap<KeyType, ValueType>();
+        this.propertyMap = new HashMap<>();
     }
 
     /**
@@ -207,7 +207,7 @@ public abstract class PropertyDatabase<KeyType extends FieldOrMethodDescriptor, 
         try {
             writer = new BufferedWriter(new OutputStreamWriter(out, UTF8.charset));
 
-            TreeSet<KeyType> sortedMethodSet = new TreeSet<KeyType>();
+            TreeSet<KeyType> sortedMethodSet = new TreeSet<>();
             sortedMethodSet.addAll(propertyMap.keySet());
             for (KeyType key : sortedMethodSet) {
                 if (AnalysisContext.currentAnalysisContext().isApplicationClass(key.getClassDescriptor())) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/Analysis.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/Analysis.java
@@ -77,7 +77,7 @@ public class Analysis {
     public static Collection<TypeQualifierValue<?>> getRelevantTypeQualifiers(MethodDescriptor methodDescriptor, CFG cfg)
             throws CheckedAnalysisException {
 
-        final HashSet<TypeQualifierValue<?>> result = new HashSet<TypeQualifierValue<?>>();
+        final HashSet<TypeQualifierValue<?>> result = new HashSet<>();
 
         XMethod xmethod = XFactory.createXMethod(methodDescriptor);
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/BackwardTypeQualifierDataflowAnalysis.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/BackwardTypeQualifierDataflowAnalysis.java
@@ -126,7 +126,7 @@ public class BackwardTypeQualifierDataflowAnalysis extends TypeQualifierDataflow
 
     private void pruneConflictingValues(TypeQualifierValueSet fact, TypeQualifierValueSet forwardFact) {
         if (forwardFact.isValid()) {
-            HashSet<ValueNumber> valueNumbers = new HashSet<ValueNumber>();
+            HashSet<ValueNumber> valueNumbers = new HashSet<>();
             valueNumbers.addAll(fact.getValueNumbers());
             valueNumbers.retainAll(forwardFact.getValueNumbers());
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/DirectlyRelevantTypeQualifiersDatabase.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/DirectlyRelevantTypeQualifiersDatabase.java
@@ -44,8 +44,8 @@ public class DirectlyRelevantTypeQualifiersDatabase {
      * Constructor.
      */
     public DirectlyRelevantTypeQualifiersDatabase() {
-        methodToDirectlyRelevantQualifiersMap = new HashMap<MethodDescriptor, Collection<TypeQualifierValue<?>>>();
-        allKnownQualifiers = new HashSet<TypeQualifierValue<?>>();
+        methodToDirectlyRelevantQualifiersMap = new HashMap<>();
+        allKnownQualifiers = new HashSet<>();
     }
 
     /**

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/TypeQualifierAnnotation.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/TypeQualifierAnnotation.java
@@ -60,7 +60,7 @@ public class TypeQualifierAnnotation {
     private static ThreadLocal<DualKeyHashMap<TypeQualifierValue<?>, When, TypeQualifierAnnotation>> instance = new ThreadLocal<DualKeyHashMap<TypeQualifierValue<?>, When, TypeQualifierAnnotation>>() {
         @Override
         protected DualKeyHashMap<TypeQualifierValue<?>, When, TypeQualifierAnnotation> initialValue() {
-            return new DualKeyHashMap<TypeQualifierValue<?>, When, TypeQualifierAnnotation>();
+            return new DualKeyHashMap<>();
         }
     };
 
@@ -158,7 +158,7 @@ public class TypeQualifierAnnotation {
 
     public static @Nonnull
     Collection<TypeQualifierAnnotation> getValues(Map<TypeQualifierValue<?>, When> map) {
-        Collection<TypeQualifierAnnotation> result = new LinkedList<TypeQualifierAnnotation>();
+        Collection<TypeQualifierAnnotation> result = new LinkedList<>();
         for (Map.Entry<TypeQualifierValue<?>, When> e : map.entrySet()) {
             result.add(getValue(e.getKey(), e.getValue()));
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/TypeQualifierAnnotationLookupResult.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/TypeQualifierAnnotationLookupResult.java
@@ -79,7 +79,7 @@ public class TypeQualifierAnnotationLookupResult {
     private final List<PartialResult> partialResultList;
 
     TypeQualifierAnnotationLookupResult() {
-        this.partialResultList = new LinkedList<PartialResult>();
+        this.partialResultList = new LinkedList<>();
     }
 
     void addPartialResult(PartialResult partialResult) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/TypeQualifierApplications.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/TypeQualifierApplications.java
@@ -74,24 +74,24 @@ public class TypeQualifierApplications {
          * Type qualifier annotations applied directly to
          * methods/fields/classes/etc.
          */
-        private final Map<AnnotatedObject, Collection<AnnotationValue>> directObjectAnnotations = new HashMap<AnnotatedObject, Collection<AnnotationValue>>();
+        private final Map<AnnotatedObject, Collection<AnnotationValue>> directObjectAnnotations = new HashMap<>();
 
         /** Type qualifier annotations applied directly to method parameters. */
-        private final HashMap<XMethod, Map<Integer, Collection<AnnotationValue>>> directParameterAnnotations = new HashMap<XMethod, Map<Integer, Collection<AnnotationValue>>>();
+        private final HashMap<XMethod, Map<Integer, Collection<AnnotationValue>>> directParameterAnnotations = new HashMap<>();
 
         /**
          * Map of TypeQualifierValues to maps containing, for each
          * AnnotatedObject, the effective TypeQualifierAnnotation (if any) for
          * that AnnotatedObject.
          */
-        private final Map<TypeQualifierValue<?>, Map<AnnotatedObject, TypeQualifierAnnotation>> effectiveObjectAnnotations = new HashMap<TypeQualifierValue<?>, Map<AnnotatedObject, TypeQualifierAnnotation>>();
+        private final Map<TypeQualifierValue<?>, Map<AnnotatedObject, TypeQualifierAnnotation>> effectiveObjectAnnotations = new HashMap<>();
 
         /**
          * Map of TypeQualifierValues to maps containing, for each
          * XMethod/parameter, the effective TypeQualifierAnnotation (if any) for
          * that XMethod/parameter.
          */
-        private final Map<TypeQualifierValue<?>, DualKeyHashMap<XMethod, Integer, TypeQualifierAnnotation>> effectiveParameterAnnotations = new HashMap<TypeQualifierValue<?>, DualKeyHashMap<XMethod, Integer, TypeQualifierAnnotation>>();
+        private final Map<TypeQualifierValue<?>, DualKeyHashMap<XMethod, Integer, TypeQualifierAnnotation>> effectiveParameterAnnotations = new HashMap<>();
     }
 
     private static ThreadLocal<Data> instance = new ThreadLocal<Data>() {
@@ -180,7 +180,7 @@ public class TypeQualifierApplications {
             {
                 n--; // ignore annotations on varargs parameters
             }
-            map = new HashMap<Integer, Collection<AnnotationValue>>(n + 2);
+            map = new HashMap<>(n + 2);
             for (int i = 0; i < n; i++) {
                 Collection<AnnotationValue> a = TypeQualifierResolver.resolveTypeQualifiers(m.getParameterAnnotations(i));
                 if (!a.isEmpty()) {
@@ -307,7 +307,7 @@ public class TypeQualifierApplications {
      * @return Collection of resolved TypeQualifierAnnotations
      */
     private static Collection<TypeQualifierAnnotation> getApplicableScopedApplications(AnnotatedObject o, ElementType e) {
-        Set<TypeQualifierAnnotation> result = new HashSet<TypeQualifierAnnotation>();
+        Set<TypeQualifierAnnotation> result = new HashSet<>();
         getApplicableScopedApplications(result, o, e);
         return result;
     }
@@ -324,7 +324,7 @@ public class TypeQualifierApplications {
      * @return Collection of resolved TypeQualifierAnnotations
      */
     private static Collection<TypeQualifierAnnotation> getApplicableScopedApplications(XMethod o, int parameter) {
-        Set<TypeQualifierAnnotation> result = new HashSet<TypeQualifierAnnotation>();
+        Set<TypeQualifierAnnotation> result = new HashSet<>();
         ElementType e = ElementType.PARAMETER;
         getApplicableScopedApplications(result, o, e);
         getDirectApplications(result, o, parameter);
@@ -598,7 +598,7 @@ public class TypeQualifierApplications {
 
         Map<AnnotatedObject, TypeQualifierAnnotation> map = getEffectiveObjectAnnotations().get(typeQualifierValue);
         if (map == null) {
-            map = new HashMap<AnnotatedObject, TypeQualifierAnnotation>();
+            map = new HashMap<>();
             getEffectiveObjectAnnotations().put(typeQualifierValue, map);
         }
 
@@ -661,7 +661,7 @@ public class TypeQualifierApplications {
             TypeQualifierValue<?> typeQualifierValue) {
         TypeQualifierAnnotation result;
 
-        Set<TypeQualifierAnnotation> applications = new HashSet<TypeQualifierAnnotation>();
+        Set<TypeQualifierAnnotation> applications = new HashSet<>();
         getDirectApplications(applications, o, o.getElementType());
 
         result = findMatchingTypeQualifierAnnotation(applications, typeQualifierValue);
@@ -729,7 +729,7 @@ public class TypeQualifierApplications {
             TypeQualifierAnnotation result;
 
             // Check direct applications of the type qualifier
-            Set<TypeQualifierAnnotation> applications = new HashSet<TypeQualifierAnnotation>();
+            Set<TypeQualifierAnnotation> applications = new HashSet<>();
             getDirectApplications(applications, o, elementType);
             result = findMatchingTypeQualifierAnnotation(applications, typeQualifierValue);
             if (result != null) {
@@ -801,7 +801,7 @@ public class TypeQualifierApplications {
             if (DEBUG) {
                 System.out.println("computeEffectiveTypeQualifierAnnotation: Creating map for " + typeQualifierValue);
             }
-            map = new DualKeyHashMap<XMethod, Integer, TypeQualifierAnnotation>();
+            map = new DualKeyHashMap<>();
             effectiveParameterAnnotations.put(typeQualifierValue, map);
         }
 
@@ -927,7 +927,7 @@ public class TypeQualifierApplications {
         if (bridge != null) {
             xmethod = bridge;
         }
-        Set<TypeQualifierAnnotation> applications = new HashSet<TypeQualifierAnnotation>();
+        Set<TypeQualifierAnnotation> applications = new HashSet<>();
         getDirectApplications(applications, xmethod, parameter);
         if (DEBUG_METHOD != null && DEBUG_METHOD.equals(xmethod.getName())) {
             System.out.println("  Direct applications are: " + applications);
@@ -1022,7 +1022,7 @@ public class TypeQualifierApplications {
                 return null;
             }
             // Check for direct type qualifier annotation
-            Set<TypeQualifierAnnotation> applications = new HashSet<TypeQualifierAnnotation>();
+            Set<TypeQualifierAnnotation> applications = new HashSet<>();
             getDirectApplications(applications, o, ElementType.PARAMETER);
             TypeQualifierAnnotation tqa = findMatchingTypeQualifierAnnotation(applications, typeQualifierValue);
             if (tqa != null) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/TypeQualifierDatabase.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/TypeQualifierDatabase.java
@@ -48,8 +48,8 @@ public class TypeQualifierDatabase {
      * Constructor.
      */
     public TypeQualifierDatabase() {
-        this.returnValueMap = new HashMap<MethodDescriptor, Map<TypeQualifierValue<?>, TypeQualifierAnnotation>>();
-        this.parameterMap = new DualKeyHashMap<MethodDescriptor, Integer, Map<TypeQualifierValue<?>, TypeQualifierAnnotation>>();
+        this.returnValueMap = new HashMap<>();
+        this.parameterMap = new DualKeyHashMap<>();
     }
 
     /**
@@ -65,7 +65,7 @@ public class TypeQualifierDatabase {
     public void setReturnValue(MethodDescriptor methodDesc, TypeQualifierValue<?> tqv, TypeQualifierAnnotation tqa) {
         Map<TypeQualifierValue<?>, TypeQualifierAnnotation> map = returnValueMap.get(methodDesc);
         if (map == null) {
-            map = new HashMap<TypeQualifierValue<?>, TypeQualifierAnnotation>();
+            map = new HashMap<>();
             returnValueMap.put(methodDesc, map);
         }
         map.put(tqv, tqa);
@@ -112,7 +112,7 @@ public class TypeQualifierDatabase {
     public void setParameter(MethodDescriptor methodDesc, int param, TypeQualifierValue<?> tqv, TypeQualifierAnnotation tqa) {
         Map<TypeQualifierValue<?>, TypeQualifierAnnotation> map = parameterMap.get(methodDesc, param);
         if (map == null) {
-            map = new HashMap<TypeQualifierValue<?>, TypeQualifierAnnotation>();
+            map = new HashMap<>();
             parameterMap.put(methodDesc, param, map);
         }
         map.put(tqv, tqa);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/TypeQualifierDataflowAnalysis.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/TypeQualifierDataflowAnalysis.java
@@ -124,7 +124,7 @@ public abstract class TypeQualifierDataflowAnalysis extends AbstractDataflowAnal
         this.vnaDataflow = vnaDataflow;
         this.cpg = cpg;
         this.typeQualifierValue = typeQualifierValue;
-        this.sourceSinkMap = new HashMap<Location, Set<SourceSinkInfo>>();
+        this.sourceSinkMap = new HashMap<>();
     }
 
     /*
@@ -283,7 +283,7 @@ public abstract class TypeQualifierDataflowAnalysis extends AbstractDataflowAnal
     protected void registerSourceSink(SourceSinkInfo sourceSinkInfo) {
         Set<SourceSinkInfo> set = sourceSinkMap.get(sourceSinkInfo.getLocation());
         if (set == null) {
-            set = new HashSet<SourceSinkInfo>();
+            set = new HashSet<>();
             sourceSinkMap.put(sourceSinkInfo.getLocation(), set);
         }
         set.add(sourceSinkInfo);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/TypeQualifierDataflowFactory.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/TypeQualifierDataflowFactory.java
@@ -66,7 +66,7 @@ public abstract class TypeQualifierDataflowFactory<AnalysisType extends TypeQual
 
     public TypeQualifierDataflowFactory(MethodDescriptor methodDescriptor) {
         this.methodDescriptor = methodDescriptor;
-        this.dataflowMap = new HashMap<TypeQualifierValue<?>, DataflowResult<DataflowType>>();
+        this.dataflowMap = new HashMap<>();
     }
 
     public DataflowType getDataflow(TypeQualifierValue<?> typeQualifierValue) throws CheckedAnalysisException {
@@ -79,7 +79,7 @@ public abstract class TypeQualifierDataflowFactory<AnalysisType extends TypeQual
     }
 
     private DataflowResult<DataflowType> compute(TypeQualifierValue<?> typeQualifierValue) {
-        DataflowResult<DataflowType> result = new DataflowResult<DataflowType>();
+        DataflowResult<DataflowType> result = new DataflowResult<>();
 
         try {
             IAnalysisCache analysisCache = Global.getAnalysisCache();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/TypeQualifierResolver.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/TypeQualifierResolver.java
@@ -78,7 +78,7 @@ public class TypeQualifierResolver {
      *         TypeQualifier annotations
      */
     public static Collection<AnnotationValue> resolveTypeQualifiers(AnnotationValue value) {
-        LinkedList<AnnotationValue> result = new LinkedList<AnnotationValue>();
+        LinkedList<AnnotationValue> result = new LinkedList<>();
         resolveTypeQualifierNicknames(value, result, new LinkedList<ClassDescriptor>());
         return result;
     }
@@ -95,7 +95,7 @@ public class TypeQualifierResolver {
      */
     public static Collection<AnnotationValue> resolveTypeQualifierDefaults(Collection<AnnotationValue> values,
             ElementType elementType) {
-        LinkedList<AnnotationValue> result = new LinkedList<AnnotationValue>();
+        LinkedList<AnnotationValue> result = new LinkedList<>();
         for (AnnotationValue value : values) {
             resolveTypeQualifierDefaults(value, elementType, result);
         }
@@ -188,8 +188,8 @@ public class TypeQualifierResolver {
         if (values.isEmpty()) {
             return Collections.emptyList();
         }
-        LinkedList<AnnotationValue> result = new LinkedList<AnnotationValue>();
-        LinkedList<ClassDescriptor> onStack = new LinkedList<ClassDescriptor>();
+        LinkedList<AnnotationValue> result = new LinkedList<>();
+        LinkedList<ClassDescriptor> onStack = new LinkedList<>();
         for (AnnotationValue value : values) {
             resolveTypeQualifierNicknames(value, result, onStack);
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/TypeQualifierValue.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/TypeQualifierValue.java
@@ -240,12 +240,12 @@ public class TypeQualifierValue<A extends Annotation> {
         /**
          * Cache in which constructed TypeQualifierValues are interned.
          */
-        DualKeyHashMap<ClassDescriptor, Object, TypeQualifierValue<?>> typeQualifierMap = new DualKeyHashMap<ClassDescriptor, Object, TypeQualifierValue<?>>();
+        DualKeyHashMap<ClassDescriptor, Object, TypeQualifierValue<?>> typeQualifierMap = new DualKeyHashMap<>();
 
         /**
          * Set of all known TypeQualifierValues.
          */
-        Set<TypeQualifierValue<?>> allKnownTypeQualifiers = new HashSet<TypeQualifierValue<?>>();
+        Set<TypeQualifierValue<?>> allKnownTypeQualifiers = new HashSet<>();
     }
 
     private static ThreadLocal<Data> instance = new ThreadLocal<Data>() {
@@ -332,7 +332,7 @@ public class TypeQualifierValue<A extends Annotation> {
     public static Collection<TypeQualifierValue<?>> getComplementaryExclusiveTypeQualifierValue(TypeQualifierValue<?> tqv) {
         assert tqv.isExclusiveQualifier();
 
-        LinkedList<TypeQualifierValue<?>> result = new LinkedList<TypeQualifierValue<?>>();
+        LinkedList<TypeQualifierValue<?>> result = new LinkedList<>();
 
         for (TypeQualifierValue<?> t : instance.get().allKnownTypeQualifiers) {
             //

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/TypeQualifierValueSet.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/TypeQualifierValueSet.java
@@ -52,9 +52,9 @@ public class TypeQualifierValueSet {
     final boolean  isStrict;
 
     public TypeQualifierValueSet(TypeQualifierValue<?> typeQualifierValue) {
-        this.valueMap = new HashMap<ValueNumber, FlowValue>(3);
-        this.whereAlways = new HashMap<ValueNumber, Set<SourceSinkInfo>>(3);
-        this.whereNever = new HashMap<ValueNumber, Set<SourceSinkInfo>>(3);
+        this.valueMap = new HashMap<>(3);
+        this.whereAlways = new HashMap<>(3);
+        this.whereNever = new HashMap<>(3);
         this.state = State.TOP;
         isStrict = typeQualifierValue.isStrictQualifier();
     }
@@ -116,7 +116,7 @@ public class TypeQualifierValueSet {
             SourceSinkInfo sourceSinkInfo) {
         Set<SourceSinkInfo> sourceSinkInfoSet = sourceSinkInfoSetMap.get(vn);
         if (sourceSinkInfoSet == null) {
-            sourceSinkInfoSet = new HashSet<SourceSinkInfo>(3);
+            sourceSinkInfoSet = new HashSet<>(3);
             sourceSinkInfoSetMap.put(vn, sourceSinkInfoSet);
         }
         sourceSinkInfoSet.add(sourceSinkInfo);
@@ -159,7 +159,7 @@ public class TypeQualifierValueSet {
             ValueNumber vn) {
         Set<SourceSinkInfo> sourceSinkInfoSet = sourceSinkInfoSetMap.get(vn);
         if (sourceSinkInfoSet == null) {
-            sourceSinkInfoSet = new HashSet<SourceSinkInfo>(3);
+            sourceSinkInfoSet = new HashSet<>(3);
             sourceSinkInfoSetMap.put(vn, sourceSinkInfoSet);
         }
         return sourceSinkInfoSet;
@@ -202,7 +202,7 @@ public class TypeQualifierValueSet {
         dest.clear();
 
         for (Map.Entry<ValueNumber, Set<SourceSinkInfo>> entry : source.entrySet()) {
-            HashSet<SourceSinkInfo> copy = new HashSet<SourceSinkInfo>(entry.getValue());
+            HashSet<SourceSinkInfo> copy = new HashSet<>(entry.getValue());
             dest.put(entry.getKey(), copy);
         }
     }
@@ -265,7 +265,7 @@ public class TypeQualifierValueSet {
             throw new DataflowAnalysisException("merging an invalid TypeQualifierValueSet");
         }
 
-        Set<ValueNumber> interesting = new HashSet<ValueNumber>();
+        Set<ValueNumber> interesting = new HashSet<>();
         interesting.addAll(this.valueMap.keySet());
         interesting.addAll(fact.valueMap.keySet());
 
@@ -322,7 +322,7 @@ public class TypeQualifierValueSet {
             return state.toString();
         }
 
-        TreeSet<ValueNumber> interesting = new TreeSet<ValueNumber>();
+        TreeSet<ValueNumber> interesting = new TreeSet<>();
         interesting.addAll(valueMap.keySet());
 
         StringBuilder buf = new StringBuilder();
@@ -378,7 +378,7 @@ public class TypeQualifierValueSet {
     }
 
     private static void appendSourceSinkInfos(StringBuilder buf, String key, Set<? extends SourceSinkInfo> sourceSinkInfoSet) {
-        TreeSet<SourceSinkInfo> sortedLocSet = new TreeSet<SourceSinkInfo>();
+        TreeSet<SourceSinkInfo> sortedLocSet = new TreeSet<>();
         sortedLocSet.addAll(sourceSinkInfoSet);
         boolean first = true;
         buf.append(key);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/IsNullValueAnalysis.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/IsNullValueAnalysis.java
@@ -114,7 +114,7 @@ IsNullValueAnalysisFeatures {
                 typeDataflow, trackValueNumbers);
         this.vnaDataflow = vnaDataflow;
         this.cfg = cfg;
-        this.locationWhereValueBecomesNullSet = new HashSet<LocationWhereValueBecomesNull>();
+        this.locationWhereValueBecomesNullSet = new HashSet<>();
         this.pointerEqualityCheck = getForPointerEqualityCheck(cfg, vnaDataflow);
 
         if (DEBUG) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/IsNullValueFrame.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/IsNullValueFrame.java
@@ -86,7 +86,7 @@ public class IsNullValueFrame extends Frame<IsNullValue> {
         super(numLocals);
         this.trackValueNumbers = trackValueNumbers;
         if (trackValueNumbers) {
-            this.knownValueMap = new HashMap<ValueNumber, IsNullValue>(3);
+            this.knownValueMap = new HashMap<>(3);
         }
     }
 
@@ -127,7 +127,7 @@ public class IsNullValueFrame extends Frame<IsNullValue> {
         }
 
         if (trackValueNumbers) {
-            Map<ValueNumber, IsNullValue> replaceMap = new HashMap<ValueNumber, IsNullValue>();
+            Map<ValueNumber, IsNullValue> replaceMap = new HashMap<>();
             for (Map.Entry<ValueNumber, IsNullValue> entry : knownValueMap.entrySet()) {
                 replaceMap.put(entry.getKey(), entry.getValue().toExceptionValue());
             }
@@ -199,7 +199,7 @@ public class IsNullValueFrame extends Frame<IsNullValue> {
             System.out.println("     " + this);
             System.out.println(" with" + otherFrame);
         }
-        Map<ValueNumber, IsNullValue> replaceMap = new HashMap<ValueNumber, IsNullValue>();
+        Map<ValueNumber, IsNullValue> replaceMap = new HashMap<>();
         for (Map.Entry<ValueNumber, IsNullValue> entry : knownValueMap.entrySet()) {
             IsNullValue otherKnownValue = otherFrame.knownValueMap.get(entry.getKey());
             if (otherKnownValue == null) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/NullDerefAndRedundantComparisonFinder.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/NullDerefAndRedundantComparisonFinder.java
@@ -134,7 +134,7 @@ public class NullDerefAndRedundantComparisonFinder {
                 AnalysisFeatures.TRACK_GUARANTEED_VALUE_DEREFS_IN_NULL_POINTER_ANALYSIS);
         this.lineMentionedMultipleTimes = classContext.linesMentionedMultipleTimes(method);
 
-        this.redundantBranchList = new LinkedList<RedundantBranch>();
+        this.redundantBranchList = new LinkedList<>();
         this.definitelySameBranchSet = new BitSet();
         this.definitelyDifferentBranchSet = new BitSet();
         this.undeterminedBranchSet = new BitSet();
@@ -231,10 +231,10 @@ public class NullDerefAndRedundantComparisonFinder {
             System.out.println("----------------------- examineNullValues " + locationWhereValueBecomesNullSet.size());
         }
 
-        Map<ValueNumber, SortedSet<Location>> bugStatementLocationMap = new HashMap<ValueNumber, SortedSet<Location>>();
+        Map<ValueNumber, SortedSet<Location>> bugStatementLocationMap = new HashMap<>();
         // Inspect the method for locations where a null value is guaranteed to
         // be dereferenced. Add the dereference locations
-        Map<ValueNumber, NullValueUnconditionalDeref> nullValueGuaranteedDerefMap = new HashMap<ValueNumber, NullValueUnconditionalDeref>();
+        Map<ValueNumber, NullValueUnconditionalDeref> nullValueGuaranteedDerefMap = new HashMap<>();
 
         // Check every location
         CFG cfg = classContext.getCFG(method);
@@ -249,8 +249,8 @@ public class NullDerefAndRedundantComparisonFinder {
                     vnaDataflow.getFactAtLocation(location), invDataflow.getFactAtLocation(location),
                     uvdDataflow.getFactAfterLocation(location), false);
         }
-        HashSet<ValueNumber> npeIfStatementCovered = new HashSet<ValueNumber>(nullValueGuaranteedDerefMap.keySet());
-        Map<ValueNumber, SortedSet<Location>> bugEdgeLocationMap = new HashMap<ValueNumber, SortedSet<Location>>();
+        HashSet<ValueNumber> npeIfStatementCovered = new HashSet<>(nullValueGuaranteedDerefMap.keySet());
+        Map<ValueNumber, SortedSet<Location>> bugEdgeLocationMap = new HashMap<>();
 
         checkEdges(cfg, nullValueGuaranteedDerefMap, bugEdgeLocationMap);
 
@@ -267,14 +267,14 @@ public class NullDerefAndRedundantComparisonFinder {
     }
 
     public Map<ValueNumber, Set<Location>> findNullAssignments(Set<LocationWhereValueBecomesNull> locationWhereValueBecomesNullSet) {
-        Map<ValueNumber, Set<Location>> nullValueAssignmentMap = new HashMap<ValueNumber, Set<Location>>();
+        Map<ValueNumber, Set<Location>> nullValueAssignmentMap = new HashMap<>();
         for (LocationWhereValueBecomesNull lwvbn : locationWhereValueBecomesNullSet) {
             if (DEBUG_DEREFS) {
                 System.out.println("OOO " + lwvbn);
             }
             Set<Location> locationSet = nullValueAssignmentMap.get(lwvbn.getValueNumber());
             if (locationSet == null) {
-                locationSet = new HashSet<Location>(4);
+                locationSet = new HashSet<>(4);
                 nullValueAssignmentMap.put(lwvbn.getValueNumber(), locationSet);
             }
             locationSet.add(lwvbn.getLocation());
@@ -423,7 +423,7 @@ public class NullDerefAndRedundantComparisonFinder {
             allDominatedBy.clear(loc.getBasicBlock().getLabel());
             strictlyDominated.or(allDominatedBy);
         }
-        LinkedList<Location> locations2 = new LinkedList<Location>(locations);
+        LinkedList<Location> locations2 = new LinkedList<>(locations);
 
         for (Iterator<Location> i = locations.iterator(); i.hasNext();) {
             Location loc = i.next();
@@ -448,7 +448,7 @@ public class NullDerefAndRedundantComparisonFinder {
             allDominatedBy.clear(loc.getBasicBlock().getLabel());
             strictlyDominated.or(allDominatedBy);
         }
-        LinkedList<Location> locations2 = new LinkedList<Location>(locations);
+        LinkedList<Location> locations2 = new LinkedList<>(locations);
 
         for (Iterator<Location> i = locations.iterator(); i.hasNext();) {
             Location loc = i.next();
@@ -628,7 +628,7 @@ public class NullDerefAndRedundantComparisonFinder {
             SortedSet<Location> locationsForThisBug = bugLocations.get(valueNumber);
 
             if (locationsForThisBug == null) {
-                locationsForThisBug = new TreeSet<Location>();
+                locationsForThisBug = new TreeSet<>();
                 bugLocations.put(valueNumber, locationsForThisBug);
             }
             locationsForThisBug.add(thisLocation);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/NullValueUnconditionalDeref.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/NullValueUnconditionalDeref.java
@@ -25,7 +25,7 @@ public class NullValueUnconditionalDeref {
         this.alwaysMethodReturnValue = true;
         this.alwaysFieldValue = true;
         this.alwaysReadlineValue = true;
-        this.derefLocationSet = new HashSet<Location>();
+        this.derefLocationSet = new HashSet<>();
     }
 
     /**

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/UsagesRequiringNonNullValues.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/UsagesRequiringNonNullValues.java
@@ -53,7 +53,7 @@ public class UsagesRequiringNonNullValues {
         }
     }
 
-    MultiMap<Integer, Pair> map = new MultiMap<Integer, Pair>(LinkedList.class);
+    MultiMap<Integer, Pair> map = new MultiMap<>(LinkedList.class);
 
     @Override
     public String toString() {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/obl/InstructionActionCache.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/obl/InstructionActionCache.java
@@ -77,7 +77,7 @@ public class InstructionActionCache {
 
     public InstructionActionCache(ObligationPolicyDatabase database, XMethod xmethod, ConstantPoolGen cpg, TypeDataflow typeDataflow) {
         this.database = database;
-        this.actionCache = new HashMap<InstructionHandle, Collection<ObligationPolicyDatabaseAction>>();
+        this.actionCache = new HashMap<>();
         this.xmethod = xmethod;
         this.cpg = cpg;
         this.typeDataflow = typeDataflow;
@@ -107,7 +107,7 @@ public class InstructionActionCache {
                     ReferenceType receiverType = inv.getReferenceType(cpg);
 
                     boolean isStatic = inv.getOpcode() == Const.INVOKESTATIC;
-                    actionList = new LinkedList<ObligationPolicyDatabaseAction>();
+                    actionList = new LinkedList<>();
 
                     database.getActions(receiverType, methodName, signature, isStatic, actionList);
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/obl/ObligationAnalysis.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/obl/ObligationAnalysis.java
@@ -348,7 +348,7 @@ public class ObligationAnalysis extends ForwardDataflowAnalysis<StateSet> {
 
             if (!obligationSet.isEmpty()) {
                 // Add the state
-                HashMap<ObligationSet, State> map = new HashMap<ObligationSet, State>();
+                HashMap<ObligationSet, State> map = new HashMap<>();
                 map.put(obligationSet, state);
                 cachedEntryFact.replaceMap(map);
             }
@@ -420,7 +420,7 @@ public class ObligationAnalysis extends ForwardDataflowAnalysis<StateSet> {
             // we're building.
             final Map<ObligationSet, State> updatedStateMap = result.createEmptyMap();
             // Build a Set of all ObligationSets.
-            Set<ObligationSet> allObligationSets = new HashSet<ObligationSet>();
+            Set<ObligationSet> allObligationSets = new HashSet<>();
             allObligationSets.addAll(inputFact.getAllObligationSets());
             allObligationSets.addAll(result.getAllObligationSets());
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/obl/ObligationFactory.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/obl/ObligationFactory.java
@@ -45,14 +45,14 @@ import edu.umd.cs.findbugs.internalAnnotations.DottedClassName;
 public class ObligationFactory {
     private final Map<String, Obligation> classNameToObligationMap;
 
-    private final Set<String> slashedClassNames = new HashSet<String>();
+    private final Set<String> slashedClassNames = new HashSet<>();
 
     // // XXX: this is just for debugging.
     // static ObligationFactory lastInstance;
 
     @SuppressFBWarnings("ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD")
     public ObligationFactory() {
-        this.classNameToObligationMap = new HashMap<String, Obligation>();
+        this.classNameToObligationMap = new HashMap<>();
         // lastInstance = this;
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/obl/ObligationPolicyDatabase.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/obl/ObligationPolicyDatabase.java
@@ -48,13 +48,13 @@ public class ObligationPolicyDatabase {
 
     private final LinkedList<ObligationPolicyDatabaseEntry> entryList;
 
-    private final HashSet<Obligation> allObligations = new HashSet<Obligation>();
+    private final HashSet<Obligation> allObligations = new HashSet<>();
 
     private boolean strictChecking;
 
     public ObligationPolicyDatabase() {
         this.factory = new ObligationFactory();
-        this.entryList = new LinkedList<ObligationPolicyDatabaseEntry>();
+        this.entryList = new LinkedList<>();
 
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/obl/StateSet.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/obl/StateSet.java
@@ -62,7 +62,7 @@ public class StateSet {
 
     public StateSet(ObligationFactory factory) {
         this.isTop = this.isBottom = false;
-        this.stateMap = new HashMap<ObligationSet, State>();
+        this.stateMap = new HashMap<>();
         this.factory = factory;
     }
 
@@ -187,7 +187,7 @@ public class StateSet {
      *            obligation
      */
     public void addObligation(final Obligation obligation, int basicBlockId) throws ObligationAcquiredOrReleasedInLoopException {
-        Map<ObligationSet, State> updatedStateMap = new HashMap<ObligationSet, State>();
+        Map<ObligationSet, State> updatedStateMap = new HashMap<>();
         if (stateMap.isEmpty()) {
             State s = new State(factory);
             s.getObligationSet().add(obligation);
@@ -215,7 +215,7 @@ public class StateSet {
      */
     public void deleteObligation(final Obligation obligation, int basicBlockId)
             throws ObligationAcquiredOrReleasedInLoopException {
-        Map<ObligationSet, State> updatedStateMap = new HashMap<ObligationSet, State>();
+        Map<ObligationSet, State> updatedStateMap = new HashMap<>();
         for (Iterator<State> i = stateIterator(); i.hasNext();) {
             State state = i.next();
             checkCircularity(state, obligation, basicBlockId);
@@ -265,7 +265,7 @@ public class StateSet {
      *         given Path
      */
     public List<State> getPrefixStates(Path path) {
-        List<State> result = new LinkedList<State>();
+        List<State> result = new LinkedList<>();
         for (State state : stateMap.values()) {
             if (state.getPath().isPrefixOf(path)) {
                 result.add(state);
@@ -311,7 +311,7 @@ public class StateSet {
      * to applyToAllStatesAndUpdateMap().
      */
     public Map<ObligationSet, State> createEmptyMap() {
-        return new HashMap<ObligationSet, State>();
+        return new HashMap<>();
     }
 }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/type/ExceptionSetFactory.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/type/ExceptionSetFactory.java
@@ -31,8 +31,8 @@ public class ExceptionSetFactory {
     private final ArrayList<ObjectType> typeList;
 
     public ExceptionSetFactory() {
-        this.typeIndexMap = new HashMap<ObjectType, Integer>();
-        this.typeList = new ArrayList<ObjectType>();
+        this.typeIndexMap = new HashMap<>();
+        this.typeList = new ArrayList<>();
     }
 
     public ExceptionSet createExceptionSet() {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/type/FieldStoreType.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/type/FieldStoreType.java
@@ -43,7 +43,7 @@ public class FieldStoreType {
     private ReferenceType loadType;
 
     public FieldStoreType() {
-        this.typeSignatureSet = new HashSet<String>();
+        this.typeSignatureSet = new HashSet<>();
     }
 
     // TODO: type may be exact

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/type/FieldStoreTypeDatabase.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/type/FieldStoreTypeDatabase.java
@@ -39,7 +39,7 @@ public class FieldStoreTypeDatabase extends FieldPropertyDatabase<FieldStoreType
     public static final String DEFAULT_FILENAME = "fieldStoreTypes.db";
 
     public void purgeBoringEntries() {
-        Collection<FieldDescriptor> keys = new ArrayList<FieldDescriptor>(getKeys());
+        Collection<FieldDescriptor> keys = new ArrayList<>(getKeys());
         for (FieldDescriptor f : keys) {
             FieldStoreType type = getProperty(f);
             Type fieldType = Type.getType(f.getSignature());

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/type/StandardTypeMerger.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/type/StandardTypeMerger.java
@@ -203,7 +203,7 @@ public class StandardTypeMerger implements TypeMerger, Constants, ExtendedTypes 
                         if (aP.size() != bP.size()) {
                             break;
                         }
-                        ArrayList<ReferenceType> result = new ArrayList<ReferenceType>(aP.size());
+                        ArrayList<ReferenceType> result = new ArrayList<>(aP.size());
                         for (int i = 0; i < aP.size(); i++) {
                             result.add(mergeReferenceTypes(aP.get(i), bP.get(i)));
                         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/type/TypeAnalysis.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/type/TypeAnalysis.java
@@ -108,7 +108,7 @@ public class TypeAnalysis extends FrameDataflowAnalysis<Type, TypeFrame> impleme
         public CachedExceptionSet(TypeFrame result, ExceptionSet exceptionSet) {
             this.result = result;
             this.exceptionSet = exceptionSet;
-            this.edgeExceptionMap = new HashMap<Edge, ExceptionSet>();
+            this.edgeExceptionMap = new HashMap<>();
         }
 
         public boolean isUpToDate(TypeFrame result) {
@@ -220,10 +220,10 @@ public class TypeAnalysis extends FrameDataflowAnalysis<Type, TypeFrame> impleme
         this.cfg = cfg;
         this.typeMerger = typeMerger;
         this.visitor = visitor;
-        this.thrownExceptionSetMap = new HashMap<BasicBlock, CachedExceptionSet>();
+        this.thrownExceptionSetMap = new HashMap<>();
         this.lookupFailureCallback = lookupFailureCallback;
         this.exceptionSetFactory = exceptionSetFactory;
-        this.instanceOfCheckMap = new HashMap<BasicBlock, InstanceOfCheck>();
+        this.instanceOfCheckMap = new HashMap<>();
         if (DEBUG) {
             System.out.println("\n\nAnalyzing " + methodGen);
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/vna/LoadedFieldSet.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/vna/LoadedFieldSet.java
@@ -71,8 +71,8 @@ public class LoadedFieldSet {
      */
     public LoadedFieldSet(MethodGen methodGen) {
         // this.methodGen = methodGen;
-        this.loadStoreCountMap = new HashMap<XField, LoadStoreCount>();
-        this.handleToFieldMap = new HashMap<InstructionHandle, XField>();
+        this.loadStoreCountMap = new HashMap<>();
+        this.handleToFieldMap = new HashMap<>();
         this.loadHandleSet = new BitSet();
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/vna/MergeTree.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/vna/MergeTree.java
@@ -48,7 +48,7 @@ public class MergeTree {
      */
     public MergeTree(ValueNumberFactory factory) {
         this.factory = factory;
-        this.outputToInputMap = new HashMap<ValueNumber, BitSet>();
+        this.outputToInputMap = new HashMap<>();
     }
 
     /**
@@ -104,7 +104,7 @@ public class MergeTree {
             System.out.println("Output: " + output.getNumber());
         }
 
-        LinkedList<ValueNumber> workList = new LinkedList<ValueNumber>();
+        LinkedList<ValueNumber> workList = new LinkedList<>();
         workList.addLast(output);
         while (!workList.isEmpty()) {
             ValueNumber valueNumber = workList.removeFirst();
@@ -137,7 +137,7 @@ public class MergeTree {
         BitSet visited = new BitSet();
         BitSet result = new BitSet();
 
-        LinkedList<Integer> workList = new LinkedList<Integer>();
+        LinkedList<Integer> workList = new LinkedList<>();
         workList.addLast(input);
         while (!workList.isEmpty()) {
             Integer valueNumber = workList.removeFirst();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/vna/ValueNumber.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/vna/ValueNumber.java
@@ -37,7 +37,7 @@ import edu.umd.cs.findbugs.util.Util;
  * @see ValueNumberAnalysis
  */
 public class ValueNumber implements Comparable<ValueNumber> {
-    static MapCache<ValueNumber, ValueNumber> cache = new MapCache<ValueNumber, ValueNumber>(200);
+    static MapCache<ValueNumber, ValueNumber> cache = new MapCache<>(200);
 
     static int valueNumbersCreated = 0;
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/vna/ValueNumberAnalysis.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/vna/ValueNumberAnalysis.java
@@ -94,7 +94,7 @@ public class ValueNumberAnalysis extends FrameDataflowAnalysis<ValueNumber, Valu
             this.entryLocalValueList[i] = factory.createFreshValue();
         }
 
-        this.exceptionHandlerValueNumberMap = new IdentityHashMap<BasicBlock, ValueNumber>();
+        this.exceptionHandlerValueNumberMap = new IdentityHashMap<>();
 
         // For non-static methods, keep track of which value represents the
         // "this" reference
@@ -102,8 +102,8 @@ public class ValueNumberAnalysis extends FrameDataflowAnalysis<ValueNumber, Valu
             this.thisValue = entryLocalValueList[0];
         }
 
-        this.factAtLocationMap = new HashMap<Location, ValueNumberFrame>();
-        this.factAfterLocationMap = new HashMap<Location, ValueNumberFrame>();
+        this.factAtLocationMap = new HashMap<>();
+        this.factAfterLocationMap = new HashMap<>();
         if (DEBUG) {
             System.out.println("VNA Analysis " + methodGen.getClassName() + "." + methodGen.getName() + " : "
                     + methodGen.getSignature());

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/vna/ValueNumberCache.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/vna/ValueNumberCache.java
@@ -107,7 +107,7 @@ public class ValueNumberCache {
     /**
      * Map of entries to output values.
      */
-    private final HashMap<Entry, ValueNumber[]> entryToOutputMap = new HashMap<Entry, ValueNumber[]>();
+    private final HashMap<Entry, ValueNumber[]> entryToOutputMap = new HashMap<>();
 
     /**
      * Look up cached output values for given entry.

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/vna/ValueNumberDataflow.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/vna/ValueNumberDataflow.java
@@ -59,7 +59,7 @@ public class ValueNumberDataflow extends AbstractDataflow<ValueNumberFrame, Valu
      * @return the value number to parameter index map
      */
     public Map<ValueNumber, Integer> getValueNumberToParamMap(String methodSignature, boolean isStatic) {
-        HashMap<ValueNumber, Integer> valueNumberToParamMap = new HashMap<ValueNumber, Integer>();
+        HashMap<ValueNumber, Integer> valueNumberToParamMap = new HashMap<>();
 
         ValueNumberFrame frameAtEntry = getStartFact(getCFG().getEntry());
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/vna/ValueNumberFactory.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/vna/ValueNumberFactory.java
@@ -39,9 +39,9 @@ public class ValueNumberFactory {
     /**
      * Store all allocated value numbers.
      */
-    private ArrayList<ValueNumber> allocatedValueList = new ArrayList<ValueNumber>();
+    private ArrayList<ValueNumber> allocatedValueList = new ArrayList<>();
 
-    private final HashMap<String, ValueNumber> classObjectValueMap = new HashMap<String, ValueNumber>();
+    private final HashMap<String, ValueNumber> classObjectValueMap = new HashMap<>();
 
     /**
      * Create a fresh (unique) value number.
@@ -89,7 +89,7 @@ public class ValueNumberFactory {
             throw new UnsupportedOperationException();
         }
         ArrayList<ValueNumber> oldList = this.allocatedValueList;
-        ArrayList<ValueNumber> newList = new ArrayList<ValueNumber>(Collections.<ValueNumber> nCopies(numValuesAllocated, null));
+        ArrayList<ValueNumber> newList = new ArrayList<>(Collections.<ValueNumber> nCopies(numValuesAllocated, null));
 
         for (ValueNumber value : oldList) {
             int newNumber = map[value.getNumber()];

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/vna/ValueNumberFrame.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/vna/ValueNumberFrame.java
@@ -180,7 +180,7 @@ public class ValueNumberFrame extends Frame<ValueNumber> implements ValueNumberA
         if (!REDUNDANT_LOAD_ELIMINATION) {
             return;
         }
-        HashSet<AvailableLoad> killMe = new HashSet<AvailableLoad>();
+        HashSet<AvailableLoad> killMe = new HashSet<>();
         for (AvailableLoad availableLoad : getAvailableLoadMap().keySet()) {
             if (availableLoad.getField().equals(field)) {
                 if (RLE_DEBUG) {
@@ -205,7 +205,7 @@ public class ValueNumberFrame extends Frame<ValueNumber> implements ValueNumberA
             return;
         }
         FieldSummary fieldSummary = AnalysisContext.currentAnalysisContext().getFieldSummary();
-        HashSet<AvailableLoad> killMe = new HashSet<AvailableLoad>();
+        HashSet<AvailableLoad> killMe = new HashSet<>();
         for (AvailableLoad availableLoad : getAvailableLoadMap().keySet()) {
             XField field = availableLoad.getField();
             if ((!primitiveOnly || !field.isReferenceType()) && (field.isVolatile() || !field.isFinal()
@@ -225,7 +225,7 @@ public class ValueNumberFrame extends Frame<ValueNumber> implements ValueNumberA
             return;
         }
         AvailableLoad myLoad = getLoad(v);
-        HashSet<AvailableLoad> killMe = new HashSet<AvailableLoad>();
+        HashSet<AvailableLoad> killMe = new HashSet<>();
         for (AvailableLoad availableLoad : getAvailableLoadMap().keySet()) {
             if (!availableLoad.getField().isFinal() && !availableLoad.equals(myLoad)) {
                 if (RLE_DEBUG) {
@@ -247,7 +247,7 @@ public class ValueNumberFrame extends Frame<ValueNumber> implements ValueNumberA
         }
         FieldSummary fieldSummary = AnalysisContext.currentAnalysisContext().getFieldSummary();
 
-        HashSet<AvailableLoad> killMe = new HashSet<AvailableLoad>();
+        HashSet<AvailableLoad> killMe = new HashSet<>();
         for (AvailableLoad availableLoad : getAvailableLoadMap().keySet()) {
             if (availableLoad.getReference() != v) {
                 continue;
@@ -267,7 +267,7 @@ public class ValueNumberFrame extends Frame<ValueNumber> implements ValueNumberA
         if (!REDUNDANT_LOAD_ELIMINATION) {
             return;
         }
-        HashSet<AvailableLoad> killMe = new HashSet<AvailableLoad>();
+        HashSet<AvailableLoad> killMe = new HashSet<>();
         for (AvailableLoad availableLoad : getAvailableLoadMap().keySet()) {
 
             if (fieldsToKill.contains(availableLoad.getField())) {
@@ -284,7 +284,7 @@ public class ValueNumberFrame extends Frame<ValueNumber> implements ValueNumberA
         }
         String packageName = extractPackageName(className);
 
-        HashSet<AvailableLoad> killMe = new HashSet<AvailableLoad>();
+        HashSet<AvailableLoad> killMe = new HashSet<>();
         for (AvailableLoad availableLoad : getAvailableLoadMap().keySet()) {
 
             XField field = availableLoad.getField();
@@ -420,7 +420,7 @@ public class ValueNumberFrame extends Frame<ValueNumber> implements ValueNumberA
         if (mergedValueList == null && other.isValid()) {
             // This is where this frame gets its size.
             // It will have the same size as long as it remains valid.
-            mergedValueList = new ArrayList<ValueNumber>(other.getNumSlots());
+            mergedValueList = new ArrayList<>(other.getNumSlots());
             int numSlots = other.getNumSlots();
             for (int i = 0; i < numSlots; ++i) {
                 mergedValueList.add(null);
@@ -583,7 +583,7 @@ public class ValueNumberFrame extends Frame<ValueNumber> implements ValueNumberA
     }
 
     public Collection<ValueNumber> valueNumbersForLoads() {
-        HashSet<ValueNumber> result = new HashSet<ValueNumber>();
+        HashSet<ValueNumber> result = new HashSet<>();
         if (REDUNDANT_LOAD_ELIMINATION) {
             for (Map.Entry<AvailableLoad, ValueNumber[]> e : getAvailableLoadMap().entrySet()) {
                 if (e.getValue() != null) {
@@ -607,7 +607,7 @@ public class ValueNumberFrame extends Frame<ValueNumber> implements ValueNumberA
 
     private Map<AvailableLoad, ValueNumber[]> getUpdateableAvailableLoadMap() {
         if (!(availableLoadMap instanceof HashMap)) {
-            HashMap<AvailableLoad, ValueNumber[]> tmp = new HashMap<AvailableLoad, ValueNumber[]>(availableLoadMap.size() + 4);
+            HashMap<AvailableLoad, ValueNumber[]> tmp = new HashMap<>(availableLoadMap.size() + 4);
             tmp.putAll(availableLoadMap);
             availableLoadMap = tmp;
         }
@@ -624,7 +624,7 @@ public class ValueNumberFrame extends Frame<ValueNumber> implements ValueNumberA
 
     private Map<AvailableLoad, ValueNumber> getUpdateableMergedLoads() {
         if (!(mergedLoads instanceof HashMap)) {
-            mergedLoads = new HashMap<AvailableLoad, ValueNumber>();
+            mergedLoads = new HashMap<>();
         }
 
         return mergedLoads;
@@ -640,10 +640,10 @@ public class ValueNumberFrame extends Frame<ValueNumber> implements ValueNumberA
 
     private Map<ValueNumber, AvailableLoad> getUpdateablePreviouslyKnownAs() {
         if (previouslyKnownAs.size() == 0) {
-            previouslyKnownAs = new HashMap<ValueNumber, AvailableLoad>(4);
+            previouslyKnownAs = new HashMap<>(4);
             createdEmptyMap++;
         } else if (!(previouslyKnownAs instanceof HashMap)) {
-            HashMap<ValueNumber, AvailableLoad> tmp = new HashMap<ValueNumber, AvailableLoad>(previouslyKnownAs.size() + 4);
+            HashMap<ValueNumber, AvailableLoad> tmp = new HashMap<>(previouslyKnownAs.size() + 4);
             tmp.putAll(previouslyKnownAs);
             previouslyKnownAs = tmp;
             madeImmutableMutable++;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/vna/ValueNumberFrameModelingVisitor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/vna/ValueNumberFrameModelingVisitor.java
@@ -123,8 +123,8 @@ Debug, ValueNumberAnalysisFeatures {
         this.factory = factory;
         this.cache = cache;
         this.loadedFieldSet = loadedFieldSet;
-        this.constantValueMap = new HashMap<Object, ValueNumber>();
-        this.stringConstantMap = new HashMap<ValueNumber, String>();
+        this.constantValueMap = new HashMap<>();
+        this.stringConstantMap = new HashMap<>();
     }
 
     @Override

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/bugReporter/SuppressionDecorator.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/bugReporter/SuppressionDecorator.java
@@ -44,9 +44,9 @@ public class SuppressionDecorator extends BugReporterDecorator {
 
     final String category;
 
-    final HashSet<String> check = new HashSet<String>();
+    final HashSet<String> check = new HashSet<>();
 
-    final HashSet<String> dontCheck = new HashSet<String>();
+    final HashSet<String> dontCheck = new HashSet<>();
 
     public SuppressionDecorator(ComponentPlugin<BugReporterDecorator> plugin, BugReporter delegate) {
         super(plugin, delegate);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/DescriptorFactory.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/DescriptorFactory.java
@@ -61,10 +61,10 @@ public class DescriptorFactory {
     private final Map<FieldDescriptor, FieldDescriptor> fieldDescriptorMap;
 
     private DescriptorFactory() {
-        this.classDescriptorMap = new HashMap<String, ClassDescriptor>();
-        this.dottedClassDescriptorMap = new HashMap<String, ClassDescriptor>();
-        this.methodDescriptorMap = new HashMap<MethodDescriptor, MethodDescriptor>();
-        this.fieldDescriptorMap = new HashMap<FieldDescriptor, FieldDescriptor>();
+        this.classDescriptorMap = new HashMap<>();
+        this.dottedClassDescriptorMap = new HashMap<>();
+        this.methodDescriptorMap = new HashMap<>();
+        this.fieldDescriptorMap = new HashMap<>();
     }
 
     /**

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/Global.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/Global.java
@@ -26,7 +26,7 @@ package edu.umd.cs.findbugs.classfile;
  * @author David Hovemeyer
  */
 public abstract class Global {
-    private static final InheritableThreadLocal<IAnalysisCache> analysisCacheThreadLocal = new InheritableThreadLocal<IAnalysisCache>();
+    private static final InheritableThreadLocal<IAnalysisCache> analysisCacheThreadLocal = new InheritableThreadLocal<>();
 
     /**
      * Remove the analysis cache for the current thread. This should be called

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/analysis/AnnotationValue.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/analysis/AnnotationValue.java
@@ -38,9 +38,9 @@ import edu.umd.cs.findbugs.classfile.engine.asm.FindBugsASM;
 public class AnnotationValue {
     private final ClassDescriptor annotationClass;
 
-    private final Map<String, Object> valueMap = new HashMap<String, Object>(4);
+    private final Map<String, Object> valueMap = new HashMap<>(4);
 
-    private final Map<String, Object> typeMap = new HashMap<String, Object>(4);
+    private final Map<String, Object> typeMap = new HashMap<>(4);
 
     /**
      * Constructor.
@@ -184,7 +184,7 @@ public class AnnotationValue {
         /**
          *
          */
-        private final List<Object> result = new LinkedList<Object>();
+        private final List<Object> result = new LinkedList<>();
 
         /**
          * @param name

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/analysis/ClassInfo.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/analysis/ClassInfo.java
@@ -82,18 +82,18 @@ public class ClassInfo extends ClassNameAndSuperclassInfo implements XClass {
     private boolean containingScopeCached;
 
     public static class Builder extends ClassNameAndSuperclassInfo.Builder {
-        private List<FieldInfo> fieldInfoList = new LinkedList<FieldInfo>();
+        private List<FieldInfo> fieldInfoList = new LinkedList<>();
 
-        private List<MethodInfo> methodInfoList = new LinkedList<MethodInfo>();
+        private List<MethodInfo> methodInfoList = new LinkedList<>();
 
         /**
          * Mapping from one method signature to its bridge method signature
          */
-        private final Map<MethodInfo, String> bridgedSignatures = new IdentityHashMap<MethodInfo, String>();
+        private final Map<MethodInfo, String> bridgedSignatures = new IdentityHashMap<>();
 
         private ClassDescriptor immediateEnclosingClass;
 
-        final Map<ClassDescriptor, AnnotationValue> classAnnotations = new HashMap<ClassDescriptor, AnnotationValue>(3);
+        final Map<ClassDescriptor, AnnotationValue> classAnnotations = new HashMap<>(3);
 
         private String classSourceSignature;
 
@@ -237,7 +237,7 @@ public class ClassInfo extends ClassNameAndSuperclassInfo implements XClass {
     }
 
     private MethodInfo[] computeMethodsInCallOrder() {
-        final Map<String, MethodInfo> map = new HashMap<String, MethodInfo>();
+        final Map<String, MethodInfo> map = new HashMap<>();
 
         for (MethodInfo m : xMethods) {
             map.put(m.getName() + m.getSignature() + m.isStatic(), m);
@@ -438,7 +438,7 @@ public class ClassInfo extends ClassNameAndSuperclassInfo implements XClass {
      *            an AnnotationValue to add to the class
      */
     public void addAnnotation(AnnotationValue annotationValue) {
-        HashMap<ClassDescriptor, AnnotationValue> updatedMap = new HashMap<ClassDescriptor, AnnotationValue>(classAnnotations);
+        HashMap<ClassDescriptor, AnnotationValue> updatedMap = new HashMap<>(classAnnotations);
         updatedMap.put(annotationValue.getAnnotationClass(), annotationValue);
         classAnnotations = Util.immutableMap(updatedMap);
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/analysis/ClassNameAndSuperclassInfo.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/analysis/ClassNameAndSuperclassInfo.java
@@ -126,7 +126,7 @@ public class ClassNameAndSuperclassInfo extends ClassDescriptor {
             if (referencedClassDescriptorList.size() == 0) {
                 this.referencedClassDescriptorList = Collections.emptyList();
             } else {
-                this.referencedClassDescriptorList = new ArrayList<ClassDescriptor>(referencedClassDescriptorList);
+                this.referencedClassDescriptorList = new ArrayList<>(referencedClassDescriptorList);
             }
         }
 
@@ -134,7 +134,7 @@ public class ClassNameAndSuperclassInfo extends ClassDescriptor {
             if (calledClassDescriptorList.size() == 0) {
                 this.calledClassDescriptors = Collections.emptySet();
             } else {
-                this.calledClassDescriptors = new HashSet<ClassDescriptor>(calledClassDescriptorList);
+                this.calledClassDescriptors = new HashSet<>(calledClassDescriptorList);
             }
         }
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/analysis/FieldInfo.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/analysis/FieldInfo.java
@@ -60,7 +60,7 @@ public class FieldInfo extends FieldDescriptor implements XField {
 
         String fieldSourceSignature;
 
-        final Map<ClassDescriptor, AnnotationValue> fieldAnnotations = new HashMap<ClassDescriptor, AnnotationValue>(3);
+        final Map<ClassDescriptor, AnnotationValue> fieldAnnotations = new HashMap<>(3);
 
         public Builder(@SlashedClassName String className, String fieldName, String fieldSignature, int accessFlags) {
             this.className = className;
@@ -274,7 +274,7 @@ public class FieldInfo extends FieldDescriptor implements XField {
      *            an AnnotationValue representing a field annotation
      */
     public void addAnnotation(AnnotationValue annotationValue) {
-        HashMap<ClassDescriptor, AnnotationValue> updatedAnnotations = new HashMap<ClassDescriptor, AnnotationValue>(
+        HashMap<ClassDescriptor, AnnotationValue> updatedAnnotations = new HashMap<>(
                 fieldAnnotations);
         updatedAnnotations.put(annotationValue.getAnnotationClass(), annotationValue);
         fieldAnnotations = updatedAnnotations;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/analysis/MethodInfo.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/analysis/MethodInfo.java
@@ -98,9 +98,9 @@ public class MethodInfo extends MethodDescriptor implements XMethod {
         MethodDescriptor accessMethodForMethod;
         FieldDescriptor accessMethodForField;
 
-        final Map<ClassDescriptor, AnnotationValue> methodAnnotations = new HashMap<ClassDescriptor, AnnotationValue>(4);
+        final Map<ClassDescriptor, AnnotationValue> methodAnnotations = new HashMap<>(4);
 
-        final Map<Integer, Map<ClassDescriptor, AnnotationValue>> methodParameterAnnotations = new HashMap<Integer, Map<ClassDescriptor, AnnotationValue>>(
+        final Map<Integer, Map<ClassDescriptor, AnnotationValue>> methodParameterAnnotations = new HashMap<>(
                 4);
 
         @Override
@@ -179,7 +179,7 @@ public class MethodInfo extends MethodDescriptor implements XMethod {
             ClassDescriptor annotationClass = DescriptorFactory.createClassDescriptorFromSignature(name);
             Map<ClassDescriptor, AnnotationValue> map = methodParameterAnnotations.get(parameter);
             if (map == null) {
-                map = new HashMap<ClassDescriptor, AnnotationValue>();
+                map = new HashMap<>();
                 methodParameterAnnotations.put(parameter, map);
             }
             map.put(annotationClass, value);
@@ -243,12 +243,12 @@ public class MethodInfo extends MethodDescriptor implements XMethod {
     Map<Integer, Map<ClassDescriptor, AnnotationValue>> methodParameterAnnotations;
 
     public static class MethodInfoDatabase {
-        final IdentityHashMap<MethodInfo, Void> unconditionalThrowers = new IdentityHashMap<MethodInfo, Void>();
-        final IdentityHashMap<MethodInfo, Void> unsupportedMethods = new IdentityHashMap<MethodInfo, Void>();
-        final IdentityHashMap<MethodInfo, MethodDescriptor> accessMethodForMethod = new IdentityHashMap<MethodInfo, MethodDescriptor>();
-        final IdentityHashMap<MethodInfo, FieldDescriptor> accessMethodForField = new IdentityHashMap<MethodInfo, FieldDescriptor>();
-        final IdentityHashMap<MethodInfo, Void> identityMethods = new IdentityHashMap<MethodInfo, Void>();
-        final IdentityHashMap<MethodInfo, Void> invokeDynamicMethods = new IdentityHashMap<MethodInfo, Void>();
+        final IdentityHashMap<MethodInfo, Void> unconditionalThrowers = new IdentityHashMap<>();
+        final IdentityHashMap<MethodInfo, Void> unsupportedMethods = new IdentityHashMap<>();
+        final IdentityHashMap<MethodInfo, MethodDescriptor> accessMethodForMethod = new IdentityHashMap<>();
+        final IdentityHashMap<MethodInfo, FieldDescriptor> accessMethodForField = new IdentityHashMap<>();
+        final IdentityHashMap<MethodInfo, Void> identityMethods = new IdentityHashMap<>();
+        final IdentityHashMap<MethodInfo, Void> invokeDynamicMethods = new IdentityHashMap<>();
 
     }
 
@@ -574,7 +574,7 @@ public class MethodInfo extends MethodDescriptor implements XMethod {
      */
     @Override
     public void addAnnotation(AnnotationValue annotationValue) {
-        HashMap<ClassDescriptor, AnnotationValue> updatedAnnotations = new HashMap<ClassDescriptor, AnnotationValue>(
+        HashMap<ClassDescriptor, AnnotationValue> updatedAnnotations = new HashMap<>(
                 methodAnnotations);
         updatedAnnotations.put(annotationValue.getAnnotationClass(), annotationValue);
         methodAnnotations = updatedAnnotations;
@@ -591,11 +591,11 @@ public class MethodInfo extends MethodDescriptor implements XMethod {
      */
     @Override
     public void addParameterAnnotation(int param, AnnotationValue annotationValue) {
-        HashMap<Integer, Map<ClassDescriptor, AnnotationValue>> updatedAnnotations = new HashMap<Integer, Map<ClassDescriptor, AnnotationValue>>(
+        HashMap<Integer, Map<ClassDescriptor, AnnotationValue>> updatedAnnotations = new HashMap<>(
                 methodParameterAnnotations);
         Map<ClassDescriptor, AnnotationValue> paramMap = updatedAnnotations.get(param);
         if (paramMap == null) {
-            paramMap = new HashMap<ClassDescriptor, AnnotationValue>();
+            paramMap = new HashMap<>();
             updatedAnnotations.put(param, paramMap);
         }
         paramMap.put(annotationValue.getAnnotationClass(), annotationValue);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/ClassParser.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/ClassParser.java
@@ -157,7 +157,7 @@ public class ClassParser implements ClassParserInterface {
      * @throws InvalidClassFileFormatException
      */
     private Collection<ClassDescriptor> extractReferencedClasses() throws InvalidClassFileFormatException {
-        Set<ClassDescriptor> referencedClassSet = new HashSet<ClassDescriptor>();
+        Set<ClassDescriptor> referencedClassSet = new HashSet<>();
         for (Constant constant : constantPool) {
             if (constant == null) {
                 continue;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/ClassParserUsingASM.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/ClassParserUsingASM.java
@@ -154,7 +154,7 @@ public class ClassParserUsingASM implements ClassParserInterface {
 
         boolean accessIsStatic;
 
-        HashSet<Label> labelsSeen = new HashSet<Label>();
+        HashSet<Label> labelsSeen = new HashSet<>();
 
         /**
          * @param calledClassSet
@@ -514,7 +514,7 @@ public class ClassParserUsingASM implements ClassParserInterface {
 
         cBuilder.setCodeBaseEntry(codeBaseEntry);
 
-        final TreeSet<ClassDescriptor> calledClassSet = new TreeSet<ClassDescriptor>();
+        final TreeSet<ClassDescriptor> calledClassSet = new TreeSet<>();
 
         classReader.accept(new ClassVisitor(FindBugsASM.ASM_VERSION) {
 
@@ -634,7 +634,7 @@ public class ClassParserUsingASM implements ClassParserInterface {
 
             }
         }, ClassReader.SKIP_FRAMES);
-        HashSet<ClassDescriptor> referencedClassSet = new HashSet<ClassDescriptor>();
+        HashSet<ClassDescriptor> referencedClassSet = new HashSet<>();
 
         // collect class references
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/ClassParserUsingBCEL.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/ClassParserUsingBCEL.java
@@ -109,9 +109,9 @@ public class ClassParserUsingBCEL implements ClassParserInterface {
     public void parse(ClassInfo.Builder builder) throws InvalidClassFileFormatException {
         parse((ClassNameAndSuperclassInfo.Builder) builder);
 
-        final List<FieldDescriptor> fieldDescriptorList = new LinkedList<FieldDescriptor>();
-        final List<MethodDescriptor> methodDescriptorList = new LinkedList<MethodDescriptor>();
-        final TreeSet<ClassDescriptor> referencedClassSet = new TreeSet<ClassDescriptor>();
+        final List<FieldDescriptor> fieldDescriptorList = new LinkedList<>();
+        final List<MethodDescriptor> methodDescriptorList = new LinkedList<>();
+        final TreeSet<ClassDescriptor> referencedClassSet = new TreeSet<>();
         javaClass.accept(new AnnotationVisitor() {
             @Override
             public void visit(Method obj) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/SelfMethodCalls.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/SelfMethodCalls.java
@@ -45,7 +45,7 @@ public class SelfMethodCalls {
     }
 
     public static <T> MultiMap<T, T> getSelfCalls(final ClassDescriptor classDescriptor, final Map<String, T> methods) {
-        final MultiMap<T, T> map = new MultiMap<T, T>(HashSet.class);
+        final MultiMap<T, T> map = new MultiMap<>(HashSet.class);
 
         FBClassReader reader;
         try {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/bcel/CFGFactory.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/bcel/CFGFactory.java
@@ -120,7 +120,7 @@ public class CFGFactory extends AnalysisFactory<CFG> {
         boolean changed = false;
         boolean ASSUME_ASSERTIONS_ENABLED = true;
         if (ASSUME_ASSERTIONS_ENABLED) {
-            LinkedList<Edge> edgesToRemove = new LinkedList<Edge>();
+            LinkedList<Edge> edgesToRemove = new LinkedList<>();
             for (Iterator<Edge> i = cfg.edgeIterator(); i.hasNext();) {
                 Edge e = i.next();
                 if (e.getType() == EdgeTypes.IFCMP_EDGE) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/bcel/DominatorsAnalysisFactory.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/bcel/DominatorsAnalysisFactory.java
@@ -33,7 +33,7 @@ public class DominatorsAnalysisFactory extends AnalysisFactory<DominatorsAnalysi
         CFG cfg = getCFG(analysisCache, descriptor);
         DepthFirstSearch dfs = getDepthFirstSearch(analysisCache, descriptor);
         DominatorsAnalysis analysis = new DominatorsAnalysis(cfg, dfs, true);
-        Dataflow<java.util.BitSet, DominatorsAnalysis> dataflow = new Dataflow<java.util.BitSet, DominatorsAnalysis>(cfg,
+        Dataflow<java.util.BitSet, DominatorsAnalysis> dataflow = new Dataflow<>(cfg,
                 analysis);
         dataflow.execute();
         return analysis;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/bcel/EngineRegistrar.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/bcel/EngineRegistrar.java
@@ -74,18 +74,18 @@ public class EngineRegistrar implements IAnalysisEngineRegistrar {
 
     private static final IDatabaseFactory<?>[] databaseFactoryList = {
         // new ReflectionDatabaseFactory<Subtypes>(Subtypes.class),
-        new ReflectionDatabaseFactory<Subtypes2>(Subtypes2.class),
-        new ReflectionDatabaseFactory<InnerClassAccessMap>(InnerClassAccessMap.class),
-        new ReflectionDatabaseFactory<CheckReturnAnnotationDatabase>(CheckReturnAnnotationDatabase.class),
-        new ReflectionDatabaseFactory<AnnotationRetentionDatabase>(AnnotationRetentionDatabase.class),
-        new ReflectionDatabaseFactory<JCIPAnnotationDatabase>(JCIPAnnotationDatabase.class),
-        new ReflectionDatabaseFactory<SourceInfoMap>(SourceInfoMap.class),
-        new ReflectionDatabaseFactory<FieldStoreTypeDatabase>(FieldStoreTypeDatabase.class),
-        new ReflectionDatabaseFactory<ParameterNullnessPropertyDatabase>(ParameterNullnessPropertyDatabase.class),
-        new ReflectionDatabaseFactory<ReturnValueNullnessPropertyDatabase>(ReturnValueNullnessPropertyDatabase.class),
-        new ReflectionDatabaseFactory<DirectlyRelevantTypeQualifiersDatabase>(DirectlyRelevantTypeQualifiersDatabase.class),
-        new ReflectionDatabaseFactory<TypeQualifierDatabase>(TypeQualifierDatabase.class),
-        new ReflectionDatabaseFactory<MethodInfoDatabase>(MethodInfoDatabase.class),
+        new ReflectionDatabaseFactory<>(Subtypes2.class),
+        new ReflectionDatabaseFactory<>(InnerClassAccessMap.class),
+        new ReflectionDatabaseFactory<>(CheckReturnAnnotationDatabase.class),
+        new ReflectionDatabaseFactory<>(AnnotationRetentionDatabase.class),
+        new ReflectionDatabaseFactory<>(JCIPAnnotationDatabase.class),
+        new ReflectionDatabaseFactory<>(SourceInfoMap.class),
+        new ReflectionDatabaseFactory<>(FieldStoreTypeDatabase.class),
+        new ReflectionDatabaseFactory<>(ParameterNullnessPropertyDatabase.class),
+        new ReflectionDatabaseFactory<>(ReturnValueNullnessPropertyDatabase.class),
+        new ReflectionDatabaseFactory<>(DirectlyRelevantTypeQualifiersDatabase.class),
+        new ReflectionDatabaseFactory<>(TypeQualifierDatabase.class),
+        new ReflectionDatabaseFactory<>(MethodInfoDatabase.class),
     };
 
     /*

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/bcel/NonExceptionPostdominatorsAnalysisFactory.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/bcel/NonExceptionPostdominatorsAnalysisFactory.java
@@ -51,7 +51,7 @@ public class NonExceptionPostdominatorsAnalysisFactory extends AnalysisFactory<N
         ReverseDepthFirstSearch rdfs = getReverseDepthFirstSearch(analysisCache, descriptor);
         NonExceptionPostdominatorsAnalysis analysis = new NonExceptionPostdominatorsAnalysis(cfg, rdfs, getDepthFirstSearch(
                 analysisCache, descriptor));
-        Dataflow<java.util.BitSet, PostDominatorsAnalysis> dataflow = new Dataflow<java.util.BitSet, PostDominatorsAnalysis>(cfg,
+        Dataflow<java.util.BitSet, PostDominatorsAnalysis> dataflow = new Dataflow<>(cfg,
                 analysis);
         dataflow.execute();
         return analysis;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/bcel/NonImplicitExceptionPostDominatorsAnalysisFactory.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/bcel/NonImplicitExceptionPostDominatorsAnalysisFactory.java
@@ -55,7 +55,7 @@ AnalysisFactory<NonImplicitExceptionPostDominatorsAnalysis> {
         CFG cfg = getCFG(analysisCache, descriptor);
         NonImplicitExceptionPostDominatorsAnalysis analysis = new NonImplicitExceptionPostDominatorsAnalysis(cfg,
                 getReverseDepthFirstSearch(analysisCache, descriptor), getDepthFirstSearch(analysisCache, descriptor));
-        Dataflow<BitSet, PostDominatorsAnalysis> dataflow = new Dataflow<BitSet, PostDominatorsAnalysis>(cfg, analysis);
+        Dataflow<BitSet, PostDominatorsAnalysis> dataflow = new Dataflow<>(cfg, analysis);
         dataflow.execute();
 
         return analysis;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/bcel/ParameterSignatureListFactory.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/bcel/ParameterSignatureListFactory.java
@@ -50,7 +50,7 @@ public class ParameterSignatureListFactory extends AnalysisFactory<String[]> {
     @Override
     public String[] analyze(IAnalysisCache analysisCache, MethodDescriptor descriptor) throws CheckedAnalysisException {
         SignatureParser parser = new SignatureParser(descriptor.getSignature());
-        ArrayList<String> resultList = new ArrayList<String>();
+        ArrayList<String> resultList = new ArrayList<>();
         for (Iterator<String> i = parser.parameterSignatureIterator(); i.hasNext();) {
             resultList.add(i.next());
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/bcel/ValueNumberDataflowFactory.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/bcel/ValueNumberDataflowFactory.java
@@ -75,7 +75,7 @@ public class ValueNumberDataflowFactory extends AnalysisFactory<ValueNumberDataf
         ValueNumberDataflow vnaDataflow = new ValueNumberDataflow(cfg, analysis);
         vnaDataflow.execute();
         if (ClassContext.DUMP_DATAFLOW_ANALYSIS) {
-            TreeSet<Location> tree = new TreeSet<Location>();
+            TreeSet<Location> tree = new TreeSet<>();
             for (Iterator<Location> locs = cfg.locationIterator(); locs.hasNext();) {
                 Location loc = locs.next();
                 tree.add(loc);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/AbstractScannableCodeBase.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/AbstractScannableCodeBase.java
@@ -48,7 +48,7 @@ public abstract class AbstractScannableCodeBase implements IScannableCodeBase {
     public AbstractScannableCodeBase(ICodeBaseLocator codeBaseLocator) {
         this.codeBaseLocator = codeBaseLocator;
         this.lastModifiedTime = -1L;
-        this.resourceNameTranslationMap = new HashMap<String, String>();
+        this.resourceNameTranslationMap = new HashMap<>();
     }
 
     /*

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/AnalysisCache.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/AnalysisCache.java
@@ -89,7 +89,7 @@ public class AnalysisCache implements IAnalysisCache {
 
     private final Map<Class<?>, Object> databaseMap;
 
-    private final Map<?, ?> analysisLocals = Collections.synchronizedMap(new HashMap<Object, Object>());
+    private final Map<?, ?> analysisLocals = Collections.synchronizedMap(new HashMap<>());
 
     @Override
     public final Map<?, ?> getAnalysisLocals() {
@@ -157,11 +157,11 @@ public class AnalysisCache implements IAnalysisCache {
     AnalysisCache(IClassPath classPath, BugReporter errorLogger) {
         this.classPath = classPath;
         this.bugReporter = errorLogger;
-        this.classAnalysisEngineMap = new HashMap<Class<?>, IClassAnalysisEngine<?>>();
-        this.methodAnalysisEngineMap = new HashMap<Class<?>, IMethodAnalysisEngine<?>>();
-        this.databaseFactoryMap = new HashMap<Class<?>, IDatabaseFactory<?>>();
-        this.classAnalysisMap = new HashMap<Class<?>, Map<ClassDescriptor, Object>>();
-        this.databaseMap = new HashMap<Class<?>, Object>();
+        this.classAnalysisEngineMap = new HashMap<>();
+        this.methodAnalysisEngineMap = new HashMap<>();
+        this.databaseFactoryMap = new HashMap<>();
+        this.classAnalysisMap = new HashMap<>();
+        this.databaseMap = new HashMap<>();
     }
 
     @Override
@@ -433,17 +433,17 @@ public class AnalysisCache implements IAnalysisCache {
         // decide that analysis results should be retained indefinitely.
         IAnalysisEngine<DescriptorType, ?> engine = engineMap.get(analysisClass);
         if (analysisClass.equals(JavaClass.class)) {
-            descriptorMap = new MapCache<DescriptorType, Object>(MAX_JAVACLASS_RESULTS_TO_CACHE);
+            descriptorMap = new MapCache<>(MAX_JAVACLASS_RESULTS_TO_CACHE);
         } else if (analysisClass.equals(FBClassReader.class)) {
-            descriptorMap = new MapCache<DescriptorType, Object>(MAX_FBCLASSREADER_RESULTS_TO_CACHE);
+            descriptorMap = new MapCache<>(MAX_FBCLASSREADER_RESULTS_TO_CACHE);
         } else if (analysisClass.equals(ConstantPoolGen.class)) {
-            descriptorMap = new MapCache<DescriptorType, Object>(MAX_CONSTANT_POOL_GEN_RESULTS_TO_CACHE);
+            descriptorMap = new MapCache<>(MAX_CONSTANT_POOL_GEN_RESULTS_TO_CACHE);
         } else if (analysisClass.equals(ClassContext.class)) {
-            descriptorMap = new MapCache<DescriptorType, Object>(10);
+            descriptorMap = new MapCache<>(10);
         } else if (engine instanceof IClassAnalysisEngine && ((IClassAnalysisEngine<?>) engine).canRecompute()) {
-            descriptorMap = new MapCache<DescriptorType, Object>(MAX_CLASS_RESULTS_TO_CACHE);
+            descriptorMap = new MapCache<>(MAX_CLASS_RESULTS_TO_CACHE);
         } else {
-            descriptorMap = new HashMap<DescriptorType, Object>();
+            descriptorMap = new HashMap<>();
         }
         return descriptorMap;
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/ClassPathBuilder.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/ClassPathBuilder.java
@@ -125,7 +125,7 @@ public class ClassPathBuilder implements IClassPathBuilder {
 
         public DiscoveredCodeBase(ICodeBase codeBase) {
             this.codeBase = codeBase;
-            this.resourceList = new LinkedList<ICodeBaseEntry>();
+            this.resourceList = new LinkedList<>();
         }
 
         public ICodeBase getCodeBase() {
@@ -185,10 +185,10 @@ public class ClassPathBuilder implements IClassPathBuilder {
     ClassPathBuilder(IClassFactory classFactory, IErrorLogger errorLogger) {
         this.classFactory = classFactory;
         this.errorLogger = errorLogger;
-        this.projectWorkList = new LinkedList<WorkListItem>();
-        this.discoveredCodeBaseList = new LinkedList<DiscoveredCodeBase>();
-        this.discoveredCodeBaseMap = new HashMap<String, DiscoveredCodeBase>();
-        this.appClassList = new LinkedList<ClassDescriptor>();
+        this.projectWorkList = new LinkedList<>();
+        this.discoveredCodeBaseList = new LinkedList<>();
+        this.discoveredCodeBaseMap = new HashMap<>();
+        this.appClassList = new LinkedList<>();
     }
 
     /*
@@ -240,7 +240,7 @@ public class ClassPathBuilder implements IClassPathBuilder {
             classPath.addCodeBase(discoveredCodeBase.getCodeBase());
         }
 
-        Set<ClassDescriptor> appClassSet = new HashSet<ClassDescriptor>();
+        Set<ClassDescriptor> appClassSet = new HashSet<>();
 
         // Build collection of all application classes.
         // Also, add resource name -> codebase entry mappings for application
@@ -343,7 +343,7 @@ public class ClassPathBuilder implements IClassPathBuilder {
         String findbugsFullJar = ClassPathUtil.findCodeBaseInClassPath("findbugs-full.jar",
                 SystemProperties.getProperty("java.class.path"));
 
-        LinkedList<WorkListItem> workList = new LinkedList<WorkListItem>();
+        LinkedList<WorkListItem> workList = new LinkedList<>();
         if (findbugsFullJar != null) {
             //
             // Found findbugs-full.jar: add it to the aux classpath.
@@ -384,7 +384,7 @@ public class ClassPathBuilder implements IClassPathBuilder {
         // org.apache.bcel.util.ClassPath.getClassPath()
         // method.
 
-        LinkedList<WorkListItem> workList = new LinkedList<WorkListItem>();
+        LinkedList<WorkListItem> workList = new LinkedList<>();
 
         String bootClassPath = SystemProperties.getProperty("sun.boot.class.path");
         // Seed worklist with system codebases.
@@ -431,7 +431,7 @@ public class ClassPathBuilder implements IClassPathBuilder {
     }
 
     private LinkedList<WorkListItem> createFindBugsLibWorkList(String jarFileName) {
-        LinkedList<WorkListItem> workList = new LinkedList<WorkListItem>();
+        LinkedList<WorkListItem> workList = new LinkedList<>();
 
         boolean found = false;
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/ClassPathImpl.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/ClassPathImpl.java
@@ -45,9 +45,9 @@ public class ClassPathImpl implements IClassPath {
     private final Map<String, ICodeBaseEntry> codeBaseEntryMap;
 
     public ClassPathImpl() {
-        this.appCodeBaseList = new LinkedList<IScannableCodeBase>();
-        this.auxCodeBaseList = new LinkedList<ICodeBase>();
-        this.codeBaseEntryMap = new HashMap<String, ICodeBaseEntry>();
+        this.appCodeBaseList = new LinkedList<>();
+        this.auxCodeBaseList = new LinkedList<>();
+        this.codeBaseEntryMap = new HashMap<>();
     }
 
     @Override
@@ -124,7 +124,7 @@ public class ClassPathImpl implements IClassPath {
 
     @Override
     public Map<String, ICodeBaseEntry> getApplicationCodebaseEntries() {
-        Map<String, ICodeBaseEntry> appEntries = new HashMap<String, ICodeBaseEntry>();
+        Map<String, ICodeBaseEntry> appEntries = new HashMap<>();
         Iterator<Entry<String, ICodeBaseEntry>> iterator = codeBaseEntryMap.entrySet().iterator();
         while(iterator.hasNext()) {
             Entry<String, ICodeBaseEntry> entry = iterator.next();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/DirectoryCodeBase.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/DirectoryCodeBase.java
@@ -203,7 +203,7 @@ public class DirectoryCodeBase extends AbstractScannableCodeBase {
 
         String relativeFileName = fileName.substring(dirPath.length());
         File file = new File(relativeFileName);
-        LinkedList<String> partList = new LinkedList<String>();
+        LinkedList<String> partList = new LinkedList<>();
         do {
             partList.addFirst(file.getName());
         } while ((file = file.getParentFile()) != null);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/ZipInputStreamCodeBase.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/ZipInputStreamCodeBase.java
@@ -44,9 +44,9 @@ public class ZipInputStreamCodeBase extends AbstractScannableCodeBase {
 
     final File file;
 
-    final MapCache<String, ZipInputStreamCodeBaseEntry> map = new MapCache<String, ZipInputStreamCodeBaseEntry>(10000);
+    final MapCache<String, ZipInputStreamCodeBaseEntry> map = new MapCache<>(10000);
 
-    final HashSet<String> entries = new HashSet<String>();
+    final HashSet<String> entries = new HashSet<>();
 
     /**
      * Constructor.

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/config/CommandLine.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/config/CommandLine.java
@@ -63,13 +63,13 @@ public abstract class CommandLine {
     int maxWidth;
 
     public CommandLine() {
-        this.unlistedOptions = new HashSet<String>();
-        this.optionList = new LinkedList<String>();
-        this.optionGroups = new HashMap<Integer, String>();
-        this.requiresArgumentSet = new HashSet<String>();
-        this.optionDescriptionMap = new HashMap<String, String>();
-        this.optionExtraPartSynopsisMap = new HashMap<String, String>();
-        this.argumentDescriptionMap = new HashMap<String, String>();
+        this.unlistedOptions = new HashSet<>();
+        this.optionList = new LinkedList<>();
+        this.optionGroups = new HashMap<>();
+        this.requiresArgumentSet = new HashSet<>();
+        this.optionDescriptionMap = new HashMap<>();
+        this.optionExtraPartSynopsisMap = new HashMap<>();
+        this.argumentDescriptionMap = new HashMap<>();
         this.maxWidth = 0;
     }
 
@@ -178,7 +178,7 @@ public abstract class CommandLine {
         // -adjustPriority
         // must always come after -pluginList).
         int lastOptionIndex = parse(argv, true);
-        ArrayList<String> resultList = new ArrayList<String>();
+        ArrayList<String> resultList = new ArrayList<>();
         ArrayList<String> expandedOptionsList = getAnalysisOptionProperties(ignoreComments, ignoreBlankLines);
         for (int i = 0; i < lastOptionIndex; i++) {
             String arg = argv[i];
@@ -204,7 +204,7 @@ public abstract class CommandLine {
     }
 
     public static ArrayList<String> getAnalysisOptionProperties(boolean ignoreComments, boolean ignoreBlankLines) {
-        ArrayList<String> resultList = new ArrayList<String>();
+        ArrayList<String> resultList = new ArrayList<>();
         URL u = DetectorFactoryCollection.getCoreResource("analysisOptions.properties");
         if (u != null) {
             BufferedReader reader = null;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/config/ProjectFilterSettings.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/config/ProjectFilterSettings.java
@@ -62,7 +62,7 @@ public class ProjectFilterSettings implements Cloneable {
 
     /** Map of priority level names to their numeric values. */
     @StaticConstant
-    private static Map<String, Integer> priorityNameToValueMap = new HashMap<String, Integer>();
+    private static Map<String, Integer> priorityNameToValueMap = new HashMap<>();
     static {
         priorityNameToValueMap.put(HIGH_PRIORITY, (Priorities.HIGH_PRIORITY));
         priorityNameToValueMap.put(MEDIUM_PRIORITY, (Priorities.NORMAL_PRIORITY));
@@ -109,8 +109,8 @@ public class ProjectFilterSettings implements Cloneable {
         // initially all known bug categories are active
         // using SortedSet to allow better revision control on saved sorted
         // properties
-        this.activeBugCategorySet = new TreeSet<String>(DetectorFactoryCollection.instance().getBugCategories());
-        this.hiddenBugCategorySet = new HashSet<String>();
+        this.activeBugCategorySet = new TreeSet<>(DetectorFactoryCollection.instance().getBugCategories());
+        this.hiddenBugCategorySet = new HashSet<>();
         activeBugCategorySet.remove("NOISE");
         hiddenBugCategorySet.add("NOISE");
         setMinRank(DEFAULT_MIN_RANK);
@@ -384,7 +384,7 @@ public class ProjectFilterSettings implements Cloneable {
      * @return the set of active categories
      */
     public Set<String> getActiveCategorySet() {
-        Set<String> result = new TreeSet<String>();
+        Set<String> result = new TreeSet<>();
         result.addAll(this.activeBugCategorySet);
         return result;
     }
@@ -509,9 +509,9 @@ public class ProjectFilterSettings implements Cloneable {
             ProjectFilterSettings clone = (ProjectFilterSettings) super.clone();
 
             // Copy field contents
-            clone.hiddenBugCategorySet = new HashSet<String>();
+            clone.hiddenBugCategorySet = new HashSet<>();
             clone.hiddenBugCategorySet.addAll(this.hiddenBugCategorySet);
-            clone.activeBugCategorySet = new TreeSet<String>();
+            clone.activeBugCategorySet = new TreeSet<>();
             clone.activeBugCategorySet.addAll(this.activeBugCategorySet);
             clone.setMinPriority(this.getMinPriority());
             clone.setMinRank(this.getMinRank());

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/config/SortedProperties.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/config/SortedProperties.java
@@ -36,7 +36,7 @@ public final class SortedProperties extends Properties {
      *         lexicographically. The list may be empty if given set was empty
      */
     static public Enumeration<?> sortKeys(Set<String> keySet) {
-        List<String> sortedList = new ArrayList<String>();
+        List<String> sortedList = new ArrayList<>();
         sortedList.addAll(keySet);
         Collections.sort(sortedList);
         return Collections.enumeration(sortedList);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/config/UserPreferences.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/config/UserPreferences.java
@@ -131,14 +131,14 @@ public class UserPreferences implements Cloneable {
 
     private UserPreferences() {
         filterSettings = ProjectFilterSettings.createDefault();
-        recentProjectsList = new LinkedList<String>();
-        detectorEnablementMap = new HashMap<String, Boolean>();
+        recentProjectsList = new LinkedList<>();
+        detectorEnablementMap = new HashMap<>();
         runAtFullBuild = true;
         effort = EFFORT_DEFAULT;
-        includeFilterFiles = new TreeMap<String, Boolean>();
-        excludeFilterFiles = new TreeMap<String, Boolean>();
-        excludeBugsFiles = new TreeMap<String, Boolean>();
-        customPlugins = new TreeMap<String, Boolean>();
+        includeFilterFiles = new TreeMap<>();
+        excludeFilterFiles = new TreeMap<>();
+        excludeBugsFiles = new TreeMap<>();
+        customPlugins = new TreeMap<>();
     }
 
     /**
@@ -520,13 +520,13 @@ public class UserPreferences implements Cloneable {
         try {
             UserPreferences dup = (UserPreferences) super.clone();
             // Deep copy
-            dup.recentProjectsList = new LinkedList<String>(recentProjectsList);
-            dup.detectorEnablementMap = new HashMap<String, Boolean>(detectorEnablementMap);
+            dup.recentProjectsList = new LinkedList<>(recentProjectsList);
+            dup.detectorEnablementMap = new HashMap<>(detectorEnablementMap);
             dup.filterSettings = (ProjectFilterSettings) this.filterSettings.clone();
-            dup.includeFilterFiles = new TreeMap<String, Boolean>(includeFilterFiles);
-            dup.excludeFilterFiles = new TreeMap<String, Boolean>(excludeFilterFiles);
-            dup.excludeBugsFiles = new TreeMap<String, Boolean>(excludeBugsFiles);
-            dup.customPlugins = new TreeMap<String, Boolean>(customPlugins);
+            dup.includeFilterFiles = new TreeMap<>(includeFilterFiles);
+            dup.excludeFilterFiles = new TreeMap<>(excludeFilterFiles);
+            dup.excludeBugsFiles = new TreeMap<>(excludeBugsFiles);
+            dup.customPlugins = new TreeMap<>(customPlugins);
             return dup;
         } catch (CloneNotSupportedException e) {
             throw new AssertionError(e);
@@ -629,7 +629,7 @@ public class UserPreferences implements Cloneable {
      */
     public Set<String> getCustomPlugins(boolean enabled){
         Set<Entry<String, Boolean>> entrySet = customPlugins.entrySet();
-        Set<String> result = new TreeSet<String>();
+        Set<String> result = new TreeSet<>();
         for (Entry<String, Boolean> entry : entrySet) {
             if(enabled) {
                 if(entry.getValue() != null && entry.getValue().booleanValue()) {
@@ -656,7 +656,7 @@ public class UserPreferences implements Cloneable {
      * @return The array of Strings, or an empty array if no values exist.
      */
     private static Map<String, Boolean> readProperties(Properties props, String keyPrefix) {
-        Map<String, Boolean> filters = new TreeMap<String, Boolean>();
+        Map<String, Boolean> filters = new TreeMap<>();
         int counter = 0;
         boolean keyFound = true;
         while (keyFound) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BadlyOverriddenAdapter.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BadlyOverriddenAdapter.java
@@ -42,8 +42,8 @@ public class BadlyOverriddenAdapter extends BytecodeScanningDetector {
 
     public BadlyOverriddenAdapter(BugReporter bugReporter) {
         this.bugReporter = bugReporter;
-        methodMap = new HashMap<String, String>();
-        badOverrideMap = new HashMap<String, BugInstance>();
+        methodMap = new HashMap<>();
+        badOverrideMap = new HashMap<>();
     }
 
     @Override

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BuildCheckReturnAnnotationDatabase.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BuildCheckReturnAnnotationDatabase.java
@@ -48,7 +48,7 @@ public class BuildCheckReturnAnnotationDatabase extends AnnotationVisitor {
     private static final String DEFAULT_ANNOTATION_ANNOTATION_CLASS = "DefaultAnnotation";
 
     @StaticConstant
-    private static final Map<String, AnnotationDatabase.Target> defaultKind = new HashMap<String, AnnotationDatabase.Target>();
+    private static final Map<String, AnnotationDatabase.Target> defaultKind = new HashMap<>();
     static {
         defaultKind.put("", AnnotationDatabase.Target.ANY);
         defaultKind.put("ForParameters", AnnotationDatabase.Target.PARAMETER);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BuildNonNullAnnotationDatabase.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BuildNonNullAnnotationDatabase.java
@@ -57,7 +57,7 @@ public class BuildNonNullAnnotationDatabase extends AnnotationVisitor {
     //    private static final String DEFAULT_ANNOTATION_ANNOTATION_CLASS = "DefaultAnnotation";
 
     @StaticConstant
-    private static final Map<String, AnnotationDatabase.Target> defaultKind = new HashMap<String, AnnotationDatabase.Target>();
+    private static final Map<String, AnnotationDatabase.Target> defaultKind = new HashMap<>();
     static {
         defaultKind.put("", AnnotationDatabase.Target.ANY);
         defaultKind.put("ForParameters", AnnotationDatabase.Target.PARAMETER);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/CalledMethods.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/CalledMethods.java
@@ -38,9 +38,9 @@ import edu.umd.cs.findbugs.classfile.ClassDescriptor;
 public class CalledMethods extends BytecodeScanningDetector implements NonReportingDetector {
     boolean emptyArrayOnTOS;
 
-    HashSet<XField> emptyArray = new HashSet<XField>();
+    HashSet<XField> emptyArray = new HashSet<>();
 
-    HashSet<XField> nonEmptyArray = new HashSet<XField>();
+    HashSet<XField> nonEmptyArray = new HashSet<>();
 
     XFactory xFactory = AnalysisContext.currentXFactory();
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/CheckExpectedWarnings.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/CheckExpectedWarnings.java
@@ -126,9 +126,9 @@ public class CheckExpectedWarnings implements Detector2, NonReportingDetector {
             // produced by this point.
             //
 
-            warningsByClass = new HashMap<ClassDescriptor, Collection<BugInstance>>();
-            warningsByMethod = new HashMap<MethodDescriptor, Collection<BugInstance>>();
-            warningsByField = new HashMap<FieldDescriptor, Collection<BugInstance>>();
+            warningsByClass = new HashMap<>();
+            warningsByMethod = new HashMap<>();
+            warningsByField = new HashMap<>();
 
             for (Iterator<BugInstance> i = bugCollection.iterator(); i.hasNext();) {
                 BugInstance warning = i.next();
@@ -137,7 +137,7 @@ public class CheckExpectedWarnings implements Detector2, NonReportingDetector {
                     MethodDescriptor methodDesc = method.toMethodDescriptor();
                     Collection<BugInstance> warnings = warningsByMethod.get(methodDesc);
                     if (warnings == null) {
-                        warnings = new LinkedList<BugInstance>();
+                        warnings = new LinkedList<>();
                         warningsByMethod.put(methodDesc, warnings);
                     }
                     warnings.add(warning);
@@ -151,7 +151,7 @@ public class CheckExpectedWarnings implements Detector2, NonReportingDetector {
                     Collection<BugInstance> warnings = warningsByField.get(fieldDescriptor);
 
                     if (warnings == null) {
-                        warnings = new LinkedList<BugInstance>();
+                        warnings = new LinkedList<>();
                         warningsByField.put(fieldDescriptor, warnings);
                     }
                     warnings.add(warning);
@@ -168,7 +168,7 @@ public class CheckExpectedWarnings implements Detector2, NonReportingDetector {
                     }
                     Collection<BugInstance> warnings = warningsByClass.get(classDesc);
                     if (warnings == null) {
-                        warnings = new LinkedList<BugInstance>();
+                        warnings = new LinkedList<>();
                         warningsByClass.put(classDesc, warnings);
                     }
                     warnings.add(warning);
@@ -366,7 +366,7 @@ public class CheckExpectedWarnings implements Detector2, NonReportingDetector {
             @CheckForNull String bugCode,
             int desiredPriority, int rank) {
 
-        Collection<SourceLineAnnotation> matching = new HashSet<SourceLineAnnotation>();
+        Collection<SourceLineAnnotation> matching = new HashSet<>();
         DetectorFactoryCollection i18n = DetectorFactoryCollection.instance();
         boolean matchPattern = false;
         try {
@@ -407,7 +407,7 @@ public class CheckExpectedWarnings implements Detector2, NonReportingDetector {
 
     @Override
     public void finishPass() {
-        HashSet<BugPattern> claimedReported = new HashSet<BugPattern>();
+        HashSet<BugPattern> claimedReported = new HashSet<>();
         for (DetectorFactory d : DetectorFactoryCollection.instance().getFactories()) {
             claimedReported.addAll(d.getReportedBugPatterns());
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/CheckRelaxingNullnessAnnotation.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/CheckRelaxingNullnessAnnotation.java
@@ -231,8 +231,8 @@ public class CheckRelaxingNullnessAnnotation extends ClassNodeDetector {
         private final Set<ClassDescriptor> visited;
 
         public HierarchyIterator(@Nonnull XClass xclass) {
-            interfacesToVisit = new LinkedList<ClassDescriptor>(Arrays.asList(xclass.getInterfaceDescriptorList()));
-            visited = new HashSet<ClassDescriptor>();
+            interfacesToVisit = new LinkedList<>(Arrays.asList(xclass.getInterfaceDescriptorList()));
+            visited = new HashSet<>();
             superclass = getClassInfo(xclass.getSuperclassDescriptor());
         }
 
@@ -255,7 +255,7 @@ public class CheckRelaxingNullnessAnnotation extends ClassNodeDetector {
             // compute next one
             superclass = getClassInfo(superclass.getSuperclassDescriptor());
             if(superclass != null){
-                interfacesToVisit = new LinkedList<ClassDescriptor>(Arrays.asList(superclass.getInterfaceDescriptorList()));
+                interfacesToVisit = new LinkedList<>(Arrays.asList(superclass.getInterfaceDescriptorList()));
             }
             return currentSuperclass;
         }
@@ -279,7 +279,7 @@ public class CheckRelaxingNullnessAnnotation extends ClassNodeDetector {
         if (parameterAnnotations == null) {
             return null;
         }
-        Map<Integer, NullnessAnnotation> nonNullParameter = new HashMap<Integer, NullnessAnnotation>();
+        Map<Integer, NullnessAnnotation> nonNullParameter = new HashMap<>();
         for (int i = 0; i < parameterAnnotations.length; i++) {
             List<AnnotationNode> annotations = parameterAnnotations[i];
             if (annotations == null) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/CheckTypeQualifiers.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/CheckTypeQualifiers.java
@@ -230,7 +230,7 @@ public class CheckTypeQualifiers extends CFGDetector {
 
         if (DEBUG_DATAFLOW) {
             System.out.println("********* Valuenumber analysis *********");
-            DataflowCFGPrinter<ValueNumberFrame, ValueNumberAnalysis> p = new DataflowCFGPrinter<ValueNumberFrame, ValueNumberAnalysis>(vnaDataflow);
+            DataflowCFGPrinter<ValueNumberFrame, ValueNumberAnalysis> p = new DataflowCFGPrinter<>(vnaDataflow);
             p.print(System.out);
         }
 
@@ -238,7 +238,7 @@ public class CheckTypeQualifiers extends CFGDetector {
 
         if (DEBUG_DATAFLOW && (DEBUG_DATAFLOW_MODE.startsWith("forward") || "both".equals(DEBUG_DATAFLOW_MODE))) {
             System.out.println("********* Forwards analysis *********");
-            DataflowCFGPrinter<TypeQualifierValueSet, ForwardTypeQualifierDataflowAnalysis> p = new DataflowCFGPrinter<TypeQualifierValueSet, ForwardTypeQualifierDataflowAnalysis>(
+            DataflowCFGPrinter<TypeQualifierValueSet, ForwardTypeQualifierDataflowAnalysis> p = new DataflowCFGPrinter<>(
                     forwardDataflow);
             p.print(System.out);
         }
@@ -247,7 +247,7 @@ public class CheckTypeQualifiers extends CFGDetector {
 
         if (DEBUG_DATAFLOW && (DEBUG_DATAFLOW_MODE.startsWith("backward") || "both".equals(DEBUG_DATAFLOW_MODE))) {
             System.out.println("********* Backwards analysis *********");
-            DataflowCFGPrinter<TypeQualifierValueSet, BackwardTypeQualifierDataflowAnalysis> p = new DataflowCFGPrinter<TypeQualifierValueSet, BackwardTypeQualifierDataflowAnalysis>(
+            DataflowCFGPrinter<TypeQualifierValueSet, BackwardTypeQualifierDataflowAnalysis> p = new DataflowCFGPrinter<>(
                     backwardDataflow);
             p.print(System.out);
         }
@@ -471,7 +471,7 @@ public class CheckTypeQualifiers extends CFGDetector {
     private void checkForConflictingValues(XMethod xMethod, CFG cfg,
             TypeQualifierValue<?> typeQualifierValue, TypeQualifierValueSet forwardsFact, TypeQualifierValueSet backwardsFact,
             Location locationToReport, Location locationWhereDoomedValueIsObserved, ValueNumberFrame vnaFrame) throws CheckedAnalysisException {
-        Set<ValueNumber> valueNumberSet = new HashSet<ValueNumber>();
+        Set<ValueNumber> valueNumberSet = new HashSet<>();
         valueNumberSet.addAll(forwardsFact.getValueNumbers());
         valueNumberSet.addAll(backwardsFact.getValueNumbers());
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/CrossSiteScripting.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/CrossSiteScripting.java
@@ -54,7 +54,7 @@ public class CrossSiteScripting extends OpcodeStackDetector {
         allFileNameStringMethods = database.getFileNameStringMethods();
     }
 
-    Map<String, OpcodeStack.Item> map = new HashMap<String, OpcodeStack.Item>();
+    Map<String, OpcodeStack.Item> map = new HashMap<>();
 
     OpcodeStack.Item top = null;
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DefaultEncodingDetector.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DefaultEncodingDetector.java
@@ -73,7 +73,7 @@ public class DefaultEncodingDetector extends OpcodeStackDetector {
             this.loadAuxiliaryAnnotations();
         }
 
-        Set<ClassDescriptor> classes = new HashSet<ClassDescriptor>();
+        Set<ClassDescriptor> classes = new HashSet<>();
         @Override
         protected void addMethodAnnotation(@DottedClassName String cName, String mName, String mSig, boolean isStatic,
                 DefaultEncodingAnnotation annotation) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DontCatchIllegalMonitorStateException.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DontCatchIllegalMonitorStateException.java
@@ -45,7 +45,7 @@ public class DontCatchIllegalMonitorStateException extends PreorderVisitor imple
     public DontCatchIllegalMonitorStateException(BugReporter bugReporter) {
         this.bugReporter = bugReporter;
         if (DEBUG) {
-            msgs = new HashSet<String>();
+            msgs = new HashSet<>();
         }
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DontIgnoreResultOfPutIfAbsent.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DontIgnoreResultOfPutIfAbsent.java
@@ -131,7 +131,7 @@ public class DontIgnoreResultOfPutIfAbsent implements Detector {
     final static boolean DEBUG = false;
 
     @edu.umd.cs.findbugs.internalAnnotations.StaticConstant
-    static HashSet<String> immutableClassNames = new HashSet<String>();
+    static HashSet<String> immutableClassNames = new HashSet<>();
     static {
         immutableClassNames.add("java/lang/Integer");
         immutableClassNames.add("java/lang/Long");

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DroppedException.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DroppedException.java
@@ -56,9 +56,9 @@ public class DroppedException extends PreorderVisitor implements Detector {
     private static final boolean LOOK_IN_SOURCE_TO_FIND_COMMENTED_CATCH_BLOCKS = SystemProperties
             .getBoolean("findbugs.de.comment");
 
-    Set<String> causes = new HashSet<String>();
+    Set<String> causes = new HashSet<>();
 
-    Set<String> checkedCauses = new HashSet<String>();
+    Set<String> checkedCauses = new HashSet<>();
 
     private final BugReporter bugReporter;
     private final BugAccumulator bugAccumulator;
@@ -416,7 +416,7 @@ public class DroppedException extends PreorderVisitor implements Detector {
             // Read the tokens into an ArrayList,
             // keeping track of where the catch block is reported
             // to start
-            ArrayList<Token> tokenList = new ArrayList<Token>(40);
+            ArrayList<Token> tokenList = new ArrayList<>(40);
             int eolOfCatchBlockStart = -1;
             for (int line = scanStartLine; line < scanStartLine + MAX_LINES;) {
                 Token token = tokenizer.next();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DuplicateBranches.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DuplicateBranches.java
@@ -58,7 +58,7 @@ public class DuplicateBranches extends PreorderVisitor implements Detector {
 
     private final BugReporter bugReporter;
 
-    private final Collection<BugInstance> pendingBugs = new LinkedList<BugInstance>();
+    private final Collection<BugInstance> pendingBugs = new LinkedList<>();
 
     public DuplicateBranches(BugReporter bugReporter) {
         this.bugReporter = bugReporter;
@@ -196,7 +196,7 @@ public class DuplicateBranches extends PreorderVisitor implements Detector {
     private void findSwitchDuplicates(CFG cfg, Method method, BasicBlock bb) {
 
         int[] switchPos = new int[cfg.getNumOutgoingEdges(bb) + 1];
-        HashMap<Integer, InstructionHandle> prevHandle = new HashMap<Integer, InstructionHandle>();
+        HashMap<Integer, InstructionHandle> prevHandle = new HashMap<>();
 
         Iterator<Edge> iei = cfg.outgoingEdgeIterator(bb);
         int idx = 0;
@@ -235,7 +235,7 @@ public class DuplicateBranches extends PreorderVisitor implements Detector {
         // switchPos[idx-1])
         switchPos[idx] = getFinalTarget(cfg, switchPos[idx - 1], prevHandle.values());
 
-        HashMap<BigInteger, Collection<Integer>> map = new HashMap<BigInteger, Collection<Integer>>();
+        HashMap<BigInteger, Collection<Integer>> map = new HashMap<>();
         for (int i = 0; i < idx; i++) {
             if (switchPos[i] + 7 >= switchPos[i + 1])
             {
@@ -291,7 +291,7 @@ public class DuplicateBranches extends PreorderVisitor implements Detector {
         Collection<Integer> values = map.get(clauseAsInt);
 
         if (values == null) {
-            values = new LinkedList<Integer>();
+            values = new LinkedList<>();
             map.put(clauseAsInt, values);
         }
         values.add(i); // index into the sorted array

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FieldItemSummary.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FieldItemSummary.java
@@ -49,7 +49,7 @@ public class FieldItemSummary extends OpcodeStackDetector implements NonReportin
         context.setFieldSummary(fieldSummary);
     }
 
-    Set<XField> touched = new HashSet<XField>();
+    Set<XField> touched = new HashSet<>();
 
     @Override
     public boolean shouldVisit(JavaClass obj) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindBadCast2.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindBadCast2.java
@@ -65,11 +65,11 @@ public class FindBadCast2 implements Detector {
 
     private final BugReporter bugReporter;
 
-    private final Set<String> concreteCollectionClasses = new HashSet<String>();
+    private final Set<String> concreteCollectionClasses = new HashSet<>();
 
-    private final Set<String> abstractCollectionClasses = new HashSet<String>();
+    private final Set<String> abstractCollectionClasses = new HashSet<>();
 
-    private final Set<String> veryAbstractCollectionClasses = new HashSet<String>();
+    private final Set<String> veryAbstractCollectionClasses = new HashSet<>();
 
     private static final boolean DEBUG = SystemProperties.getBoolean("bc.debug");
 
@@ -131,7 +131,7 @@ public class FindBadCast2 implements Detector {
             throws DataflowAnalysisException, CFGBuilderException {
         ValueNumberDataflow vnaDataflow = classContext.getValueNumberDataflow(method);
         ValueNumberFrame vnaFrameAtEntry = vnaDataflow.getStartFact(cfg.getEntry());
-        Set<ValueNumber> paramValueNumberSet = new HashSet<ValueNumber>();
+        Set<ValueNumber> paramValueNumberSet = new HashSet<>();
         int firstParam = method.isStatic() ? 0 : 1;
         for (int i = firstParam; i < vnaFrameAtEntry.getNumLocals(); ++i) {
             paramValueNumberSet.add(vnaFrameAtEntry.getValue(i));
@@ -163,10 +163,10 @@ public class FindBadCast2 implements Detector {
             System.out.println("Checking " + methodName);
         }
 
-        Set<SourceLineAnnotation> haveInstanceOf = new HashSet<SourceLineAnnotation>();
-        Set<SourceLineAnnotation> haveCast = new HashSet<SourceLineAnnotation>();
-        Set<SourceLineAnnotation> haveMultipleInstanceOf = new HashSet<SourceLineAnnotation>();
-        Set<SourceLineAnnotation> haveMultipleCast = new HashSet<SourceLineAnnotation>();
+        Set<SourceLineAnnotation> haveInstanceOf = new HashSet<>();
+        Set<SourceLineAnnotation> haveCast = new HashSet<>();
+        Set<SourceLineAnnotation> haveMultipleInstanceOf = new HashSet<>();
+        Set<SourceLineAnnotation> haveMultipleCast = new HashSet<>();
         for (Iterator<Location> i = cfg.locationIterator(); i.hasNext();) {
             Location location = i.next();
             InstructionHandle handle = location.getHandle();
@@ -196,7 +196,7 @@ public class FindBadCast2 implements Detector {
         }
         BitSet linesMentionedMultipleTimes = classContext.linesMentionedMultipleTimes(method);
         LineNumberTable lineNumberTable = methodGen.getLineNumberTable(methodGen.getConstantPool());
-        Map<BugAnnotation, String> instanceOfChecks = new HashMap<BugAnnotation, String>();
+        Map<BugAnnotation, String> instanceOfChecks = new HashMap<>();
         String constantClass = null;
         boolean methodInvocationWasGeneric = false;
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindCircularDependencies.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindCircularDependencies.java
@@ -42,7 +42,7 @@ public class FindCircularDependencies extends BytecodeScanningDetector {
 
     public FindCircularDependencies(BugReporter bugReporter) {
         this.bugReporter = bugReporter;
-        this.dependencyGraph = new HashMap<String, Set<String>>();
+        this.dependencyGraph = new HashMap<>();
     }
 
     @Override
@@ -73,7 +73,7 @@ public class FindCircularDependencies extends BytecodeScanningDetector {
 
             Set<String> dependencies = dependencyGraph.get(clsName);
             if (dependencies == null) {
-                dependencies = new HashSet<String>();
+                dependencies = new HashSet<>();
                 dependencyGraph.put(clsName, dependencies);
             }
 
@@ -172,8 +172,8 @@ public class FindCircularDependencies extends BytecodeScanningDetector {
         public Set<String> findLoop(Map<String, Set<String>> dependencyGraph, String startCls) {
             dGraph = dependencyGraph;
             startClass = startCls;
-            visited = new HashSet<String>();
-            loop = new LinkedHashSet<String>();
+            visited = new HashSet<>();
+            loop = new LinkedHashSet<>();
             if (findLoop(startClass)) {
                 return loop;
             }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindDeadLocalStores.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindDeadLocalStores.java
@@ -104,7 +104,7 @@ public class FindDeadLocalStores implements Detector {
 
     // Define a collection of excluded local variables...
     @StaticConstant
-    private static final Set<String> EXCLUDED_LOCALS = new HashSet<String>();
+    private static final Set<String> EXCLUDED_LOCALS = new HashSet<>();
 
     //    private static final boolean DO_EXCLUDE_LOCALS = SystemProperties.getProperty(FINDBUGS_EXCLUDED_LOCALS_PROP_NAME) != null;
 
@@ -253,7 +253,7 @@ public class FindDeadLocalStores implements Detector {
 
             BugInstance pendingBugReportAboutOverwrittenParameter = null;
             try {
-                WarningPropertySet<WarningProperty> propertySet = new WarningPropertySet<WarningProperty>();
+                WarningPropertySet<WarningProperty> propertySet = new WarningPropertySet<>();
                 // Skip any instruction which is not a store
                 if (!isStore(location)) {
                     continue;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindDoubleCheck.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindDoubleCheck.java
@@ -46,9 +46,9 @@ public class FindDoubleCheck extends OpcodeStackDetector {
 
     boolean sawMonitorEnter;
 
-    Set<FieldAnnotation> fields = new HashSet<FieldAnnotation>();
+    Set<FieldAnnotation> fields = new HashSet<>();
 
-    Set<FieldAnnotation> twice = new HashSet<FieldAnnotation>();
+    Set<FieldAnnotation> twice = new HashSet<>();
 
     FieldAnnotation pendingFieldLoad;
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindFieldSelfAssignment.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindFieldSelfAssignment.java
@@ -65,7 +65,7 @@ public class FindFieldSelfAssignment extends OpcodeStackDetector implements Stat
     int register;
 
     int lastMethodCall;
-    Set<String> initializedFields = new HashSet<String>();
+    Set<String> initializedFields = new HashSet<>();
 
     XField possibleOverwrite;
     @Override

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindFloatEquality.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindFloatEquality.java
@@ -53,7 +53,7 @@ public class FindFloatEquality extends OpcodeStackDetector implements StatelessD
         this.bugAccumulator = new BugAccumulator(bugReporter);
     }
 
-    Collection<SourceLineAnnotation> found = new LinkedList<SourceLineAnnotation>();
+    Collection<SourceLineAnnotation> found = new LinkedList<>();
 
     @Override
     public void visit(Code obj) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindHEmismatch.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindHEmismatch.java
@@ -115,8 +115,8 @@ public class FindHEmismatch extends OpcodeStackDetector implements StatelessDete
 
     public FindHEmismatch(BugReporter bugReporter) {
         this.bugReporter = bugReporter;
-        nonHashableClasses = new HashSet<String>();
-        potentialBugs = new HashMap<String, BugInstance>();
+        nonHashableClasses = new HashSet<>();
+        potentialBugs = new HashMap<>();
     }
 
     public boolean isHashableClassName(String dottedClassName) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindInconsistentSync2.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindInconsistentSync2.java
@@ -190,7 +190,7 @@ public class FindInconsistentSync2 implements Detector {
         }
 
         public static Collection<SourceLineAnnotation> asSourceLineAnnotation(Collection<FieldAccess> c) {
-            ArrayList<SourceLineAnnotation> result = new ArrayList<SourceLineAnnotation>(c.size());
+            ArrayList<SourceLineAnnotation> result = new ArrayList<>(c.size());
             for (FieldAccess f : c) {
                 result.add(f.asSourceLineAnnotation());
             }
@@ -327,7 +327,7 @@ public class FindInconsistentSync2 implements Detector {
 
     private final BugReporter bugReporter;
 
-    private final Map<XField, FieldStats> statMap = new HashMap<XField, FieldStats>();
+    private final Map<XField, FieldStats> statMap = new HashMap<>();
 
     /*
      * ----------------------------------------------------------------------
@@ -356,7 +356,7 @@ public class FindInconsistentSync2 implements Detector {
 
         Set<Method> lockedMethodSet;
         // Set<Method> publicReachableMethods;
-        Set<Method> allMethods = new HashSet<Method>(Arrays.asList(javaClass.getMethods()));
+        Set<Method> allMethods = new HashSet<>(Arrays.asList(javaClass.getMethods()));
 
         try {
             selfCalls.execute();
@@ -456,7 +456,7 @@ public class FindInconsistentSync2 implements Detector {
             }
             boolean threadSafe = jcipAnotationDatabase.hasClassAnnotation(xfield.getClassName(), "ThreadSafe");
 
-            WarningPropertySet<InconsistentSyncWarningProperty> propertySet = new WarningPropertySet<InconsistentSyncWarningProperty>();
+            WarningPropertySet<InconsistentSyncWarningProperty> propertySet = new WarningPropertySet<>();
 
             int numReadUnlocked = stats.getNumAccesses(READ_UNLOCKED);
             int numWriteUnlocked = stats.getNumAccesses(WRITE_UNLOCKED);
@@ -893,7 +893,7 @@ public class FindInconsistentSync2 implements Detector {
 
         // Initially, assume no methods are called from an
         // unlocked context
-        Set<Method> lockedMethodSet = new HashSet<Method>();
+        Set<Method> lockedMethodSet = new HashSet<>();
         lockedMethodSet.addAll(Arrays.asList(methodList));
 
         // Assume all public methods are called from
@@ -959,7 +959,7 @@ public class FindInconsistentSync2 implements Detector {
         CallGraph callGraph = selfCalls.getCallGraph();
 
         // Initially, assume all methods are locked
-        Set<Method> lockedMethodSet = new HashSet<Method>();
+        Set<Method> lockedMethodSet = new HashSet<>();
 
         // Assume all public methods are unlocked
         for (Method method : methodList) {
@@ -1052,7 +1052,7 @@ public class FindInconsistentSync2 implements Detector {
         ConstantPoolGen cpg = classContext.getConstantPoolGen();
 
         // Find all obviously locked call sites
-        Set<CallSite> obviouslyLockedSites = new HashSet<CallSite>();
+        Set<CallSite> obviouslyLockedSites = new HashSet<>();
         for (Iterator<CallSite> i = selfCalls.callSiteIterator(); i.hasNext();) {
             CallSite callSite = i.next();
             Method method = callSite.getMethod();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindMaskedFields.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindMaskedFields.java
@@ -50,11 +50,11 @@ public class FindMaskedFields extends BytecodeScanningDetector {
 
     private int numParms;
 
-    private final Map<String, Field> classFields = new HashMap<String, Field>();
+    private final Map<String, Field> classFields = new HashMap<>();
 
     private boolean staticMethod;
 
-    private final Collection<RememberedBug> rememberedBugs = new LinkedList<RememberedBug>();
+    private final Collection<RememberedBug> rememberedBugs = new LinkedList<>();
 
     static class RememberedBug {
         BugInstance bug;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNullDeref.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNullDeref.java
@@ -587,7 +587,7 @@ public class FindNullDeref implements Detector, UseAnnotationDatabase, NullDeref
     }
 
     @StaticConstant
-    public static final Set<String> catchTypesForNull = Collections.unmodifiableSet(new HashSet<String>(Arrays.asList(
+    public static final Set<String> catchTypesForNull = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
             "java/lang/NullPointerException", "java/lang/RuntimeException", "java/lang/Exception")));
 
     public static boolean catchesNull(ConstantPool constantPool, Code code, Location location) {
@@ -674,8 +674,8 @@ public class FindNullDeref implements Detector, UseAnnotationDatabase, NullDeref
         // See if any call targets unconditionally dereference one of the null
         // arguments
         BitSet unconditionallyDereferencedNullArgSet = new BitSet();
-        List<JavaClassAndMethod> dangerousCallTargetList = new LinkedList<JavaClassAndMethod>();
-        List<JavaClassAndMethod> veryDangerousCallTargetList = new LinkedList<JavaClassAndMethod>();
+        List<JavaClassAndMethod> dangerousCallTargetList = new LinkedList<>();
+        List<JavaClassAndMethod> veryDangerousCallTargetList = new LinkedList<>();
         for (JavaClassAndMethod targetMethod : targetMethodSet) {
             if (DEBUG_NULLARG) {
                 System.out.println("For target method " + targetMethod);
@@ -708,10 +708,10 @@ public class FindNullDeref implements Detector, UseAnnotationDatabase, NullDeref
             return;
         }
 
-        WarningPropertySet<WarningProperty> propertySet = new WarningPropertySet<WarningProperty>();
+        WarningPropertySet<WarningProperty> propertySet = new WarningPropertySet<>();
 
         // See if there are any safe targets
-        Set<JavaClassAndMethod> safeCallTargetSet = new HashSet<JavaClassAndMethod>();
+        Set<JavaClassAndMethod> safeCallTargetSet = new HashSet<>();
         safeCallTargetSet.addAll(targetMethodSet);
         safeCallTargetSet.removeAll(dangerousCallTargetList);
         if (safeCallTargetSet.isEmpty()) {
@@ -892,7 +892,7 @@ public class FindNullDeref implements Detector, UseAnnotationDatabase, NullDeref
                     priority = NORMAL_PRIORITY;
                 }
                 String description = definitelyNull ? "INT_NULL_ARG" : "INT_MAYBE_NULL_ARG";
-                WarningPropertySet<WarningProperty> propertySet = new WarningPropertySet<WarningProperty>();
+                WarningPropertySet<WarningProperty> propertySet = new WarningPropertySet<>();
                 Set<Location> derefLocationSet = Collections.singleton(location);
 
                 addPropertiesForDereferenceLocations(propertySet, derefLocationSet, false);
@@ -937,7 +937,7 @@ public class FindNullDeref implements Detector, UseAnnotationDatabase, NullDeref
     @Override
     public void foundNullDeref(Location location, ValueNumber valueNumber, IsNullValue refValue, ValueNumberFrame vnaFrame,
             boolean isConsistent) {
-        WarningPropertySet<WarningProperty> propertySet = new WarningPropertySet<WarningProperty>();
+        WarningPropertySet<WarningProperty> propertySet = new WarningPropertySet<>();
         if (valueNumber.hasFlag(ValueNumber.CONSTANT_CLASS_OBJECT)) {
             return;
         }
@@ -1282,7 +1282,7 @@ public class FindNullDeref implements Detector, UseAnnotationDatabase, NullDeref
         }
 
         if (FindBugsAnalysisFeatures.isRelaxedMode()) {
-            WarningPropertySet<WarningProperty> propertySet = new WarningPropertySet<WarningProperty>();
+            WarningPropertySet<WarningProperty> propertySet = new WarningPropertySet<>();
             WarningPropertyUtil.addPropertiesForDataMining(propertySet, classContext, method, location);
             if (isChecked) {
                 propertySet.addProperty(NullDerefProperty.CHECKED_VALUE);
@@ -1454,7 +1454,7 @@ public class FindNullDeref implements Detector, UseAnnotationDatabase, NullDeref
 
         SortedSet<Location> sourceLocations;
         if (doomedLocations.isEmpty() || doomedLocations.size() > 3 && doomedLocations.size() > assignedNullLocationSet.size()) {
-            sourceLocations = new TreeSet<Location>(assignedNullLocationSet);
+            sourceLocations = new TreeSet<>(assignedNullLocationSet);
         } else {
             sourceLocations = doomedLocations;
         }
@@ -1463,7 +1463,7 @@ public class FindNullDeref implements Detector, UseAnnotationDatabase, NullDeref
             return;
         }
 
-        WarningPropertySet<WarningProperty> propertySet = new WarningPropertySet<WarningProperty>();
+        WarningPropertySet<WarningProperty> propertySet = new WarningPropertySet<>();
 
         addPropertiesForDereferenceLocations(propertySet, derefLocationSet, false);
 
@@ -1482,7 +1482,7 @@ public class FindNullDeref implements Detector, UseAnnotationDatabase, NullDeref
 
         BitSet knownNull = new BitSet();
 
-        SortedSet<SourceLineAnnotation> knownNullLocations = new TreeSet<SourceLineAnnotation>();
+        SortedSet<SourceLineAnnotation> knownNullLocations = new TreeSet<>();
         for (Location loc : sourceLocations) {
             SourceLineAnnotation sourceLineAnnotation = SourceLineAnnotation.fromVisitedInstruction(classContext, method, loc);
             if (sourceLineAnnotation == null) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindOpenStream.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindOpenStream.java
@@ -90,7 +90,7 @@ public final class FindOpenStream extends ResourceTrackingDetector<Stream, Strea
     static final StreamFactory[] streamFactoryList;
 
     static {
-        ArrayList<StreamFactory> streamFactoryCollection = new ArrayList<StreamFactory>();
+        ArrayList<StreamFactory> streamFactoryCollection = new ArrayList<>();
 
         // Examine InputStreams, OutputStreams, Readers, and Writers,
         // ignoring byte array, char array, and String variants.
@@ -264,7 +264,7 @@ public final class FindOpenStream extends ResourceTrackingDetector<Stream, Strea
 
     public FindOpenStream(BugReporter bugReporter) {
         super(bugReporter);
-        this.potentialOpenStreamList = new LinkedList<PotentialOpenStream>();
+        this.potentialOpenStreamList = new LinkedList<>();
     }
 
     @Override

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindPuzzlers.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindPuzzlers.java
@@ -526,7 +526,7 @@ public class FindPuzzlers extends OpcodeStackDetector {
                 }
                 //                String name = null;
                 int reg = item.getRegisterNumber();
-                Collection<BugAnnotation> as = new ArrayList<BugAnnotation>();
+                Collection<BugAnnotation> as = new ArrayList<>();
                 XField field = item.getXField();
                 FieldAnnotation fieldAnnotation = null;
                 if (field != null) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindRefComparison.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindRefComparison.java
@@ -131,7 +131,7 @@ public class FindRefComparison implements Detector, ExtendedTypes {
      * Classes that are suspicious if compared by reference.
      */
     @StaticConstant
-    private static final HashSet<String> DEFAULT_SUSPICIOUS_SET = new HashSet<String>();
+    private static final HashSet<String> DEFAULT_SUSPICIOUS_SET = new HashSet<>();
 
     static {
         DEFAULT_SUSPICIOUS_SET.add("java.lang.Boolean");
@@ -654,7 +654,7 @@ public class FindRefComparison implements Detector, ExtendedTypes {
     public FindRefComparison(BugReporter bugReporter) {
         this.bugReporter = bugReporter;
         this.bugAccumulator = new BugAccumulator(bugReporter);
-        this.suspiciousSet = new HashSet<String>(DEFAULT_SUSPICIOUS_SET);
+        this.suspiciousSet = new HashSet<>(DEFAULT_SUSPICIOUS_SET);
 
         // Check frc.suspicious system property for additional suspicious types
         // to check
@@ -745,11 +745,11 @@ public class FindRefComparison implements Detector, ExtendedTypes {
         // Normally we'll only report the first highest-priority warning,
         // but if in relaxed mode or if REPORT_ALL_REF_COMPARISONS is set,
         // then we'll report everything.
-        LinkedList<WarningWithProperties> refComparisonList = new LinkedList<WarningWithProperties>();
-        LinkedList<WarningWithProperties> stringComparisonList = new LinkedList<WarningWithProperties>();
+        LinkedList<WarningWithProperties> refComparisonList = new LinkedList<>();
+        LinkedList<WarningWithProperties> stringComparisonList = new LinkedList<>();
 
 
-        comparedForEqualityInThisMethod = new HashMap<String,Integer>();
+        comparedForEqualityInThisMethod = new HashMap<>();
         CFG cfg = classContext.getCFG(method);
         DepthFirstSearch dfs = classContext.getDepthFirstSearch(method);
         ExceptionSetFactory exceptionSetFactory = classContext.getExceptionSetFactory(method);
@@ -1005,7 +1005,7 @@ public class FindRefComparison implements Detector, ExtendedTypes {
         // ? D high
         // S ? normal
         // ? S normal
-        WarningPropertySet<WarningProperty> propertySet = new WarningPropertySet<WarningProperty>();
+        WarningPropertySet<WarningProperty> propertySet = new WarningPropertySet<>();
         if (type1 == T_STATIC_STRING && type2 == T_STATIC_STRING) {
             propertySet.addProperty(RefComparisonWarningProperty.COMPARE_STATIC_STRINGS);
         } else if (type1 == T_DYNAMIC_STRING || type2 == T_DYNAMIC_STRING) {
@@ -1068,7 +1068,7 @@ public class FindRefComparison implements Detector, ExtendedTypes {
         SourceLineAnnotation sourceLineAnnotation = SourceLineAnnotation.fromVisitedInstruction(classContext, methodGen,
                 sourceFile, location.getHandle());
 
-        refComparisonList.add(new WarningWithProperties(instance, new WarningPropertySet<WarningProperty>(),
+        refComparisonList.add(new WarningWithProperties(instance, new WarningPropertySet<>(),
                 sourceLineAnnotation, location));
     }
 
@@ -1213,7 +1213,7 @@ public class FindRefComparison implements Detector, ExtendedTypes {
                 priorityModifier = 0;
             }
             if (true) {
-                Set<XMethod> targets = new HashSet<XMethod>();
+                Set<XMethod> targets = new HashSet<>();
                 boolean allOk = checkForWeirdEquals(lhsSig, rhsSig, targets);
                 if (allOk) {
                     priorityModifier += 2;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindRoughConstants.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindRoughConstants.java
@@ -47,7 +47,7 @@ public class FindRoughConstants extends BytecodeScanningDetector {
         double value;
         int basePriority;
 
-        Set<Number> approxSet = new HashSet<Number>();
+        Set<Number> approxSet = new HashSet<>();
 
         BadConstant(double base, double factor, String replacement, int basePriority) {
             this.base = base;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindTwoLockWait.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindTwoLockWait.java
@@ -51,9 +51,9 @@ public final class FindTwoLockWait implements Detector, StatelessDetector {
 
     private JavaClass javaClass;
 
-    private final Collection<BugInstance> possibleWaitBugs = new LinkedList<BugInstance>();
+    private final Collection<BugInstance> possibleWaitBugs = new LinkedList<>();
 
-    private final Collection<SourceLineAnnotation> possibleNotifyLocations = new LinkedList<SourceLineAnnotation>();
+    private final Collection<SourceLineAnnotation> possibleNotifyLocations = new LinkedList<>();
 
     public FindTwoLockWait(BugReporter bugReporter) {
         this.bugReporter = bugReporter;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindUncalledPrivateMethods.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindUncalledPrivateMethods.java
@@ -100,9 +100,9 @@ public class FindUncalledPrivateMethods extends BytecodeScanningDetector impleme
 
     @Override
     public void visitClassContext(ClassContext classContext) {
-        definedPrivateMethods = new HashSet<MethodAnnotation>();
-        calledMethods = new HashSet<MethodAnnotation>();
-        calledMethodNames = new HashSet<String>();
+        definedPrivateMethods = new HashSet<>();
+        calledMethods = new HashSet<>();
+        calledMethodNames = new HashSet<>();
         className = classContext.getJavaClass().getClassName();
         String[] parts = className.split("[$+.]");
         String simpleClassName = parts[parts.length - 1];

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindUninitializedGet.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindUninitializedGet.java
@@ -45,13 +45,13 @@ import edu.umd.cs.findbugs.ba.XFactory;
 import edu.umd.cs.findbugs.ba.XField;
 
 public class FindUninitializedGet extends BytecodeScanningDetector implements StatelessDetector {
-    Set<FieldAnnotation> initializedFields = new HashSet<FieldAnnotation>();
+    Set<FieldAnnotation> initializedFields = new HashSet<>();
 
-    Set<FieldAnnotation> declaredFields = new HashSet<FieldAnnotation>();
+    Set<FieldAnnotation> declaredFields = new HashSet<>();
 
-    Set<FieldAnnotation> containerFields = new HashSet<FieldAnnotation>();
+    Set<FieldAnnotation> containerFields = new HashSet<>();
 
-    Collection<BugInstance> pendingBugs = new LinkedList<BugInstance>();
+    Collection<BugInstance> pendingBugs = new LinkedList<>();
 
     BugInstance uninitializedFieldReadAndCheckedForNonnull;
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindUnrelatedTypesInGenericContainer.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindUnrelatedTypesInGenericContainer.java
@@ -135,7 +135,7 @@ public class FindUnrelatedTypesInGenericContainer implements Detector {
      * Get the String key by calling getCollectionsMapKey()
      */
 
-    private final MultiMap<String, Info> callMap = new MultiMap<String, Info>(LinkedList.class);
+    private final MultiMap<String, Info> callMap = new MultiMap<>(LinkedList.class);
 
 
     private void addCheckedCall(@DottedClassName String className, String methodName, String sig, int argumentParameterIndex, int typeParameterIndex) {
@@ -300,7 +300,7 @@ public class FindUnrelatedTypesInGenericContainer implements Detector {
     }
 
     @StaticConstant
-    final static Set<String> baseGenericTypes = new LinkedHashSet<String>();
+    final static Set<String> baseGenericTypes = new LinkedHashSet<>();
     static {
         baseGenericTypes.addAll(Arrays.asList(new String[] { "java.util.Map", "java.util.Collection", "java.lang.Iterable",
                 "java.util.Iterator", "com.google.common.collect.Multimap", "com.google.common.collect.Multiset",
@@ -685,7 +685,7 @@ public class FindUnrelatedTypesInGenericContainer implements Detector {
                                         ValueNumberSourceInfo.findAnnotationFromValueNumber(method, location, argVN, vnFrame, "ARGUMENT"))
                                         .addEqualsMethodUsed(targets);
                 if (noisy) {
-                    WarningPropertySet<WarningProperty> propertySet = new WarningPropertySet<WarningProperty>();
+                    WarningPropertySet<WarningProperty> propertySet = new WarningPropertySet<>();
 
                     propertySet.addProperty(GeneralWarningProperty.NOISY_BUG);
                     propertySet.decorateBugInstance(bug);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindUnsatisfiedObligation.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindUnsatisfiedObligation.java
@@ -259,7 +259,7 @@ public class FindUnsatisfiedObligation extends CFGDetector {
             // Main loop: looking at the StateSet at the exit block of the CFG,
             // see if there are any states with nonempty obligation sets.
             //
-            Map<Obligation, State> leakedObligationMap = new HashMap<Obligation, State>();
+            Map<Obligation, State> leakedObligationMap = new HashMap<>();
             StateSet factAtExit = dataflow.getResultFact(cfg.getExit());
             for (Iterator<State> i = factAtExit.stateIterator(); i.hasNext();) {
                 State state = i.next();
@@ -384,7 +384,7 @@ public class FindUnsatisfiedObligation extends CFGDetector {
                 this.state = state;
                 this.adjustedLeakCount = state.getObligationSet().getCount(possiblyLeakedObligation.getId());
                 if (COMPUTE_TRANSFERS) {
-                    this.transferList = new LinkedList<PossibleObligationTransfer>();
+                    this.transferList = new LinkedList<>();
                 }
             }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindUnsyncGet.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindUnsyncGet.java
@@ -40,9 +40,9 @@ public class FindUnsyncGet extends BytecodeScanningDetector {
     static final int doNotConsider = Const.ACC_PRIVATE | Const.ACC_STATIC | Const.ACC_NATIVE;
 
     // Maps of property names to get and set methods
-    private final HashMap<String, MethodAnnotation> getMethods = new HashMap<String, MethodAnnotation>();
+    private final HashMap<String, MethodAnnotation> getMethods = new HashMap<>();
 
-    private final HashMap<String, MethodAnnotation> setMethods = new HashMap<String, MethodAnnotation>();
+    private final HashMap<String, MethodAnnotation> setMethods = new HashMap<>();
 
     public FindUnsyncGet(BugReporter bugReporter) {
         this.bugReporter = bugReporter;
@@ -52,7 +52,7 @@ public class FindUnsyncGet extends BytecodeScanningDetector {
     public void report() {
         // Find the set of properties for which we have both
         // unsynchronized get and synchronized set methods
-        Set<String> commonProperties = new HashSet<String>(getMethods.keySet());
+        Set<String> commonProperties = new HashSet<>(getMethods.keySet());
         commonProperties.retainAll(setMethods.keySet());
 
         // Report method pairs

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FunctionsThatMightBeMistakenForProcedures.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FunctionsThatMightBeMistakenForProcedures.java
@@ -89,13 +89,13 @@ public class FunctionsThatMightBeMistakenForProcedures extends OpcodeStackDetect
 
     }
 
-    HashSet<XMethod> okToIgnore = new HashSet<XMethod>();
+    HashSet<XMethod> okToIgnore = new HashSet<>();
 
-    HashSet<XMethod> methodsSeen = new HashSet<XMethod>();
+    HashSet<XMethod> methodsSeen = new HashSet<>();
 
-    HashSet<XMethod> doNotIgnore = new HashSet<XMethod>();
+    HashSet<XMethod> doNotIgnore = new HashSet<>();
 
-    HashSet<XMethod> doNotIgnoreHigh = new HashSet<XMethod>();
+    HashSet<XMethod> doNotIgnoreHigh = new HashSet<>();
 
     int returnSelf, returnOther, returnNew, returnUnknown;
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/HugeSharedStringConstants.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/HugeSharedStringConstants.java
@@ -47,11 +47,11 @@ public class HugeSharedStringConstants extends BytecodeScanningDetector {
         return s.length() + ":" + s.hashCode();
     }
 
-    HashMap<String, SortedSet<String>> map = new HashMap<String, SortedSet<String>>();
+    HashMap<String, SortedSet<String>> map = new HashMap<>();
 
-    HashMap<String, XField> definition = new HashMap<String, XField>();
+    HashMap<String, XField> definition = new HashMap<>();
 
-    HashMap<String, Integer> stringSize = new HashMap<String, Integer>();
+    HashMap<String, Integer> stringSize = new HashMap<>();
 
     BugReporter bugReporter;
 
@@ -68,7 +68,7 @@ public class HugeSharedStringConstants extends BytecodeScanningDetector {
         String key = getStringKey(value);
         SortedSet<String> set = map.get(key);
         if (set == null) {
-            set = new TreeSet<String>();
+            set = new TreeSet<>();
             map.put(key, set);
         }
         set.add(getDottedClassName());

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InfiniteLoop.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InfiniteLoop.java
@@ -44,7 +44,7 @@ public class InfiniteLoop extends OpcodeStackDetector {
 
     //    private static final boolean active = true;
 
-    ArrayList<BitSet> regModifiedAt = new ArrayList<BitSet>();
+    ArrayList<BitSet> regModifiedAt = new ArrayList<>();
 
     @Nonnull
     BitSet getModifiedBitSet(int reg) {
@@ -106,7 +106,7 @@ public class InfiniteLoop extends OpcodeStackDetector {
     }
 
     static class BackwardsBranch extends Jump {
-        final List<Integer> invariantRegisters = new LinkedList<Integer>();
+        final List<Integer> invariantRegisters = new LinkedList<>();
 
         final int numLastUpdates;
 
@@ -162,13 +162,13 @@ public class InfiniteLoop extends OpcodeStackDetector {
 
     BugReporter bugReporter;
 
-    HashSet<Jump> backwardReach = new HashSet<Jump>();
+    HashSet<Jump> backwardReach = new HashSet<>();
 
-    HashSet<BackwardsBranch> backwardBranches = new HashSet<BackwardsBranch>();
+    HashSet<BackwardsBranch> backwardBranches = new HashSet<>();
 
-    HashSet<ForwardConditionalBranch> forwardConditionalBranches = new HashSet<ForwardConditionalBranch>();
+    HashSet<ForwardConditionalBranch> forwardConditionalBranches = new HashSet<>();
 
-    LinkedList<Jump> forwardJumps = new LinkedList<Jump>();
+    LinkedList<Jump> forwardJumps = new LinkedList<>();
 
     void purgeForwardJumps(int before) {
         if (true) {
@@ -220,7 +220,7 @@ public class InfiniteLoop extends OpcodeStackDetector {
         backwardReach.clear();
         super.visit(obj);
         backwardBranchLoop: for (BackwardsBranch bb : backwardBranches) {
-            LinkedList<ForwardConditionalBranch> myForwardBranches = new LinkedList<ForwardConditionalBranch>();
+            LinkedList<ForwardConditionalBranch> myForwardBranches = new LinkedList<>();
             int myBackwardsReach = getBackwardsReach(bb.to);
 
             for (ForwardConditionalBranch fcb : forwardConditionalBranches) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InitializationChain.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InitializationChain.java
@@ -44,21 +44,21 @@ import edu.umd.cs.findbugs.ba.XField;
 import edu.umd.cs.findbugs.ba.XMethod;
 
 public class InitializationChain extends BytecodeScanningDetector {
-    Set<String> requires = new TreeSet<String>();
+    Set<String> requires = new TreeSet<>();
 
-    Map<String, Set<String>> classRequires = new TreeMap<String, Set<String>>();
+    Map<String, Set<String>> classRequires = new TreeMap<>();
 
 
 
     private final BugReporter bugReporter;
 
-    private final Map<XMethod, Set<XField>> staticFieldsRead = new HashMap<XMethod, Set<XField>>();
-    private final Set<XField> staticFieldsReadInAnyConstructor = new HashSet<XField>();
-    private Set<XField> fieldsReadInThisConstructor = new HashSet<XField>();
+    private final Map<XMethod, Set<XField>> staticFieldsRead = new HashMap<>();
+    private final Set<XField> staticFieldsReadInAnyConstructor = new HashSet<>();
+    private Set<XField> fieldsReadInThisConstructor = new HashSet<>();
 
-    private final Set<XMethod> constructorsInvokedInStaticInitializer = new HashSet<XMethod>();
-    private final List<InvocationInfo> invocationInfo = new ArrayList<InvocationInfo>();
-    private final Set<XField> warningGiven = new HashSet<XField>();
+    private final Set<XMethod> constructorsInvokedInStaticInitializer = new HashSet<>();
+    private final List<InvocationInfo> invocationInfo = new ArrayList<>();
+    private final Set<XField> warningGiven = new HashSet<>();
 
     private InvocationInfo lastInvocation;
 
@@ -80,7 +80,7 @@ public class InitializationChain extends BytecodeScanningDetector {
 
     @Override
     protected Iterable<Method> getMethodVisitOrder(JavaClass obj) {
-        ArrayList<Method> visitOrder = new ArrayList<Method>();
+        ArrayList<Method> visitOrder = new ArrayList<>();
         Method staticInitializer = null;
         for(Method m : obj.getMethods()) {
             String name = m.getName();
@@ -100,7 +100,7 @@ public class InitializationChain extends BytecodeScanningDetector {
 
     @Override
     public void visit(Code obj) {
-        fieldsReadInThisConstructor  = new HashSet<XField>();
+        fieldsReadInThisConstructor  = new HashSet<>();
         super.visit(obj);
         staticFieldsRead.put(getXMethod(), fieldsReadInThisConstructor);
         requires.remove(getDottedClassName());
@@ -113,7 +113,7 @@ public class InitializationChain extends BytecodeScanningDetector {
         }
         if (!requires.isEmpty()) {
             classRequires.put(getDottedClassName(), requires);
-            requires = new TreeSet<String>();
+            requires = new TreeSet<>();
         }
     }
 
@@ -186,11 +186,11 @@ public class InitializationChain extends BytecodeScanningDetector {
 
     public void compute() {
         Set<String> allClasses = classRequires.keySet();
-        Set<String> emptyClasses = new TreeSet<String>();
+        Set<String> emptyClasses = new TreeSet<>();
         for (String c : allClasses) {
             Set<String> needs = classRequires.get(c);
             needs.retainAll(allClasses);
-            Set<String> extra = new TreeSet<String>();
+            Set<String> extra = new TreeSet<>();
             for (String need : needs) {
                 extra.addAll(classRequires.get(need));
             }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InitializeNonnullFieldsInConstructor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InitializeNonnullFieldsInConstructor.java
@@ -40,11 +40,11 @@ public class InitializeNonnullFieldsInConstructor extends OpcodeStackDetector {
 
     final BugReporter bugReporter;
 
-    final HashSet<XField> initializedFields = new HashSet<XField>();
+    final HashSet<XField> initializedFields = new HashSet<>();
 
-    final HashSet<XField> nonnullFields = new HashSet<XField>();
+    final HashSet<XField> nonnullFields = new HashSet<>();
 
-    final HashSet<XField> nonnullStaticFields = new HashSet<XField>();
+    final HashSet<XField> nonnullStaticFields = new HashSet<>();
 
     public InitializeNonnullFieldsInConstructor(BugReporter bugReporter) {
         this.bugReporter = bugReporter;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/LoadOfKnownNullValue.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/LoadOfKnownNullValue.java
@@ -117,7 +117,7 @@ public class LoadOfKnownNullValue implements Detector {
             }
         }
 
-        IdentityHashMap<InstructionHandle, Object> sometimesGood = new IdentityHashMap<InstructionHandle, Object>();
+        IdentityHashMap<InstructionHandle, Object> sometimesGood = new IdentityHashMap<>();
 
         for (Iterator<Location> i = cfg.locationIterator(); i.hasNext();) {
             Location location = i.next();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/LostLoggerDueToWeakReference.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/LostLoggerDueToWeakReference.java
@@ -53,7 +53,7 @@ public class LostLoggerDueToWeakReference extends OpcodeStackDetector {
 
     final BugAccumulator bugAccumulator;
 
-    final HashSet<String> namesOfSetterMethods = new HashSet<String>();
+    final HashSet<String> namesOfSetterMethods = new HashSet<>();
 
     public LostLoggerDueToWeakReference(BugReporter bugReporter) {
         //        this.bugReporter = bugReporter;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MultithreadedInstanceAccess.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MultithreadedInstanceAccess.java
@@ -66,7 +66,7 @@ public class MultithreadedInstanceAccess extends OpcodeStackDetector {
             return mtClasses;
         }
 
-        mtClasses = new HashSet<JavaClass>();
+        mtClasses = new HashSet<>();
         try {
             mtClasses.add(Repository.lookupClass(STRUTS_ACTION_NAME));
         } catch (ClassNotFoundException cnfe) {
@@ -123,7 +123,7 @@ public class MultithreadedInstanceAccess extends OpcodeStackDetector {
     @Override
     public void visitMethod(Method obj) {
         monitorCount = 0;
-        alreadyReported = new HashSet<String>();
+        alreadyReported = new HashSet<>();
         writingField = false;
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MutableLock.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MutableLock.java
@@ -33,9 +33,9 @@ import edu.umd.cs.findbugs.BytecodeScanningDetector;
 import edu.umd.cs.findbugs.StatelessDetector;
 
 public class MutableLock extends BytecodeScanningDetector implements StatelessDetector {
-    Set<String> setFields = new HashSet<String>();
+    Set<String> setFields = new HashSet<>();
 
-    Set<String> finalFields = new HashSet<String>();
+    Set<String> finalFields = new HashSet<>();
 
     boolean thisOnTOS = false;
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MutableStaticFields.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MutableStaticFields.java
@@ -87,7 +87,7 @@ public class MutableStaticFields extends BytecodeScanningDetector {
                 sig.charAt(0) == '[';
     }
 
-    LinkedList<XField> seen = new LinkedList<XField>();
+    LinkedList<XField> seen = new LinkedList<>();
 
     boolean publicClass;
 
@@ -101,23 +101,23 @@ public class MutableStaticFields extends BytecodeScanningDetector {
 
     String packageName;
 
-    Set<XField> readAnywhere = new HashSet<XField>();
+    Set<XField> readAnywhere = new HashSet<>();
 
-    Set<XField> unsafeValue = new HashSet<XField>();
+    Set<XField> unsafeValue = new HashSet<>();
 
-    Set<XField> mutableCollection = new HashSet<XField>();
+    Set<XField> mutableCollection = new HashSet<>();
 
-    Set<XField> notFinal = new HashSet<XField>();
+    Set<XField> notFinal = new HashSet<>();
 
-    Set<XField> outsidePackage = new HashSet<XField>();
+    Set<XField> outsidePackage = new HashSet<>();
 
-    Set<XField> needsRefactoringToBeFinal = new HashSet<XField>();
+    Set<XField> needsRefactoringToBeFinal = new HashSet<>();
 
-    Set<XField> writtenInMethod = new HashSet<XField>();
+    Set<XField> writtenInMethod = new HashSet<>();
 
-    Set<XField> writtenTwiceInMethod = new HashSet<XField>();
+    Set<XField> writtenTwiceInMethod = new HashSet<>();
 
-    Map<XField, SourceLineAnnotation> firstFieldUse = new HashMap<XField, SourceLineAnnotation>();
+    Map<XField, SourceLineAnnotation> firstFieldUse = new HashMap<>();
 
     private final BugReporter bugReporter;
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/Naming.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/Naming.java
@@ -128,9 +128,9 @@ public class Naming extends PreorderVisitor implements Detector {
     }
 
     // map of canonicalName -> Set<XMethod>
-    HashMap<String, TreeSet<XMethod>> canonicalToXMethod = new HashMap<String, TreeSet<XMethod>>();
+    HashMap<String, TreeSet<XMethod>> canonicalToXMethod = new HashMap<>();
 
-    HashSet<String> visited = new HashSet<String>();
+    HashSet<String> visited = new HashSet<>();
 
     private final BugReporter bugReporter;
 
@@ -154,7 +154,7 @@ public class Naming extends PreorderVisitor implements Detector {
             try {
                 if ((confusingMethodNamesWrongCapitalization(m, m2) || confusingMethodNamesWrongPackage(m, m2))
                         && Repository.instanceOf(m.getClassName(), m2.getClassName())) {
-                    WarningPropertySet<NamingProperty> propertySet = new WarningPropertySet<NamingProperty>();
+                    WarningPropertySet<NamingProperty> propertySet = new WarningPropertySet<>();
 
                     int priority = HIGH_PRIORITY;
                     boolean intentional = false;
@@ -278,7 +278,7 @@ public class Naming extends PreorderVisitor implements Detector {
 
         for (Map.Entry<String, TreeSet<XMethod>> e : canonicalToXMethod.entrySet()) {
             TreeSet<XMethod> conflictingMethods = e.getValue();
-            HashSet<String> trueNames = new HashSet<String>();
+            HashSet<String> trueNames = new HashSet<>();
 
             for (XMethod m : conflictingMethods) {
                 trueNames.add(m.getName() + m.getSignature());
@@ -602,7 +602,7 @@ public class Naming extends PreorderVisitor implements Detector {
         {
             TreeSet<XMethod> s = canonicalToXMethod.get(allSmall);
             if (s == null) {
-                s = new TreeSet<XMethod>();
+                s = new TreeSet<>();
                 canonicalToXMethod.put(allSmall, s);
             }
             s.add(xm);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/NoiseNullDeref.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/NoiseNullDeref.java
@@ -252,7 +252,7 @@ public class NoiseNullDeref implements Detector, UseAnnotationDatabase, NullDere
         if (!refValue.isNullOnComplicatedPath23()) {
             return;
         }
-        WarningPropertySet<WarningProperty> propertySet = new WarningPropertySet<WarningProperty>();
+        WarningPropertySet<WarningProperty> propertySet = new WarningPropertySet<>();
         if (valueNumber.hasFlag(ValueNumber.CONSTANT_CLASS_OBJECT)) {
             return;
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/NoteDirectlyRelevantTypeQualifiers.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/NoteDirectlyRelevantTypeQualifiers.java
@@ -70,7 +70,7 @@ public class NoteDirectlyRelevantTypeQualifiers extends DismantleBytecode implem
 
     @Override
     public void visit(Code m) {
-        applicableApplications = new HashSet<TypeQualifierValue<?>>();
+        applicableApplications = new HashSet<>();
         XMethod xMethod = getXMethod();
 
         // Find the direct annotations on this method
@@ -80,7 +80,7 @@ public class NoteDirectlyRelevantTypeQualifiers extends DismantleBytecode implem
         super.visit(m);
 
         if (applicableApplications.size() > 0) {
-            qualifiers.setDirectlyRelevantTypeQualifiers(getMethodDescriptor(), new ArrayList<TypeQualifierValue<?>>(
+            qualifiers.setDirectlyRelevantTypeQualifiers(getMethodDescriptor(), new ArrayList<>(
                     applicableApplications));
         }
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/NoteSuppressedWarnings.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/NoteSuppressedWarnings.java
@@ -47,7 +47,7 @@ import edu.umd.cs.findbugs.visitclass.AnnotationVisitor;
 
 public class NoteSuppressedWarnings extends AnnotationVisitor implements Detector, NonReportingDetector {
 
-    private final Set<String> packages = new HashSet<String>();
+    private final Set<String> packages = new HashSet<>();
 
     private final SuppressionMatcher suppressionMatcher;
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/NumberConstructor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/NumberConstructor.java
@@ -64,7 +64,7 @@ public class NumberConstructor extends OpcodeStackDetector {
             this.parsingMethod = parsingMethod;
         }
     }
-    private final Map<String, Pair> boxClasses = new HashMap<String, Pair>();
+    private final Map<String, Pair> boxClasses = new HashMap<>();
 
     private final List<MethodDescriptor> methods = new ArrayList<>();
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/OverridingEqualsNotSymmetrical.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/OverridingEqualsNotSymmetrical.java
@@ -57,13 +57,13 @@ public class OverridingEqualsNotSymmetrical extends OpcodeStackDetector implemen
 
     private static final String STATIC_EQUALS_SIGNATURE = "(Ljava/lang/Object;Ljava/lang/Object;)Z";
 
-    Map<ClassDescriptor, Set<ClassDescriptor>> classesWithGetClassBasedEquals = new HashMap<ClassDescriptor, Set<ClassDescriptor>>();
+    Map<ClassDescriptor, Set<ClassDescriptor>> classesWithGetClassBasedEquals = new HashMap<>();
 
-    Map<ClassDescriptor, Set<ClassDescriptor>> classesWithInstanceOfBasedEquals = new HashMap<ClassDescriptor, Set<ClassDescriptor>>();
+    Map<ClassDescriptor, Set<ClassDescriptor>> classesWithInstanceOfBasedEquals = new HashMap<>();
 
-    Map<ClassAnnotation, ClassAnnotation> parentMap = new TreeMap<ClassAnnotation, ClassAnnotation>();
+    Map<ClassAnnotation, ClassAnnotation> parentMap = new TreeMap<>();
 
-    Map<ClassAnnotation, MethodDescriptor> equalsMethod = new TreeMap<ClassAnnotation, MethodDescriptor>();
+    Map<ClassAnnotation, MethodDescriptor> equalsMethod = new TreeMap<>();
 
     final BugReporter bugReporter;
 
@@ -192,7 +192,7 @@ public class OverridingEqualsNotSymmetrical extends OpcodeStackDetector implemen
 
     boolean sawEqualsBuilder;
 
-    private final EnumMap<EqualsKindSummary.KindOfEquals, Integer> count = new EnumMap<EqualsKindSummary.KindOfEquals, Integer>(
+    private final EnumMap<EqualsKindSummary.KindOfEquals, Integer> count = new EnumMap<>(
             EqualsKindSummary.KindOfEquals.class);
 
     private void count(EqualsKindSummary.KindOfEquals k) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/PreferZeroLengthArrays.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/PreferZeroLengthArrays.java
@@ -40,7 +40,7 @@ public class PreferZeroLengthArrays extends BytecodeScanningDetector implements 
         this.bugReporter = bugReporter;
     }
 
-    Collection<SourceLineAnnotation> found = new LinkedList<SourceLineAnnotation>();
+    Collection<SourceLineAnnotation> found = new LinkedList<>();
 
     @Override
     public void visit(Code obj) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ReadOfInstanceFieldInMethodInvokedByConstructorInSuperclass.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ReadOfInstanceFieldInMethodInvokedByConstructorInSuperclass.java
@@ -60,8 +60,8 @@ public class ReadOfInstanceFieldInMethodInvokedByConstructorInSuperclass extends
         if (getMethod().isStatic()) {
             return;
         }
-        initializedFields = new HashSet<XField>();
-        nullCheckedFields = new HashSet<XField>();
+        initializedFields = new HashSet<>();
+        nullCheckedFields = new HashSet<>();
         super.visit(obj);
         accumulator.reportAccumulatedBugs();
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/RedundantInterfaces.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/RedundantInterfaces.java
@@ -55,7 +55,7 @@ public class RedundantInterfaces extends PreorderVisitor implements Detector, St
 
         try {
             JavaClass superObj = obj.getSuperClass();
-            SortedSet<String> redundantInfNames = new TreeSet<String>();
+            SortedSet<String> redundantInfNames = new TreeSet<>();
 
             for (String interfaceName : interfaceNames) {
                 if (!"java.io.Serializable".equals(interfaceName)) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/RepeatedConditionals.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/RepeatedConditionals.java
@@ -68,11 +68,11 @@ public class RepeatedConditionals extends OpcodeStackDetector {
      */
     int oldPC;
 
-    LinkedList<Integer> emptyStackLocations = new LinkedList<Integer>();
+    LinkedList<Integer> emptyStackLocations = new LinkedList<>();
 
-    LinkedList<Integer> prevOpcodeLocations = new LinkedList<Integer>();
+    LinkedList<Integer> prevOpcodeLocations = new LinkedList<>();
 
-    Map<Integer, Integer> branchTargets = new HashMap<Integer, Integer>();
+    Map<Integer, Integer> branchTargets = new HashMap<>();
 
     @Override
     public void sawBranchTo(int pc) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ResolveAllReferences.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ResolveAllReferences.java
@@ -47,7 +47,7 @@ public class ResolveAllReferences extends PreorderVisitor implements Detector {
     private void compute() {
         if (defined == null) {
             // System.out.println("Computing");
-            defined = new HashSet<String>();
+            defined = new HashSet<>();
 
             Subtypes2 subtypes2 = AnalysisContext.currentAnalysisContext().getSubtypes2();
             Collection<XClass> allClasses = subtypes2.getXClassCollection();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/RuntimeExceptionCapture.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/RuntimeExceptionCapture.java
@@ -73,9 +73,9 @@ public class RuntimeExceptionCapture extends OpcodeStackDetector implements Stat
 
     private final BugReporter bugReporter;
 
-    private final List<ExceptionCaught> catchList = new ArrayList<ExceptionCaught>();
+    private final List<ExceptionCaught> catchList = new ArrayList<>();
 
-    private final List<ExceptionThrown> throwList = new ArrayList<ExceptionThrown>();
+    private final List<ExceptionThrown> throwList = new ArrayList<>();
 
     private final BugAccumulator accumulator;
 
@@ -122,7 +122,7 @@ public class RuntimeExceptionCapture extends OpcodeStackDetector implements Stat
     @Override
     public void visitAfter(Code obj) {
         for (ExceptionCaught caughtException : catchList) {
-            Set<String> thrownSet = new HashSet<String>();
+            Set<String> thrownSet = new HashSet<>();
             for (ExceptionThrown thrownException : throwList) {
                 if (thrownException.offset >= caughtException.startOffset && thrownException.offset < caughtException.endOffset) {
                     thrownSet.add(thrownException.exceptionClass);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SerializableIdiom.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SerializableIdiom.java
@@ -90,15 +90,15 @@ public class SerializableIdiom extends OpcodeStackDetector {
 
     boolean isAbstract;
 
-    private final List<BugInstance> fieldWarningList = new LinkedList<BugInstance>();
+    private final List<BugInstance> fieldWarningList = new LinkedList<>();
 
-    private final HashMap<String, XField> fieldsThatMightBeAProblem = new HashMap<String, XField>();
+    private final HashMap<String, XField> fieldsThatMightBeAProblem = new HashMap<>();
 
-    private final HashMap<XField, Integer> transientFieldsUpdates = new HashMap<XField, Integer>();
+    private final HashMap<XField, Integer> transientFieldsUpdates = new HashMap<>();
 
-    private final HashSet<XField> transientFieldsSetInConstructor = new HashSet<XField>();
+    private final HashSet<XField> transientFieldsSetInConstructor = new HashSet<>();
 
-    private final HashSet<XField> transientFieldsSetToDefaultValueInConstructor = new HashSet<XField>();
+    private final HashSet<XField> transientFieldsSetToDefaultValueInConstructor = new HashSet<>();
 
     private boolean sawReadExternal;
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/StaticCalendarDetector.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/StaticCalendarDetector.java
@@ -103,7 +103,7 @@ public class StaticCalendarDetector extends OpcodeStackDetector {
     /** Stores current LDF */
     private LockDataflow currentLockDataFlow;
 
-    private final Map<XField, BugInstance> pendingBugs = new HashMap<XField, BugInstance>();
+    private final Map<XField, BugInstance> pendingBugs = new HashMap<>();
 
     /**
      * Creates a new instance of this Detector.

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/StreamEquivalenceClass.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/StreamEquivalenceClass.java
@@ -36,7 +36,7 @@ public class StreamEquivalenceClass {
      * Constructor. Creates an empty set.
      */
     public StreamEquivalenceClass() {
-        this.memberSet = new HashSet<Stream>();
+        this.memberSet = new HashSet<>();
         this.isClosed = false;
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/StreamResourceTracker.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/StreamResourceTracker.java
@@ -94,10 +94,10 @@ public class StreamResourceTracker implements ResourceTracker<Stream> {
 
         this.streamFactoryList = streamFactoryList;
         this.lookupFailureCallback = lookupFailureCallback;
-        this.streamOpenLocationMap = new HashMap<Location, Stream>();
-        this.uninterestingStreamEscapeSet = new HashSet<Stream>();
-        this.streamEscapeSet = new TreeSet<StreamEscape>();
-        this.streamEquivalenceMap = new HashMap<Stream, StreamEquivalenceClass>();
+        this.streamOpenLocationMap = new HashMap<>();
+        this.uninterestingStreamEscapeSet = new HashSet<>();
+        this.streamEscapeSet = new TreeSet<>();
+        this.streamEquivalenceMap = new HashMap<>();
     }
 
     /**
@@ -154,7 +154,7 @@ public class StreamResourceTracker implements ResourceTracker<Stream> {
         // Starting with the set of uninteresting stream open location points,
         // propagate all uninteresting stream escapes. Iterate until there
         // is no change. This also builds the map of stream equivalence classes.
-        Set<Stream> orig = new HashSet<Stream>();
+        Set<Stream> orig = new HashSet<>();
         do {
             orig.clear();
             orig.addAll(uninterestingStreamEscapeSet);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/StringConcatenation.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/StringConcatenation.java
@@ -75,7 +75,7 @@ public class StringConcatenation extends BytecodeScanningDetector implements Sta
 
     // Keep track of which registers where clobbered at which PC, on
     // a per-method basis
-    private Map<Integer, Integer> clobberedRegisters = new HashMap<Integer, Integer>();
+    private Map<Integer, Integer> clobberedRegisters = new HashMap<>();
 
     @Override
     public void visit(Method obj) {
@@ -83,7 +83,7 @@ public class StringConcatenation extends BytecodeScanningDetector implements Sta
             System.out.println("------------------- Analyzing " + obj.getName() + " ----------------");
         }
         reset();
-        clobberedRegisters = new HashMap<Integer, Integer>();
+        clobberedRegisters = new HashMap<>();
         reportedThisMethod = false;
         super.visit(obj);
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SwitchFallthrough.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SwitchFallthrough.java
@@ -67,11 +67,11 @@ public class SwitchFallthrough extends OpcodeStackDetector implements StatelessD
 
     private final BitSet potentiallyDeadStores = new BitSet();
 
-    private final Set<XField> potentiallyDeadFields = new HashSet<XField>();
+    private final Set<XField> potentiallyDeadFields = new HashSet<>();
 
     private BitSet potentiallyDeadStoresFromBeforeFallthrough = new BitSet();
 
-    private Set<XField> potentiallyDeadFieldsFromBeforeFallthrough = new HashSet<XField>();
+    private Set<XField> potentiallyDeadFieldsFromBeforeFallthrough = new HashSet<>();
 
     private LocalVariableAnnotation deadStore = null;
 
@@ -88,7 +88,7 @@ public class SwitchFallthrough extends OpcodeStackDetector implements StatelessD
         classContext.getJavaClass().accept(this);
     }
 
-    Collection<SourceLineAnnotation> found = new LinkedList<SourceLineAnnotation>();
+    Collection<SourceLineAnnotation> found = new LinkedList<>();
 
     @Override
     public void visit(Code obj) {
@@ -165,7 +165,7 @@ public class SwitchFallthrough extends OpcodeStackDetector implements StatelessD
             }
             fallthroughDistance = 0;
             potentiallyDeadStoresFromBeforeFallthrough = (BitSet) potentiallyDeadStores.clone();
-            potentiallyDeadFieldsFromBeforeFallthrough = new HashSet<XField>(potentiallyDeadFields);
+            potentiallyDeadFieldsFromBeforeFallthrough = new HashSet<>(potentiallyDeadFields);
             if (!hasFallThruComment(lastPC + 1, getPC() - 1)) {
                 if (!isDefaultOffset) {
                     SourceLineAnnotation sourceLineAnnotation = SourceLineAnnotation.fromVisitedInstructionRange(

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SynchronizationOnSharedBuiltinConstant.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SynchronizationOnSharedBuiltinConstant.java
@@ -47,7 +47,7 @@ public class SynchronizationOnSharedBuiltinConstant extends OpcodeStackDetector 
 
     public SynchronizationOnSharedBuiltinConstant(BugReporter bugReporter) {
         this.bugAccumulator = new BugAccumulator(bugReporter);
-        badSignatures = new HashSet<String>();
+        badSignatures = new HashSet<>();
         badSignatures.addAll(Arrays.asList(new String[] { "Ljava/lang/Boolean;", "Ljava/lang/Double;", "Ljava/lang/Float;",
                 "Ljava/lang/Byte;", "Ljava/lang/Character;", "Ljava/lang/Short;", "Ljava/lang/Integer;", "Ljava/lang/Long;" }));
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/TestDataflowAnalysis.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/TestDataflowAnalysis.java
@@ -122,7 +122,7 @@ public class TestDataflowAnalysis<Fact,AnalysisType extends DataflowAnalysis<Fac
 
             if (SystemProperties.getBoolean("dataflow.printcfg")) {
                 DataflowCFGPrinter<Fact,AnalysisType> cfgPrinter
-                = new DataflowCFGPrinter<Fact,AnalysisType>(dataflow);
+                = new DataflowCFGPrinter<>(dataflow);
                 cfgPrinter.print(System.out);
             }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UncallableMethodOfAnonymousClass.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UncallableMethodOfAnonymousClass.java
@@ -136,7 +136,7 @@ public class UncallableMethodOfAnonymousClass extends BytecodeScanningDetector {
     }
 
     Set<String> definedInClass(JavaClass clazz) {
-        HashSet<String> result = new HashSet<String>();
+        HashSet<String> result = new HashSet<>();
         for (Method m : clazz.getMethods()) {
             if (!skip(m)) {
                 result.add(m.getName() + m.getSignature());

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UnreadFields.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UnreadFields.java
@@ -819,7 +819,7 @@ public class UnreadFields extends OpcodeStackDetector {
 
     @Override
     public void report() {
-        Set<String> fieldNamesSet = new HashSet<String>();
+        Set<String> fieldNamesSet = new HashSet<>();
         for (XField f : data.writtenNonNullFields) {
             fieldNamesSet.add(f.getName());
         }
@@ -855,7 +855,7 @@ public class UnreadFields extends OpcodeStackDetector {
                 System.out.println("  " + f);
             }
         }
-        Set<XField> declaredFields = new HashSet<XField>();
+        Set<XField> declaredFields = new HashSet<>();
         AnalysisContext currentAnalysisContext = AnalysisContext.currentAnalysisContext();
         XFactory xFactory = AnalysisContext.currentXFactory();
         for (XField f : AnalysisContext.currentXFactory().allFields()) {
@@ -866,7 +866,7 @@ public class UnreadFields extends OpcodeStackDetector {
             }
         }
         // Don't report anything about ejb3Fields
-        HashSet<XField> unknownAnotationAndUnwritten = new HashSet<XField>(data.unknownAnnotation.keySet());
+        HashSet<XField> unknownAnotationAndUnwritten = new HashSet<>(data.unknownAnnotation.keySet());
         unknownAnotationAndUnwritten.removeAll(data.writtenFields);
         declaredFields.removeAll(unknownAnotationAndUnwritten);
         declaredFields.removeAll(data.containerFields);
@@ -878,7 +878,7 @@ public class UnreadFields extends OpcodeStackDetector {
             }
         }
 
-        TreeSet<XField> notInitializedInConstructors = new TreeSet<XField>(declaredFields);
+        TreeSet<XField> notInitializedInConstructors = new TreeSet<>(declaredFields);
         notInitializedInConstructors.retainAll(data.readFields);
         notInitializedInConstructors.retainAll(data.writtenNonNullFields);
         notInitializedInConstructors.retainAll(data.assumedNonNull.keySet());
@@ -891,12 +891,12 @@ public class UnreadFields extends OpcodeStackDetector {
             }
         }
 
-        TreeSet<XField> readOnlyFields = new TreeSet<XField>(declaredFields);
+        TreeSet<XField> readOnlyFields = new TreeSet<>(declaredFields);
         readOnlyFields.removeAll(data.writtenFields);
 
         readOnlyFields.retainAll(data.readFields);
 
-        TreeSet<XField> nullOnlyFields = new TreeSet<XField>(declaredFields);
+        TreeSet<XField> nullOnlyFields = new TreeSet<>(declaredFields);
         nullOnlyFields.removeAll(data.writtenNonNullFields);
 
         nullOnlyFields.retainAll(data.readFields);
@@ -904,9 +904,9 @@ public class UnreadFields extends OpcodeStackDetector {
         Set<XField> writeOnlyFields = declaredFields;
         writeOnlyFields.removeAll(data.readFields);
 
-        Map<String, Integer> count = new HashMap<String, Integer>();
-        Bag<String> nullOnlyFieldNames = new Bag<String>();
-        Bag<ClassDescriptor> classContainingNullOnlyFields = new Bag<ClassDescriptor>();
+        Map<String, Integer> count = new HashMap<>();
+        Bag<String> nullOnlyFieldNames = new Bag<>();
+        Bag<ClassDescriptor> classContainingNullOnlyFields = new Bag<>();
 
         for (XField f : nullOnlyFields) {
             nullOnlyFieldNames.add(f.getName());
@@ -925,9 +925,9 @@ public class UnreadFields extends OpcodeStackDetector {
                 }
             }
         }
-        Map<XField, Integer> maxCount = new HashMap<XField, Integer>();
+        Map<XField, Integer> maxCount = new HashMap<>();
 
-        LinkedList<XField> assumeReflective = new LinkedList<XField>();
+        LinkedList<XField> assumeReflective = new LinkedList<>();
         for (XField f : nullOnlyFields) {
             int myMaxCount = 0;
             for (String s : data.unknownAnnotation.get(f)) {
@@ -955,7 +955,7 @@ public class UnreadFields extends OpcodeStackDetector {
         nullOnlyFields.removeAll(assumeReflective);
         notInitializedInConstructors.removeAll(assumeReflective);
 
-        Bag<String> notInitializedUses = new Bag<String>();
+        Bag<String> notInitializedUses = new Bag<>();
         for (XField f : notInitializedInConstructors) {
             String className = f.getClassName();
             Set<ProgramPoint> assumedNonnullAt = data.assumedNonNull.get(f);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UnreadFieldsData.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UnreadFieldsData.java
@@ -36,58 +36,58 @@ import edu.umd.cs.findbugs.util.MultiMap;
  * @author  pugh
  */
 public class UnreadFieldsData {
-    final Map<XField, Set<ProgramPoint>> assumedNonNull = new HashMap<XField, Set<ProgramPoint>>();
+    final Map<XField, Set<ProgramPoint>> assumedNonNull = new HashMap<>();
 
-    final  Map<XField, ProgramPoint> threadLocalAssignedInConstructor = new HashMap<XField, ProgramPoint>();
+    final  Map<XField, ProgramPoint> threadLocalAssignedInConstructor = new HashMap<>();
 
-    final Set<XField> nullTested = new HashSet<XField>();
+    final Set<XField> nullTested = new HashSet<>();
 
-    final Set<XField> containerFields = new TreeSet<XField>();
+    final Set<XField> containerFields = new TreeSet<>();
 
-    final MultiMap<XField, String> unknownAnnotation = new MultiMap<XField, String>(LinkedList.class);
+    final MultiMap<XField, String> unknownAnnotation = new MultiMap<>(LinkedList.class);
 
-    final Set<String> abstractClasses = new HashSet<String>();
+    final Set<String> abstractClasses = new HashSet<>();
 
-    final Set<String> hasNonAbstractSubClass = new HashSet<String>();
+    final Set<String> hasNonAbstractSubClass = new HashSet<>();
 
-    final Set<String> classesScanned = new HashSet<String>();
+    final Set<String> classesScanned = new HashSet<>();
 
-    final Set<XField> fieldsOfNativeClasses = new HashSet<XField>();
+    final Set<XField> fieldsOfNativeClasses = new HashSet<>();
 
-    final Set<XField> reflectiveFields = new HashSet<XField>();
+    final Set<XField> reflectiveFields = new HashSet<>();
 
-    final Set<XField> fieldsOfSerializableOrNativeClassed = new HashSet<XField>();
+    final Set<XField> fieldsOfSerializableOrNativeClassed = new HashSet<>();
 
-    final  Set<XField> staticFieldsReadInThisMethod = new HashSet<XField>();
+    final  Set<XField> staticFieldsReadInThisMethod = new HashSet<>();
 
-    final  Set<XField> allMyFields = new TreeSet<XField>();
+    final  Set<XField> allMyFields = new TreeSet<>();
 
-    final Set<XField> myFields = new TreeSet<XField>();
+    final Set<XField> myFields = new TreeSet<>();
 
-    final  Set<XField> writtenFields = new HashSet<XField>();
+    final  Set<XField> writtenFields = new HashSet<>();
 
 
-    final Map<XField, SourceLineAnnotation> fieldAccess = new HashMap<XField, SourceLineAnnotation>();
+    final Map<XField, SourceLineAnnotation> fieldAccess = new HashMap<>();
 
-    final  Set<XField> writtenNonNullFields = new HashSet<XField>();
+    final  Set<XField> writtenNonNullFields = new HashSet<>();
 
-    final  Set<String> calledFromConstructors = new HashSet<String>();
+    final  Set<String> calledFromConstructors = new HashSet<>();
 
-    final Set<XField> writtenInConstructorFields = new HashSet<XField>();
+    final Set<XField> writtenInConstructorFields = new HashSet<>();
 
-    final Set<XField> writtenInInitializationFields = new HashSet<XField>();
+    final Set<XField> writtenInInitializationFields = new HashSet<>();
 
-    final Set<XField> writtenOutsideOfInitializationFields = new HashSet<XField>();
+    final Set<XField> writtenOutsideOfInitializationFields = new HashSet<>();
 
-    final  Set<XField> readFields = new HashSet<XField>();
+    final  Set<XField> readFields = new HashSet<>();
 
-    final  Set<XField> constantFields = new HashSet<XField>();
+    final  Set<XField> constantFields = new HashSet<>();
 
-    final Set<String> needsOuterObjectInConstructor = new HashSet<String>();
+    final Set<String> needsOuterObjectInConstructor = new HashSet<>();
 
-    final  Set<String> innerClassCannotBeStatic = new HashSet<String>();
+    final  Set<String> innerClassCannotBeStatic = new HashSet<>();
 
-    final   HashSet<ClassDescriptor> toldStrongEvidenceForIntendedSerialization = new HashSet<ClassDescriptor>();
+    final   HashSet<ClassDescriptor> toldStrongEvidenceForIntendedSerialization = new HashSet<>();
 
     public boolean isContainerField(XField f) {
         return containerFields.contains(f);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UselessSubclassMethod.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UselessSubclassMethod.java
@@ -73,7 +73,7 @@ public class UselessSubclassMethod extends BytecodeScanningDetector implements S
             JavaClass[] interfaces = null;
             if (cls.isClass() && ((cls.getAccessFlags() & Const.ACC_ABSTRACT) != 0)) {
                 interfaces = cls.getAllInterfaces();
-                interfaceMethods = new HashSet<String>();
+                interfaceMethods = new HashSet<>();
                 for (JavaClass aInterface : interfaces) {
                     Method[] infMethods = aInterface.getMethods();
                     for (Method meth : infMethods) {
@@ -298,7 +298,7 @@ public class UselessSubclassMethod extends BytecodeScanningDetector implements S
     }
 
     HashSet<String> thrownExceptions(Method m) {
-        HashSet<String> result = new HashSet<String>();
+        HashSet<String> result = new HashSet<>();
         ExceptionTable exceptionTable = m.getExceptionTable();
         if (exceptionTable != null) {
             for (String e : exceptionTable.getExceptionNames()) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/VolatileUsage.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/VolatileUsage.java
@@ -50,9 +50,9 @@ public class VolatileUsage extends BytecodeScanningDetector {
         classContext.getJavaClass().accept(this);
     }
 
-    Set<XField> initializationWrites = new HashSet<XField>();
+    Set<XField> initializationWrites = new HashSet<>();
 
-    Set<XField> otherWrites = new HashSet<XField>();
+    Set<XField> otherWrites = new HashSet<>();
 
     IncrementState state = IncrementState.START;
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/XMLFactoryBypass.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/XMLFactoryBypass.java
@@ -53,7 +53,7 @@ public class XMLFactoryBypass extends BytecodeScanningDetector {
         }
     };
 
-    private final Set<String> rejectedXMLClasses = new HashSet<String>();
+    private final Set<String> rejectedXMLClasses = new HashSet<>();
 
     private JavaClass curClass;
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/filter/CompoundMatcher.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/filter/CompoundMatcher.java
@@ -28,7 +28,7 @@ import java.util.LinkedHashSet;
 import edu.umd.cs.findbugs.xml.XMLOutput;
 
 public abstract class CompoundMatcher implements Matcher {
-    protected LinkedHashSet<Matcher> children = new LinkedHashSet<Matcher>();
+    protected LinkedHashSet<Matcher> children = new LinkedHashSet<>();
 
     @Override
     public int hashCode() {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/filter/Filter.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/filter/Filter.java
@@ -53,7 +53,7 @@ public class Filter extends OrMatcher {
     private static final boolean DEBUG = SystemProperties.getBoolean("filter.debug");
     private static final int PRIME = 31;
 
-    private final IdentityHashMap<Matcher, Boolean> disabled = new IdentityHashMap<Matcher, Boolean>();
+    private final IdentityHashMap<Matcher, Boolean> disabled = new IdentityHashMap<>();
 
     /**
      * Constructor for empty filter

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/filter/RelationalOp.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/filter/RelationalOp.java
@@ -37,7 +37,7 @@ public abstract class RelationalOp {
     final String name;
 
     @StaticConstant
-    private static final Map<String, RelationalOp> map = new HashMap<String, RelationalOp>();
+    private static final Map<String, RelationalOp> map = new HashMap<>();
 
     public static RelationalOp byName(String s) {
         RelationalOp relationalOp = map.get(s);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/filter/StringSetMatch.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/filter/StringSetMatch.java
@@ -32,7 +32,7 @@ import java.util.StringTokenizer;
  * @author rak
  */
 public class StringSetMatch {
-    private final Set<String> strings = new HashSet<String>();
+    private final Set<String> strings = new HashSet<>();
 
     @Override
     public int hashCode() {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/graph/AbstractDepthFirstSearch.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/graph/AbstractDepthFirstSearch.java
@@ -105,7 +105,7 @@ implements DFSEdgeTypes {
 
         timestamp = 0;
 
-        topologicalSortList = new LinkedList<VertexType>();
+        topologicalSortList = new LinkedList<>();
     }
 
     // Abstract methods allow the concrete subclass to define
@@ -146,7 +146,7 @@ implements DFSEdgeTypes {
     }
 
     public Collection<VertexType> unvisitedVertices() {
-        LinkedList<VertexType> result = new LinkedList<VertexType>();
+        LinkedList<VertexType> result = new LinkedList<>();
 
         for (Iterator<VertexType> i = graph.vertexIterator(); i.hasNext();) {
             VertexType v = i.next();
@@ -302,7 +302,7 @@ implements DFSEdgeTypes {
                 searchTreeCallback.startSearchTree(searchTreeRoot);
             }
 
-            ArrayList<Visit> stack = new ArrayList<Visit>(graph.getNumVertexLabels());
+            ArrayList<Visit> stack = new ArrayList<>(graph.getNumVertexLabels());
             stack.add(new Visit(searchTreeRoot));
 
             while (!stack.isEmpty()) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/graph/AbstractGraph.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/graph/AbstractGraph.java
@@ -133,8 +133,8 @@ implements Graph<EdgeType, VertexType> {
      */
 
     public AbstractGraph() {
-        this.vertexList = new ArrayList<VertexType>();
-        this.edgeList = new ArrayList<EdgeType>();
+        this.vertexList = new ArrayList<>();
+        this.edgeList = new ArrayList<>();
         this.maxVertexLabel = 0;
         this.maxEdgeLabel = 0;
     }
@@ -247,12 +247,12 @@ implements Graph<EdgeType, VertexType> {
 
     @Override
     public Iterator<EdgeType> outgoingEdgeIterator(VertexType source) {
-        return new OutgoingEdgeIterator<EdgeType, VertexType>(source);
+        return new OutgoingEdgeIterator<>(source);
     }
 
     @Override
     public Iterator<EdgeType> incomingEdgeIterator(VertexType target) {
-        return new IncomingEdgeIterator<EdgeType, VertexType>(target);
+        return new IncomingEdgeIterator<>(target);
     }
 
     @Override

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/graph/MergeVertices.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/graph/MergeVertices.java
@@ -61,7 +61,7 @@ public class MergeVertices<GraphType extends Graph<EdgeType, VertexType>, EdgeTy
         // Get all vertices to which we have outgoing edges
         // or from which we have incoming edges, since they'll need
         // to be fixed
-        TreeSet<EdgeType> edgeSet = new TreeSet<EdgeType>();
+        TreeSet<EdgeType> edgeSet = new TreeSet<>();
         for (Iterator<EdgeType> i = g.edgeIterator(); i.hasNext();) {
             EdgeType e = i.next();
             if (vertexSet.contains(e.getSource()) || vertexSet.contains(e.getTarget())) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/graph/SearchTree.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/graph/SearchTree.java
@@ -40,7 +40,7 @@ public class SearchTree<VertexType extends GraphVertex<VertexType>> {
      */
     public SearchTree(VertexType v) {
         m_vertex = v;
-        m_childList = new ArrayList<SearchTree<VertexType>>();
+        m_childList = new ArrayList<>();
     }
 
     /**

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/graph/SearchTreeBuilder.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/graph/SearchTreeBuilder.java
@@ -32,9 +32,9 @@ import java.util.LinkedList;
  */
 public class SearchTreeBuilder<VertexType extends GraphVertex<VertexType>> implements SearchTreeCallback<VertexType> {
 
-    private final HashMap<VertexType, SearchTree<VertexType>> searchTreeMap = new HashMap<VertexType, SearchTree<VertexType>>();
+    private final HashMap<VertexType, SearchTree<VertexType>> searchTreeMap = new HashMap<>();
 
-    private final LinkedList<SearchTree<VertexType>> searchTreeList = new LinkedList<SearchTree<VertexType>>();
+    private final LinkedList<SearchTree<VertexType>> searchTreeList = new LinkedList<>();
 
     @Override
     public void startSearchTree(VertexType vertex) {
@@ -59,7 +59,7 @@ public class SearchTreeBuilder<VertexType extends GraphVertex<VertexType>> imple
     }
 
     private SearchTree<VertexType> createSearchTree(VertexType vertex) {
-        SearchTree<VertexType> searchTree = new SearchTree<VertexType>(vertex);
+        SearchTree<VertexType> searchTree = new SearchTree<>(vertex);
         searchTreeMap.put(vertex, searchTree);
         return searchTree;
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/graph/StronglyConnectedComponents.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/graph/StronglyConnectedComponents.java
@@ -40,7 +40,7 @@ public class StronglyConnectedComponents<GraphType extends Graph<EdgeType, Verte
      * Constructor.
      */
     public StronglyConnectedComponents() {
-        m_stronglyConnectedSearchTreeList = new ArrayList<SearchTree<VertexType>>();
+        m_stronglyConnectedSearchTreeList = new ArrayList<>();
         m_vertexChooser = null;
     }
 
@@ -65,29 +65,29 @@ public class StronglyConnectedComponents<GraphType extends Graph<EdgeType, Verte
     public void findStronglyConnectedComponents(GraphType g, GraphToolkit<GraphType, EdgeType, VertexType> toolkit) {
 
         // Perform the initial depth first search
-        DepthFirstSearch<GraphType, EdgeType, VertexType> initialDFS = new DepthFirstSearch<GraphType, EdgeType, VertexType>(g);
+        DepthFirstSearch<GraphType, EdgeType, VertexType> initialDFS = new DepthFirstSearch<>(g);
         if (m_vertexChooser != null) {
             initialDFS.setVertexChooser(m_vertexChooser);
         }
         initialDFS.search();
 
         // Create a transposed graph
-        Transpose<GraphType, EdgeType, VertexType> t = new Transpose<GraphType, EdgeType, VertexType>();
+        Transpose<GraphType, EdgeType, VertexType> t = new Transpose<>();
         GraphType transpose = t.transpose(g, toolkit);
 
         // Create a set of vertices in the transposed graph,
         // in descending order of finish time in the initial
         // depth first search.
-        VisitationTimeComparator<VertexType> comparator = new VisitationTimeComparator<VertexType>(
+        VisitationTimeComparator<VertexType> comparator = new VisitationTimeComparator<>(
                 initialDFS.getFinishTimeList(), VisitationTimeComparator.DESCENDING);
-        Set<VertexType> descendingByFinishTimeSet = new TreeSet<VertexType>(comparator);
+        Set<VertexType> descendingByFinishTimeSet = new TreeSet<>(comparator);
         Iterator<VertexType> i = transpose.vertexIterator();
         while (i.hasNext()) {
             descendingByFinishTimeSet.add(i.next());
         }
 
         // Create a SearchTreeBuilder for transposed DFS
-        SearchTreeBuilder<VertexType> searchTreeBuilder = new SearchTreeBuilder<VertexType>();
+        SearchTreeBuilder<VertexType> searchTreeBuilder = new SearchTreeBuilder<>();
 
         // Now perform a DFS on the transpose, choosing the vertices
         // to visit in the main loop by descending finish time
@@ -133,7 +133,7 @@ public class StronglyConnectedComponents<GraphType extends Graph<EdgeType, Verte
      */
     private SearchTree<VertexType> copySearchTree(SearchTree<VertexType> tree, Transpose<GraphType, EdgeType, VertexType> t) {
         // Copy this node
-        SearchTree<VertexType> copy = new SearchTree<VertexType>(t.getOriginalGraphVertex(tree.getVertex()));
+        SearchTree<VertexType> copy = new SearchTree<>(t.getOriginalGraphVertex(tree.getVertex()));
 
         // Copy children
         Iterator<SearchTree<VertexType>> i = tree.childIterator();
@@ -174,7 +174,7 @@ public class StronglyConnectedComponents<GraphType extends Graph<EdgeType, Verte
         @Override
         public Set<VertexType> next() {
             SearchTree<VertexType> tree = m_searchTreeIterator.next();
-            TreeSet<VertexType> set = new TreeSet<VertexType>();
+            TreeSet<VertexType> set = new TreeSet<>();
             tree.addVerticesToSet(set);
             return set;
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/graph/Transpose.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/graph/Transpose.java
@@ -37,8 +37,8 @@ public class Transpose<GraphType extends Graph<EdgeType, VertexType>, EdgeType e
      * Constructor.
      */
     public Transpose() {
-        m_origToTransposeMap = new IdentityHashMap<VertexType, VertexType>();
-        m_transposeToOrigMap = new IdentityHashMap<VertexType, VertexType>();
+        m_origToTransposeMap = new IdentityHashMap<>();
+        m_transposeToOrigMap = new IdentityHashMap<>();
     }
 
     /**

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/log/Profiler.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/log/Profiler.java
@@ -46,8 +46,8 @@ public class Profiler implements XMLWriteable {
     final static boolean MAX_CONTEXT = SystemProperties.getBoolean("findbugs.profiler.maxcontext");
 
     public Profiler() {
-        startTimes = new Stack<Clock>();
-        profile = new ConcurrentHashMap<Class<?>, Profile>();
+        startTimes = new Stack<>();
+        profile = new ConcurrentHashMap<>();
         if (REPORT) {
             System.err.println("Profiling activated");
         }
@@ -211,7 +211,7 @@ public class Profiler implements XMLWriteable {
 
     final ConcurrentMap<Class<?>, Profile> profile;
 
-    final Stack<Object> context = new Stack<Object>();
+    final Stack<Object> context = new Stack<>();
 
     public void startContext(Object context) {
         this.context.push(context);
@@ -383,7 +383,7 @@ public class Profiler implements XMLWriteable {
         stream.println("PROFILE REPORT");
         try {
 
-            TreeSet<Class<?>> treeSet = new TreeSet<Class<?>>(reportComparator);
+            TreeSet<Class<?>> treeSet = new TreeSet<>(reportComparator);
             treeSet.addAll(profile.keySet());
 
             stream.printf("%8s  %8s %9s %s%n", "msecs", "#calls", "usecs/call", "Class");
@@ -443,7 +443,7 @@ public class Profiler implements XMLWriteable {
     public void writeXML(XMLOutput xmlOutput) throws IOException {
         xmlOutput.startTag("FindBugsProfile");
         xmlOutput.stopTag(false);
-        TreeSet<Class<?>> treeSet = new TreeSet<Class<?>>(new TotalTimeComparator(this));
+        TreeSet<Class<?>> treeSet = new TreeSet<>(new TotalTimeComparator(this));
         treeSet.addAll(profile.keySet());
         long totalTime = 0;
         for (Profile p : profile.values()) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/model/ClassFeatureSet.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/model/ClassFeatureSet.java
@@ -64,7 +64,7 @@ public class ClassFeatureSet implements XMLWriteable {
      * Constructor. Creates an empty feature set.
      */
     public ClassFeatureSet() {
-        this.featureSet = new HashSet<String>();
+        this.featureSet = new HashSet<>();
     }
 
     /**

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/model/MovedClassMap.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/model/MovedClassMap.java
@@ -51,17 +51,17 @@ public class MovedClassMap implements ClassNameRewriter {
     public MovedClassMap(BugCollection before, BugCollection after) {
         this.before = before;
         this.after = after;
-        this.rewriteMap = new HashMap<String, String>();
+        this.rewriteMap = new HashMap<>();
     }
 
     public MovedClassMap execute() {
         Set<String> beforeClasses = buildClassSet(before);
         Set<String> afterClasses = buildClassSet(after);
 
-        Set<String> removedClasses = new HashSet<String>(beforeClasses);
+        Set<String> removedClasses = new HashSet<>(beforeClasses);
         removedClasses.removeAll(afterClasses);
 
-        Set<String> addedClasses = new HashSet<String>(afterClasses);
+        Set<String> addedClasses = new HashSet<>(afterClasses);
         addedClasses.removeAll(beforeClasses);
 
         Map<String, String> removedShortNameToFullNameMap = buildShortNameToFullNameMap(removedClasses);
@@ -107,7 +107,7 @@ public class MovedClassMap implements ClassNameRewriter {
      * @return set of classes referenced in the BugCollection
      */
     private Set<String> buildClassSet(BugCollection bugCollection) {
-        Set<String> classSet = new HashSet<String>();
+        Set<String> classSet = new HashSet<>();
 
         for (Iterator<BugInstance> i = bugCollection.iterator(); i.hasNext();) {
             BugInstance warning = i.next();
@@ -131,7 +131,7 @@ public class MovedClassMap implements ClassNameRewriter {
      * @return map of short class names to fully-qualified class names
      */
     private Map<String, String> buildShortNameToFullNameMap(Set<String> classSet) {
-        Map<String, String> result = new HashMap<String, String>();
+        Map<String, String> result = new HashMap<>();
         for (String className : classSet) {
             String shortClassName = getShortClassName(className);
             result.put(shortClassName, className);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/model/RegenerateClassFeatures.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/model/RegenerateClassFeatures.java
@@ -52,7 +52,7 @@ public class RegenerateClassFeatures {
         bugCollection.clearClassFeatures();
 
 
-        ArrayList<JavaClass> classList = new ArrayList<JavaClass>();
+        ArrayList<JavaClass> classList = new ArrayList<>();
 
         try (ZipFile zipFile = new ZipFile(jarFile)){
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/model/SimilarClassFinder.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/model/SimilarClassFinder.java
@@ -30,7 +30,7 @@ public class SimilarClassFinder {
     private final List<SimilarClassSet> similarClassSetList;
 
     public SimilarClassFinder() {
-        this.similarClassSetList = new LinkedList<SimilarClassSet>();
+        this.similarClassSetList = new LinkedList<>();
     }
 
     public void add(ClassFeatureSet classFeatureSet) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/model/SimilarClassSet.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/model/SimilarClassSet.java
@@ -31,7 +31,7 @@ public class SimilarClassSet {
     private final List<ClassFeatureSet> memberList;
 
     public SimilarClassSet() {
-        this.memberList = new LinkedList<ClassFeatureSet>();
+        this.memberList = new LinkedList<>();
     }
 
     public boolean shouldContain(ClassFeatureSet candidate) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/plan/AnalysisPass.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/plan/AnalysisPass.java
@@ -50,8 +50,8 @@ public class AnalysisPass {
      * Creates an empty analysis pass.
      */
     public AnalysisPass() {
-        this.orderedFactoryList = new LinkedList<DetectorFactory>();
-        this.memberSet = new HashSet<DetectorFactory>();
+        this.orderedFactoryList = new LinkedList<>();
+        this.memberSet = new HashSet<>();
     }
 
     /**
@@ -93,7 +93,7 @@ public class AnalysisPass {
      * pass.
      */
     public Set<DetectorFactory> getUnpositionedMembers() {
-        HashSet<DetectorFactory> result = new HashSet<DetectorFactory>(memberSet);
+        HashSet<DetectorFactory> result = new HashSet<>(memberSet);
         result.removeAll(orderedFactoryList);
         return result;
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/plan/ExecutionPlan.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/plan/ExecutionPlan.java
@@ -70,7 +70,7 @@ public class ExecutionPlan {
      * Constructor. Creates an empty plan.
      */
     public ExecutionPlan() {
-        this.pluginList = new LinkedList<Plugin>();
+        this.pluginList = new LinkedList<>();
         this.factoryChooser = new DetectorFactoryChooser() {
             @Override
             public boolean choose(DetectorFactory factory) {
@@ -82,11 +82,11 @@ public class ExecutionPlan {
                 // OK...
             }
         };
-        this.passList = new LinkedList<AnalysisPass>();
-        this.factoryMap = new HashMap<String, DetectorFactory>();
-        this.interPassConstraintList = new LinkedList<DetectorOrderingConstraint>();
-        this.intraPassConstraintList = new LinkedList<DetectorOrderingConstraint>();
-        this.assignedToPassSet = new HashSet<DetectorFactory>();
+        this.passList = new LinkedList<>();
+        this.factoryMap = new HashMap<>();
+        this.interPassConstraintList = new LinkedList<>();
+        this.intraPassConstraintList = new LinkedList<>();
+        this.assignedToPassSet = new HashSet<>();
     }
 
     public void dispose() {
@@ -152,14 +152,14 @@ public class ExecutionPlan {
             detectorFactory.setEnabledButNonReporting(false);
         }
 
-        ArrayList<DetectorOrderingConstraint> allConstraints = new ArrayList<DetectorOrderingConstraint>(
+        ArrayList<DetectorOrderingConstraint> allConstraints = new ArrayList<>(
                 interPassConstraintList.size() + intraPassConstraintList.size());
         allConstraints.addAll(interPassConstraintList);
         allConstraints.addAll(intraPassConstraintList);
 
-        Map<String, DetectorNode> nodeMapAll = new HashMap<String, DetectorNode>();
+        Map<String, DetectorNode> nodeMapAll = new HashMap<>();
         ConstraintGraph allPassConstraintGraph = buildConstraintGraph(nodeMapAll,
-                new HashSet<DetectorFactory>(factoryMap.values()), allConstraints);
+                new HashSet<>(factoryMap.values()), allConstraints);
         boolean change;
         do {
             change = false;
@@ -198,9 +198,9 @@ public class ExecutionPlan {
         }
 
         // Build inter-pass constraint graph
-        Map<String, DetectorNode> nodeMap = new HashMap<String, DetectorNode>();
+        Map<String, DetectorNode> nodeMap = new HashMap<>();
         ConstraintGraph interPassConstraintGraph = buildConstraintGraph(nodeMap,
-                new HashSet<DetectorFactory>(factoryMap.values()), interPassConstraintList);
+                new HashSet<>(factoryMap.values()), interPassConstraintList);
         if (DEBUG) {
             System.out.println(interPassConstraintGraph.getNumVertices() + " nodes in inter-pass constraint graph");
         }
@@ -293,7 +293,7 @@ public class ExecutionPlan {
     }
 
     private Set<DetectorFactory> selectDetectors(DetectorFactorySelector selector, Set<DetectorFactory> candidateSet) {
-        Set<DetectorFactory> result = new HashSet<DetectorFactory>();
+        Set<DetectorFactory> result = new HashSet<>();
         for (DetectorFactory factory : candidateSet) {
             if (selector.selectFactory(factory)) {
                 result.add(factory);
@@ -304,7 +304,7 @@ public class ExecutionPlan {
 
     private Set<DetectorNode> addOrCreateDetectorNodes(DetectorFactorySelector selector, Map<String, DetectorNode> nodeMap,
             Set<DetectorFactory> factorySet, ConstraintGraph constraintGraph) {
-        HashSet<DetectorNode> result = new HashSet<DetectorNode>();
+        HashSet<DetectorNode> result = new HashSet<>();
 
         Set<DetectorFactory> chosenSet = selectDetectors(selector, factorySet);
 
@@ -348,7 +348,7 @@ public class ExecutionPlan {
 
         int passCount = 0;
         while (constraintGraph.getNumVertices() > 0) {
-            List<DetectorNode> inDegreeZeroList = new LinkedList<DetectorNode>();
+            List<DetectorNode> inDegreeZeroList = new LinkedList<>();
             // Get all of the detectors nodes with in-degree 0.
             // These have no unsatisfied prerequisites, and thus can
             // be chosen for the current pass.
@@ -401,13 +401,13 @@ public class ExecutionPlan {
             AnalysisPass pass) throws OrderingConstraintException {
 
         // Build set of all (initial) detectors in pass
-        Set<DetectorFactory> detectorSet = new HashSet<DetectorFactory>(pass.getMembers());
+        Set<DetectorFactory> detectorSet = new HashSet<>(pass.getMembers());
         if (DEBUG) {
             System.out.println(detectorSet.size() + " detectors currently in this pass");
         }
 
         // Build list of ordering constraints in this pass only
-        List<DetectorOrderingConstraint> passConstraintList = new LinkedList<DetectorOrderingConstraint>();
+        List<DetectorOrderingConstraint> passConstraintList = new LinkedList<>();
         for (DetectorOrderingConstraint constraint : constraintList) {
             // Does this constraint specify any detectors in this pass?
             // If so, add it to the pass constraints
@@ -421,12 +421,12 @@ public class ExecutionPlan {
         }
 
         // Build set of all detectors available to be added to this pass
-        HashSet<DetectorFactory> availableSet = new HashSet<DetectorFactory>();
+        HashSet<DetectorFactory> availableSet = new HashSet<>();
         availableSet.addAll(detectorSet);
         availableSet.addAll(getUnassignedSet());
 
         // Build intra-pass constraint graph
-        Map<String, DetectorNode> nodeMap = new HashMap<String, DetectorNode>();
+        Map<String, DetectorNode> nodeMap = new HashMap<>();
         ConstraintGraph constraintGraph = buildConstraintGraph(nodeMap, availableSet, passConstraintList);
         if (DEBUG) {
             System.out.println("Pass constraint graph:");
@@ -443,7 +443,7 @@ public class ExecutionPlan {
         }
 
         // Perform DFS, check for cycles
-        DepthFirstSearch<ConstraintGraph, ConstraintEdge, DetectorNode> dfs = new DepthFirstSearch<ConstraintGraph, ConstraintEdge, DetectorNode>(
+        DepthFirstSearch<ConstraintGraph, ConstraintEdge, DetectorNode> dfs = new DepthFirstSearch<>(
                 constraintGraph);
         dfs.search();
         if (dfs.containsCycle()) {
@@ -464,7 +464,7 @@ public class ExecutionPlan {
     }
 
     private Set<DetectorFactory> getUnassignedSet() {
-        Set<DetectorFactory> unassignedSet = new HashSet<DetectorFactory>();
+        Set<DetectorFactory> unassignedSet = new HashSet<>();
         unassignedSet.addAll(factoryMap.values());
         unassignedSet.removeAll(assignedToPassSet);
         return unassignedSet;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/props/WarningPropertySet.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/props/WarningPropertySet.java
@@ -60,7 +60,7 @@ public class WarningPropertySet<T extends WarningProperty> implements Cloneable 
      * Constructor Creates empty object.
      */
     public WarningPropertySet() {
-        this.map = new HashMap<T, Object>();
+        this.map = new HashMap<>();
     }
 
     @Override

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/Bag.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/Bag.java
@@ -33,7 +33,7 @@ public class Bag<E> {
     final Map<E, Integer> map;
 
     public Bag() {
-        map = new HashMap<E, Integer>();
+        map = new HashMap<>();
     }
 
     public Bag(Map<E, Integer> map) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/DualKeyHashMap.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/DualKeyHashMap.java
@@ -28,7 +28,7 @@ import java.util.Set;
  * @author William Pugh
  */
 public class DualKeyHashMap<K1, K2, V> {
-    Map<K1, Map<K2, V>> map = new HashMap<K1, Map<K2, V>>();
+    Map<K1, Map<K2, V>> map = new HashMap<>();
 
     public V get(K1 k1, K2 k2) {
         Map<K2, V> m = map.get(k1);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/FractionalMultiset.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/FractionalMultiset.java
@@ -35,7 +35,7 @@ public class FractionalMultiset<K> {
     final Map<K, Double> map;
 
     public FractionalMultiset() {
-        map = new HashMap<K, Double>();
+        map = new HashMap<>();
     }
 
     public FractionalMultiset(Map<K, Double> map) {
@@ -85,7 +85,7 @@ public class FractionalMultiset<K> {
 
     @SuppressFBWarnings("DMI_ENTRY_SETS_MAY_REUSE_ENTRY_OBJECTS")
     public Iterable<Map.Entry<K, Double>> entriesInDecreasingOrder() {
-        TreeSet<Map.Entry<K, Double>> result = new TreeSet<Map.Entry<K, Double>>(new DecreasingOrderEntryComparator<K>());
+        TreeSet<Map.Entry<K, Double>> result = new TreeSet<>(new DecreasingOrderEntryComparator<K>());
         result.addAll(map.entrySet());
         if (result.size() != map.size()) {
             throw new IllegalStateException("Map " + map.getClass().getSimpleName()
@@ -96,7 +96,7 @@ public class FractionalMultiset<K> {
 
     @SuppressFBWarnings("DMI_ENTRY_SETS_MAY_REUSE_ENTRY_OBJECTS")
     public Iterable<Map.Entry<K, Double>> entriesInIncreasingOrder() {
-        TreeSet<Map.Entry<K, Double>> result = new TreeSet<Map.Entry<K, Double>>(new DecreasingOrderEntryComparator<K>());
+        TreeSet<Map.Entry<K, Double>> result = new TreeSet<>(new DecreasingOrderEntryComparator<K>());
         result.addAll(map.entrySet());
         if (result.size() != map.size()) {
             throw new IllegalStateException("Map " + map.getClass().getSimpleName()

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/MergeMap.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/MergeMap.java
@@ -56,7 +56,7 @@ public abstract class MergeMap<K, V> {
     protected abstract V mergeValues(V oldValue, V newValue);
 
     public MergeMap() {
-        map = new HashMap<K, V>();
+        map = new HashMap<>();
     }
 
     public MergeMap(Map<K, V> map) {
@@ -91,7 +91,7 @@ public abstract class MergeMap<K, V> {
 
     public static void main(String args[]) {
 
-        MergeMap<String, Integer> m = new MaxMap<String, Integer>();
+        MergeMap<String, Integer> m = new MaxMap<>();
 
         m.put("a", 1);
         m.put("a", 2);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/MultiMap.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/MultiMap.java
@@ -45,7 +45,7 @@ public class MultiMap<K, V> {
         }
     }
 
-    Map<K, Collection<V>> map = new HashMap<K, Collection<V>>();
+    Map<K, Collection<V>> map = new HashMap<>();
 
     public Collection<? extends K> keySet() {
         return map.keySet();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/Multiset.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/Multiset.java
@@ -36,7 +36,7 @@ public class Multiset<K> {
     final Map<K, Integer> map;
 
     public Multiset() {
-        map = new HashMap<K, Integer>();
+        map = new HashMap<>();
     }
 
     public Multiset(Map<K, Integer> map) {
@@ -44,7 +44,7 @@ public class Multiset<K> {
     }
 
     public Multiset(Multiset<K> mset) {
-        this.map = new HashMap<K, Integer>(mset.map);
+        this.map = new HashMap<>(mset.map);
     }
 
     public void clear() {
@@ -109,7 +109,7 @@ public class Multiset<K> {
 
     @SuppressFBWarnings("DMI_ENTRY_SETS_MAY_REUSE_ENTRY_OBJECTS")
     public Iterable<Map.Entry<K, Integer>> entriesInDecreasingFrequency() {
-        TreeSet<Map.Entry<K, Integer>> result = new TreeSet<Map.Entry<K, Integer>>(new EntryComparator<K>());
+        TreeSet<Map.Entry<K, Integer>> result = new TreeSet<>(new EntryComparator<K>());
         result.addAll(map.entrySet());
         if (result.size() != map.size()) {
             throw new IllegalStateException("Map " + map.getClass().getSimpleName()

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/SplitCamelCaseIdentifier.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/SplitCamelCaseIdentifier.java
@@ -48,7 +48,7 @@ public class SplitCamelCaseIdentifier {
      */
     public Collection<String> split() {
         String s = ident;
-        Set<String> result = new HashSet<String>();
+        Set<String> result = new HashSet<>();
 
         while (s.length() > 0) {
             StringBuilder buf = new StringBuilder();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/TestDesktopIntegration.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/TestDesktopIntegration.java
@@ -240,7 +240,7 @@ public class TestDesktopIntegration extends JPanel {
 
         if (SHOW_CONSOLE) {
             writer.println("System properties:");
-            TreeSet<String> props = new TreeSet<String>();
+            TreeSet<String> props = new TreeSet<>();
             for (Object o : System.getProperties().keySet()) {
                 if (o instanceof String) {
                     props.add((String) o);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/TopologicalSort.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/TopologicalSort.java
@@ -51,7 +51,7 @@ public class TopologicalSort {
 
     public static class OutEdgesCache<E> implements OutEdges<E> {
 
-        final Map<E, Collection<E>> map = new IdentityHashMap<E, Collection<E>>();
+        final Map<E, Collection<E>> map = new IdentityHashMap<>();
 
         final OutEdges<E> base;
 
@@ -75,7 +75,7 @@ public class TopologicalSort {
         Profiler profile = Global.getAnalysisCache().getProfiler();
         profile.start(TopologicalSort.class);
         try {
-            SortAlgorithm<E> instance = new Worker2<E>(elements, outEdges);
+            SortAlgorithm<E> instance = new Worker2<>(elements, outEdges);
             return instance.compute();
         } finally {
             profile.end(TopologicalSort.class);
@@ -86,8 +86,8 @@ public class TopologicalSort {
         if (!DEBUG) {
             return;
         }
-        HashSet<E> seen = new HashSet<E>();
-        HashSet<E> all = new HashSet<E>(elements);
+        HashSet<E> seen = new HashSet<>();
+        HashSet<E> all = new HashSet<>(elements);
         int result = 0;
         int total = 0;
         for (E e : elements) {
@@ -110,9 +110,9 @@ public class TopologicalSort {
 
     static class Worker<E> implements SortAlgorithm<E> {
         Worker(Collection<E> consider, OutEdges<E> outEdges) {
-            this.consider = new LinkedHashSet<E>(consider);
+            this.consider = new LinkedHashSet<>(consider);
             this.outEdges = outEdges;
-            this.result = new ArrayList<E>(consider.size());
+            this.result = new ArrayList<>(consider.size());
 
         }
 
@@ -120,9 +120,9 @@ public class TopologicalSort {
 
         List<E> result;
 
-        HashSet<E> visited = new HashSet<E>();
+        HashSet<E> visited = new HashSet<>();
 
-        Set<E> consider = new HashSet<E>();
+        Set<E> consider = new HashSet<>();
 
         @Override
         public List<E> compute() {
@@ -152,14 +152,14 @@ public class TopologicalSort {
             if (outEdges == null) {
                 throw new IllegalArgumentException("outEdges must not be null");
             }
-            this.consider = new LinkedHashSet<E>(consider);
+            this.consider = new LinkedHashSet<>(consider);
             this.outEdges = outEdges;
 
         }
 
         OutEdges<E> outEdges;
 
-        Set<E> consider = new HashSet<E>();
+        Set<E> consider = new HashSet<>();
 
         MultiMap<E, E> iEdges, oEdges;
 
@@ -179,12 +179,12 @@ public class TopologicalSort {
 
         @Override
         public List<E> compute() {
-            ArrayList<E> doFirst = new ArrayList<E>(consider.size());
-            ArrayList<E> doLast = new ArrayList<E>(consider.size());
+            ArrayList<E> doFirst = new ArrayList<>(consider.size());
+            ArrayList<E> doLast = new ArrayList<>(consider.size());
 
-            HashSet<E> remaining = new HashSet<E>(consider);
-            iEdges = new MultiMap<E, E>(LinkedList.class);
-            oEdges = new MultiMap<E, E>(LinkedList.class);
+            HashSet<E> remaining = new HashSet<>(consider);
+            iEdges = new MultiMap<>(LinkedList.class);
+            oEdges = new MultiMap<>(LinkedList.class);
 
             for (E e : consider) {
                 for (E e2 : outEdges.getOutEdges(e)) {
@@ -195,7 +195,7 @@ public class TopologicalSort {
                 }
             }
             for (E e : consider) {
-                HashSet<E> both = new HashSet<E>(iEdges.get(e));
+                HashSet<E> both = new HashSet<>(iEdges.get(e));
                 both.retainAll(oEdges.get(e));
                 for (E e2 : both) {
                     iEdges.remove(e, e2);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/TripleKeyHashMap.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/TripleKeyHashMap.java
@@ -26,7 +26,7 @@ import java.util.Map;
  * @author pugh
  */
 public class TripleKeyHashMap<K1, K2, K3, V> {
-    Map<K1, DualKeyHashMap<K2, K3, V>> map = new HashMap<K1, DualKeyHashMap<K2, K3, V>>();
+    Map<K1, DualKeyHashMap<K2, K3, V>> map = new HashMap<>();
 
     public V get(K1 k1, K2 k2, K3 k3) {
         DualKeyHashMap<K2, K3, V> m = map.get(k1);
@@ -39,7 +39,7 @@ public class TripleKeyHashMap<K1, K2, K3, V> {
     public V put(K1 k1, K2 k2, K3 k3, V v) {
         DualKeyHashMap<K2, K3, V> m = map.get(k1);
         if (m == null) {
-            m = new DualKeyHashMap<K2, K3, V>();
+            m = new DualKeyHashMap<>();
             map.put(k1, m);
         }
         return m.put(k2, k3, v);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/Util.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/Util.java
@@ -180,7 +180,7 @@ public class Util {
     public static synchronized void runLogAtShutdown(Runnable r) {
         if (ShutdownLogging.LOGGING) {
             if (runAtShutdown == null) {
-                runAtShutdown = new LinkedList<Runnable>();
+                runAtShutdown = new LinkedList<>();
                 Runtime.getRuntime().addShutdownHook(new Thread() {
                     @Override
                     public void run() {
@@ -442,7 +442,7 @@ public class Util {
 
     /** Duplication 1.6 functionality of Collections.newSetFromMap */
     public static <E> Set<E> newSetFromMap(Map<E, Boolean> m) {
-        return new SetFromMap<E>(m);
+        return new SetFromMap<>(m);
     }
 
     private static class SetFromMap<E> extends AbstractSet<E> {
@@ -535,21 +535,21 @@ public class Util {
     static final float DEFAULT_LOAD_FACTOR = 0.75f;
 
     public static <K, V> HashMap<K, V> makeSmallHashMap(Map<K, V> m) {
-        HashMap<K, V> result = new HashMap<K, V>((int) (m.size() / DEFAULT_LOAD_FACTOR + 2));
+        HashMap<K, V> result = new HashMap<>((int) (m.size() / DEFAULT_LOAD_FACTOR + 2));
         result.putAll(m);
         return result;
 
     }
 
     public static <K> HashSet<K> makeSmallHashSet(Collection<K> m) {
-        HashSet<K> result = new HashSet<K>((int) (m.size() / DEFAULT_LOAD_FACTOR + 2));
+        HashSet<K> result = new HashSet<>((int) (m.size() / DEFAULT_LOAD_FACTOR + 2));
         result.addAll(m);
         return result;
 
     }
 
     public static <K> ArrayList<K> makeSmallArrayList(List<K> m) {
-        ArrayList<K> result = new ArrayList<K>(m.size() + 2);
+        ArrayList<K> result = new ArrayList<>(m.size() + 2);
         result.addAll(m);
         return result;
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/WriteOnceProperties.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/WriteOnceProperties.java
@@ -7,7 +7,7 @@ import java.util.Properties;
 public class WriteOnceProperties extends Properties {
 
     private static final long serialVersionUID = 1L;
-    private final Map<String, PropertyReadAt> propertReadAt = new HashMap<String, PropertyReadAt>();
+    private final Map<String, PropertyReadAt> propertReadAt = new HashMap<>();
 
     static class PropertyReadAt extends Exception {
         private static final long serialVersionUID = 1L;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/visitclass/AnnotationVisitor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/visitclass/AnnotationVisitor.java
@@ -270,7 +270,7 @@ public class AnnotationVisitor extends PreorderVisitor {
                     continue;
                 }
                 name = ClassName.toDottedClassName(name);
-                Map<String, ElementValue> map = new HashMap<String, ElementValue>();
+                Map<String, ElementValue> map = new HashMap<>();
                 for (ElementValuePair ev : ae.getElementValuePairs()) {
                     map.put(ev.getNameString(), ev.getValue());
                 }
@@ -296,7 +296,7 @@ public class AnnotationVisitor extends PreorderVisitor {
                 continue;
             }
             name = ClassName.toDottedClassName(name);
-            Map<String, ElementValue> map = new HashMap<String, ElementValue>();
+            Map<String, ElementValue> map = new HashMap<>();
             for (ElementValuePair ev : ae.getElementValuePairs()) {
                 map.put(ev.getNameString(), ev.getValue());
             }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/visitclass/PreorderVisitor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/visitclass/PreorderVisitor.java
@@ -175,7 +175,7 @@ public class PreorderVisitor extends BetterVisitor implements Constants2 {
     }
 
     public Set<String> getSurroundingCaughtExceptions(int pc, int maxTryBlockSize) {
-        HashSet<String> result = new HashSet<String>();
+        HashSet<String> result = new HashSet<>();
         if (code == null) {
             throw new IllegalStateException("Not visiting Code");
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/visitclass/PrintClass.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/visitclass/PrintClass.java
@@ -106,7 +106,7 @@ public class PrintClass {
                 file_name[i] = file_name[i].replace('.', '/');
             }
             try(ZipFile z = new ZipFile(zip_file)){
-                TreeSet<ZipEntry> zipEntries = new TreeSet<ZipEntry>(new ZipEntryComparator());
+                TreeSet<ZipEntry> zipEntries = new TreeSet<>(new ZipEntryComparator());
                 for (Enumeration<? extends ZipEntry> e = z.entries(); e.hasMoreElements();) {
                     zipEntries.add(e.nextElement());
                 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/Churn.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/Churn.java
@@ -78,7 +78,7 @@ public class Churn {
             return count;
         }
 
-        Map<Long, Integer> lastCount = new HashMap<Long, Integer>();
+        Map<Long, Integer> lastCount = new HashMap<>();
 
         void update(BugInstance bug) {
             if (bug.isDead()) {
@@ -98,7 +98,7 @@ public class Churn {
         }
     }
 
-    Map<String, Data> data = new TreeMap<String, Data>();
+    Map<String, Data> data = new TreeMap<>();
 
     Data all = new Data();
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/CopyBuggySource.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/CopyBuggySource.java
@@ -92,9 +92,9 @@ public class CopyBuggySource {
     byte buf[] = new byte[4096];
     Project project;
     SourceFinder sourceFinder;
-    HashSet<String> copied = new HashSet<String>();
-    HashSet<String> couldNotFind = new HashSet<String>();
-    HashSet<String> couldNotCreate = new HashSet<String>();
+    HashSet<String> copied = new HashSet<>();
+    HashSet<String> couldNotFind = new HashSet<>();
+    HashSet<String> couldNotCreate = new HashSet<>();
     int copyCount = 0;
     File dstFile;
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/CountByPackagePrefix.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/CountByPackagePrefix.java
@@ -59,8 +59,8 @@ public class CountByPackagePrefix {
         } else {
             origCollection.readXML(args[1]);
         }
-        Map<String, Integer> map = new TreeMap<String, Integer>();
-        Map<String, Integer> ncss = new TreeMap<String, Integer>();
+        Map<String, Integer> map = new TreeMap<>();
+        Map<String, Integer> ncss = new TreeMap<>();
 
         for (BugInstance b : origCollection.getCollection()) {
             String prefix = ClassName.extractPackagePrefix(b.getPrimaryClass().getPackageName(), prefixLength);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/CountClassVersions.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/CountClassVersions.java
@@ -53,7 +53,7 @@ public class CountClassVersions {
 
     public static List<String> readFrom(Reader r) throws IOException {
         BufferedReader in = new BufferedReader(r);
-        List<String> lst = new LinkedList<String>();
+        List<String> lst = new LinkedList<>();
         while (true) {
             String s = in.readLine();
             if (s == null) {
@@ -114,7 +114,7 @@ public class CountClassVersions {
         }
         byte buffer[] = new byte[8192];
         MessageDigest digest = Util.getMD5Digest();
-        DualKeyHashMap<String, String, String> map = new DualKeyHashMap<String, String, String>();
+        DualKeyHashMap<String, String, String> map = new DualKeyHashMap<>();
 
         for (String fInName : fileList) {
             File f = new File(fInName);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/FileBugHash.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/FileBugHash.java
@@ -44,11 +44,11 @@ import edu.umd.cs.findbugs.util.Util;
  */
 public class FileBugHash {
 
-    Map<String, StringBuilder> hashes = new LinkedHashMap<String, StringBuilder>();
+    Map<String, StringBuilder> hashes = new LinkedHashMap<>();
 
-    Map<String, Integer> counts = new HashMap<String, Integer>();
+    Map<String, Integer> counts = new HashMap<>();
 
-    Map<String, Integer> sizes = new HashMap<String, Integer>();
+    Map<String, Integer> sizes = new HashMap<>();
 
     MessageDigest digest = Util.getMD5Digest();
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/Filter.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/Filter.java
@@ -188,15 +188,15 @@ public class Filter {
 
         public boolean withMessages = false;
 
-        private final List<Matcher> includeFilter = new LinkedList<Matcher>();
+        private final List<Matcher> includeFilter = new LinkedList<>();
 
-        private final List<Matcher> excludeFilter = new LinkedList<Matcher>();
+        private final List<Matcher> excludeFilter = new LinkedList<>();
 
-        HashSet<String> excludedInstanceHashes = new HashSet<String>();
+        HashSet<String> excludedInstanceHashes = new HashSet<>();
 
-        Set<String> designationKey = new HashSet<String>();
+        Set<String> designationKey = new HashSet<>();
 
-        Set<String> categoryKey = new HashSet<String>();
+        Set<String> categoryKey = new HashSet<>();
 
         SortedSet<BugInstance> uniqueSloppy;
 
@@ -263,8 +263,8 @@ public class Filter {
             if (val == null) {
                 return -1;
             }
-            Map<String, AppVersion> versions = new HashMap<String, AppVersion>();
-            SortedMap<Long, AppVersion> timeStamps = new TreeMap<Long, AppVersion>();
+            Map<String, AppVersion> versions = new HashMap<>();
+            SortedMap<Long, AppVersion> timeStamps = new TreeMap<>();
 
             for (Iterator<AppVersion> i = collection.appVersionIterator(); i.hasNext();) {
                 AppVersion v = i.next();
@@ -353,7 +353,7 @@ public class Filter {
             absent = getVersionNum(collection, absentAsString, true);
 
             if (sloppyUniqueSpecified) {
-                uniqueSloppy = new TreeSet<BugInstance>(new SloppyBugComparator());
+                uniqueSloppy = new TreeSet<>(new SloppyBugComparator());
             }
 
             long fixed = getVersionNum(collection, fixedAsString, true);
@@ -607,7 +607,7 @@ public class Filter {
                     throw new IllegalArgumentException("Error processing include file: " + argument, e);
                 }
             } else if ("-hashes".equals(option)) {
-                hashesFromFile = new HashSet<String>();
+                hashesFromFile = new HashSet<>();
                 BufferedReader in = null;
                 try {
                     in = new BufferedReader(UTF8.fileReader(argument));
@@ -638,8 +638,8 @@ public class Filter {
          */
         public void getReady(SortedBugCollection origCollection) {
             if (maybeMutatedAsString != null) {
-                HashSet<String> addedIssues = new HashSet<String>();
-                HashSet<String> removedIssues = new HashSet<String>();
+                HashSet<String> addedIssues = new HashSet<>();
+                HashSet<String> removedIssues = new HashSet<>();
                 for (BugInstance b : origCollection) {
                     if (b.getFirstVersion() == maybeMutated) {
                         addedIssues.add(getBugLocation(b));
@@ -730,8 +730,8 @@ public class Filter {
 
         long trimToVersion = -1;
         if (commandLine.trimToVersionAsString != null) {
-            Map<String, AppVersion> versions = new HashMap<String, AppVersion>();
-            SortedMap<Long, AppVersion> timeStamps = new TreeMap<Long, AppVersion>();
+            Map<String, AppVersion> versions = new HashMap<>();
+            SortedMap<Long, AppVersion> timeStamps = new TreeMap<>();
 
             for (Iterator<AppVersion> i = origCollection.appVersionIterator(); i.hasNext();) {
                 AppVersion v = i.next();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/MergeSummarizeAndView.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/MergeSummarizeAndView.java
@@ -54,11 +54,11 @@ public class MergeSummarizeAndView {
 
     public static class MSVOptions {
 
-        public List<String> workingDirList = new ArrayList<String>();
+        public List<String> workingDirList = new ArrayList<>();
 
-        public List<String> analysisFiles = new ArrayList<String>();
+        public List<String> analysisFiles = new ArrayList<>();
 
-        public List<String> srcDirList = new ArrayList<String>();
+        public List<String> srcDirList = new ArrayList<>();
 
         public int maxRank = 12;
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/MineBugHistory.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/MineBugHistory.java
@@ -100,7 +100,7 @@ public class MineBugHistory {
 
     Version[] versionList;
 
-    Map<Long, AppVersion> sequenceToAppVersionMap = new HashMap<Long, AppVersion>();
+    Map<Long, AppVersion> sequenceToAppVersionMap = new HashMap<>();
 
     boolean formatDates = false;
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/RebornIssues.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/RebornIssues.java
@@ -56,12 +56,12 @@ public class RebornIssues {
 
     public RebornIssues execute() {
 
-        Map<String, List<BugInstance>> map = new HashMap<String, List<BugInstance>>();
+        Map<String, List<BugInstance>> map = new HashMap<>();
         for (BugInstance b : bugCollection.getCollection()) {
             if (b.getFirstVersion() != 0 || b.getLastVersion() != -1) {
                 List<BugInstance> lst = map.get(b.getInstanceHash());
                 if (lst == null) {
-                    lst = new LinkedList<BugInstance>();
+                    lst = new LinkedList<>();
                     map.put(b.getInstanceHash(), lst);
                 }
                 lst.add(b);
@@ -69,8 +69,8 @@ public class RebornIssues {
         }
         for (List<BugInstance> lst : map.values()) {
             if (lst.size() > 1) {
-                TreeSet<Long> removalTimes = new TreeSet<Long>();
-                TreeSet<Long> additionTimes = new TreeSet<Long>();
+                TreeSet<Long> removalTimes = new TreeSet<>();
+                TreeSet<Long> additionTimes = new TreeSet<>();
 
                 String bugPattern = "XXX";
                 for (BugInstance b : lst) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/RecursiveSearchForJavaFiles.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/RecursiveSearchForJavaFiles.java
@@ -33,9 +33,9 @@ public class RecursiveSearchForJavaFiles {
     }
 
     public static Set<File> search(File root) {
-        Set<File> result = new HashSet<File>();
-        Set<File> directories = new HashSet<File>();
-        LinkedList<File> worklist = new LinkedList<File>();
+        Set<File> result = new HashSet<>();
+        Set<File> directories = new HashSet<>();
+        LinkedList<File> worklist = new LinkedList<>();
         directories.add(root);
         worklist.add(root);
         while (!worklist.isEmpty()) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/RejarClassesForAnalysis.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/RejarClassesForAnalysis.java
@@ -224,7 +224,7 @@ public class RejarClassesForAnalysis {
         readFrom(result, UserTextFile.bufferedReader(System.in));
     }
 
-    SortedMap<String, ZipOutputStream> analysisOutputFiles = new TreeMap<String, ZipOutputStream>();
+    SortedMap<String, ZipOutputStream> analysisOutputFiles = new TreeMap<>();
 
     public @Nonnull
     ZipOutputStream getZipOutputFile(String path) {
@@ -283,13 +283,13 @@ public class RejarClassesForAnalysis {
     }
 
     /** For each file, give the latest timestamp */
-    Map<String, Long> copied = new HashMap<String, Long>();
+    Map<String, Long> copied = new HashMap<>();
     /** While file should we copy it from */
-    Map<String, File> copyFrom = new HashMap<String, File>();
+    Map<String, File> copyFrom = new HashMap<>();
 
-    Set<String> excluded = new HashSet<String>();
+    Set<String> excluded = new HashSet<>();
 
-    TreeSet<String> filesToAnalyze = new TreeSet<String>();
+    TreeSet<String> filesToAnalyze = new TreeSet<>();
 
     int numFilesToAnalyze = 0;
 
@@ -323,7 +323,7 @@ public class RejarClassesForAnalysis {
     boolean classFileFound;
     public void execute() throws IOException {
 
-        ArrayList<String> fileList = new ArrayList<String>();
+        ArrayList<String> fileList = new ArrayList<>();
 
         if (commandLine.inputFileList != null) {
             readFrom(fileList, UTF8.fileReader(commandLine.inputFileList));
@@ -332,14 +332,14 @@ public class RejarClassesForAnalysis {
         } else {
             fileList.addAll(Arrays.asList(args).subList(argCount, args.length));
         }
-        ArrayList<String> auxFileList = new ArrayList<String>();
+        ArrayList<String> auxFileList = new ArrayList<>();
         if (commandLine.auxFileList != null) {
             readFrom(auxFileList, UTF8.fileReader(commandLine.auxFileList));
             auxFileList.removeAll(fileList);
         }
 
-        List<File> inputZipFiles = new ArrayList<File>(fileList.size());
-        List<File> auxZipFiles = new ArrayList<File>(auxFileList.size());
+        List<File> inputZipFiles = new ArrayList<>(fileList.size());
+        List<File> auxZipFiles = new ArrayList<>(auxFileList.size());
         for (String fInName : fileList) {
             final File f = new File(fInName);
             if (f.lastModified() < commandLine.maxAge) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/SetBugDatabaseInfo.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/SetBugDatabaseInfo.java
@@ -76,9 +76,9 @@ public class SetBugDatabaseInfo {
 
         long revisionTimestamp = 0L;
 
-        public List<String> sourcePaths = new LinkedList<String>();
+        public List<String> sourcePaths = new LinkedList<>();
 
-        public List<String> searchSourcePaths = new LinkedList<String>();
+        public List<String> searchSourcePaths = new LinkedList<>();
 
         SetInfoCommandLine() {
             addOption("-name", "name", "set name for (last) revision");
@@ -206,7 +206,7 @@ public class SetBugDatabaseInfo {
 
         }
 
-        Map<String, Set<String>> missingFiles = new HashMap<String, Set<String>>();
+        Map<String, Set<String>> missingFiles = new HashMap<>();
         if (!commandLine.searchSourcePaths.isEmpty()) {
             sourceSearcher = new SourceSearcher(project);
             for (BugInstance bug : origCollection.getCollection()) {
@@ -214,7 +214,7 @@ public class SetBugDatabaseInfo {
                 if (!sourceSearcher.sourceNotFound.contains(src.getClassName()) && !sourceSearcher.findSource(src)) {
                     Set<String> paths = missingFiles.get(src.getSourceFile());
                     if (paths == null) {
-                        paths = new HashSet<String>();
+                        paths = new HashSet<>();
                         missingFiles.put(src.getSourceFile(), paths);
                     }
                     String fullPath = fullPath(src);
@@ -222,7 +222,7 @@ public class SetBugDatabaseInfo {
                     paths.add(fullPath);
                 }
             }
-            Set<String> foundPaths = new HashSet<String>();
+            Set<String> foundPaths = new HashSet<>();
             for (String f : commandLine.searchSourcePaths) {
                 for (File javaFile : RecursiveSearchForJavaFiles.search(new File(f))) {
                     Set<String> matchingMissingClasses = missingFiles.get(javaFile.getName());
@@ -242,7 +242,7 @@ public class SetBugDatabaseInfo {
                 }
             }
 
-            Set<String> toRemove = new HashSet<String>();
+            Set<String> toRemove = new HashSet<>();
             for (String p1 : foundPaths) {
                 for (String p2 : foundPaths) {
                     if (!p1.equals(p2) && p1.startsWith(p2)) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/SourceSearcher.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/SourceSearcher.java
@@ -31,9 +31,9 @@ import edu.umd.cs.findbugs.ba.SourceFinder;
  * @author pugh
  */
 public class SourceSearcher {
-    final HashSet<String> sourceFound = new HashSet<String>();
+    final HashSet<String> sourceFound = new HashSet<>();
 
-    final HashSet<String> sourceNotFound = new HashSet<String>();
+    final HashSet<String> sourceNotFound = new HashSet<>();
 
     private final SourceFinder sourceFinder;
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/TestingGround.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/TestingGround.java
@@ -79,9 +79,9 @@ public class TestingGround {
         } else {
             bugCollection.readXML(System.in);
         }
-        ArrayList<Bag<String>> live = new ArrayList<Bag<String>>();
-        ArrayList<Bag<String>> died = new ArrayList<Bag<String>>();
-        Bag<String> allBugs = new Bag<String>();
+        ArrayList<Bag<String>> live = new ArrayList<>();
+        ArrayList<Bag<String>> died = new ArrayList<>();
+        Bag<String> allBugs = new Bag<>();
         for (int i = 0; i <= bugCollection.getSequenceNumber(); i++) {
             live.add(new Bag<String>());
             died.add(new Bag<String>());

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/TreemapVisualization.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/TreemapVisualization.java
@@ -33,13 +33,13 @@ import edu.umd.cs.findbugs.util.Bag;
 
 public class TreemapVisualization {
 
-    HashSet<String> buggyPackages = new HashSet<String>();
+    HashSet<String> buggyPackages = new HashSet<>();
 
-    HashSet<String> interiorPackages = new HashSet<String>();
+    HashSet<String> interiorPackages = new HashSet<>();
 
-    Bag<String> goodCodeSize = new Bag<String>(new TreeMap<String, Integer>());
+    Bag<String> goodCodeSize = new Bag<>(new TreeMap<String, Integer>());
 
-    Bag<String> goodCodeCount = new Bag<String>(new TreeMap<String, Integer>());
+    Bag<String> goodCodeCount = new Bag<>(new TreeMap<String, Integer>());
 
     public void addInteriorPackages(String packageName) {
         String p = superpackage(packageName);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/UnionResults.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/UnionResults.java
@@ -123,7 +123,7 @@ public class UnionResults {
                 + " [options] [<results1> <results2> ... <resultsn>] ");
 
         SortedBugCollection results = null;
-        HashSet<String> hashes = new HashSet<String>();
+        HashSet<String> hashes = new HashSet<>();
 
         for (int i = argCount; i < argv.length; i++) {
             try {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/Update.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/Update.java
@@ -61,11 +61,11 @@ public class Update {
 
     private static final String USAGE = "Usage: " + Update.class.getName() + " [options]  data1File data2File data3File ... ";
 
-    private final Map<BugInstance, BugInstance> mapFromNewToOldBug = new IdentityHashMap<BugInstance, BugInstance>();
+    private final Map<BugInstance, BugInstance> mapFromNewToOldBug = new IdentityHashMap<>();
 
-    private final Set<String> resurrected = new HashSet<String>();
+    private final Set<String> resurrected = new HashSet<>();
 
-    private final Map<BugInstance, Void> matchedOldBugs = new IdentityHashMap<BugInstance, Void>();
+    private final Map<BugInstance, Void> matchedOldBugs = new IdentityHashMap<>();
 
     boolean noPackageMoves = false;
 
@@ -171,7 +171,7 @@ public class Update {
     }
 
     HashSet<String> sourceFilesInCollection(BugCollection collection) {
-        HashSet<String> result = new HashSet<String>();
+        HashSet<String> result = new HashSet<>();
         for (PackageStats pStats : collection.getProjectStats().getPackageStats()) {
             for (ClassStats cStats : pStats.getClassStats()) {
                 result.add(cStats.getSourceFile());
@@ -341,7 +341,7 @@ public class Update {
     private void discardUnwantedBugs(BugCollection newCollection) {
         BugRanker.trimToMaxRank(newCollection, maxRank);
         if (sloppyMatch) {
-            TreeSet<BugInstance> sloppyUnique = new TreeSet<BugInstance>(new SloppyBugComparator());
+            TreeSet<BugInstance> sloppyUnique = new TreeSet<>(new SloppyBugComparator());
             for(Iterator<BugInstance> i = newCollection.iterator(); i.hasNext(); ) {
                 if (!sloppyUnique.add(i.next())) {
                     i.remove();
@@ -594,7 +594,7 @@ public class Update {
     private void matchBugs(Comparator<BugInstance> bugInstanceComparator, BugCollection origCollection,
             BugCollection newCollection, MatchOldBugs matchOld) {
 
-        TreeMap<BugInstance, LinkedList<BugInstance>> set = new TreeMap<BugInstance, LinkedList<BugInstance>>(
+        TreeMap<BugInstance, LinkedList<BugInstance>> set = new TreeMap<>(
                 bugInstanceComparator);
         //        int oldBugs = 0;
         //        int newBugs = 0;
@@ -605,7 +605,7 @@ public class Update {
                     //                    oldBugs++;
                     LinkedList<BugInstance> q = set.get(bug);
                     if (q == null) {
-                        q = new LinkedList<BugInstance>();
+                        q = new LinkedList<>();
                         set.put(bug, q);
                     }
                     q.add(bug);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/xml/Dom4JXMLOutput.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/xml/Dom4JXMLOutput.java
@@ -43,7 +43,7 @@ public class Dom4JXMLOutput implements XMLOutput {
      *            built
      */
     public Dom4JXMLOutput(Branch topLevel) {
-        this.stack = new LinkedList<Branch>();
+        this.stack = new LinkedList<>();
         stack.addLast(topLevel);
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/xml/MetaCharacterMap.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/xml/MetaCharacterMap.java
@@ -39,7 +39,7 @@ public class MetaCharacterMap {
      */
     public MetaCharacterMap() {
         this.metaCharacterSet = new BitSet();
-        this.replacementMap = new HashMap<String, String>();
+        this.replacementMap = new HashMap<>();
     }
 
     /**

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/xml/XMLAttributeList.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/xml/XMLAttributeList.java
@@ -60,7 +60,7 @@ public class XMLAttributeList {
      * Constructor. Creates an empty object.
      */
     public XMLAttributeList() {
-        this.nameValuePairList = new LinkedList<NameValuePair>();
+        this.nameValuePairList = new LinkedList<>();
     }
 
     /**

--- a/spotbugs/src/test/java/edu/umd/cs/findbugs/workflow/FindSeqNumTest.java
+++ b/spotbugs/src/test/java/edu/umd/cs/findbugs/workflow/FindSeqNumTest.java
@@ -24,9 +24,9 @@ public class FindSeqNumTest {
 
     @Before
     public void setUp() throws Exception {
-        versionNames = new HashMap<String, AppVersion>();
-        timeStamps = new TreeMap<Long, AppVersion>();
-        Set<AppVersion> versions = new HashSet<AppVersion>();
+        versionNames = new HashMap<>();
+        timeStamps = new TreeMap<>();
+        Set<AppVersion> versions = new HashSet<>();
         SimpleDateFormat format = new SimpleDateFormat("MMMMM dd, yyyy", Locale.ENGLISH);
         versions.add(new AppVersion(0, format.parse("June 1, 2005"), "v1.0"));
         versions.add(new AppVersion(1, format.parse("June 10, 2005"), "v1.1"));

--- a/test-harness/src/main/java/edu/umd/cs/findbugs/test/CountMatcher.java
+++ b/test-harness/src/main/java/edu/umd/cs/findbugs/test/CountMatcher.java
@@ -27,7 +27,7 @@ public final class CountMatcher<T> extends TypeSafeMatcher<Iterable<T>> {
      */
     @Factory
     public static <T> Matcher<Iterable<T>> containsExactly(final int count, final Matcher<T> matcher) {
-        return new CountMatcher<T>(count, matcher);
+        return new CountMatcher<>(count, matcher);
     }
 
     @Override

--- a/test-harness/src/main/java/org/sonar/plugins/findbugs/resource/SmapParser.java
+++ b/test-harness/src/main/java/org/sonar/plugins/findbugs/resource/SmapParser.java
@@ -148,7 +148,7 @@ public class SmapParser {
     }
 
     public List<Integer> getJavaLineNumbers(Integer jspLineNo) {
-        final List<Integer> javaLines = new ArrayList<Integer>();
+        final List<Integer> javaLines = new ArrayList<>();
         for (final Map.Entry<Integer, int[]> lineMap : java2jsp.entrySet()) {
             if (lineMap.getValue()[1] == jspLineNo) {
                 javaLines.add(lineMap.getKey());


### PR DESCRIPTION
All changes done automatically by Eclipse -> Source -> Clean Up -> Remove redundant type arguments