### PR TITLE
Run smokeTest on Java9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: java
-sudo: true
-jdk: oraclejdk8
+sudo: false
+dist: trusty
 
 env:
+  matrix:
+    - JDK_FOR_TEST=oraclejdk9
+    - JDK_FOR_TEST=oraclejdk8
   global:
     - SONAR_HOST_URL="https://sonarcloud.io"
 
@@ -24,19 +27,16 @@ env:
     - secure: "lZc3FKJlHOKrtYJp2Tc+SDLTye5vip0Hp2jpLj9GwxyP74DgmfzdABeptcvbfbxAHP7+emAyV7en0jdfS6iK9YWDTKpu4FKH/WrH4b03ArdkowJTYQI1pi2TLBlUNg64xaP/eeao1oWg44jCqp/sbU414zlA3+9gynnGED3mpsRQieRF3niBIt2bnzIeIusWxIqMWCXSzRnxC4RvlYpV7lhhJQb+2nJRets/KykhGs4RZj+bZB2I/WqgorzVN8GXBKevjAvR6HCaVClfa9A5boA4qsxb1P7UEurcMT4dJUXJHCW1tMBXpGDxtyNAhJgbKr4cVL7skzVsDaqSE1szLNwnDf9P5+a23EZeaT7juVsf7kXpR4KZ1JRWbss6Md035Px0KrbNFGtiojdtqRHBkAYnNNB1AwfeD4ZmsRip7oKU7mnwXOK5yUtuFnssZaIVIQHeGeNJOmtL69ELhEju07fmellIf5+fpBYwJVj62t/MvTEt9I1NbXCNPHpeHOVq6HY8OhMQ0Gzpzy8OfM/F6Nu8lowFV9LK/G3NZ7Uh206xZ+ArGDJ59a3mjsJ0eIVbkar1XxoJDZkQrrUx3GSN19o4Jw8y62V9E5A486nA3zjRSl5uOUhbnPTNO9RsxcIvwFx1dHYTTXkZMLqZarvhSjj+Pi0mCLxKjcoUyvtWZMk="
     # GRADLE_PUBLISH_SECRET value
     - secure: "mfFuR4+xh23Q71jdwv43hL4LnwNPE3m3zH4h+q5XkNeKbdEQMb+Sn5nXmhgR/vJ9zFTchmlmyg4bjEdV4Dc65g2kNPSu0CvSgn+ypURhPwvN+5JAeplh+XBqtE8gVh8qxCXAR4ZCVsEEUg4KyW+Rb9U0Uuy04b+45f1RfjqO5dayYvob0DQg3c5OrqyQ6pD88Y2LGUjfVAB+/8RZvvLJeEQTvBvISNceBCTxQrRt00y8f9p2VqqLG5lVZD1mnceIRgLWIkTiK/nxUqOh5IBpeyUF6Y9/uLKNeNn/5U11RnYL4O3XMICReBD/HcwW4hVTT+gAg8vNVVTuANbyG8AcsWGTF0Yck52W8DK9j07vGIeqgqDetvmh+a+hvCwsfpM9Wl0sv5lx7iim9VSE2DappFDaWKRF8ixGvjndL8Up8yCsfdJPYVafH81Ybv+Fd5GQX59Q5GIQs2IYFZ7312wzRswFfy5j1Hn74cnQWInxtbn7SXVaRj5CswEFearua38KDjkrx0GY1pt3ypbjf//kkgPmjRj8PRtPe/SEuZvCWlqBOym8QkZ2mIhiPn+pz6RO+mNRll5bmAaOtHLLkcIziMuFD7fi1YrCtCuY3PKiW0Xt7NHQQlD+y6X3RK2qsV8txPGXZz3F2Cnk9GvJepQv14hbc8OKPtJdJG/2uaLUuDg="
-  matrix:
-    - JDK_FOR_TEST=oraclejdk8
-#    - JDK_FOR_TEST=oraclejdk9
 
-# Java 9 is not currently officially supported, so install it manually
-#matrix:
-#  include:
-#     env: JDK_FOR_TEST=oraclejdk9
+addons:
+  apt:
+    packages:
+      - oracle-java9-installer
+      - oracle-java8-installer
+      - oracle-java8-set-default
 
 before_install:
   - mkdir -p deps
-  - if [[ $JDK_FOR_TEST == "oraclejdk9" && ! -e deps/oracle-java9-installer.deb ]]; then wget -O deps/oracle-java9-installer.deb http://ppa.launchpad.net/webupd8team/java/ubuntu/pool/main/o/oracle-java9-installer/oracle-java9-installer_9b140+9b140arm-1~webupd8~3_all.deb; fi
-  - if [[ $JDK_FOR_TEST == "oraclejdk9" ]]; then sudo dpkg -i deps/oracle-java9-installer.deb; fi
   # In forked repository, encrypted environment variable is undefined. We need to skip this decryption.
   - if [ -n "$encrypted_05a1b17af1e9_key" ]; then openssl aes-256-cbc -K $encrypted_05a1b17af1e9_key -iv $encrypted_05a1b17af1e9_iv -in secring.gpg.enc -out secring.gpg -d; fi
 
@@ -47,9 +47,12 @@ install:
   - echo eclipseRoot.dir=$(pwd)/eclipse > eclipsePlugin/local.properties
 
 script:
-  # Manually switch to JDK9 if needed
-  - if [[ $JDK_FOR_TEST == "oraclejdk9" ]]; then remove_dir_from_path $JAVA_HOME/bin; export JAVA_HOME=/usr/lib/jvm/java-9-oracle; export JAVA_HOME=/usr/lib/jvm/java-9-oracle; fi
-  - ./gradlew build smoketest sonarqube -S
+  - ./gradlew build -S
+  - jdk_switcher use $JDK_FOR_TEST
+  - ./gradlew -v --no-daemon
+  - ./gradlew smoketest -S --no-daemon
+  - jdk_switcher use oraclejdk8
+  - if [[ $JDK_FOR_TEST == "oraclejdk8" ]]; then ./gradlew sonarqube -S; fi
 
 after_success:
   - if [[ $JDK_FOR_TEST == "oraclejdk8" ]]; then ./gradlew coveralls; fi


### PR DESCRIPTION
Run `smokeTest` task with Java 9 installed by apt package.

Currently our `smokeTest` task is not enough, it runs `spotbugs-ant` but it does not check execution result. We need to add more smoke test to script & gradle plugin.