### PR TITLE
Test on Java 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,10 +47,10 @@ install:
   - echo eclipseRoot.dir=$(pwd)/eclipse > eclipsePlugin/local.properties
 
 script:
-  - ./gradlew build -S
+  - ./gradlew compileJava compileTestJava -S
   - jdk_switcher use $JDK_FOR_TEST
   - ./gradlew -v --no-daemon
-  - ./gradlew smoketest -S --no-daemon
+  - ./gradlew build smoketest -S --no-daemon
   - jdk_switcher use oraclejdk8
   - if [[ $JDK_FOR_TEST == "oraclejdk8" ]]; then ./gradlew sonarqube -S; fi
 

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -4,8 +4,9 @@ tasks.withType(Test) {
         exceptionFormat 'full'
     }
     doFirst {
+      // http://openjdk.java.net/jeps/223
       if (System.getProperty("java.specification.version") == "9") {
-        jvmArgs = [
+        jvmArgs += [
           '--add-opens', 'java.base/java.lang=ALL-UNNAMED'
         ]
       }

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -3,5 +3,11 @@ tasks.withType(Test) {
         events 'FAILED'
         exceptionFormat 'full'
     }
+    doFirst {
+      if (System.getProperty("java.specification.version") == "9") {
+        jvmArgs = [
+          '--add-opens', 'java.base/java.lang=ALL-UNNAMED'
+        ]
+      }
+    }
 }
-

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -6,7 +6,7 @@ tasks.withType(Test) {
     doFirst {
       // http://openjdk.java.net/jeps/223
       if (System.getProperty("java.specification.version") == "9") {
-        jvmArgs += [
+        jvmArgs = [
           '--add-opens', 'java.base/java.lang=ALL-UNNAMED'
         ]
       }

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -1,4 +1,5 @@
-apply plugin: 'findbugs'
+// FindBugs Gradle plugin does not support Java 9
+// apply plugin: 'findbugs'
 apply from: "$rootDir/gradle/jacoco.gradle"
 apply from: "$rootDir/gradle/maven.gradle"
 
@@ -55,6 +56,7 @@ dependencies {
   compile fileTree(dir: 'lib', include: '*.jar')
 }
 
+/*
 findbugs {
   effort = "max"
   reportLevel = "high"
@@ -62,6 +64,7 @@ findbugs {
     findbugs 'com.google.code.findbugs:findbugs:3.0.1'
   }
 }
+*/
 
 clean {
 	delete ".libs"

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -1,5 +1,7 @@
-// FindBugs Gradle plugin does not support Java 9
-// apply plugin: 'findbugs'
+plugins {
+  id "com.github.spotbugs" version "1.2"
+}
+
 apply from: "$rootDir/gradle/jacoco.gradle"
 apply from: "$rootDir/gradle/maven.gradle"
 
@@ -56,15 +58,11 @@ dependencies {
   compile fileTree(dir: 'lib', include: '*.jar')
 }
 
-/*
-findbugs {
+spotbugs {
   effort = "max"
   reportLevel = "high"
-  dependencies {
-    findbugs 'com.google.code.findbugs:findbugs:3.0.1'
-  }
+  toolVersion '3.1.0-RC5'
 }
-*/
 
 clean {
 	delete ".libs"


### PR DESCRIPTION
Run not only smoke test but also unit test on Java 9.

Note that [Gradle does not support Java 9 yet](https://github.com/gradle/gradle/issues/719), but no problem found in building SpotBugs.