### PR TITLE
[docs] Explain usage of maven plugin

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,6 +28,7 @@ Contents
    gui
    eclipse
    ant
+   maven
    gradle
    filter
    analysisprops

--- a/docs/locale/ja/LC_MESSAGES/maven.po
+++ b/docs/locale/ja/LC_MESSAGES/maven.po
@@ -1,0 +1,114 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2016-2017, spotbugs community
+# This file is distributed under the same license as the spotbugs package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: spotbugs 3.1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-09-23 14:06+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 1.3\n"
+
+#: ../../maven.rst:2
+msgid "Using the SpotBugs Maven Plugin"
+msgstr ""
+
+#: ../../maven.rst:4
+msgid "This chapter describes how to integrate SpotBugs into a Maven project."
+msgstr ""
+
+#: ../../maven.rst:7
+msgid "Add spotbugs-maven-plugin to your pom.xml"
+msgstr ""
+
+#: ../../maven.rst:9
+msgid "Add ``<plugin>`` into your ``pom.xml`` like below:"
+msgstr ""
+
+#: ../../maven.rst:28
+msgid "Goals of spotbugs-maven-plugin"
+msgstr ""
+
+#: ../../maven.rst:31
+msgid "spotbugs goal"
+msgstr ""
+
+#: ../../maven.rst:33
+msgid ""
+"``spotbugs`` goal analyses target project by SpotBugs. For detail, please"
+" refer `spotbugs goal description in maven site "
+"<https://spotbugs.github.io/spotbugs-maven-plugin/spotbugs-mojo.html>`_."
+msgstr ""
+
+#: ../../maven.rst:37
+msgid "check goal"
+msgstr ""
+
+#: ../../maven.rst:39
+msgid ""
+"``check`` goal runs analysis like ``spotbugs`` goal, and make the build "
+"failed if it found any bugs. For detail, please refer `check goal "
+"description in maven site <https://spotbugs.github.io/spotbugs-maven-"
+"plugin/check-mojo.html>`_."
+msgstr ""
+
+#: ../../maven.rst:43
+msgid "gui goal"
+msgstr ""
+
+#: ../../maven.rst:45
+msgid ""
+"``gui`` goal launches SpotBugs GUI to check analysis result. For detail, "
+"please refer `gui goal description in maven site "
+"<https://spotbugs.github.io/spotbugs-maven-plugin/gui-mojo.html>`_."
+msgstr ""
+
+#: ../../maven.rst:49
+msgid "help goal"
+msgstr ""
+
+#: ../../maven.rst:51
+msgid "``help`` goal displays usage of this Maven plugin."
+msgstr ""
+
+#~ msgid "This goal launches SpotBugs GUI to check analysis result."
+#~ msgstr ""
+
+#~ msgid "This goal displays usage of this Maven plugin."
+#~ msgstr ""
+
+#~ msgid ""
+#~ msgstr ""
+
+#~ msgid ""
+#~ "``spotbugs`` goal analyses target project "
+#~ "by SpotBugs. For detail, please refer"
+#~ " `Maven site <https://spotbugs.github.io/spotbugs-"
+#~ "maven-plugin/spotbugs-mojo.html>`_."
+#~ msgstr ""
+
+#~ msgid ""
+#~ "``check`` goal runs analysis like "
+#~ "``spotbugs`` goal, and make the build"
+#~ " failed if it found any bugs. "
+#~ "For detail, please refer `Maven site "
+#~ "<https://spotbugs.github.io/spotbugs-maven-plugin"
+#~ "/check-mojo.html>`_."
+#~ msgstr ""
+
+#~ msgid ""
+#~ "``gui`` goal launches SpotBugs GUI to"
+#~ " check analysis result. For detail, "
+#~ "please refer `Maven site "
+#~ "<https://spotbugs.github.io/spotbugs-maven-plugin/gui-"
+#~ "mojo.html>`_."
+#~ msgstr ""
+

--- a/docs/locale/ja/LC_MESSAGES/migration.po
+++ b/docs/locale/ja/LC_MESSAGES/migration.po
@@ -4,16 +4,17 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
 #
 msgid ""
-msgstr "Project-Id-Version: spotbugs 3.1\n"
+msgstr ""
+"Project-Id-Version: spotbugs 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-17 15:12+0900\n"
+"POT-Creation-Date: 2017-09-23 10:02+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.4.0\n"
+"Generated-By: Babel 1.3\n"
 
 #: ../../migration.rst:2
 msgid "Guide for migration from FindBugs 3.0 to SpotBugs 3.1"
@@ -27,7 +28,9 @@ msgstr ""
 msgid ""
 "Simply replace ``com.google.code.findbugs:findbugs`` with "
 "``com.github.spotbugs:spotbugs``."
-msgstr "``com.google.code.findbugs:findbugs`` を ``com.github.spotbugs:spotbugs`` に換えてください。"
+msgstr ""
+"``com.google.code.findbugs:findbugs`` を ``com.github.spotbugs:spotbugs`` "
+"に換えてください。"
 
 #: ../../migration.rst:24
 msgid "com.google.code.findbugs:jsr305"
@@ -37,7 +40,9 @@ msgstr ""
 msgid ""
 "JSR305 is already Dormant status, so SpotBugs does not release ``jsr305``"
 " jar file. Please continue using findbugs' one."
-msgstr "JSR305 は，すでに休止状態なので，SpotBugs は ``jsr305`` jarファイルをリリースしません。FindBugs のものを使い続けてください。"
+msgstr ""
+"JSR305 は，すでに休止状態なので，SpotBugs は ``jsr305`` jarファイルをリリースしません。FindBugs "
+"のものを使い続けてください。"
 
 #: ../../migration.rst:30
 msgid "com.google.code.findbugs:findbugs-annotations"
@@ -55,7 +60,9 @@ msgstr ""
 msgid ""
 "Please depend on both of ``spotbugs-annotations`` and ``net.jcip:jcip-"
 "annotations:1.0`` instead."
-msgstr "代わりに ``spotbugs-annotations`` と ``net.jcip:jcip-annotations:1.0`` の両方に依存してください。"
+msgstr ""
+"代わりに ``spotbugs-annotations`` と ``net.jcip:jcip-annotations:1.0`` "
+"の両方に依存してください。"
 
 #: ../../migration.rst:77
 msgid "FindBugs Ant task"
@@ -70,10 +77,13 @@ msgid "FindBugs Maven plugin"
 msgstr "FindBugs Maven プラグイン"
 
 #: ../../migration.rst:101
+#, fuzzy
 msgid ""
-"Please use `com.github.hazendaz.spotbugs:spotbugs-maven-plugin` instead "
-"of `org.codehaus.mojo:findbugs-maven-plugin`."
-msgstr "``org.codehaus.mojo:findbugs-maven-plugin`` の代わりに ``com.github.hazendaz.spotbugs:spotbugs-maven-plugin`` を使用してください。"
+"Please use `com.github.spotbugs:spotbugs-maven-plugin` instead of "
+"`org.codehaus.mojo:findbugs-maven-plugin`."
+msgstr ""
+"``org.codehaus.mojo:findbugs-maven-plugin`` の代わりに "
+"``com.github.hazendaz.spotbugs:spotbugs-maven-plugin`` を使用してください。"
 
 #: ../../migration.rst:120
 msgid "FindBugs Gradle plugin"
@@ -83,7 +93,9 @@ msgstr "FindBugs Gradle プラグイン"
 msgid ""
 "Please use spotbugs plugin found on "
 "https://plugins.gradle.org/plugin/com.github.spotbugs"
-msgstr "https://plugins.gradle.org/plugin/com.github.spotbugs にある spotbugs プラグインを使用してください。"
+msgstr ""
+"https://plugins.gradle.org/plugin/com.github.spotbugs にある spotbugs "
+"プラグインを使用してください。"
 
 #: ../../migration.rst:142
 msgid "FindBugs Eclipse plugin"

--- a/docs/maven.rst
+++ b/docs/maven.rst
@@ -1,0 +1,51 @@
+Using the SpotBugs Maven Plugin
+===============================
+
+This chapter describes how to integrate SpotBugs into a Maven project.
+
+Add spotbugs-maven-plugin to your pom.xml
+-----------------------------------------
+
+Add ``<plugin>`` into your ``pom.xml`` like below:
+
+.. code-block:: xml
+
+  <plugin>
+    <groupId>com.github.spotbugs</groupId>
+    <artifactId>spotbugs-maven-plugin</artifactId>
+    <version>3.0.6</version>
+    <dependencies>
+      <!-- overwrite dependency on spotbugs if you want to specify the version of spotbugs -->
+      <dependency>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs</artifactId>
+        <version>3.1.0-RC5</version>
+      </dependency>
+    </dependencies>
+  </plugin>
+
+Goals of spotbugs-maven-plugin
+------------------------------
+
+spotbugs goal
+^^^^^^^^^^^^^
+
+``spotbugs`` goal analyses target project by SpotBugs.
+For detail, please refer `spotbugs goal description in maven site <https://spotbugs.github.io/spotbugs-maven-plugin/spotbugs-mojo.html>`_.
+
+check goal
+^^^^^^^^^^
+
+``check`` goal runs analysis like ``spotbugs`` goal, and make the build failed if it found any bugs.
+For detail, please refer `check goal description in maven site <https://spotbugs.github.io/spotbugs-maven-plugin/check-mojo.html>`_.
+
+gui goal
+^^^^^^^^
+
+``gui`` goal launches SpotBugs GUI to check analysis result.
+For detail, please refer `gui goal description in maven site <https://spotbugs.github.io/spotbugs-maven-plugin/gui-mojo.html>`_.
+
+help goal
+^^^^^^^^^
+
+``help`` goal displays usage of this Maven plugin.

--- a/docs/maven.rst
+++ b/docs/maven.rst
@@ -13,13 +13,13 @@ Add ``<plugin>`` into your ``pom.xml`` like below:
   <plugin>
     <groupId>com.github.spotbugs</groupId>
     <artifactId>spotbugs-maven-plugin</artifactId>
-    <version>3.0.6</version>
+    <version>3.1.0-RC6</version>
     <dependencies>
       <!-- overwrite dependency on spotbugs if you want to specify the version of spotbugs -->
       <dependency>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs</artifactId>
-        <version>3.1.0-RC5</version>
+        <version>3.1.0-RC6</version>
       </dependency>
     </dependencies>
   </plugin>

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -98,12 +98,12 @@ Please replace ``findbugs-ant.jar`` with ``spotbugs-ant.jar``.
 FindBugs Maven plugin
 ---------------------
 
-Please use `com.github.hazendaz.spotbugs:spotbugs-maven-plugin` instead of `org.codehaus.mojo:findbugs-maven-plugin`.
+Please use `com.github.spotbugs:spotbugs-maven-plugin` instead of `org.codehaus.mojo:findbugs-maven-plugin`.
 
 .. code-block:: xml
 
   <plugin>
-    <groupId>com.github.hazendaz.spotbugs</groupId>
+    <groupId>com.github.spotbugs</groupId>
     <artifactId>spotbugs-maven-plugin</artifactId>
     <version>3.0.6</version>
     <dependencies>

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -12,13 +12,13 @@ Simply replace ``com.google.code.findbugs:findbugs`` with ``com.github.spotbugs:
   <dependency>
     <groupId>com.github.spotbugs</groupId>
     <artifactId>spotbugs</artifactId>
-    <version>3.1.0-RC5</version>
+    <version>3.1.0-RC6</version>
   </dependency>
 
 .. code-block:: groovy
 
   // for Gradle
-  compileOnly 'com.github.spotbugs:spotbugs:3.1.0-RC5'
+  compileOnly 'com.github.spotbugs:spotbugs:3.1.0-RC6'
 
 com.google.code.findbugs:jsr305
 -------------------------------
@@ -37,14 +37,14 @@ Please depend on ``spotbugs-annotations`` instead.
   <dependency>
     <groupId>com.github.spotbugs</groupId>
     <artifactId>spotbugs-annotations</artifactId>
-    <version>3.1.0-RC5</version>
+    <version>3.1.0-RC6</version>
     <optional>true</optional>
   </dependency>
 
 .. code-block:: groovy
 
   // for Gradle
-  compileOnly 'com.github.spotbugs:spotbugs-annotations:3.1.0-RC5'
+  compileOnly 'com.github.spotbugs:spotbugs-annotations:3.1.0-RC6'
 
 com.google.code.findbugs:annotations
 ------------------------------------
@@ -63,7 +63,7 @@ Please depend on both of ``spotbugs-annotations`` and ``net.jcip:jcip-annotation
   <dependency>
     <groupId>com.github.spotbugs</groupId>
     <artifactId>spotbugs-annotations</artifactId>
-    <version>3.1.0-RC5</version>
+    <version>3.1.0-RC6</version>
     <optional>true</optional>
   </dependency>
 
@@ -71,7 +71,7 @@ Please depend on both of ``spotbugs-annotations`` and ``net.jcip:jcip-annotation
 
   // for Gradle
   compileOnly 'net.jcip:jcip-annotations:1.0'
-  compileOnly 'com.github.spotbugs:spotbugs-annotations:3.1.0-RC5'
+  compileOnly 'com.github.spotbugs:spotbugs-annotations:3.1.0-RC6'
 
 FindBugs Ant task
 -----------------
@@ -105,13 +105,13 @@ Please use `com.github.spotbugs:spotbugs-maven-plugin` instead of `org.codehaus.
   <plugin>
     <groupId>com.github.spotbugs</groupId>
     <artifactId>spotbugs-maven-plugin</artifactId>
-    <version>3.0.6</version>
+    <version>3.1.0-RC6</version>
     <dependencies>
       <!-- overwrite dependency on spotbugs if you want to specify the version of spotbugs -->
       <dependency>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs</artifactId>
-        <version>3.1.0-RC5</version>
+        <version>3.1.0-RC6</version>
       </dependency>
     </dependencies>
   </plugin>
@@ -127,7 +127,7 @@ Please use spotbugs plugin found on https://plugins.gradle.org/plugin/com.github
     id  'com.github.spotbugs' version '1.3'
   }
   spotbugs {
-    toolVersion = '3.1.0-RC5'
+    toolVersion = '3.1.0-RC6'
   }
 
   // To generate an HTML report instead of XML


### PR DESCRIPTION
Current manual has no page for spotbugs-maven-plugin, so this PR will add it.
I will suggest [another PR](https://github.com/spotbugs/spotbugs-maven-plugin/pull/3) to deploy maven site to GitHub Pages of spotbugs/spotbugs-maven-plugin repository.