### PR TITLE
Upgrade ASM to 6.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,9 @@ subprojects {
 
   repositories {
     jcenter()
+    maven {
+      url 'https://repository.ow2.org/nexus/content/repositories/releases/'
+    }
   }
 }
 

--- a/gradlePlugin/src/test/java/com/github/spotbugs/SpotBugsPluginTest.java
+++ b/gradlePlugin/src/test/java/com/github/spotbugs/SpotBugsPluginTest.java
@@ -36,6 +36,9 @@ public class SpotBugsPluginTest extends Assert{
       "repositories {\n" +
       "  mavenCentral()\n" +
       "  mavenLocal()\n" +
+      "  maven {\n" +
+      "    url 'https://repository.ow2.org/nexus/content/repositories/releases/'\n" +
+      "  }\n" +
       "}";
     File buildFile = folder.newFile("build.gradle");
     Files.write(buildFile.toPath(), buildScript.getBytes(StandardCharsets.UTF_8), StandardOpenOption.WRITE);

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -36,7 +36,8 @@ sourceSets {
 }
 
 dependencies {
-  compile 'org.ow2.asm:asm-debug-all:6.0_BETA'
+  compile 'org.ow2.asm:asm:6.0'
+  compile 'org.ow2.asm:asm-tree:6.0'
   compile 'org.apache.bcel:bcel:6.1'
   compile 'net.jcip:jcip-annotations:1.0'
   compile 'dom4j:dom4j:1.6.1'


### PR DESCRIPTION
This PR tries to upgrade ASM from 6.0 beta to to 6.0.
Currently Maven Central Repository has no 6.0 binaries, so we need to add entry to `repository` in `build.gradle`. Before we merge this, it is better to wait release on Maven Central Repository and revert the commit 6670219.

refs #373