### PR TITLE
Reserve Jigsaw module name for future release

### DIFF
--- a/gradle/jigsaw.gradle
+++ b/gradle/jigsaw.gradle
@@ -1,0 +1,9 @@
+// Reserve module name
+// https://guides.gradle.org/building-java-9-modules/#optional_add_code_automatic_module_name_code_manifest_entries_for_all_other_projects
+// http://blog.joda.org/2017/05/java-se-9-jpms-automatic-modules.html
+jar {
+  inputs.property('moduleName', moduleName)
+  manifest {
+    attributes('Automatic-Module-Name': moduleName)
+  }
+}

--- a/spotbugs-annotations/build.gradle
+++ b/spotbugs-annotations/build.gradle
@@ -63,3 +63,8 @@ uploadArchives {
     }
   }
 }
+
+// Module name should be reverse-DNS (com.github.spotbugs) just like package name
+// http://blog.joda.org/2017/04/java-se-9-jpms-module-naming.html
+ext.moduleName = 'com.github.spotbugs.annotations'
+apply from: "$rootDir/gradle/jigsaw.gradle"

--- a/spotbugs-ant/build.gradle
+++ b/spotbugs-ant/build.gradle
@@ -38,3 +38,8 @@ uploadArchives {
     }
   }
 }
+
+// Module name should be reverse-DNS (com.github.spotbugs) just like package name
+// http://blog.joda.org/2017/04/java-se-9-jpms-module-naming.html
+ext.moduleName = 'com.github.spotbugs.ant'
+apply from: "$rootDir/gradle/jigsaw.gradle"

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -269,6 +269,11 @@ uploadArchives {
   }
 }
 
+// Module name should be reverse-DNS (com.github.spotbugs) just like package name
+// http://blog.joda.org/2017/04/java-se-9-jpms-module-naming.html
+ext.moduleName = 'com.github.spotbugs.spotbugs'
+apply from: "$rootDir/gradle/jigsaw.gradle"
+
 // TODO : jsr305.jar (really?)
 // TODO : generatemanual (we should decide what to do with the manual)
 // TODO : generatepdfmanual

--- a/test-harness/build.gradle
+++ b/test-harness/build.gradle
@@ -37,3 +37,8 @@ uploadArchives {
     }
   }
 }
+
+// Module name should be reverse-DNS (com.github.spotbugs) just like package name
+// http://blog.joda.org/2017/04/java-se-9-jpms-module-naming.html
+ext.moduleName = 'com.github.spotbugs.test'
+apply from: "$rootDir/gradle/jigsaw.gradle"


### PR DESCRIPTION
According to [Gradle guide](https://guides.gradle.org/building-java-9-modules/#optional_add_code_automatic_module_name_code_manifest_entries_for_all_other_projects) and [Stephen Colebourne's blog](http://blog.joda.org/2017/04/java-se-9-jpms-module-naming.html), it is recommended to put module name as `Automatic-Module-Name` into `MANIFEST.MF`.