### PR TITLE
Revert "use repository.ow2.org as temporal solution"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,9 +24,6 @@ subprojects {
 
   repositories {
     jcenter()
-    maven {
-      url 'https://repository.ow2.org/nexus/content/repositories/releases/'
-    }
   }
 }
 

--- a/gradlePlugin/src/test/java/com/github/spotbugs/SpotBugsPluginTest.java
+++ b/gradlePlugin/src/test/java/com/github/spotbugs/SpotBugsPluginTest.java
@@ -36,9 +36,6 @@ public class SpotBugsPluginTest extends Assert{
       "repositories {\n" +
       "  mavenCentral()\n" +
       "  mavenLocal()\n" +
-      "  maven {\n" +
-      "    url 'https://repository.ow2.org/nexus/content/repositories/releases/'\n" +
-      "  }\n" +
       "}";
     File buildFile = folder.newFile("build.gradle");
     Files.write(buildFile.toPath(), buildScript.getBytes(StandardCharsets.UTF_8), StandardOpenOption.WRITE);


### PR DESCRIPTION
This reverts commit 521562182080e1177d64b495de365757ed76ee82.

Now ASM 6 is released to Maven Central Repository so these configurations are needless.