### PR TITLE
Upgrade spotbugs plugin used in the build

### DIFF
--- a/spotbugs-annotations/build.gradle
+++ b/spotbugs-annotations/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+  id "com.github.spotbugs" version "1.4"
+}
+
 apply from: "$rootDir/gradle/checkstyle.gradle"
 apply from: "$rootDir/gradle/javadoc.gradle"
 apply from: "$rootDir/gradle/maven.gradle"
@@ -68,3 +72,9 @@ uploadArchives {
 // http://blog.joda.org/2017/04/java-se-9-jpms-module-naming.html
 ext.moduleName = 'com.github.spotbugs.annotations'
 apply from: "$rootDir/gradle/jigsaw.gradle"
+
+spotbugs {
+  effort = "max"
+  reportLevel = "high"
+  toolVersion '3.1.0-RC6'
+}

--- a/spotbugs-ant/build.gradle
+++ b/spotbugs-ant/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+  id "com.github.spotbugs" version "1.4"
+}
+
 apply from: "$rootDir/gradle/checkstyle.gradle"
 apply from: "$rootDir/gradle/javadoc.gradle"
 apply from: "$rootDir/gradle/maven.gradle"
@@ -43,3 +47,9 @@ uploadArchives {
 // http://blog.joda.org/2017/04/java-se-9-jpms-module-naming.html
 ext.moduleName = 'com.github.spotbugs.ant'
 apply from: "$rootDir/gradle/jigsaw.gradle"
+
+spotbugs {
+  effort = "max"
+  reportLevel = "high"
+  toolVersion '3.1.0-RC6'
+}

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.github.spotbugs" version "1.2"
+  id "com.github.spotbugs" version "1.4"
 }
 
 apply from: "$rootDir/gradle/jacoco.gradle"
@@ -66,7 +66,7 @@ dependencies {
 spotbugs {
   effort = "max"
   reportLevel = "high"
-  toolVersion '3.1.0-RC5'
+  toolVersion '3.1.0-RC6'
 }
 
 clean {

--- a/test-harness/build.gradle
+++ b/test-harness/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+  id "com.github.spotbugs" version "1.4"
+}
+
 apply from: "$rootDir/gradle/checkstyle.gradle"
 apply from: "$rootDir/gradle/javadoc.gradle"
 apply from: "$rootDir/gradle/maven.gradle"
@@ -42,3 +46,9 @@ uploadArchives {
 // http://blog.joda.org/2017/04/java-se-9-jpms-module-naming.html
 ext.moduleName = 'com.github.spotbugs.test'
 apply from: "$rootDir/gradle/jigsaw.gradle"
+
+spotbugs {
+  effort = "max"
+  reportLevel = "high"
+  toolVersion '3.1.0-RC6'
+}

--- a/test-harness/src/main/java/org/sonar/plugins/findbugs/resource/SmapParser.java
+++ b/test-harness/src/main/java/org/sonar/plugins/findbugs/resource/SmapParser.java
@@ -11,6 +11,8 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * This class is a highly modified version of Michael Schierl's "SmapParser.java".
  * It was test with Jetty and WebLogic SMAP.
@@ -74,6 +76,7 @@ public class SmapParser {
         return s;
     }
 
+    @SuppressFBWarnings(value = "DM_DEFAULT_ENCODING", justification = "To keep backward compatibility")
     public SmapParser(String smap) throws IOException {
         //BufferedReader is use to support multiple types of line return
         BufferedReader reader = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(smap.getBytes())));


### PR DESCRIPTION
Previously we introduced SpotBugs Gradle plugin v1.2, but now v1.4 is released and it can dismiss the warning message about usage of deprecated API. It is also good to introduce it to more submodules.

I tried to make `gradle/spotbugs.gradle` to share code and configuration, but it failed because `plugin {}` works only in submodule and `apply plugin` with `buildscript {}` does not work (it says "Plugin with id 'com.github.spotbugs' not found"). So I simply did copy-and-paste.