### PR TITLE
Update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-This is the changelog for SpotBugs. This follows [Keep a Changelog v0.3](http://keepachangelog.com/en/0.3.0/).
+This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased (2017/??/??)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http://keepachangelog.com/en/1.0.0/).
 
-## Unreleased (2017/??/??)
+## Unreleased
 
 ### Fixed
 
 * Wrong Class-Path in MANIFEST.MF ([#407](https://github.com/spotbugs/spotbugs/pull/407))
 
-## 3.1.0-RC6 (2017/Sep/25)
+## 3.1.0-RC6 - 2017-09-25
 
 ### Removed
 
@@ -30,7 +30,7 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 * Fix errors on processing INVOKEDYNAMIC instructions ([#371](https://github.com/spotbugs/spotbugs/issues/371))
 * Fix errors on processing i2f, i2d and i2l instructions if the lhs is a character ([#389](https://github.com/spotbugs/spotbugs/issues/389))
 
-## 3.1.0-RC5 (2017/Aug/16)
+## 3.1.0-RC5 - 2017-08-16
 
 ### Removed
 
@@ -40,7 +40,7 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 
 * SpotBugs now consumes ASM 6.0 *beta* rather than *alpha* ([#268](https://github.com/spotbugs/spotbugs/issues/268))
 
-## 3.1.0-RC4 (2017/Jul/21)
+## 3.1.0-RC4 - 2017-07-21
 
 ### Added
 
@@ -62,7 +62,7 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
   Subclasses should either implement this interface themselves or, preferably, use the constants defined in the (non-deprecated) `org.apache.bcel.Const` class instead.
   ([#262](https://github.com/spotbugs/spotbugs/issues/262))
 
-## 3.1.0-RC3 (2017/Jun/10)
+## 3.1.0-RC3 - 2017-06-10
 
 ### Added
 
@@ -73,7 +73,7 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 * Fix wrong version in Eclipse Plugin ([#173](https://github.com/spotbugs/spotbugs/pull/173))
 * When AnalysisRunner has findbugs.xml in jar, don't create temp jar ([#183](https://github.com/spotbugs/spotbugs/pull/183))
 
-## 3.1.0-RC2 (2017/May/16)
+## 3.1.0-RC2 - 2017-05-16
 
 ### Added
 
@@ -90,7 +90,7 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 * Fix HTML format in `messages.xml` and others ([#166](https://github.com/spotbugs/spotbugs/pull/166))
 * Fix Japanese message in `messages_ja.xml` ([#164](https://github.com/spotbugs/spotbugs/pull/164))
 
-## 3.1.0-RC1 (2017/Feb/21)
+## 3.1.0-RC1 - 2017-02-21
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v0.3](http://
 
 ## Unreleased (2017/??/??)
 
+### Fixed
+
+* Wrong Class-Path in MANIFEST.MF ([#407](https://github.com/spotbugs/spotbugs/pull/407))
+
 ## 3.1.0-RC6 (2017/Sep/25)
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http://keepachangelog.com/en/1.0.0/).
 
+Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
+
 ## Unreleased
 
 ### Fixed

--- a/gradlePlugin/CHANGELOG.md
+++ b/gradlePlugin/CHANGELOG.md
@@ -10,7 +10,7 @@ This is the changelog for SpotBugs Gradle Plugin. This follows [Keep a Changelog
 * Fix "Cannot convert the provided notation to a File or URI: classesDirs" error ([#320](https://github.com/spotbugs/spotbugs/issues/320))
 * Support working with Android Gradle Plugin 2.3 ([#256](https://github.com/spotbugs/spotbugs/issues/256))
 
-## 1.3 - 2017-08-16
+## 1.3 - 2017-08-16 [YANKED]
 
 * Use SpotBugs 3.1.0-RC5
 * Stop using [single class directory](https://docs.gradle.org/4.0.2/release-notes.html#multiple-class-directories-for-a-single-source-set) to prepare for Gradle v5 ([#299](https://github.com/spotbugs/spotbugs/issues/299))

--- a/gradlePlugin/CHANGELOG.md
+++ b/gradlePlugin/CHANGELOG.md
@@ -3,28 +3,28 @@
 This is the changelog for SpotBugs Gradle Plugin. This follows [Keep a Changelog v1.0.0](http://keepachangelog.com/en/1.0.0/).
 
 
-## Unreleased (2017/??/??)
+## Unreleased
 
-## 1.4 (2017/Sep/25)
+## 1.4 - 2017-09-25
 
 * Fix "Cannot convert the provided notation to a File or URI: classesDirs" error ([#320](https://github.com/spotbugs/spotbugs/issues/320))
 * Support working with Android Gradle Plugin 2.3 ([#256](https://github.com/spotbugs/spotbugs/issues/256))
 
-## 1.3 (2017/Aug/16)
+## 1.3 - 2017-08-16
 
 * Use SpotBugs 3.1.0-RC5
 * Stop using [single class directory](https://docs.gradle.org/4.0.2/release-notes.html#multiple-class-directories-for-a-single-source-set) to prepare for Gradle v5 ([#299](https://github.com/spotbugs/spotbugs/issues/299))
 * Print 'SpotBugs' instead of 'FindBugs' ([#291](https://github.com/spotbugs/spotbugs/issues/291))
 
-## 1.2 (2017/Jul/21)
+## 1.2 - 2017-07-21
 
 * Use SpotBugs 3.1.0-RC4
 * Fixed [#214](https://github.com/spotbugs/spotbugs/issues/214)
 
-## 1.1 (2017/Jun/10)
+## 1.1 - 2017-06-10
 
 * Use SpotBugs 3.1.0-RC2
 
-## 1.0 (2017/May/16)
+## 1.0 - 2017-05-16
 
 * First release which uses FindBugs 3.0.1

--- a/gradlePlugin/CHANGELOG.md
+++ b/gradlePlugin/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
-This is the changelog for SpotBugs Gradle Plugin. This follows [Keep a Changelog v0.3](http://keepachangelog.com/en/0.3.0/).
+This is the changelog for SpotBugs Gradle Plugin. This follows [Keep a Changelog v1.0.0](http://keepachangelog.com/en/1.0.0/).
+
 
 ## Unreleased (2017/??/??)
 

--- a/gradlePlugin/CHANGELOG.md
+++ b/gradlePlugin/CHANGELOG.md
@@ -7,6 +7,7 @@ This is the changelog for SpotBugs Gradle Plugin. This follows [Keep a Changelog
 
 ## 1.4 - 2017-09-25
 
+* Use SpotBugs 3.1.0-RC6
 * Fix "Cannot convert the provided notation to a File or URI: classesDirs" error ([#320](https://github.com/spotbugs/spotbugs/issues/320))
 * Support working with Android Gradle Plugin 2.3 ([#256](https://github.com/spotbugs/spotbugs/issues/256))
 

--- a/gradlePlugin/CHANGELOG.md
+++ b/gradlePlugin/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 This is the changelog for SpotBugs Gradle Plugin. This follows [Keep a Changelog v1.0.0](http://keepachangelog.com/en/1.0.0/).
 
+Currently the versioning policy of this project does not follow [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 


### PR DESCRIPTION
I found that keep a changelog released v1.0.0, so let's follow it. I also added missing entries (91d7885, 2e13228) to make this better changelog.

BTW, in my understanding, SpotBugs follows semver2, then we need to consider how to manage our branches after 3.1.0 release. I will propose a topic at [mailing list](https://github.com/spotbugs/discuss).