### PR TITLE
Avoid ArithmeticExceptions while interpreting ldiv/lrem values

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue413Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue413Test.java
@@ -1,0 +1,21 @@
+package edu.umd.cs.findbugs.ba;
+
+import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
+
+public class Issue413Test extends AbstractIntegrationTest {
+
+    @Test
+    public void test() {
+        performAnalysis("ghIssues/Issue413.class");
+        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder().build();
+        assertThat(getBugCollection(), containsExactly(0, bugTypeMatcher));
+    }
+
+}

--- a/spotbugsTestCases/src/java/ghIssues/Issue413.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue413.java
@@ -1,0 +1,13 @@
+package ghIssues;
+
+public class Issue413 {
+
+	public long error_in_ldiv() {
+		return 1L / (1L / 2);
+	}
+
+	public long error_in_lrem() {
+		return 1L % (1L / 2);
+	}
+
+}


### PR DESCRIPTION
This fixes #413.

Note: this is not a new issue, the commit bf2470ea8 just added more error logging to find out the reason for a try/catch(RuntimeException) block. This PR fixes two cases where the ArithmeticExceptions were thrown and catched immediately by the old code. We don't need to throw ArithmeticException if we know that 1/0 or 1%0 will never fly with long values.