### PR TITLE
stop replacing filename on-demand

### DIFF
--- a/spotbugs-annotations/build.gradle
+++ b/spotbugs-annotations/build.gradle
@@ -26,6 +26,8 @@ task updateManifest {
 tasks.eclipse.dependsOn(updateManifest)
 
 jar {
+  // To keep backward compatibility, delete version number from jar name
+  archiveName "${baseName}.${extension}"
   manifest {
     attributes 'Bundle-Name': 'spotbugs-annotations',
                'Bundle-SymbolicName': 'spotbugs-annotations',

--- a/spotbugs-ant/build.gradle
+++ b/spotbugs-ant/build.gradle
@@ -18,6 +18,11 @@ javadoc {
   }
 }
 
+jar {
+  // To keep backward compatibility, delete version number from jar name
+  archiveName "${baseName}.${extension}"
+}
+
 task javadocJar(type: Jar) {
   classifier = 'javadoc'
   from javadoc

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -130,10 +130,11 @@ tasks.eclipse.dependsOn(updateManifest)
 
 // Manually define what goes into the default jar, since it's not only main sourceset
 jar {
+  // To keep backward compatibility, delete version number from jar name
+  archiveName "${baseName}.${extension}"
+
   from sourceSets.main.output
-  def jarInClasspath = project.configurations.runtime.collect{it.getName()}.collect{
-    it.replaceFirst("-${project.version}.jar", '.jar')
-  }
+  def jarInClasspath = project.configurations.runtime.collect{it.getName()}
   manifest {
     attributes 'Main-Class': 'edu.umd.cs.findbugs.LaunchAppropriateUI',
                'Bundle-Version': project.version,
@@ -220,11 +221,9 @@ distributions {
       from(configurations.compile) {
         into 'lib'
         include '**/*.jar'
-        rename "(.*)-${project.version}.jar", '$1.jar'
       }
       from([jar, project(':spotbugs-ant').jar]) {
         into 'lib'
-        rename "(.*)-${project.version}.jar", '$1.jar'
       }
       from('src/xsl') {
         into 'src/xsl'

--- a/spotbugs/etc/script.properties
+++ b/spotbugs/etc/script.properties
@@ -94,10 +94,15 @@ script.wrap.java=\
     fb_javacmd=\${fb_javacmd:-"java"}\n\
     fb_maxheap=\${fb_maxheap:-"-Xmx768m"}\n\
     fb_appjar=\${fb_appjar:-"$spotbugs_home/lib/spotbugs.jar"}\n\
+    if [ -n "$CLASSPATH" ]; then\n\
+    \tfb_classpath=$fb_appjar$fb_pathsep$CLASSPATH\n\
+    else\n\
+    \tfb_classpath=$fb_appjar\n\
+    fi\n\
     set -f\n\
     #echo command: \\\n\
     exec "$fb_javacmd" \\\n\
-    \t-classpath "$fb_appjar$fb_pathsep$CLASSPATH" \\\n\
+    \t-classpath "$fb_classpath" \\\n\
     \t-Dspotbugs.home="$spotbugs_home"\\\n\
     \t$fb_maxheap $fb_jvmargs $fb_mainclass \${@:+"$@"} $fb_appargs
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/PrintingBugReporter.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/PrintingBugReporter.java
@@ -149,7 +149,7 @@ public class PrintingBugReporter extends TextUIBugReporter {
         PrintingCommandLine commandLine = reporter.new PrintingCommandLine();
 
         int argCount = commandLine.parse(args, 0, 2, "Usage: " + PrintingCommandLine.class.getName()
-                + " [options] [<xml results> [<test results]] ");
+                + " [options] [<xml results> [<test results>]] ");
 
 
         if (commandLine.stylesheet != null) {
@@ -171,7 +171,7 @@ public class PrintingBugReporter extends TextUIBugReporter {
         }
         boolean bugsReported = false;
         RuntimeException storedException = null;
-        
+
         Bag<String> lowRank = new Bag<>(new TreeMap<String, Integer>());
         for (BugInstance warning : bugCollection.getCollection()) {
             if (!reporter.isApplySuppressions() || !bugCollection.getProject().getSuppressionFilter().match(warning)) {
@@ -250,4 +250,3 @@ public class PrintingBugReporter extends TextUIBugReporter {
         return null;
     }
 }
-

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/Churn.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/Churn.java
@@ -225,7 +225,7 @@ public class Churn {
         Churn churn = new Churn();
         ChurnCommandLine commandLine = churn.new ChurnCommandLine();
         int argCount = commandLine
-                .parse(args, 0, 2, "Usage: " + Churn.class.getName() + " [options] [<xml results> [<history]] ");
+                .parse(args, 0, 2, "Usage: " + Churn.class.getName() + " [options] [<xml results> [<history>]] ");
 
         SortedBugCollection bugCollection = new SortedBugCollection();
         if (argCount < args.length) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/Filter.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/Filter.java
@@ -703,7 +703,7 @@ public class Filter {
         final FilterCommandLine commandLine = new FilterCommandLine();
 
         int argCount = commandLine.parse(args, 0, 2, "Usage: " + Filter.class.getName()
-                + " [options] [<orig results> [<new results]] ");
+                + " [options] [<orig results> [<new results>]] ");
         SortedBugCollection origCollection = new SortedBugCollection();
 
         if (argCount == args.length) {
@@ -811,4 +811,3 @@ public class Filter {
 
     }
 }
-

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/MineBugHistory.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/MineBugHistory.java
@@ -461,7 +461,7 @@ public class MineBugHistory {
         MineBugHistory mineBugHistory = new MineBugHistory();
         MineBugHistoryCommandLine commandLine = mineBugHistory.new MineBugHistoryCommandLine();
         int argCount = commandLine.parse(args, 0, 2, "Usage: " + MineBugHistory.class.getName()
-                + " [options] [<xml results> [<history]] ");
+                + " [options] [<xml results> [<history>]] ");
 
         SortedBugCollection bugCollection = new SortedBugCollection();
         if (argCount < args.length) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/RebornIssues.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/RebornIssues.java
@@ -122,7 +122,7 @@ public class RebornIssues {
         RebornIssues reborn = new RebornIssues();
         CommandLine commandLine = new CommandLine();
         int argCount = commandLine.parse(args, 0, 2, "Usage: " + RebornIssues.class.getName()
-                + " [options] [<xml results> [<history]] ");
+                + " [options] [<xml results> [<history>]] ");
 
         SortedBugCollection bugCollection = new SortedBugCollection();
         if (argCount < args.length) {


### PR DESCRIPTION
Currently we're replacing filename on-demand, and it will introduce trouble when our version becomes the same with some of dependencies. e.g. when we release spotbugs version 6.0, renaming method will rename not only spotbugs relatives but also ASM 6.0.

To stop replacing filename, we can use `archiveName` attribute to remove version from jar file name.