### PR TITLE
Make build failed if SpotBugsPlugin runs on unsupported Gradle version

### DIFF
--- a/gradlePlugin/CHANGELOG.md
+++ b/gradlePlugin/CHANGELOG.md
@@ -6,6 +6,8 @@ Currently the versioning policy of this project does not follow [Semantic Versio
 
 ## Unreleased
 
+* Make build failed when user uses unsupported Gradle version ([#357](https://github.com/spotbugs/spotbugs/issues/357))
+
 ## 1.4 - 2017-09-25
 
 * Use SpotBugs 3.1.0-RC6

--- a/gradlePlugin/src/main/java/com/github/spotbugs/SpotBugsPlugin.java
+++ b/gradlePlugin/src/main/java/com/github/spotbugs/SpotBugsPlugin.java
@@ -24,6 +24,7 @@ import org.gradle.api.plugins.quality.internal.AbstractCodeQualityPlugin;
 import org.gradle.api.reporting.SingleFileReport;
 import org.gradle.api.resources.TextResource;
 import org.gradle.api.tasks.SourceSet;
+import org.gradle.util.GradleVersion;
 
 /**
  * A plugin for the <a href="https://spotbugs.github.io">SpotBugs</a> byte code analyzer.
@@ -41,6 +42,12 @@ import org.gradle.api.tasks.SourceSet;
  */
 public class SpotBugsPlugin extends AbstractCodeQualityPlugin<SpotBugsTask> {
 
+    /**
+     * Supported Gradle version described at <a href="http://spotbugs.readthedocs.io/en/latest/gradle.html">official
+     * manual site</a>.
+     */
+    private static final GradleVersion SUPPORTED_VERSION = GradleVersion.version("4.0");
+
     private SpotBugsExtension extension;
 
     @Override
@@ -55,7 +62,24 @@ public class SpotBugsPlugin extends AbstractCodeQualityPlugin<SpotBugsTask> {
 
     @Override
     protected void beforeApply() {
+        verifyGradleVersion(GradleVersion.current());
         configureSpotBugsConfigurations();
+    }
+
+    /**
+     * Verify that given version is supported by {@link SpotBugsPlugin} or not.
+     * 
+     * @param version
+     *            to verify
+     * @throws IllegalArgumentException
+     *             if given version is not supported
+     */
+    void verifyGradleVersion(GradleVersion version) throws IllegalArgumentException {
+        if (version.compareTo(SUPPORTED_VERSION) < 0) {
+            String message = String.format("Gradle version %s is unsupported. Please use %s or later.", version,
+                    SUPPORTED_VERSION);
+            throw new IllegalArgumentException(message);
+        }
     }
 
     private void configureSpotBugsConfigurations() {

--- a/gradlePlugin/src/test/java/com/github/spotbugs/SpotBugsPluginTest.java
+++ b/gradlePlugin/src/test/java/com/github/spotbugs/SpotBugsPluginTest.java
@@ -16,6 +16,7 @@ import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.BuildTask;
 import org.gradle.testkit.runner.GradleRunner;
 import org.gradle.testkit.runner.TaskOutcome;
+import org.gradle.util.GradleVersion;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -96,4 +97,34 @@ public class SpotBugsPluginTest extends Assert{
     SpotBugsPlugin plugin = new SpotBugsPlugin();
     assertThat(plugin.loadToolVersion(), is(notNullValue()));
   }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testVersionVerifyForGradleVersion2() {
+        SpotBugsPlugin plugin = new SpotBugsPlugin();
+        plugin.verifyGradleVersion(GradleVersion.version("2.0"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testVersionVerifyForGradleVersion3() {
+        SpotBugsPlugin plugin = new SpotBugsPlugin();
+        plugin.verifyGradleVersion(GradleVersion.version("3.0"));
+    }
+
+    @Test
+    public void testVersionVerifyForGradleVersion4() {
+        SpotBugsPlugin plugin = new SpotBugsPlugin();
+        plugin.verifyGradleVersion(GradleVersion.version("4.0"));
+    }
+
+    @Test
+    public void testVersionVerifyForGradleVersion41() {
+        SpotBugsPlugin plugin = new SpotBugsPlugin();
+        plugin.verifyGradleVersion(GradleVersion.version("4.1"));
+    }
+
+    @Test
+    public void testVersionVerifyForGradleVersion42() {
+        SpotBugsPlugin plugin = new SpotBugsPlugin();
+        plugin.verifyGradleVersion(GradleVersion.version("4.2"));
+    }
 }


### PR DESCRIPTION
This change will make the build failure, when user uses too old Gradle.
Here is sample output:

```
    An exception occurred applying plugin request [id: 'com.github.spotbugs']
    > Failed to apply plugin [id 'com.github.spotbugs']
       > Gradle version Gradle 3.4 is unsupported. Please use Gradle 4.0 or later.
```

This will close #357 