### PR TITLE
stop replacing filename on-demand

### DIFF
--- a/spotbugs-annotations/build.gradle
+++ b/spotbugs-annotations/build.gradle
@@ -26,6 +26,8 @@ task updateManifest {
 tasks.eclipse.dependsOn(updateManifest)
 
 jar {
+  // To keep backward compatibility, delete version number from jar name
+  archiveName "${baseName}.${extension}"
   manifest {
     attributes 'Bundle-Name': 'spotbugs-annotations',
                'Bundle-SymbolicName': 'spotbugs-annotations',

--- a/spotbugs-ant/build.gradle
+++ b/spotbugs-ant/build.gradle
@@ -18,6 +18,11 @@ javadoc {
   }
 }
 
+jar {
+  // To keep backward compatibility, delete version number from jar name
+  archiveName "${baseName}.${extension}"
+}
+
 task javadocJar(type: Jar) {
   classifier = 'javadoc'
   from javadoc

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -130,10 +130,11 @@ tasks.eclipse.dependsOn(updateManifest)
 
 // Manually define what goes into the default jar, since it's not only main sourceset
 jar {
+  // To keep backward compatibility, delete version number from jar name
+  archiveName "${baseName}.${extension}"
+
   from sourceSets.main.output
-  def jarInClasspath = project.configurations.runtime.collect{it.getName()}.collect{
-    it.replaceFirst("-${project.version}.jar", '.jar')
-  }
+  def jarInClasspath = project.configurations.runtime.collect{it.getName()}
   manifest {
     attributes 'Main-Class': 'edu.umd.cs.findbugs.LaunchAppropriateUI',
                'Bundle-Version': project.version,
@@ -220,11 +221,9 @@ distributions {
       from(configurations.compile) {
         into 'lib'
         include '**/*.jar'
-        rename "(.*)-${project.version}.jar", '$1.jar'
       }
       from([jar, project(':spotbugs-ant').jar]) {
         into 'lib'
-        rename "(.*)-${project.version}.jar", '$1.jar'
       }
       from('src/xsl') {
         into 'src/xsl'


### PR DESCRIPTION
Currently we're replacing filename on-demand, and it will introduce trouble when our version becomes the same with some of dependencies. e.g. when we release spotbugs version 6.0, renaming method will rename not only spotbugs relatives but also ASM 6.0.

To stop replacing filename, we can use `archiveName` attribute to remove version from jar file name.