### PR TITLE
Parse package-info from aux classpath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 * Wrong Class-Path in MANIFEST.MF ([#407](https://github.com/spotbugs/spotbugs/pull/407))
 * Avoid ArithmeticExceptions while interpreting ldiv/lrem values ([#413](https://github.com/spotbugs/spotbugs/issues/413))
+* Parse `@CheckReturnValue` even in package-info from aux classpath ([#429](https://github.com/spotbugs/spotbugs/issues/429))
 
 ## 3.1.0-RC6 - 2017-09-25
 

--- a/spotbugs-tests/build.gradle
+++ b/spotbugs-tests/build.gradle
@@ -14,6 +14,14 @@ dependencies {
   compile 'org.apache.ant:ant:1.9.4'
 }
 
+
+test {
+  doFirst {
+    def auxClasspath = project(':spotbugsTestCases').configurations.runtime.resolvedConfiguration.resolvedArtifacts.file
+    systemProperty 'AUX_CLASSPATH', auxClasspath.join(',')
+  }
+}
+
 task sourcesJar(type: Jar) {
   classifier = 'sources'
   from sourceSets.main.allSource

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue429Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue429Test.java
@@ -1,0 +1,34 @@
+package edu.umd.cs.findbugs.ba;
+
+import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
+import static org.junit.Assert.assertThat;
+
+import java.nio.file.Paths;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import edu.umd.cs.findbugs.BugCollection;
+import edu.umd.cs.findbugs.test.SpotBugsRule;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
+
+/**
+ * Unit test to reproduce <a href="https://github.com/spotbugs/spotbugs/issues/429">#429</a>.
+ */
+public class Issue429Test {
+    @Rule
+    public SpotBugsRule spotbugs = new SpotBugsRule();
+
+    @Test
+    public void test() {
+        for (String path : System.getProperty("AUX_CLASSPATH").split(",")) {
+            spotbugs.addAuxClasspathEntry(Paths.get(path));
+        }
+        BugCollection bugCollection = spotbugs.performAnalysis(
+                Paths.get("../spotbugsTestCases/build/classes/java/main/ghIssues/Issue429.class"));
+        BugInstanceMatcher matcher = new BugInstanceMatcherBuilder().bugType("RV_RETURN_VALUE_IGNORED")
+                .build();
+        assertThat(bugCollection, containsExactly(1, matcher));
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/CheckReturnAnnotationDatabase.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/CheckReturnAnnotationDatabase.java
@@ -33,6 +33,7 @@ import org.apache.bcel.Const;
 import org.apache.bcel.Repository;
 import org.apache.bcel.classfile.JavaClass;
 
+import edu.umd.cs.findbugs.FindBugs2;
 import edu.umd.cs.findbugs.annotations.CheckReturnValue;
 import edu.umd.cs.findbugs.annotations.Confidence;
 import edu.umd.cs.findbugs.classfile.CheckedAnalysisException;
@@ -310,7 +311,9 @@ public class CheckReturnAnnotationDatabase extends AnnotationDatabase<CheckRetur
             return null;
         } catch (CheckedAnalysisException e) {
             // ignore unexpected error to keep backward compatibility
-            e.printStackTrace();
+            if (FindBugs2.DEBUG) {
+                e.printStackTrace();
+            }
             return null;
         }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/CheckReturnValueAnnotation.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/CheckReturnValueAnnotation.java
@@ -20,8 +20,10 @@
 package edu.umd.cs.findbugs.ba;
 
 import javax.annotation.CheckForNull;
+import javax.annotation.meta.When;
 
 import edu.umd.cs.findbugs.Detector;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * @author pugh
@@ -105,4 +107,18 @@ public class CheckReturnValueAnnotation extends AnnotationEnumeration<CheckRetur
         priority = p;
     }
 
+    @CheckForNull
+    public static CheckReturnValueAnnotation createFor(@NonNull When when) {
+        switch (when.name()) {
+        case "NEVER":
+        case "UNKNOWN":
+            return CheckReturnValueAnnotation.CHECK_RETURN_VALUE_IGNORE;
+        case "MAYBE":
+            return CheckReturnValueAnnotation.CHECK_RETURN_VALUE_MEDIUM_BAD_PRACTICE;
+        case "ALWAYS":
+            return CheckReturnValueAnnotation.CHECK_RETURN_VALUE_HIGH;
+        default:
+            return null;
+        }
+    }
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BuildCheckReturnAnnotationDatabase.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BuildCheckReturnAnnotationDatabase.java
@@ -102,6 +102,8 @@ public class BuildCheckReturnAnnotationDatabase extends AnnotationVisitor {
             if (v instanceof EnumElementValue) {
                 EnumElementValue when = (EnumElementValue) v;
                 String w = simpleClassName(when.getEnumValueString());
+                // TODO move mapping logic (When -> CheckReturnValueAnnotation)
+                // to factory method of CheckReturnValueAnnotation
                 if ("NEVER".equals(w) || "UNKNOWN".equals(w)) {
                     n = CheckReturnValueAnnotation.CHECK_RETURN_VALUE_IGNORE;
                 } else if ("MAYBE".equals(w)) {

--- a/spotbugsTestCases/build.gradle
+++ b/spotbugsTestCases/build.gradle
@@ -15,6 +15,7 @@ dependencies {
   compile 'com.google.inject:guice:4.1.0'
   compile 'com.google.inject.extensions:guice-assistedinject:4.1.0'
   compile 'com.google.inject.extensions:guice-servlet:4.1.0'
+  compile 'com.google.truth:truth:0.36'
   compile 'joda-time:joda-time:2.9.9'
   compile 'net.jcip:jcip-annotations:1.0'
   compile 'org.springframework:spring-core:4.3.8.RELEASE'

--- a/spotbugsTestCases/src/java/ghIssues/Issue429.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue429.java
@@ -1,0 +1,12 @@
+package ghIssues;
+
+import static com.google.common.truth.Truth.assertThat;
+
+/**
+ * An implementation to reproduce bug, shared by <a href="https://github.com/spotbugs/spotbugs/issues/429">#429</a>.
+ */
+public class Issue429 {
+	public void method() {
+		assertThat(System.currentTimeMillis() > 0);
+	}
+}

--- a/spotbugsTestCases/src/java/ghIssues/Issue429.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue429.java
@@ -6,7 +6,7 @@ import static com.google.common.truth.Truth.assertThat;
  * An implementation to reproduce bug, shared by <a href="https://github.com/spotbugs/spotbugs/issues/429">#429</a>.
  */
 public class Issue429 {
-	public void method() {
-		assertThat(System.currentTimeMillis() > 0);
-	}
+    public void method() {
+        assertThat(System.currentTimeMillis() > 0);
+    }
 }


### PR DESCRIPTION
This change is enough to close #429. AFAIK there are still known problems (e.g. annotation on class in aux classpath does not work), I will make separated issue for them. Maybe we need refactoring around `Database` classes.