### PR TITLE
[docs] List detectors and don't render hidden elements

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -2,3 +2,6 @@
 *.pyc
 generated/*.inc
 locale/ja/LC_MESSAGES/generated/*.po
+
+# compiled gettext messages
+locale/**/*.mo

--- a/docs/detectors.rst
+++ b/docs/detectors.rst
@@ -1,0 +1,18 @@
+Detectors
+=========
+
+This document lists all detectors in SpotBugs.
+
+Standard detectors
+------------------
+
+These detectors are on by default:
+
+.. include:: generated/detectorListEnabled.inc
+
+Disabled detectors
+------------------
+
+These detectors are off by default:
+
+.. include:: generated/detectorListDisabled.inc

--- a/docs/extensions/generate_bug_description.py
+++ b/docs/extensions/generate_bug_description.py
@@ -86,10 +86,14 @@ def generate_category(messages, category):
     yield ""
 
 
-def generate_raw_section(html):
+def generate_raw_section(html, prolog=None):
     yield ".. raw:: html"
-    for line in html.splitlines():
-        yield "   " + line.strip()
+    yield ""
+    if prolog:
+        yield "   " + prolog
+        yield ""
+    for line in html.strip().splitlines():
+        yield "   " + line
     yield ""
 
 
@@ -102,14 +106,19 @@ def generate_bug(messages, bug):
     description = i18n_text(msg_elem, "ShortDescription")
     details = i18n_text(msg_elem, "Details")
 
-    title = "{bug.abbrev}: {short_desc} ({bug.name})".format(bug=bug, short_desc=description)
+    title = "{bug.abbrev}: {short_desc}".format(bug=bug, short_desc=description)
 
-    yield ".. _bug-pattern-{0}:".format(bug.name.lower())
+    # This creates a target for :ref:`my-bug-pattern` links
+    yield ".. _{bug.name}:".format(bug=bug)
     yield ""
     yield title
     yield "^" * len(title)
 
-    for line in generate_raw_section(details):
+    # This is needed because Sphinx turns FOO_BAR into foo-bar, but
+    # we still want bugDescription.html#FOO_BAR to work
+    anchor = '<p><em id="{bug.name}">{bug.name}</em></p>'.format(bug=bug)
+
+    for line in generate_raw_section(details, prolog=anchor):
         yield line
 
 

--- a/docs/extensions/generate_bug_description.py
+++ b/docs/extensions/generate_bug_description.py
@@ -6,6 +6,7 @@
 from __future__ import print_function, unicode_literals
 
 from collections import namedtuple
+from docutils.utils import column_width
 import io
 import os
 import xml.etree.ElementTree as ET
@@ -76,7 +77,7 @@ def generate_category(messages, category):
     yield ".. _bug-category-{0}:".format(category.name.lower())
     yield ""
     yield title
-    yield "-" * len(title)
+    yield "-" * column_width(title)
     yield ""
 
     for line in i18n_text(msg_elem, "Details").splitlines():
@@ -112,7 +113,7 @@ def generate_bug(messages, bug):
     yield ".. _{bug.name}:".format(bug=bug)
     yield ""
     yield title
-    yield "^" * len(title)
+    yield "^" * column_width(title)
 
     # This is needed because Sphinx turns FOO_BAR into foo-bar, but
     # we still want bugDescription.html#FOO_BAR to work

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,4 +37,5 @@ Contents
    faq
    links
    bugDescriptions
+   detectors
    migration


### PR DESCRIPTION
This is a draft patch for the code that generates the bug list. Changes:

* Bug patterns are sorted inside Categories
* All sections have predictable anchors (not translation sensitive) to use with `:ref:`
* Hidden categories (like Noise) are omitted - not sure if that's ok
* Detectors are listed as an extra category with list of links to bugs it reports
* Detectors which are disabled by default have "(disabled by default)" under their title

I have trouble translating that last one. Is it ok to add some fake entries to "messages.xml" ?

If you think this is usefull, I would also like to add information about Rank for each Bug and speed for each detector.

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [X] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
- [X] Added an entry into `gradlePlugin/CHANGELOG.md` if you have changed Gradle plugin code
