### PR TITLE
XSLT version 2.0 upgrade.

### DIFF
--- a/spotbugs/src/xsl/color.xsl
+++ b/spotbugs/src/xsl/color.xsl
@@ -19,9 +19,9 @@
   License along with this library; if not, write to the Free Software
   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 -->
-<xsl:stylesheet version="1.0"
-	xmlns="http://www.w3.org/1999/xhtml"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:stylesheet version="2.0"
+                xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 <xsl:output
 	method="xml"

--- a/spotbugs/src/xsl/default.xsl
+++ b/spotbugs/src/xsl/default.xsl
@@ -42,10 +42,9 @@
   Chris Nappin (summary table)
 -->
 
-<xsl:stylesheet
-	version="1.0"
-	xmlns="http://www.w3.org/1999/xhtml"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:stylesheet version="2.0"
+                xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 <xsl:output
 	method="xml"

--- a/spotbugs/src/xsl/fancy-hist.xsl
+++ b/spotbugs/src/xsl/fancy-hist.xsl
@@ -18,7 +18,8 @@
   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 -->
 
-<xsl:transform xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0" >
+<xsl:transform version="2.0"
+               xmlns:xsl="http://www.w3.org/1999/XSL/Transform" >
    <xsl:output
          method="xml" indent="yes"
          doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"

--- a/spotbugs/src/xsl/fancy.xsl
+++ b/spotbugs/src/xsl/fancy.xsl
@@ -17,7 +17,8 @@
   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 -->
 
-<xsl:transform xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0" >
+<xsl:transform version="2.0"
+               xmlns:xsl="http://www.w3.org/1999/XSL/Transform" >
    <xsl:output
          method="xml" indent="yes"
          doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"

--- a/spotbugs/src/xsl/plain.xsl
+++ b/spotbugs/src/xsl/plain.xsl
@@ -18,9 +18,9 @@
   License along with this library; if not, write to the Free Software
   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 -->
-<xsl:stylesheet version="1.0"
-	xmlns="http://www.w3.org/1999/xhtml"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:stylesheet version="2.0"
+                xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 <xsl:output
 	method="xml"

--- a/spotbugs/src/xsl/summary.xsl
+++ b/spotbugs/src/xsl/summary.xsl
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0" >
+<xsl:stylesheet version="2.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform" >
 
 <xsl:output
          method="xml" indent="yes"


### PR DESCRIPTION
Hello
All XSL transformation scripts use the old XSLT 1.0 version.
They ought to be upgraded to version 2.0 so that some tools (eg the Gradle plugin `com.github.eerohele.saxon-gradle `) can process them.

TODO:
- [ ] Add an entry into `CHANGELOG.md`
