### PR TITLE
upgrade SpotBugs Gradle Plugin to the latest

### DIFF
--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.github.spotbugs" version "1.4"
+  id "com.github.spotbugs" version "1.5"
 }
 
 apply from: "$rootDir/gradle/jacoco.gradle"
@@ -68,7 +68,6 @@ dependencies {
 spotbugs {
   effort = "max"
   reportLevel = "high"
-  toolVersion '3.1.0-RC6'
 }
 
 clean {


### PR DESCRIPTION
This PR uses the latest SpotBugs Gradle Plugin which depends on SpotBugs 3.1.0-RC7.
I'm not sure when we can merge this PR, though.

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [ ] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
- [ ] Added an entry into `gradlePlugin/CHANGELOG.md` if you have changed Gradle plugin code
