### PR TITLE
Removed toolVersion from spotbugs tasks

### DIFF
--- a/spotbugs-annotations/build.gradle
+++ b/spotbugs-annotations/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.github.spotbugs" version "1.4"
+  id "com.github.spotbugs" version "1.5"
 }
 
 apply from: "$rootDir/gradle/checkstyle.gradle"
@@ -86,5 +86,4 @@ apply from: "$rootDir/gradle/jigsaw.gradle"
 spotbugs {
   effort = "max"
   reportLevel = "high"
-  toolVersion '3.1.0-RC6'
 }

--- a/spotbugs-ant/build.gradle
+++ b/spotbugs-ant/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.github.spotbugs" version "1.4"
+  id "com.github.spotbugs" version "1.5"
 }
 
 apply from: "$rootDir/gradle/checkstyle.gradle"
@@ -56,5 +56,4 @@ apply from: "$rootDir/gradle/jigsaw.gradle"
 spotbugs {
   effort = "max"
   reportLevel = "high"
-  toolVersion '3.1.0-RC6'
 }

--- a/test-harness/build.gradle
+++ b/test-harness/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.github.spotbugs" version "1.4"
+  id "com.github.spotbugs" version "1.5"
 }
 
 apply from: "$rootDir/gradle/checkstyle.gradle"
@@ -45,5 +45,4 @@ apply from: "$rootDir/gradle/jigsaw.gradle"
 spotbugs {
   effort = "max"
   reportLevel = "high"
-  toolVersion '3.1.0-RC6'
 }


### PR DESCRIPTION
Cleaning up spotbugs task version from gradle build files, to always use latest available. See discussion on #455 .

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [ ] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
- [ ] Added an entry into `gradlePlugin/CHANGELOG.md` if you have changed Gradle plugin code
