### PR TITLE
Release versions of Eclipse plugins must be higher as nightly versions

### DIFF
--- a/eclipsePlugin/build.gradle
+++ b/eclipsePlugin/build.gradle
@@ -1,12 +1,26 @@
 // TODO: deploy not only jar but also sources and javadoc, to pass validation by Sonatype nexus
 // apply from: "$rootDir/gradle/maven.gradle"
+plugins {
+  id 'org.ajoberstar.grgit' version '1.7.2'
+}
+
+def readLastCommitHash() {
+  // Same as 'git log -1 --pretty=format:"%h"'.execute().getText()
+  org.ajoberstar.grgit.Grgit.open(file('../')).head().abbreviatedId
+}
 
 if (version.endsWith('-SNAPSHOT')) {
   // eclipse doesn't like the `-SNAPSHOT`, so we timestamp uniquely
-  version = version - '-SNAPSHOT' + '.' + new Date().format('yyyyMMdd') + '-' + System.currentTimeMillis()
+  version = version - '-SNAPSHOT' + '.' + new Date().format('yyyyMMddHHmm') + '-' + readLastCommitHash()
 } else if (version.contains('-RC')) {
   // eclipse doesn't like the `-RC`, so we timestamp uniquely
-  version = version.substring(0, version.lastIndexOf('-RC')) + '.' + new Date().format('yyyyMMdd') + '-' + System.currentTimeMillis()
+  version = version.substring(0, version.lastIndexOf('-RC')) + '.' + new Date().format('yyyyMMddHHmm') + '-' + readLastCommitHash()
+} else {
+  // A release build version like 3.0.0 without qualifier will always be smaller
+  // then nightly build 3.0.0.20171023-1508734123102, but to update from nightlies
+  // we must give Eclipse a higher version number.
+  // The "r" makes the release version to be always higher then nightly builds
+  version = version + '.r' + new Date().format('yyyyMMddHHmm') + '-' + readLastCommitHash()
 }
 
 sourceSets {


### PR DESCRIPTION
Fixes #472, additionally uses commit hash to identify the build instead
of the timestamp.

This PR is the precondition for #465, otherwise no user with already installed SpotBugs Eclipse plugin will be able update to the released 3.1.0 version.

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [ ] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
- [ ] Added an entry into `gradlePlugin/CHANGELOG.md` if you have changed Gradle plugin code
