### PR TITLE
Replaced explicit null-checks by automatically generated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ## Unreleased - 2017-??-??
 
-## 3.1.0 - 2017-10-25
-
 ### Changed
 
 * Replaced explicit *null*-checks by automatically generated ([#512](https://github.com/spotbugs/spotbugs/pull/512))
+
+## 3.1.0 - 2017-10-25
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ## 3.1.0 - 2017-10-25
 
+### Changed
+
+* Replaced explicit *null*-checks by automatically generated ([#512](https://github.com/spotbugs/spotbugs/pull/512))
+
 ### Fixed
 
 * Do not try to parse module-info.class ([#408](https://github.com/spotbugs/spotbugs/issues/408))

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
   id 'org.sonarqube' version '2.5'
+  id 'tech.harmonysoft.oss.traute' version '1.1.7'
 }
 
 version = '4.0.0-SNAPSHOT'
@@ -9,6 +10,7 @@ apply from: "$rootDir/gradle/jacoco.gradle"
 apply from: "$rootDir/gradle/sonar.gradle"
 
 subprojects {
+  apply plugin: 'tech.harmonysoft.oss.traute'
   apply from: "$rootDir/gradle/java.gradle"
   apply from: "$rootDir/gradle/eclipse.gradle"
   apply from: "$rootDir/gradle/idea.gradle"

--- a/spotbugs/src/gui/edu/umd/cs/findbugs/gui2/BugLoader.java
+++ b/spotbugs/src/gui/edu/umd/cs/findbugs/gui2/BugLoader.java
@@ -19,8 +19,6 @@
 
 package edu.umd.cs.findbugs.gui2;
 
-import static java.util.Objects.requireNonNull;
-
 import java.awt.Dimension;
 import java.io.File;
 import java.io.IOException;
@@ -279,8 +277,6 @@ public class BugLoader {
      */
     public static @CheckForNull
     BugCollection doAnalysis(@Nonnull Project p) {
-        requireNonNull(p, "null project");
-
         RedoAnalysisCallback ac = new RedoAnalysisCallback();
 
         AnalyzingDialog.show(p, ac, true);
@@ -302,8 +298,6 @@ public class BugLoader {
      */
     public static @CheckForNull
     BugCollection redoAnalysisKeepComments(@Nonnull Project p) {
-        requireNonNull(p, "null project");
-
         BugCollection current = MainFrame.getInstance().getBugCollection();
 
         Update update = new Update();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/BugInstance.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/BugInstance.java
@@ -2092,8 +2092,6 @@ public class BugInstance implements Comparable<BugInstance>, XMLWriteable, Clone
     }
 
     public BugInstance add(@Nonnull BugAnnotation annotation) {
-        requireNonNull(annotation, "Missing BugAnnotation!");
-
         // Add to list
         annotationList.add(annotation);
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/Project.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/Project.java
@@ -25,7 +25,6 @@
 
 package edu.umd.cs.findbugs;
 import static edu.umd.cs.findbugs.xml.XMLOutputUtil.writeElementList;
-import static java.util.Objects.requireNonNull;
 
 import java.io.BufferedInputStream;
 import java.io.File;
@@ -132,7 +131,6 @@ public class Project implements XMLWriteable {
      * @param configuration The configuration to set, non null
      */
     public void setConfiguration(@Nonnull UserPreferences configuration) {
-        requireNonNull(configuration);
         this.configuration = configuration;
     }
 
@@ -1074,7 +1072,6 @@ public class Project implements XMLWriteable {
     }
 
     public void setSuppressionFilter(@Nonnull Filter suppressionFilter) {
-        requireNonNull(suppressionFilter);
         this.suppressionFilter = suppressionFilter;
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/SourceLineAnnotation.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/SourceLineAnnotation.java
@@ -21,7 +21,6 @@ package edu.umd.cs.findbugs;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Objects;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
@@ -135,8 +134,6 @@ public class SourceLineAnnotation implements BugAnnotation {
      */
     public SourceLineAnnotation(@Nonnull @DottedClassName String className, @Nonnull String sourceFile, int startLine, int endLine,
             int startBytecode, int endBytecode) {
-        Objects.requireNonNull(className, "class name is null");
-        Objects.requireNonNull(sourceFile, "source file is null");
         this.description = DEFAULT_ROLE;
         this.className = className;
         this.sourceFile = sourceFile;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/AbstractClassMember.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/AbstractClassMember.java
@@ -24,6 +24,8 @@ import edu.umd.cs.findbugs.classfile.ClassDescriptor;
 import edu.umd.cs.findbugs.classfile.DescriptorFactory;
 import edu.umd.cs.findbugs.internalAnnotations.DottedClassName;
 
+import javax.annotation.CheckForNull;
+
 public abstract class AbstractClassMember implements ClassMember {
     private final @DottedClassName
     String className;
@@ -183,7 +185,7 @@ public abstract class AbstractClassMember implements ClassMember {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@CheckForNull Object o) {
         if (o == null || this.getClass() != o.getClass()) {
             return false;
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/AnalysisContext.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/AnalysisContext.java
@@ -18,7 +18,6 @@
  */
 
 package edu.umd.cs.findbugs.ba;
-import static java.util.Objects.requireNonNull;
 
 import java.io.File;
 import java.io.IOException;
@@ -173,7 +172,6 @@ public class AnalysisContext {
 
 
     public AnalysisContext(@Nonnull Project project) {
-        requireNonNull(project);
         this.project = project;
         this.boolPropertySet = new BitSet();
         this.lookupFailureCallback = new DelegatingRepositoryLookupFailureCallback();
@@ -291,7 +289,6 @@ public class AnalysisContext {
      * @see #getLookupFailureCallback()
      */
     static public void reportMissingClass(ClassNotFoundException e) {
-        requireNonNull(e, "argument is null");
         String missing = AbstractBugReporter.getMissingClassName(e);
         if (skipReportingMissingClass(missing)) {
             return;
@@ -307,7 +304,6 @@ public class AnalysisContext {
     }
 
     static public void reportMissingClass(edu.umd.cs.findbugs.ba.MissingClassException e) {
-        requireNonNull(e, "argument is null");
         reportMissingClass(e.getClassDescriptor());
     }
 
@@ -324,12 +320,10 @@ public class AnalysisContext {
     }
 
     static public void reportMissingClass(edu.umd.cs.findbugs.classfile.MissingClassException e) {
-        requireNonNull(e, "argument is null");
         reportMissingClass(e.getClassDescriptor());
     }
 
     static public void reportMissingClass(ClassDescriptor c) {
-        requireNonNull(c, "argument is null");
         if (!analyzingApplicationClass()) {
             return;
         }
@@ -535,7 +529,6 @@ public class AnalysisContext {
     public static JavaClass lookupSystemClass(@Nonnull String className) throws ClassNotFoundException {
         // TODO: eventually we should move to our own thread-safe repository
         // implementation
-        requireNonNull (className, "className is null");
         if (originalRepository == null) {
             throw new IllegalStateException("originalRepository is null");
         }
@@ -559,7 +552,6 @@ public class AnalysisContext {
      *         determine
      */
     public final String lookupSourceFile(@Nonnull @DottedClassName String dottedClassName) {
-        requireNonNull(dottedClassName, "className is null");
         try {
             XClass xClass = Global.getAnalysisCache().getClassAnalysis(XClass.class,
                     DescriptorFactory.createClassDescriptorFromDottedClassName(dottedClassName));

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/BasicBlock.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/BasicBlock.java
@@ -261,7 +261,7 @@ public class BasicBlock extends AbstractVertex<Edge, BasicBlock> implements Debu
         private InstructionHandle next;
         private final InstructionHandle last;
 
-        public InstructionIterator(InstructionHandle first, InstructionHandle last) {
+        public InstructionIterator(@CheckForNull InstructionHandle first, @CheckForNull InstructionHandle last) {
             this.next = first;
             this.last = last;
         }
@@ -343,7 +343,7 @@ public class BasicBlock extends AbstractVertex<Edge, BasicBlock> implements Debu
         private InstructionHandle next;
         private final InstructionHandle first;
 
-        public InstructionReverseIterator(InstructionHandle last, InstructionHandle first) {
+        public InstructionReverseIterator(@CheckForNull InstructionHandle last, @CheckForNull InstructionHandle first) {
             this.next = last;
             this.first = first;
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/CheckReturnValueAnnotation.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/CheckReturnValueAnnotation.java
@@ -66,7 +66,7 @@ public class CheckReturnValueAnnotation extends AnnotationEnumeration<CheckRetur
         CHECK_RETURN_VALUE_LOW_BAD_PRACTICE, CHECK_RETURN_VALUE_MEDIUM_BAD_PRACTICE, CHECK_RETURN_VALUE_INFERRED};
 
     @CheckForNull
-    public static CheckReturnValueAnnotation parse(String priority) {
+    public static CheckReturnValueAnnotation parse(@CheckForNull String priority) {
         if (priority == null) {
             return CHECK_RETURN_VALUE_MEDIUM;
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/Dataflow.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/Dataflow.java
@@ -35,6 +35,8 @@ import edu.umd.cs.findbugs.classfile.CheckedAnalysisException;
 import edu.umd.cs.findbugs.classfile.DescriptorFactory;
 import edu.umd.cs.findbugs.classfile.Global;
 
+import javax.annotation.CheckForNull;
+
 /**
  * Perform dataflow analysis on a method using a control flow graph. Both
  * forward and backward analyses can be performed.
@@ -511,7 +513,7 @@ public class Dataflow<Fact, AnalysisType extends DataflowAnalysis<Fact>> {
      * @return the dataflow value after given Location
      * @throws DataflowAnalysisException
      */
-    public/* final */Fact getFactAfterLocation(Location location) throws DataflowAnalysisException {
+    public/* final */Fact getFactAfterLocation(@CheckForNull Location location) throws DataflowAnalysisException {
         return analysis.getFactAfterLocation(location);
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/FieldSummary.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/FieldSummary.java
@@ -63,7 +63,7 @@ public class FieldSummary {
 
     private boolean complete = false;
 
-    public OpcodeStack.Item getSummary(XField field) {
+    public OpcodeStack.Item getSummary(@CheckForNull XField field) {
         if (field == null) {
             return new OpcodeStack.Item();
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/Hierarchy.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/Hierarchy.java
@@ -119,7 +119,7 @@ public class Hierarchy {
      *            the ObjectType of the exception handler
      * @return true if catchType is null, or if catchType is java.lang.Throwable
      */
-    public static boolean isUniversalExceptionHandler(ObjectType catchType) {
+    public static boolean isUniversalExceptionHandler(@CheckForNull ObjectType catchType) {
         return catchType == null || catchType.equals(Type.THROWABLE);
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/JCIPAnnotationDatabase.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/JCIPAnnotationDatabase.java
@@ -89,7 +89,7 @@ public class JCIPAnnotationDatabase {
     }
 
     public void addEntryForClass(@DottedClassName String dottedClassName,
-            String annotationClass, ElementValue value) {
+            String annotationClass, @CheckForNull ElementValue value) {
         Map<String, ElementValue> map = getEntryForClass(dottedClassName);
         if (map == null) {
             map = new HashMap<>(3);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/Location.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/Location.java
@@ -19,8 +19,6 @@
 
 package edu.umd.cs.findbugs.ba;
 
-import java.util.Objects;
-
 import javax.annotation.Nonnull;
 
 import org.apache.bcel.generic.InstructionHandle;
@@ -57,8 +55,6 @@ public class Location implements Comparable<Location> {
      *            the basic block containing the instruction
      */
     public Location(@Nonnull InstructionHandle handle, @Nonnull BasicBlock basicBlock) {
-        Objects.requireNonNull(handle, "handle cannot be null");
-        Objects.requireNonNull(basicBlock, "basicBlock cannot be null");
         this.handle = handle;
         this.basicBlock = basicBlock;
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/SourceInfoMap.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/SourceInfoMap.java
@@ -150,7 +150,7 @@ public class SourceInfoMap {
          * @see java.lang.Object#equals(java.lang.Object)
          */
         @Override
-        public boolean equals(Object obj) {
+        public boolean equals(@CheckForNull Object obj) {
             if (obj == null || obj.getClass() != this.getClass()) {
                 return false;
             }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/bcp/BindingSet.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/bcp/BindingSet.java
@@ -19,6 +19,8 @@
 
 package edu.umd.cs.findbugs.ba.bcp;
 
+import javax.annotation.CheckForNull;
+
 /**
  * A set of Bindings, which are definitions of variables occurring in a
  * ByteCodePattern. BindingSets are immutable; to add a binding, a new cell is
@@ -40,7 +42,7 @@ public class BindingSet {
      * @param parent
      *            the parent BindingSet, containing other bindings
      */
-    public BindingSet(Binding binding, BindingSet parent) {
+    public BindingSet(Binding binding, @CheckForNull BindingSet parent) {
         this.binding = binding;
         this.parent = parent;
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/bcp/FieldAccess.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/bcp/FieldAccess.java
@@ -28,6 +28,8 @@ import edu.umd.cs.findbugs.ba.DataflowAnalysisException;
 import edu.umd.cs.findbugs.ba.vna.ValueNumber;
 import edu.umd.cs.findbugs.ba.vna.ValueNumberFrame;
 
+import javax.annotation.CheckForNull;
+
 /**
  * Base class for Load and Store PatternElements. Handles some of the grunt work
  * of representing fields and extracting field values from the stack frame.
@@ -68,7 +70,7 @@ public abstract class FieldAccess extends SingleInstruction implements org.apach
      * @return a MatchResult containing an updated BindingSet if successful, or
      *         null if unsuccessful
      */
-    protected MatchResult checkConsistent(Variable field, Variable value, BindingSet bindingSet) {
+    protected MatchResult checkConsistent(Variable field, Variable value, @CheckForNull BindingSet bindingSet) {
         // Ensure that the field and value variables are consistent with
         // previous definitions (if any)
         bindingSet = addOrCheckDefinition(fieldVarName, field, bindingSet);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/bcp/Load.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/bcp/Load.java
@@ -30,6 +30,8 @@ import edu.umd.cs.findbugs.ba.DataflowAnalysisException;
 import edu.umd.cs.findbugs.ba.vna.ValueNumber;
 import edu.umd.cs.findbugs.ba.vna.ValueNumberFrame;
 
+import javax.annotation.CheckForNull;
+
 /**
  * A PatternElement representing a load from a field. Variables represent the
  * field and the result of the load.
@@ -53,7 +55,7 @@ public class Load extends FieldAccess {
 
     @Override
     public MatchResult match(InstructionHandle handle, ConstantPoolGen cpg, ValueNumberFrame before, ValueNumberFrame after,
-            BindingSet bindingSet) throws DataflowAnalysisException {
+            @CheckForNull BindingSet bindingSet) throws DataflowAnalysisException {
 
         Variable field;
         Instruction ins = handle.getInstruction();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/bcp/PatternElement.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/bcp/PatternElement.java
@@ -136,7 +136,7 @@ public abstract class PatternElement {
      *            the BindingSet to look in
      * @return the Variable, or null if no Variable is bound to the name
      */
-    public static Variable lookup(String varName, BindingSet bindingSet) {
+    public static Variable lookup(String varName, @CheckForNull BindingSet bindingSet) {
         if (bindingSet == null) {
             return null;
         }
@@ -205,7 +205,8 @@ public abstract class PatternElement {
      *         previous bindings), or null if the new variable is inconsistent
      *         with the previous bindings
      */
-    protected static BindingSet addOrCheckDefinition(String varName, Variable variable, BindingSet bindingSet) {
+    protected static BindingSet addOrCheckDefinition(String varName, Variable variable,
+            @CheckForNull BindingSet bindingSet) {
         Variable existingVariable = lookup(varName, bindingSet);
         if (existingVariable == null) {
             bindingSet = new BindingSet(new Binding(varName, variable), bindingSet);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/bcp/PatternElementMatch.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/bcp/PatternElementMatch.java
@@ -23,6 +23,8 @@ import org.apache.bcel.generic.InstructionHandle;
 
 import edu.umd.cs.findbugs.ba.BasicBlock;
 
+import javax.annotation.CheckForNull;
+
 /**
  * PatternElementMatch represents matching a PatternElement against a single
  * instruction. The "prev" field points to the previous PatternElementMatch. By
@@ -57,7 +59,7 @@ public class PatternElementMatch {
      *            the previous PatternElementMatch
      */
     public PatternElementMatch(PatternElement patternElement, InstructionHandle matchedInstruction, BasicBlock basicBlock,
-            int matchCount, PatternElementMatch prev) {
+            int matchCount, @CheckForNull PatternElementMatch prev) {
         this.patternElement = patternElement;
         this.matchedInstruction = matchedInstruction;
         this.basicBlock = basicBlock;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/bcp/PatternMatcher.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/bcp/PatternMatcher.java
@@ -24,6 +24,7 @@ import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
 
+import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
 import org.apache.bcel.classfile.Method;
@@ -208,7 +209,7 @@ public class PatternMatcher implements DFSEdgeTypes {
          * Constructor.
          */
         public State(@Nullable State parent, BasicBlock basicBlock, BasicBlock.InstructionIterator instructionIterator,
-                PatternElement patternElement, int matchCount, @Nullable PatternElementMatch currentMatch,
+                @Nullable PatternElement patternElement, int matchCount, @Nullable PatternElementMatch currentMatch,
                 @Nullable BindingSet bindingSet, boolean canFork) {
             this.basicBlock = basicBlock;
             this.instructionIterator = instructionIterator;
@@ -349,7 +350,7 @@ public class PatternMatcher implements DFSEdgeTypes {
          *            a MatchResult representing the match of the last
          *            instruction in the predecessor block; null if none
          */
-        public State advanceToSuccessor(Edge edge, MatchResult matchResult) {
+        public State advanceToSuccessor(Edge edge, @CheckForNull MatchResult matchResult) {
             // If we have just matched an instruction, then we allow the
             // matching PatternElement to choose which edges are acceptable.
             // This allows PatternElements to select particular control edges;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/BackwardTypeQualifierDataflowAnalysis.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/BackwardTypeQualifierDataflowAnalysis.java
@@ -22,6 +22,7 @@ package edu.umd.cs.findbugs.ba.jsr305;
 import java.util.HashSet;
 import java.util.Iterator;
 
+import javax.annotation.CheckForNull;
 import javax.annotation.meta.When;
 
 import org.apache.bcel.Const;
@@ -180,7 +181,8 @@ public class BackwardTypeQualifierDataflowAnalysis extends TypeQualifierDataflow
         }
     }
 
-    private void modelReturn(TypeQualifierAnnotation returnValueAnnotation, Location location) throws DataflowAnalysisException {
+    private void modelReturn(@CheckForNull TypeQualifierAnnotation returnValueAnnotation, Location location)
+            throws DataflowAnalysisException {
         When when = (returnValueAnnotation != null) ? returnValueAnnotation.when : When.UNKNOWN;
 
         // Model return statement

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/SourceSinkInfo.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/SourceSinkInfo.java
@@ -19,6 +19,7 @@
 
 package edu.umd.cs.findbugs.ba.jsr305;
 
+import javax.annotation.CheckForNull;
 import javax.annotation.meta.When;
 
 import edu.umd.cs.findbugs.ba.Location;
@@ -168,7 +169,7 @@ public class SourceSinkInfo implements Comparable<SourceSinkInfo> {
         return constantValue;
     }
 
-    public void setConstantValue(Object constantValue) {
+    public void setConstantValue(@CheckForNull Object constantValue) {
         this.constantValue = constantValue;
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/TypeQualifierAnnotation.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/TypeQualifierAnnotation.java
@@ -41,7 +41,7 @@ public class TypeQualifierAnnotation {
 
     public final When when;
 
-    private TypeQualifierAnnotation(TypeQualifierValue<?> typeQualifier, When when) {
+    private TypeQualifierAnnotation(@CheckForNull TypeQualifierValue<?> typeQualifier, @CheckForNull When when) {
         this.typeQualifier = typeQualifier;
         this.when = when;
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/IsNullValueAnalysis.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/IsNullValueAnalysis.java
@@ -839,8 +839,9 @@ IsNullValueAnalysisFeatures {
      *            the IsNullValue representing the updated is-null information
      * @return a modified IsNullValueFrame with updated is-null information
      */
-    private IsNullValueFrame replaceValues(IsNullValueFrame origFrame, IsNullValueFrame frame, ValueNumber replaceMe,
-            ValueNumberFrame prevVnaFrame, ValueNumberFrame targetVnaFrame, IsNullValue replacementValue) {
+    private IsNullValueFrame replaceValues(IsNullValueFrame origFrame, @CheckForNull IsNullValueFrame frame,
+            ValueNumber replaceMe, ValueNumberFrame prevVnaFrame, ValueNumberFrame targetVnaFrame,
+            IsNullValue replacementValue) {
 
         if (!targetVnaFrame.isValid()) {
             throw new IllegalArgumentException("Invalid frame in " + methodGen.getClassName() + "." + methodGen.getName() + " : "

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/ReturnPathTypeAnalysis.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/ReturnPathTypeAnalysis.java
@@ -31,6 +31,8 @@ import edu.umd.cs.findbugs.ba.Edge;
 import edu.umd.cs.findbugs.ba.ReverseDFSOrder;
 import edu.umd.cs.findbugs.ba.ReverseDepthFirstSearch;
 
+import javax.annotation.CheckForNull;
+
 /**
  * A dataflow analysis to determine, at each location in a method's CFG, whether
  * or not it is possible to return normally at that location.
@@ -165,7 +167,8 @@ public class ReturnPathTypeAnalysis extends BasicAbstractDataflowAnalysis<Return
     }
 
     @Override
-    public void transfer(BasicBlock basicBlock, InstructionHandle end, ReturnPathType start, ReturnPathType result)
+    public void transfer(BasicBlock basicBlock, @CheckForNull InstructionHandle end, ReturnPathType start,
+            ReturnPathType result)
             throws DataflowAnalysisException {
         // just copy the start fact
         result.copyFrom(start);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/type/StandardTypeMerger.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/type/StandardTypeMerger.java
@@ -36,6 +36,8 @@ import edu.umd.cs.findbugs.ba.ch.Subtypes2;
 import edu.umd.cs.findbugs.ba.generic.GenericObjectType;
 import edu.umd.cs.findbugs.ba.generic.GenericUtilities;
 
+import javax.annotation.CheckForNull;
+
 /**
  * A TypeMerger which applies standard Java semantics when merging Types.
  * Subclasses may override mergeReferenceTypes() in order to implement special
@@ -65,7 +67,7 @@ public class StandardTypeMerger implements TypeMerger, Constants, ExtendedTypes 
     }
 
     @Override
-    public Type mergeTypes(Type a, Type b) throws DataflowAnalysisException {
+    public Type mergeTypes(@CheckForNull Type a, @CheckForNull Type b) throws DataflowAnalysisException {
         if (a == null) {
             return b;
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/type/TypeAnalysis.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/type/TypeAnalysis.java
@@ -141,7 +141,7 @@ public class TypeAnalysis extends FrameDataflowAnalysis<Type, TypeFrame> impleme
 
         final Type type;
 
-        InstanceOfCheck(ValueNumber valueNumber, Type type) {
+        InstanceOfCheck(@CheckForNull ValueNumber valueNumber, @CheckForNull Type type) {
             this.valueNumber = valueNumber;
             this.type = type;
         }
@@ -560,7 +560,7 @@ public class TypeAnalysis extends FrameDataflowAnalysis<Type, TypeFrame> impleme
         mergeInto(fact, result);
     }
 
-    private TypeFrame handleInstanceOfBranch(TypeFrame fact, TypeFrame tmpFact, Edge edge) {
+    private TypeFrame handleInstanceOfBranch(TypeFrame fact, @CheckForNull TypeFrame tmpFact, Edge edge) {
 
         InstanceOfCheck check = instanceOfCheckMap.get(edge.getSource());
         if (check == null) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/vna/AvailableLoad.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/vna/AvailableLoad.java
@@ -21,6 +21,8 @@ package edu.umd.cs.findbugs.ba.vna;
 
 import edu.umd.cs.findbugs.ba.XField;
 
+import javax.annotation.CheckForNull;
+
 /**
  * <p>An AvailableLoad indicates a field and (optionally) object reference for
  * which a value is available. It is used to implement redundant load
@@ -119,7 +121,7 @@ public class AvailableLoad implements Comparable<AvailableLoad> {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@CheckForNull Object o) {
         if (o == null || this.getClass() != o.getClass()) {
             return false;
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/vna/ValueNumber.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/vna/ValueNumber.java
@@ -22,6 +22,8 @@ package edu.umd.cs.findbugs.ba.vna;
 import edu.umd.cs.findbugs.util.MapCache;
 import edu.umd.cs.findbugs.util.Util;
 
+import javax.annotation.CheckForNull;
+
 /**
  * <p>A "value number" is a value produced somewhere in a methods. We use value
  * numbers as dataflow values in Frames. When two frame slots have the same
@@ -140,7 +142,7 @@ public class ValueNumber implements Comparable<ValueNumber> {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@CheckForNull Object o) {
         if (o instanceof ValueNumber) {
             return number == ((ValueNumber) o).number && flags == ((ValueNumber) o).flags;
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/vna/ValueNumberAnalysis.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/vna/ValueNumberAnalysis.java
@@ -195,8 +195,8 @@ public class ValueNumberAnalysis extends FrameDataflowAnalysis<ValueNumber, Valu
     }
 
     @Override
-    public void transfer(BasicBlock basicBlock, InstructionHandle end, ValueNumberFrame start, ValueNumberFrame result)
-            throws DataflowAnalysisException {
+    public void transfer(BasicBlock basicBlock, @CheckForNull InstructionHandle end, ValueNumberFrame start,
+            ValueNumberFrame result) throws DataflowAnalysisException {
         if(basicBlock.isExceptionThrower() && isFactValid(start)) {
             /* If exceptionThrower is invoke instruction then it's possible that
              * it was partially executed before an exception occurred
@@ -320,7 +320,7 @@ public class ValueNumberAnalysis extends FrameDataflowAnalysis<ValueNumber, Valu
 
 
     @Override
-    public ValueNumberFrame getFactAfterLocation(Location location) {
+    public ValueNumberFrame getFactAfterLocation(@CheckForNull Location location) {
         if (TRACE) {
             System.out.println("getting fact after " + location);
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/vna/ValueNumberFrame.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/vna/ValueNumberFrame.java
@@ -28,7 +28,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Objects;
 import java.util.Set;
 
 import javax.annotation.CheckForNull;
@@ -148,7 +147,6 @@ public class ValueNumberFrame extends Frame<ValueNumber> implements ValueNumberA
      *            the value(s) loaded
      */
     public void addAvailableLoad(AvailableLoad availableLoad, @Nonnull ValueNumber[] value) {
-        Objects.requireNonNull(value);
         getUpdateableAvailableLoadMap().put(availableLoad, value);
 
         for (ValueNumber v : value) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/ClassDescriptor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/ClassDescriptor.java
@@ -253,7 +253,7 @@ public class ClassDescriptor implements Comparable<ClassDescriptor>, Serializabl
      * @see java.lang.Object#equals(java.lang.Object)
      */
     @Override
-    public final boolean equals(Object obj) {
+    public final boolean equals(@CheckForNull Object obj) {
         if (obj == null || !(obj instanceof ClassDescriptor)) {
             return false;
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/FieldDescriptor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/FieldDescriptor.java
@@ -22,6 +22,8 @@ package edu.umd.cs.findbugs.classfile;
 import edu.umd.cs.findbugs.ba.ComparableField;
 import edu.umd.cs.findbugs.internalAnnotations.SlashedClassName;
 
+import javax.annotation.CheckForNull;
+
 /**
  * Descriptor uniquely identifying a field in a class.
  *
@@ -56,7 +58,7 @@ public class FieldDescriptor extends FieldOrMethodDescriptor implements Comparab
     }
 
     @Override
-    public final boolean equals(Object obj) {
+    public final boolean equals(@CheckForNull Object obj) {
         if (obj instanceof FieldDescriptor) {
             return haveEqualFields((FieldDescriptor) obj);
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/MethodDescriptor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/MethodDescriptor.java
@@ -27,6 +27,8 @@ import edu.umd.cs.findbugs.ba.ComparableMethod;
 import edu.umd.cs.findbugs.internalAnnotations.SlashedClassName;
 import edu.umd.cs.findbugs.util.ClassName;
 
+import javax.annotation.CheckForNull;
+
 /**
  * Descriptor uniquely identifying a method in a class.
  *
@@ -65,7 +67,7 @@ public class MethodDescriptor extends FieldOrMethodDescriptor implements Compara
     }
 
     @Override
-    public final boolean equals(Object obj) {
+    public final boolean equals(@CheckForNull Object obj) {
         if (obj instanceof MethodDescriptor) {
             return haveEqualFields((MethodDescriptor) obj);
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/analysis/AnnotationValue.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/analysis/AnnotationValue.java
@@ -30,6 +30,8 @@ import edu.umd.cs.findbugs.classfile.ClassDescriptor;
 import edu.umd.cs.findbugs.classfile.DescriptorFactory;
 import edu.umd.cs.findbugs.classfile.engine.asm.FindBugsASM;
 
+import javax.annotation.CheckForNull;
+
 /**
  * The "raw" version of an annotation appearing in a class file.
  *
@@ -204,7 +206,7 @@ public class AnnotationValue {
         }
 
         @Override
-        public void visit(String name, Object value) {
+        public void visit(@CheckForNull String name, Object value) {
             result.add(value);
         }
 
@@ -230,7 +232,7 @@ public class AnnotationValue {
         }
 
         @Override
-        public void visitEnum(String name, String desc, String value) {
+        public void visitEnum(@CheckForNull String name, String desc, String value) {
             result.add(new EnumValue(desc, value));
 
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/analysis/ClassInfo.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/analysis/ClassInfo.java
@@ -190,7 +190,7 @@ public class ClassInfo extends ClassNameAndSuperclassInfo implements XClass {
             return classDescriptor;
         }
 
-        public void setSourceSignature(String classSourceSignature) {
+        public void setSourceSignature(@CheckForNull String classSourceSignature) {
             this.classSourceSignature = classSourceSignature;
         }
 
@@ -215,7 +215,7 @@ public class ClassInfo extends ClassNameAndSuperclassInfo implements XClass {
             methodInfoList.add(method);
         }
 
-        public void addBridgeMethodDescriptor(MethodInfo from, String bridgedSignature) {
+        public void addBridgeMethodDescriptor(MethodInfo from, @CheckForNull String bridgedSignature) {
             if (bridgedSignature != null) {
                 bridgedSignatures.put(from, bridgedSignature);
             }
@@ -280,12 +280,14 @@ public class ClassInfo extends ClassNameAndSuperclassInfo implements XClass {
      * @param methodInfoList
      *            MethodDescriptors of methods defined in the class
      */
-    private ClassInfo(ClassDescriptor classDescriptor, String classSourceSignature, ClassDescriptor superclassDescriptor,
-            ClassDescriptor[] interfaceDescriptorList, ICodeBaseEntry codeBaseEntry, int accessFlags, String source,
-            int majorVersion, int minorVersion, Collection<ClassDescriptor> referencedClassDescriptorList,
+    private ClassInfo(ClassDescriptor classDescriptor, @CheckForNull String classSourceSignature,
+            @CheckForNull ClassDescriptor superclassDescriptor,
+            @CheckForNull ClassDescriptor[] interfaceDescriptorList, @CheckForNull ICodeBaseEntry codeBaseEntry,
+            int accessFlags, @CheckForNull String source, int majorVersion, int minorVersion,
+            @CheckForNull Collection<ClassDescriptor> referencedClassDescriptorList,
             Set<ClassDescriptor> calledClassDescriptors, Map<ClassDescriptor, AnnotationValue> classAnnotations,
-            FieldInfo[] fieldDescriptorList, MethodInfo[] methodInfoList, ClassDescriptor immediateEnclosingClass,
-            boolean usesConcurrency, boolean hasStubs) {
+            FieldInfo[] fieldDescriptorList, MethodInfo[] methodInfoList,
+            @CheckForNull ClassDescriptor immediateEnclosingClass, boolean usesConcurrency, boolean hasStubs) {
         super(classDescriptor, superclassDescriptor, interfaceDescriptorList, codeBaseEntry, accessFlags,
                 referencedClassDescriptorList, calledClassDescriptors, majorVersion, minorVersion);
         this.source = source;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/analysis/ClassNameAndSuperclassInfo.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/analysis/ClassNameAndSuperclassInfo.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
 import org.objectweb.asm.Opcodes;
@@ -140,19 +141,17 @@ public class ClassNameAndSuperclassInfo extends ClassDescriptor {
     }
 
 
-    ClassNameAndSuperclassInfo(ClassDescriptor classDescriptor, ClassDescriptor superclassDescriptor,
-            ClassDescriptor[] interfaceDescriptorList, ICodeBaseEntry codeBaseEntry, int accessFlags,
+    ClassNameAndSuperclassInfo(ClassDescriptor classDescriptor, @CheckForNull ClassDescriptor superclassDescriptor,
+            @CheckForNull ClassDescriptor[] interfaceDescriptorList, @CheckForNull ICodeBaseEntry codeBaseEntry,
+            int accessFlags,
             /* TODO: We aren't doing anything with this */
-            Collection<ClassDescriptor> referencedClassDescriptorList,
+            @CheckForNull Collection<ClassDescriptor> referencedClassDescriptorList,
             @Nonnull Set<ClassDescriptor> calledClassDescriptors, int majorVersion, int minorVersion) {
         super(classDescriptor.getClassName());
         this.superclassDescriptor = superclassDescriptor;
         this.interfaceDescriptorList = interfaceDescriptorList;
         this.codeBaseEntry = codeBaseEntry;
         this.accessFlags = accessFlags;
-        if (calledClassDescriptors == null) {
-            throw new NullPointerException("calledClassDescriptors must not be null");
-        }
         this.calledClassDescriptors = calledClassDescriptors;
         this.majorVersion = majorVersion;
         this.minorVersion = minorVersion;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/analysis/FieldInfo.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/analysis/FieldInfo.java
@@ -69,7 +69,7 @@ public class FieldInfo extends FieldDescriptor implements XField {
             this.accessFlags = accessFlags;
         }
 
-        public void setSourceSignature(String fieldSourceSignature) {
+        public void setSourceSignature(@CheckForNull String fieldSourceSignature) {
             this.fieldSourceSignature = fieldSourceSignature;
         }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/analysis/MethodInfo.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/analysis/MethodInfo.java
@@ -121,7 +121,7 @@ public class MethodInfo extends MethodDescriptor implements XMethod {
             accessMethodForField = new FieldDescriptor(owner, name, sig, isStatic);
         }
 
-        public void setSourceSignature(String methodSourceSignature) {
+        public void setSourceSignature(@CheckForNull String methodSourceSignature) {
             this.methodSourceSignature = methodSourceSignature;
         }
 
@@ -149,7 +149,7 @@ public class MethodInfo extends MethodDescriptor implements XMethod {
             this.hasBackBranch = true;
         }
 
-        public void setThrownExceptions(String[] exceptions) {
+        public void setThrownExceptions(@CheckForNull String[] exceptions) {
             this.exceptions = exceptions;
         }
 
@@ -281,7 +281,8 @@ public class MethodInfo extends MethodDescriptor implements XMethod {
         return getDatabase().invokeDynamicMethods;
     }
 
-    MethodInfo(@SlashedClassName String className, String methodName, String methodSignature, String methodSourceSignature,
+    MethodInfo(@SlashedClassName String className, String methodName, String methodSignature,
+            @CheckForNull String methodSourceSignature,
             int accessFlags, boolean isUnconditionalThrower, boolean isUnsupported, boolean usesConcurrency,
             boolean hasBackBranch, boolean isStub, boolean isIdentity,
             boolean usesInvokeDynamic, int methodCallCount, @CheckForNull String[] exceptions,

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/AbstractMethodVisitor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/AbstractMethodVisitor.java
@@ -26,6 +26,8 @@ import org.objectweb.asm.MethodVisitor;
 
 import edu.umd.cs.findbugs.classfile.engine.asm.FindBugsASM;
 
+import javax.annotation.CheckForNull;
+
 /**
  * @author pwilliam
  */
@@ -259,7 +261,7 @@ public abstract class AbstractMethodVisitor extends MethodVisitor {
      * java.lang.String)
      */
     @Override
-    public void visitTryCatchBlock(Label start, Label end, Label handler, String type) {
+    public void visitTryCatchBlock(Label start, Label end, Label handler, @CheckForNull String type) {
         // TODO Auto-generated method stub
 
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/ClassParserUsingASM.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/ClassParserUsingASM.java
@@ -186,7 +186,7 @@ public class ClassParserUsingASM implements ClassParserInterface {
         public
         void visitLocalVariable(String name,
                 String desc,
-                String signature,
+                @CheckForNull String signature,
                 Label start,
                 Label end,
                 int index) {
@@ -521,7 +521,8 @@ public class ClassParserUsingASM implements ClassParserInterface {
             //            boolean isInnerClass = false;
 
             @Override
-            public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+            public void visit(int version, int access, String name, @CheckForNull String signature,
+                    @CheckForNull String superName, String[] interfaces) {
                 ClassParserUsingASM.this.slashedClassName = name;
                 cBuilder.setClassfileVersion(version >>> 16, version & 0xffff);
                 cBuilder.setAccessFlags(access);
@@ -556,7 +557,8 @@ public class ClassParserUsingASM implements ClassParserInterface {
             }
 
             @Override
-            public FieldVisitor visitField(int access, String name, String desc, String signature, Object value) {
+            public FieldVisitor visitField(int access, String name, String desc, @CheckForNull String signature,
+                                           @CheckForNull Object value) {
                 //                if (name.equals("this$0"))
                 //                    isInnerClass = true;
 
@@ -592,7 +594,8 @@ public class ClassParserUsingASM implements ClassParserInterface {
             }
 
             @Override
-            public void visitInnerClass(String name, String outerName, String innerName, int access) {
+            public void visitInnerClass(String name, @CheckForNull String outerName, @CheckForNull String innerName,
+                    int access) {
                 if (name.equals(slashedClassName) && outerName != null) {
                     if (cBuilder instanceof ClassInfo.Builder) {
                         ClassDescriptor outerClassDescriptor = DescriptorFactory.createClassDescriptor(outerName);
@@ -606,7 +609,7 @@ public class ClassParserUsingASM implements ClassParserInterface {
 
             @Override
             public MethodVisitor visitMethod(final int access, final String methodName, final String methodDesc,
-                    String signature, String[] exceptions) {
+                                             @CheckForNull String signature, @CheckForNull String[] exceptions) {
                 if (cBuilder instanceof ClassInfo.Builder) {
                     final MethodInfo.Builder mBuilder = new MethodInfo.Builder(slashedClassName, methodName, methodDesc, access);
                     mBuilder.setSourceSignature(signature);
@@ -622,12 +625,12 @@ public class ClassParserUsingASM implements ClassParserInterface {
             }
 
             @Override
-            public void visitOuterClass(String owner, String name, String desc) {
+            public void visitOuterClass(String owner, @CheckForNull String name, @CheckForNull String desc) {
 
             }
 
             @Override
-            public void visitSource(String arg0, String arg1) {
+            public void visitSource(String arg0, @CheckForNull String arg1) {
                 if (cBuilder instanceof ClassInfo.Builder) {
                     ((ClassInfo.Builder) cBuilder).setSource(arg0);
                 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/SelfMethodCalls.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/SelfMethodCalls.java
@@ -35,6 +35,8 @@ import edu.umd.cs.findbugs.classfile.Global;
 import edu.umd.cs.findbugs.classfile.engine.asm.FindBugsASM;
 import edu.umd.cs.findbugs.util.MultiMap;
 
+import javax.annotation.CheckForNull;
+
 /**
  * @author pugh
  */
@@ -57,8 +59,8 @@ public class SelfMethodCalls {
         reader.accept(new ClassVisitor(FindBugsASM.ASM_VERSION) {
 
             @Override
-            public MethodVisitor visitMethod(final int access, final String name, final String desc, String signature,
-                    String[] exceptions) {
+            public MethodVisitor visitMethod(final int access, final String name, final String desc,
+                    @CheckForNull String signature, @CheckForNull String[] exceptions) {
                 return new MethodVisitor(FindBugsASM.ASM_VERSION) {
                     @Override
                     public void visitMethodInsn(int opcode, String owner, String name2, String desc2, boolean itf) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/bcel/ValueRangeAnalysisFactory.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/bcel/ValueRangeAnalysisFactory.java
@@ -36,6 +36,7 @@ import static org.apache.bcel.Const.IF_ICMPNE;
 import java.util.*;
 import java.util.Map.Entry;
 
+import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
 import org.apache.bcel.classfile.Constant;
@@ -390,7 +391,8 @@ public class ValueRangeAnalysisFactory implements IMethodAnalysisEngine<ValueRan
         final Map<Integer, Value> types;
         final ValueNumberDataflow vnaDataflow;
 
-        public Context(ConstantPool cp, LocalVariableTable lvTable, Map<Integer, Value> types, ValueNumberDataflow vnaDataflow) {
+        public Context(ConstantPool cp, @CheckForNull LocalVariableTable lvTable, Map<Integer, Value> types,
+                ValueNumberDataflow vnaDataflow) {
             this.cp = cp;
             this.lvTable = lvTable;
             this.types = types;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/AnalysisCache.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/AnalysisCache.java
@@ -19,8 +19,6 @@
 
 package edu.umd.cs.findbugs.classfile.impl;
 
-import static java.util.Objects.requireNonNull;
-
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -139,7 +137,7 @@ public class AnalysisCache implements IAnalysisCache {
     static final AbnormalAnalysisResult NULL_ANALYSIS_RESULT = new AbnormalAnalysisResult();
 
     @SuppressWarnings("unchecked")
-    static <E> E checkedCast(Class<E> analysisClass, Object o) {
+    static <E> E checkedCast(Class<E> analysisClass, @CheckForNull Object o) {
         if (SystemProperties.ASSERTIONS_ENABLED) {
             return analysisClass.cast(o);
         }
@@ -238,7 +236,6 @@ public class AnalysisCache implements IAnalysisCache {
     @Override
     @SuppressWarnings("unchecked")
     public <E> E getClassAnalysis(Class<E> analysisClass, @Nonnull ClassDescriptor classDescriptor) throws CheckedAnalysisException {
-        requireNonNull(classDescriptor, "classDescriptor is null");
         // Get the descriptor->result map for this analysis class,
         // creating if necessary
         Map<ClassDescriptor, Object> descriptorMap = findOrCreateDescriptorMap(classAnalysisMap,
@@ -313,7 +310,6 @@ public class AnalysisCache implements IAnalysisCache {
 
     @Override
     public <E> E getMethodAnalysis(Class<E> analysisClass, @Nonnull MethodDescriptor methodDescriptor) throws CheckedAnalysisException {
-        requireNonNull(methodDescriptor, "methodDescriptor is null");
         ClassContext classContext = getClassAnalysis(ClassContext.class, methodDescriptor.getClassDescriptor());
         Object object = classContext.getMethodAnalysis(analysisClass, methodDescriptor);
 

--- a/spotbugsTestCases/src/java/bugIdeas/Ideas_2011_08_05.java
+++ b/spotbugsTestCases/src/java/bugIdeas/Ideas_2011_08_05.java
@@ -1,4 +1,4 @@
-    package bugIdeas;
+package bugIdeas;
 
 import javax.annotation.Nonnull;
 

--- a/spotbugsTestCases/src/java/bugIdeas/Ideas_2011_08_05.java
+++ b/spotbugsTestCases/src/java/bugIdeas/Ideas_2011_08_05.java
@@ -1,4 +1,4 @@
-package bugIdeas;
+    package bugIdeas;
 
 import javax.annotation.Nonnull;
 
@@ -49,8 +49,6 @@ public class Ideas_2011_08_05 {
 
     @NoWarning("RCN")
     public int test5(@Nonnull String x) {
-        if (x == null)
-            throw new RuntimeException();
         return x.hashCode();
     }
     public int test5OK(@Nonnull String x) {

--- a/test-harness-core/src/main/java/edu/umd/cs/findbugs/test/AnalysisRunner.java
+++ b/test-harness-core/src/main/java/edu/umd/cs/findbugs/test/AnalysisRunner.java
@@ -17,7 +17,6 @@ import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.jar.JarOutputStream;
 import java.util.zip.ZipEntry;
 
@@ -72,8 +71,7 @@ public class AnalysisRunner {
     }
 
     @Nonnull
-    public AnalysisRunner addAuxClasspathEntry(Path path) {
-        Objects.requireNonNull(path);
+    public AnalysisRunner addAuxClasspathEntry(@Nonnull Path path) {
         if (!path.toFile().canRead()) {
             throw new IllegalArgumentException("Cannot read " + path.toAbsolutePath());
         }


### PR DESCRIPTION
This *PR* applies [Traute](http://traute.oss.harmonysoft.tech/) *javac* plugin to the project. The idea is to achieve the following:  
* enforce *null*-checks [implied by package-level ParametersAreNonnullByDefault annotations](https://github.com/spotbugs/spotbugs/blob/master/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/package-info.java#L5)
* remove explicit *null*-checks like [this](https://github.com/spotbugs/spotbugs/blob/master/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/AnalysisContext.java#L176)  

Let's consider [AnalysisContext](https://github.com/spotbugs/spotbugs/blob/master/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/AnalysisContext.java) as an example:  

*Source code*  

```java
public AnalysisContext(@Nonnull Project project) {
    this.project = project;
    ...
}
```  

Resulting bytecode looks like if it's compiled from the source below:  

```java
public AnalysisContext(@Nonnull Project project) {
    if (project == null) {
        throw new NullPointerException("Argument 'project' of type Project (#0 out of 1, zero-based) is marked by @javax.annotation.Nonnull but got null for it");
    }
    this.project = project;
    ...
}
```  

*Bytecode*  

```
javap -c ./spotbugs/build/classes/java/main/edu/umd/cs/findbugs/ba/AnalysisContext.class
...
public edu.umd.cs.findbugs.ba.AnalysisContext(edu.umd.cs.findbugs.Project);
    Code:
       0: aload_0
       1: invokespecial #1                  // Method java/lang/Object."<init>":()V
       4: aload_1
       5: ifnonnull     18
       8: new           #2                  // class java/lang/NullPointerException
      11: dup
      12: ldc           #3                  // String Argument 'project' of type Project (#0 out of 1, zero-based) is marked by @javax.annotation.Nonnull but got null for it
      14: invokespecial #4                  // Method java/lang/NullPointerException."<init>":(Ljava/lang/String;)V
      17: athrow
```  

**Note:** added a number of *CheckForNull* annotations in the source code because tests show that *null* is given as method parameters and generated checks fail otherwise. So, the change already made the code better documented.
----

Make sure these boxes are checked before submitting your PR -- thank you!

- [ ] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
- [ ] Added an entry into `gradlePlugin/CHANGELOG.md` if you have changed Gradle plugin code
