### PR TITLE
497: Do not print exceptions for unsupported classpath files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 * Unused variable reported with wrong name ([#516](https://github.com/spotbugs/spotbugs/issues/516))
 * Require gradle 4.2.1 to fix gradle build failures on Java 9.0.1
+* Do not print exceptions for unsupported classpath files ([#497](https://github.com/spotbugs/spotbugs/issues/497))
 
 ## 3.1.1 - 2017-11-29
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/ClassFactory.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/ClassFactory.java
@@ -19,6 +19,7 @@
 
 package edu.umd.cs.findbugs.classfile.impl;
 
+import edu.umd.cs.findbugs.FindBugs2;
 import java.io.File;
 import java.io.IOException;
 
@@ -107,11 +108,11 @@ public class ClassFactory implements IClassFactory {
         File file = new File(fileName);
 
         if (!file.exists() || !file.canRead()) {
-            return new EmptyCodeBase(codeBaseLocator);
+            return createEmptyCodeBase(codeBaseLocator, file);
         } else if (file.isDirectory()) {
             return new DirectoryCodeBase(codeBaseLocator, file);
         } else if (!file.isFile()) {
-            return new EmptyCodeBase(codeBaseLocator);
+            return createEmptyCodeBase(codeBaseLocator, file);
         } else if (fileName.endsWith(".class")) {
             return new SingleFileCodeBase(codeBaseLocator, fileName);
         } else if (fileName.endsWith(File.separator + "jrt-fs.jar")) {
@@ -120,9 +121,16 @@ public class ClassFactory implements IClassFactory {
             try {
                 return ZipCodeBaseFactory.makeZipCodeBase(codeBaseLocator, file);
             } catch (IOException e) {
-                return new EmptyCodeBase(codeBaseLocator);
+                return createEmptyCodeBase(codeBaseLocator, file);
             }
         }
+    }
+
+    private static IScannableCodeBase createEmptyCodeBase(FilesystemCodeBaseLocator codeBaseLocator, File file) {
+        if (FindBugs2.DEBUG) {
+            System.out.println("Ignoring unreadable or non-existent file " + file);
+        }
+        return new EmptyCodeBase(codeBaseLocator);
     }
 
     static IScannableCodeBase createNestedZipFileCodeBase(NestedZipFileCodeBaseLocator codeBaseLocator)

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/ClassFactory.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/ClassFactory.java
@@ -20,7 +20,6 @@
 package edu.umd.cs.findbugs.classfile.impl;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 
 import edu.umd.cs.findbugs.BugReporter;
@@ -107,20 +106,22 @@ public class ClassFactory implements IClassFactory {
 
         File file = new File(fileName);
 
-        if (!file.exists()) {
-            throw new FileNotFoundException("File " + file.getAbsolutePath() + " doesn't exist");
-        } else if (!file.canRead()) {
-            throw new IOException("File " + file.getAbsolutePath() + " not readable");
+        if (!file.exists() || !file.canRead()) {
+            return new EmptyCodeBase(codeBaseLocator);
         } else if (file.isDirectory()) {
             return new DirectoryCodeBase(codeBaseLocator, file);
         } else if (!file.isFile()) {
-            throw new IOException("File " + file.getAbsolutePath() + " is not a normal file");
+            return new EmptyCodeBase(codeBaseLocator);
         } else if (fileName.endsWith(".class")) {
             return new SingleFileCodeBase(codeBaseLocator, fileName);
         } else if (fileName.endsWith(File.separator + "jrt-fs.jar")) {
             return new JrtfsCodeBase(codeBaseLocator, fileName);
         } else {
-            return ZipCodeBaseFactory.makeZipCodeBase(codeBaseLocator, file);
+            try {
+                return ZipCodeBaseFactory.makeZipCodeBase(codeBaseLocator, file);
+            } catch (IOException e) {
+                return new EmptyCodeBase(codeBaseLocator);
+            }
         }
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/EmptyCodeBase.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/EmptyCodeBase.java
@@ -1,0 +1,61 @@
+/*
+ * Contributions to SpotBugs
+ * Copyright (C) 2018, Brian Riehman
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+package edu.umd.cs.findbugs.classfile.impl;
+
+import edu.umd.cs.findbugs.classfile.ICodeBaseEntry;
+import edu.umd.cs.findbugs.classfile.ICodeBaseIterator;
+import edu.umd.cs.findbugs.classfile.ICodeBaseLocator;
+import java.util.NoSuchElementException;
+
+public class EmptyCodeBase extends AbstractScannableCodeBase {
+
+    public EmptyCodeBase(ICodeBaseLocator codeBaseLocator) {
+        super(codeBaseLocator);
+    }
+
+    @Override
+    public ICodeBaseIterator iterator() throws InterruptedException {
+        return new ICodeBaseIterator() {
+            @Override
+            public boolean hasNext() throws InterruptedException {
+                return false;
+            }
+
+            @Override
+            public ICodeBaseEntry next() throws InterruptedException {
+                throw new NoSuchElementException();
+            }
+        };
+    }
+
+    @Override
+    public ICodeBaseEntry lookupResource(String resourceName) {
+        return null;
+    }
+
+    @Override
+    public String getPathName() {
+        return null;
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/spotbugs/src/test/java/edu/umd/cs/findbugs/classfile/impl/ClassFactoryTest.java
+++ b/spotbugs/src/test/java/edu/umd/cs/findbugs/classfile/impl/ClassFactoryTest.java
@@ -1,0 +1,110 @@
+/*
+ * Contributions to SpotBugs
+ * Copyright (C) 2018, Brian Riehman
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+package edu.umd.cs.findbugs.classfile.impl;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
+import edu.umd.cs.findbugs.classfile.Global;
+import edu.umd.cs.findbugs.classfile.IScannableCodeBase;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ClassFactoryTest {
+
+    @Before
+    public void setUp () {
+        Global.setAnalysisCacheForCurrentThread(new NoopAnalysisCache());
+    }
+
+    @After
+    public void tearDown() {
+        Global.setAnalysisCacheForCurrentThread(null);
+    }
+
+    @Test
+    public void ignoreNonExistentFile() throws Exception {
+        File file = tempFile();
+        file.delete();
+        FilesystemCodeBaseLocator locator = buildLocator(file);
+        assertHasNoCodeBase(ClassFactory.createFilesystemCodeBase(locator));
+    }
+
+    @Test
+    public void ignoreUnreadableFile() throws Exception {
+        File file = createZipFile();
+        file.deleteOnExit();
+        file.setReadable(false);
+        FilesystemCodeBaseLocator locator = buildLocator(file);
+        assertHasNoCodeBase(ClassFactory.createFilesystemCodeBase(locator));
+    }
+
+    @Test
+    public void ignoreUnknownNonClassFileFormat() throws Exception {
+        FilesystemCodeBaseLocator locator = buildLocator(tempFile());
+        assertHasNoCodeBase(ClassFactory.createFilesystemCodeBase(locator));
+    }
+
+    @Test
+    public void acceptZipFile() throws Exception {
+        File zipFile = createZipFile();
+        zipFile.deleteOnExit();
+        FilesystemCodeBaseLocator locator = buildLocator(zipFile);
+        assertHasCodeBase(ClassFactory.createFilesystemCodeBase(locator));
+    }
+
+    private static File tempFile() throws Exception {
+        File tempFile = File.createTempFile("bug-497", ".txt");
+        tempFile.deleteOnExit();
+        return tempFile;
+    }
+
+    private static File createZipFile() throws Exception {
+        File zipFile = tempFile();
+        ZipOutputStream out = new ZipOutputStream(new FileOutputStream(zipFile));
+        ZipEntry entry = new ZipEntry("firstEntry");
+        out.putNextEntry(entry);
+        out.write("fileContents".getBytes(StandardCharsets.UTF_8));
+        out.closeEntry();
+        out.close();
+        return zipFile;
+    }
+
+    private FilesystemCodeBaseLocator buildLocator(File file) throws Exception {
+        return new FilesystemCodeBaseLocator(file.getCanonicalPath());
+    }
+
+    private void assertHasNoCodeBase(IScannableCodeBase codeBase) throws Exception {
+        assertNotNull(codeBase);
+        assertFalse(codeBase.iterator().hasNext());
+    }
+
+    private void assertHasCodeBase(IScannableCodeBase codeBase) throws Exception {
+        assertNotNull(codeBase);
+        assertTrue(codeBase.iterator().hasNext());
+    }
+}

--- a/spotbugs/src/test/java/edu/umd/cs/findbugs/classfile/impl/NoopAnalysisCache.java
+++ b/spotbugs/src/test/java/edu/umd/cs/findbugs/classfile/impl/NoopAnalysisCache.java
@@ -1,0 +1,130 @@
+/*
+ * Contributions to SpotBugs
+ * Copyright (C) 2018, Brian Riehman
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+package edu.umd.cs.findbugs.classfile.impl;
+
+import edu.umd.cs.findbugs.classfile.CheckedAnalysisException;
+import edu.umd.cs.findbugs.classfile.ClassDescriptor;
+import edu.umd.cs.findbugs.classfile.IAnalysisCache;
+import edu.umd.cs.findbugs.classfile.IClassAnalysisEngine;
+import edu.umd.cs.findbugs.classfile.IClassPath;
+import edu.umd.cs.findbugs.classfile.IDatabaseFactory;
+import edu.umd.cs.findbugs.classfile.IErrorLogger;
+import edu.umd.cs.findbugs.classfile.IMethodAnalysisEngine;
+import edu.umd.cs.findbugs.classfile.MethodDescriptor;
+import edu.umd.cs.findbugs.log.Profiler;
+import java.util.Map;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
+public class NoopAnalysisCache implements IAnalysisCache {
+    @Override
+    public <E> void registerClassAnalysisEngine(Class<E> analysisResultType,
+            IClassAnalysisEngine<E> classAnalysisEngine) {
+
+    }
+
+    @Override
+    public <E> void registerMethodAnalysisEngine(Class<E> analysisResultType,
+            IMethodAnalysisEngine<E> methodAnalysisEngine) {
+
+    }
+
+    @Override
+    public <E> E getClassAnalysis(Class<E> analysisClass,
+            @Nonnull ClassDescriptor classDescriptor)
+                throws CheckedAnalysisException {
+        return null;
+    }
+
+    @Override
+    public <E> E probeClassAnalysis(Class<E> analysisClass,
+            @Nonnull ClassDescriptor classDescriptor) {
+        return null;
+    }
+
+    @Override
+    public <E> E getMethodAnalysis(Class<E> analysisClass,
+            @Nonnull MethodDescriptor methodDescriptor) throws CheckedAnalysisException {
+        return null;
+    }
+
+    @Override
+    public <E> void eagerlyPutMethodAnalysis(Class<E> analysisClass,
+            @Nonnull MethodDescriptor methodDescriptor, E analysisObject) {
+
+    }
+
+    @Override
+    public void purgeMethodAnalyses(@Nonnull MethodDescriptor methodDescriptor) {
+
+    }
+
+    @Override
+    public void purgeAllMethodAnalysis() {
+
+    }
+
+    @Override
+    public void purgeClassAnalysis(Class<?> analysisClass) {
+
+    }
+
+    @Override
+    public <E> void registerDatabaseFactory(Class<E> databaseClass,
+            IDatabaseFactory<E> databaseFactory) {
+
+    }
+
+    @Override
+    public <E> E getDatabase(Class<E> databaseClass) {
+        return null;
+    }
+
+    @CheckForNull
+    @Override
+    public <E> E getOptionalDatabase(Class<E> databaseClass) {
+        return null;
+    }
+
+    @Override
+    public <E> void eagerlyPutDatabase(Class<E> databaseClass, E database) {
+
+    }
+
+    @Override
+    public IClassPath getClassPath() {
+        return null;
+    }
+
+    @Override
+    public IErrorLogger getErrorLogger() {
+        return null;
+    }
+
+    @Override
+    public Map<?, ?> getAnalysisLocals() {
+        return null;
+    }
+
+    @Override
+    public Profiler getProfiler() {
+        return new Profiler();
+    }
+}


### PR DESCRIPTION
Assume that any files thought to be a zip file in the classpath that
cannot be loaded as a zip file should be ignored. Many files may be
placed on the classpath but this does not guarantee they are valid.

Prior to this change, an exception would be thrown which was presented
to the user regarding the invalid path. This did not cause a failure,
but was hard to discern from an actual exception. Ignoring these files
reduces unnecessary output and mimics the behavior of the JVM which does not
complain about invalid files on the classpath.



----

Make sure these boxes are checked before submitting your PR -- thank you!

- [X] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
- [X] Added an entry into `gradlePlugin/CHANGELOG.md` if you have changed Gradle plugin code
