### PR TITLE
Add usage section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,5 +25,14 @@ To see a list of build options, run `gradle tasks` (or `gradlew tasks`). The `bu
 To build the SpotBugs plugin for Eclipse, you'll need to create the file `eclipsePlugin/local.properties`, containing a property `eclipseRoot.dir` that points to an Eclipse installation's root directory (see `.travis.yml` for an example), then run the build.
 To prepare Eclipse environment only, run `./gradlew eclipse`. See also [detailed steps](https://github.com/spotbugs/spotbugs/blob/master/eclipsePlugin/doc/building_spotbugs_plugin.txt).
 
+# Using SpotBugs
+
+SpotBugs can be used standalone and through several integrations, including:
+
+* [Ant](http://spotbugs.readthedocs.io/en/latest/ant.html)
+* [Maven](https://github.com/hazendaz/findbugs-maven-plugin/tree/spotbugs)
+* [Gradle](https://plugins.gradle.org/plugin/com.github.spotbugs)
+* [Eclipse](http://spotbugs.readthedocs.io/en/latest/eclipse.html)
+
 # Questions?
 You can contact us using [our general purpose mailing list](https://github.com/spotbugs/discuss/issues?q=).

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ To prepare Eclipse environment only, run `./gradlew eclipse`. See also [detailed
 SpotBugs can be used standalone and through several integrations, including:
 
 * [Ant](http://spotbugs.readthedocs.io/en/latest/ant.html)
-* [Maven](https://github.com/hazendaz/findbugs-maven-plugin/tree/spotbugs)
-* [Gradle](https://plugins.gradle.org/plugin/com.github.spotbugs)
+* [Maven](http://spotbugs.readthedocs.io/en/latest/maven.html)
+* [Gradle](http://spotbugs.readthedocs.io/en/latest/gradle.html)
 * [Eclipse](http://spotbugs.readthedocs.io/en/latest/eclipse.html)
 
 # Questions?


### PR DESCRIPTION
This is the information from the [official website](https://spotbugs.github.io/#using-spotbugs).
Adding the information to the readme directly makes it easier to direct users attention to it.

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
- [x] Added an entry into `gradlePlugin/CHANGELOG.md` if you have changed Gradle plugin code
