### PR TITLE
Fix for issue #527: Lambda methods reported as missing classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ### Fixed
 
+* Lambda methods reported as missing classes ([#527](https://github.com/spotbugs/spotbugs/issues/527))
 * Unused variable reported with wrong name ([#516](https://github.com/spotbugs/spotbugs/issues/516))
 * Require gradle 4.2.1 to fix gradle build failures on Java 9.0.1
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue527Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue527Test.java
@@ -1,0 +1,34 @@
+package edu.umd.cs.findbugs.ba;
+
+import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+import org.junit.Test;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import edu.umd.cs.findbugs.SortedBugCollection;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
+
+public class Issue527Test extends AbstractIntegrationTest {
+
+    @Test
+    public void testSimpleLambdas() {
+        performAnalysis("lambdas/Issue527.class");
+        final BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
+                .bugType("NP_NULL_ON_SOME_PATH").build();
+        SortedBugCollection bugCollection = (SortedBugCollection) getBugCollection();
+        assertThat(bugCollection, containsExactly(2, bugTypeMatcher));
+        Iterator<String> missingIter = bugCollection.missingClassIterator();
+        List<String> strings = new ArrayList<>();
+        missingIter.forEachRemaining(x -> strings.add(x));
+        assertEquals(Collections.EMPTY_LIST, strings);
+    }
+
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/PruneUnconditionalExceptionThrowerEdges.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/PruneUnconditionalExceptionThrowerEdges.java
@@ -29,6 +29,7 @@ import org.apache.bcel.Const;
 import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.classfile.Method;
 import org.apache.bcel.generic.ConstantPoolGen;
+import org.apache.bcel.generic.INVOKEDYNAMIC;
 import org.apache.bcel.generic.INVOKEINTERFACE;
 import org.apache.bcel.generic.INVOKESTATIC;
 import org.apache.bcel.generic.Instruction;
@@ -119,6 +120,9 @@ public class PruneUnconditionalExceptionThrowerEdges implements EdgeTypes {
             InstructionHandle instructionHandle = basicBlock.getExceptionThrower();
             Instruction exceptionThrower = instructionHandle.getInstruction();
             if (!(exceptionThrower instanceof InvokeInstruction)) {
+                continue;
+            }
+            if (exceptionThrower instanceof INVOKEDYNAMIC) {
                 continue;
             }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/XFactory.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/XFactory.java
@@ -35,6 +35,7 @@ import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.classfile.Method;
 import org.apache.bcel.generic.ConstantPoolGen;
 import org.apache.bcel.generic.FieldInstruction;
+import org.apache.bcel.generic.INVOKEDYNAMIC;
 import org.apache.bcel.generic.InvokeInstruction;
 import org.apache.bcel.generic.MethodGen;
 import org.objectweb.asm.Opcodes;
@@ -615,7 +616,16 @@ public class XFactory {
         String className = invokeInstruction.getClassName(cpg);
         String methodName = invokeInstruction.getName(cpg);
         String methodSig = invokeInstruction.getSignature(cpg);
-
+        if (invokeInstruction instanceof INVOKEDYNAMIC) {
+            // XXX the lambda representation makes no sense for XMethod
+            // "classical" instruction attributes are filled with garbage, causing
+            // the code later to produce crazy errors (looking for non existing types etc)
+            // We should NOT be called here from our code, but 3rd party code still may
+            // use this method. So *at least* provide a valid class name, which is
+            // (don't ask me why) is encoded in the first argument type of the lambda
+            // className = invokeInstruction.getArgumentTypes(cpg)[0].toString();
+            className = "java.lang.Object";
+        }
         return createXMethod(className, methodName, methodSig, invokeInstruction.getOpcode() == Const.INVOKESTATIC);
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/BackwardTypeQualifierDataflowAnalysis.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/BackwardTypeQualifierDataflowAnalysis.java
@@ -27,6 +27,7 @@ import javax.annotation.meta.When;
 import org.apache.bcel.Const;
 import org.apache.bcel.generic.ConstantPoolGen;
 import org.apache.bcel.generic.FieldInstruction;
+import org.apache.bcel.generic.INVOKEDYNAMIC;
 import org.apache.bcel.generic.Instruction;
 import org.apache.bcel.generic.InstructionHandle;
 import org.apache.bcel.generic.InvokeInstruction;
@@ -212,6 +213,9 @@ public class BackwardTypeQualifierDataflowAnalysis extends TypeQualifierDataflow
     private void modelArguments(Location location) throws DataflowAnalysisException {
         // Model arguments to called method
         InvokeInstruction inv = (InvokeInstruction) location.getHandle().getInstruction();
+        if (inv instanceof INVOKEDYNAMIC) {
+            return;
+        }
         XMethod calledMethod = XFactory.createXMethod(inv, cpg);
 
         SignatureParser sigParser = new SignatureParser(calledMethod.getSignature());

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/ForwardTypeQualifierDataflowAnalysis.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/ForwardTypeQualifierDataflowAnalysis.java
@@ -30,6 +30,7 @@ import org.apache.bcel.generic.CHECKCAST;
 import org.apache.bcel.generic.ConstantPoolGen;
 import org.apache.bcel.generic.ConstantPushInstruction;
 import org.apache.bcel.generic.FieldInstruction;
+import org.apache.bcel.generic.INVOKEDYNAMIC;
 import org.apache.bcel.generic.Instruction;
 import org.apache.bcel.generic.InvokeInstruction;
 import org.apache.bcel.generic.LDC;
@@ -172,6 +173,9 @@ public class ForwardTypeQualifierDataflowAnalysis extends TypeQualifierDataflowA
     private void registerReturnValueSource(Location location) throws DataflowAnalysisException {
         // Nothing to do if called method does not return a value
         InvokeInstruction inv = (InvokeInstruction) location.getHandle().getInstruction();
+        if (inv instanceof INVOKEDYNAMIC) {
+            return;
+        }
         String calledMethodSig = inv.getSignature(cpg);
         if (calledMethodSig.endsWith(")V")) {
             return;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/TypeQualifierDataflowAnalysis.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/TypeQualifierDataflowAnalysis.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.bcel.generic.ConstantPoolGen;
+import org.apache.bcel.generic.INVOKEDYNAMIC;
 import org.apache.bcel.generic.Instruction;
 import org.apache.bcel.generic.InstructionHandle;
 import org.apache.bcel.generic.InvokeInstruction;
@@ -322,6 +323,9 @@ public abstract class TypeQualifierDataflowAnalysis extends AbstractDataflowAnal
         Instruction i = handle.getInstruction();
         if (i instanceof InvokeInstruction) {
             InvokeInstruction ii = (InvokeInstruction) i;
+            if (i instanceof INVOKEDYNAMIC) {
+                return;
+            }
             XMethod m = XFactory.createXMethod(ii, cpg);
             if (TypeQualifierDataflowAnalysis.isIdentifyFunctionForTypeQualifiers(m)) {
                 ValueNumberFrame vnaFrameAtLocation = vnaDataflow.getFactAtLocation(location);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/DerefFinder.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/DerefFinder.java
@@ -28,6 +28,7 @@ import org.apache.bcel.generic.ARETURN;
 import org.apache.bcel.generic.ConstantPoolGen;
 import org.apache.bcel.generic.FieldInstruction;
 import org.apache.bcel.generic.IFNONNULL;
+import org.apache.bcel.generic.INVOKEDYNAMIC;
 import org.apache.bcel.generic.Instruction;
 import org.apache.bcel.generic.InstructionHandle;
 import org.apache.bcel.generic.InvokeInstruction;
@@ -119,6 +120,9 @@ public class DerefFinder {
                 TypeFrame typeFrame = typeDataflow.getFactAtLocation(location);
                 if (ins instanceof InvokeInstruction) {
                     InvokeInstruction inv = (InvokeInstruction) ins;
+                    if (inv instanceof INVOKEDYNAMIC) {
+                        continue;
+                    }
                     XMethod m = XFactory.createXMethod(inv, cpg);
                     SignatureParser sigParser = new SignatureParser(m.getSignature());
                     int numParams = sigParser.getNumParameters();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/IsNullValueFrameModelingVisitor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/IsNullValueFrameModelingVisitor.java
@@ -28,6 +28,7 @@ import org.apache.bcel.generic.CHECKCAST;
 import org.apache.bcel.generic.ConstantPoolGen;
 import org.apache.bcel.generic.GETFIELD;
 import org.apache.bcel.generic.GETSTATIC;
+import org.apache.bcel.generic.INVOKEDYNAMIC;
 import org.apache.bcel.generic.INVOKEINTERFACE;
 import org.apache.bcel.generic.INVOKESPECIAL;
 import org.apache.bcel.generic.INVOKESTATIC;
@@ -173,6 +174,10 @@ public class IsNullValueFrameModelingVisitor extends AbstractFrameModelingVisito
      * information following a call to a likely exception thrower or assertion.
      */
     private void handleInvoke(InvokeInstruction obj) {
+        if (obj instanceof INVOKEDYNAMIC) {
+            // should not happen
+            return;
+        }
         Type returnType = obj.getReturnType(getCPG());
 
         Location location = getLocation();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/obl/InstructionActionCache.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/obl/InstructionActionCache.java
@@ -32,6 +32,7 @@ import javax.annotation.WillClose;
 import org.apache.bcel.Const;
 import org.apache.bcel.generic.ARETURN;
 import org.apache.bcel.generic.ConstantPoolGen;
+import org.apache.bcel.generic.INVOKEDYNAMIC;
 import org.apache.bcel.generic.Instruction;
 import org.apache.bcel.generic.InstructionHandle;
 import org.apache.bcel.generic.InvokeInstruction;
@@ -90,7 +91,9 @@ public class InstructionActionCache {
             Instruction ins = handle.getInstruction();
             actionList = Collections.emptyList();
             if (ins instanceof InvokeInstruction) {
-
+                if (ins instanceof INVOKEDYNAMIC) {
+                    return actionList;
+                }
                 InvokeInstruction inv = (InvokeInstruction) ins;
                 XMethod invokedMethod = XFactory.createXMethod(inv, cpg);
                 String signature = invokedMethod.getSignature();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/CallToUnconditionalThrower.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/CallToUnconditionalThrower.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Method;
 import org.apache.bcel.generic.ConstantPoolGen;
+import org.apache.bcel.generic.INVOKEDYNAMIC;
 import org.apache.bcel.generic.INVOKEINTERFACE;
 import org.apache.bcel.generic.Instruction;
 import org.apache.bcel.generic.InstructionHandle;
@@ -98,7 +99,7 @@ public class CallToUnconditionalThrower extends PreorderVisitor implements Detec
             boolean foundThrower = false;
             boolean foundNonThrower = false;
 
-            if (inv instanceof INVOKEINTERFACE) {
+            if (inv instanceof INVOKEINTERFACE || inv instanceof INVOKEDYNAMIC) {
                 continue;
             }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindBadCast2.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindBadCast2.java
@@ -18,6 +18,7 @@ import org.apache.bcel.classfile.Method;
 import org.apache.bcel.generic.CHECKCAST;
 import org.apache.bcel.generic.ConstantPoolGen;
 import org.apache.bcel.generic.INSTANCEOF;
+import org.apache.bcel.generic.INVOKEDYNAMIC;
 import org.apache.bcel.generic.Instruction;
 import org.apache.bcel.generic.InstructionHandle;
 import org.apache.bcel.generic.InvokeInstruction;
@@ -211,6 +212,9 @@ public class FindBadCast2 implements Detector {
             boolean wasMethodInvocationWasGeneric = methodInvocationWasGeneric;
             methodInvocationWasGeneric = false;
             if (ins instanceof InvokeInstruction) {
+                if (ins instanceof INVOKEDYNAMIC) {
+                    continue;
+                }
                 InvokeInstruction iinv = (InvokeInstruction) ins;
                 XMethod m = XFactory.createXMethod(iinv, cpg);
                 if (m != null) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindUnrelatedTypesInGenericContainer.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindUnrelatedTypesInGenericContainer.java
@@ -42,6 +42,7 @@ import org.apache.bcel.classfile.Synthetic;
 import org.apache.bcel.generic.ArrayType;
 import org.apache.bcel.generic.BasicType;
 import org.apache.bcel.generic.ConstantPoolGen;
+import org.apache.bcel.generic.INVOKEDYNAMIC;
 import org.apache.bcel.generic.INVOKESTATIC;
 import org.apache.bcel.generic.Instruction;
 import org.apache.bcel.generic.InstructionHandle;
@@ -412,7 +413,9 @@ public class FindUnrelatedTypesInGenericContainer implements Detector {
             if (!(ins instanceof InvokeInstruction)) {
                 continue;
             }
-
+            if (ins instanceof INVOKEDYNAMIC) {
+                continue;
+            }
             InvokeInstruction inv = (InvokeInstruction) ins;
 
             XMethod invokedMethod = XFactory.createXMethod(inv, cpg);
@@ -511,7 +514,9 @@ public class FindUnrelatedTypesInGenericContainer implements Detector {
                         InstructionHandle next = handle.getNext();
                         if (next != null) {
                             Instruction nextIns = next.getInstruction();
-
+                            if (nextIns instanceof INVOKEDYNAMIC) {
+                                continue;
+                            }
                             if (nextIns instanceof InvokeInstruction) {
                                 XMethod nextMethod = XFactory.createXMethod((InvokeInstruction) nextIns, cpg);
                                 if ("assertFalse".equals(nextMethod.getName())) {
@@ -600,7 +605,9 @@ public class FindUnrelatedTypesInGenericContainer implements Detector {
                     InstructionHandle next = handle.getNext();
                     if (next != null) {
                         Instruction nextIns = next.getInstruction();
-
+                        if (nextIns instanceof INVOKEDYNAMIC) {
+                            continue;
+                        }
                         if (nextIns instanceof InvokeInstruction) {
                             XMethod nextMethod = XFactory.createXMethod((InvokeInstruction) nextIns, cpg);
                             if ("assertFalse".equals(nextMethod.getName())) {
@@ -612,7 +619,9 @@ public class FindUnrelatedTypesInGenericContainer implements Detector {
                     InstructionHandle next = handle.getNext();
                     if (next != null) {
                         Instruction nextIns = next.getInstruction();
-
+                        if (nextIns instanceof INVOKEDYNAMIC) {
+                            continue;
+                        }
                         if (nextIns instanceof InvokeInstruction) {
                             XMethod nextMethod = XFactory.createXMethod((InvokeInstruction) nextIns, cpg);
                             if ("assertNull".equals(nextMethod.getName())) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindUnsatisfiedObligation.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindUnsatisfiedObligation.java
@@ -33,6 +33,7 @@ import org.apache.bcel.classfile.ConstantClass;
 import org.apache.bcel.classfile.ConstantNameAndType;
 import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.generic.ConstantPoolGen;
+import org.apache.bcel.generic.INVOKEDYNAMIC;
 import org.apache.bcel.generic.Instruction;
 import org.apache.bcel.generic.InstructionHandle;
 import org.apache.bcel.generic.InvokeInstruction;
@@ -512,7 +513,9 @@ public class FindUnsatisfiedObligation extends CFGDetector {
                 // there must be an instance of InputStream at
                 // the transfer point.
                 //
-
+                if (inv instanceof INVOKEDYNAMIC) {
+                    return;
+                }
                 if (DEBUG_FP) {
                     System.out.println("Checking " + handle + " as possible obligation transfer...:");
                 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/NoiseNullDeref.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/NoiseNullDeref.java
@@ -35,6 +35,7 @@ import org.apache.bcel.classfile.Method;
 import org.apache.bcel.generic.ATHROW;
 import org.apache.bcel.generic.ConstantPoolGen;
 import org.apache.bcel.generic.FieldInstruction;
+import org.apache.bcel.generic.INVOKEDYNAMIC;
 import org.apache.bcel.generic.Instruction;
 import org.apache.bcel.generic.InstructionHandle;
 import org.apache.bcel.generic.InstructionTargeter;
@@ -269,6 +270,9 @@ public class NoiseNullDeref implements Detector, UseAnnotationDatabase, NullDere
         final ConstantPoolGen cpg = classContext.getConstantPoolGen();
 
         if (ins instanceof InvokeInstruction) {
+            if (ins instanceof INVOKEDYNAMIC) {
+                return;
+            }
             InvokeInstruction iins = (InvokeInstruction) ins;
             XMethod invokedMethod = XFactory.createXMethod((InvokeInstruction) ins, cpg);
             cause = MethodAnnotation.fromXMethod(invokedMethod);

--- a/spotbugsTestCases/src/java/lambdas/Issue527.java
+++ b/spotbugsTestCases/src/java/lambdas/Issue527.java
@@ -1,0 +1,24 @@
+package lambdas;
+
+public class Issue527 {
+
+	public void errorOnLambda() {
+		Object o = getObject();
+		if (o != null) {
+			useRunnable(() -> toString());
+		}
+		o.hashCode();
+		Object o2 = getObject();
+		if (o2 != null) {
+			useRunnable(() -> toString());
+		}
+		o2.hashCode();
+	}
+
+	public Object getObject() {
+		return null;
+	}
+
+	public void useRunnable(Runnable listener) {
+	}
+}


### PR DESCRIPTION
Muted silly errors coming by analyzing XMethod instances created from garbage attributes of INVOKEDYNAMIC instructions.

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
- [ ] Added an entry into `gradlePlugin/CHANGELOG.md` if you have changed Gradle plugin code
