### PR TITLE
Add support for errorprone's @CanIgnoreReturnValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ## Unreleased - 2017-??-??
 
+### Added
+
+* Support for errorprone @CanIgnoreReturnValue annotation ([#463](https://github.com/spotbugs/spotbugs/issues/463))
+
 ### Fixed
 
 * Lambda methods reported as missing classes ([#527](https://github.com/spotbugs/spotbugs/issues/527))

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue463Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue463Test.java
@@ -1,0 +1,24 @@
+package edu.umd.cs.findbugs.detect;
+
+import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
+
+/**
+ * @see <a href="https://github.com/spotbugs/spotbugs/issues/463">GitHub issue</a>
+ */
+public class Issue463Test extends AbstractIntegrationTest {
+    @Test
+    public void test() {
+        performAnalysis("ghIssues/Issue463.class");
+        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder().bugType("RV_RETURN_VALUE_IGNORED")
+                .build();
+        assertThat(getBugCollection(), containsExactly(1, bugTypeMatcher));
+    }
+
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/CheckReturnAnnotationDatabase.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/CheckReturnAnnotationDatabase.java
@@ -292,6 +292,8 @@ public class CheckReturnAnnotationDatabase extends AnnotationDatabase<CheckRetur
             .createClassDescriptor(CheckReturnValue.class);
     private static final ClassDescriptor CHECK_RETURN_NULL_JSR305 = DescriptorFactory
             .createClassDescriptor("javax/annotation/CheckReturnValue");
+    private static final ClassDescriptor CAN_IGNORE_RETURN_VALUE = DescriptorFactory
+            .createClassDescriptor("com/google/errorprone/annotations/CanIgnoreReturnValue");
 
     private final Map<String, CheckReturnValueAnnotation> packageInfoCache = new HashMap<>();
 
@@ -338,6 +340,12 @@ public class CheckReturnAnnotationDatabase extends AnnotationDatabase<CheckRetur
                 return CheckReturnValueAnnotation.createFor(When.ALWAYS);
             }
         }
+
+        annotation = clazz.getAnnotation(CAN_IGNORE_RETURN_VALUE);
+        if (annotation != null) {
+            return CheckReturnValueAnnotation.createFor(When.NEVER);
+        }
+
         return null;
     }
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BuildCheckReturnAnnotationDatabase.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BuildCheckReturnAnnotationDatabase.java
@@ -121,6 +121,8 @@ public class BuildCheckReturnAnnotationDatabase extends AnnotationVisitor {
             n = CheckReturnValueAnnotation.parse(getAnnotationParameterAsString(map, "priority"));
         } else if ("CheckReturnValue".equals(annotationClassSimpleName)) {
             n = CheckReturnValueAnnotation.CHECK_RETURN_VALUE_MEDIUM;
+        } else if ("CanIgnoreReturnValue".equals(annotationClassSimpleName)) {
+            n = CheckReturnValueAnnotation.CHECK_RETURN_VALUE_IGNORE;
         } else {
             return;
         }

--- a/spotbugsTestCases/src/fakeAnnotations/com/google/errorprone/annotations/CanIgnoreReturnValue.java
+++ b/spotbugsTestCases/src/fakeAnnotations/com/google/errorprone/annotations/CanIgnoreReturnValue.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2015 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.annotations;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that the return value of the annotated method can be safely ignored.
+ *
+ * <p>This is the opposite of {@code javax.annotation.CheckReturnValue}. It can be used inside
+ * classes or packages annotated with {@code @CheckReturnValue} to exempt specific methods from the
+ * default.
+ */
+@Documented
+@Target({METHOD, TYPE})
+@Retention(CLASS)
+public @interface CanIgnoreReturnValue {}

--- a/spotbugsTestCases/src/java/ghIssues/Issue463.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue463.java
@@ -1,0 +1,41 @@
+package ghIssues;
+
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.meta.When;
+
+/**
+ * @see <a href="https://github.com/spotbugs/spotbugs/issues/463">GitHub issue</a>
+ */
+@CheckReturnValue
+public class Issue463 {
+    private String value;
+
+    String getValue() {
+        return value;
+    }
+
+    @CanIgnoreReturnValue
+    String returnAValue(String newValue) {
+        value = newValue;
+        return newValue;
+    }
+
+    String returnAnotherValue(String newValue) {
+        value = newValue;
+        return newValue;
+    }
+
+    public static String testNoError() {
+        Issue463 i = new Issue463();
+        i.returnAValue("foobar");
+        return i.getValue();
+    }
+
+    public static String testWithError() {
+        Issue463 i = new Issue463();
+        i.returnAnotherValue("foobar");
+        return i.getValue();
+    }
+}


### PR DESCRIPTION
Guava switched to using this errorprone annotation, which leads to RV_RETURN_VALUE_IGNORED false positives when using Guava.

Fixes #463 