### PR TITLE
Update dom4j to 2.1.0 to fix 'WARNING: Illegal reflective access by org.dom4j.io.SAXContentHandler' in java 9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 * Lambda methods reported as missing classes ([#527](https://github.com/spotbugs/spotbugs/issues/527))
 * Unused variable reported with wrong name ([#516](https://github.com/spotbugs/spotbugs/issues/516))
 * Require gradle 4.2.1 to fix gradle build failures on Java 9.0.1
+* Update dom4j to 2.1.0 to fix Illegal reflective access on Java 9
 
 ## 3.1.1 - 2017-11-29
 

--- a/eclipsePlugin/doc/installing_findbugsplugin.txt
+++ b/eclipsePlugin/doc/installing_findbugsplugin.txt
@@ -25,7 +25,7 @@ Install the plug-in
             |     asm-tree-3.3.jar
             |     bcel.jar
             |     commons-lang-2.6.jar
-            |     dom4j-1.6.1.jar
+            |     dom4j-2.1.0.jar
             |     jaxen-1.1.6.jar
             |     jFormatString.jar
             |     jsr305.jar

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -46,7 +46,7 @@ dependencies {
   compile 'org.ow2.asm:asm-xml:6.0'
   compile 'org.apache.bcel:bcel:6.1'
   compile 'net.jcip:jcip-annotations:1.0'
-  compile 'dom4j:dom4j:1.6.1'
+  compile 'org.dom4j:dom4j:2.1.0'
   compile 'jaxen:jaxen:1.1.6' // only transitive through dom4j:dom4j:1.6.1, which has an *optional* dependency on jaxen:jaxen.
   compile 'commons-lang:commons-lang:2.6'
   compile 'com.google.code.findbugs:jFormatString:3.0.0'

--- a/spotbugs/etc/MANIFEST-findbugs.MF
+++ b/spotbugs/etc/MANIFEST-findbugs.MF
@@ -1,3 +1,3 @@
 Manifest-Version: 1.0
 Main-Class: edu.umd.cs.findbugs.LaunchAppropriateUI
-Class-Path: bcel.jar dom4j-1.6.1.jar jaxen-1.1.6.jar asm-debug-all-6.0-SNAPSHOT.jar jsr305.jar jFormatString.jar commons-lang-2.6.jar
+Class-Path: bcel.jar dom4j-2.1.0.jar jaxen-1.1.6.jar asm-debug-all-6.0-SNAPSHOT.jar jsr305.jar jFormatString.jar commons-lang-2.6.jar

--- a/spotbugs/etc/MANIFEST-findbugsGUI.MF
+++ b/spotbugs/etc/MANIFEST-findbugsGUI.MF
@@ -1,3 +1,3 @@
 Manifest-Version: 1.0
 Main-Class: edu.umd.cs.findbugs.LaunchAppropriateUI
-Class-Path: bcel.jar dom4j-1.6.1.jar jaxen-1.1.6.jar asm-debug-all-6.0-SNAPSHOT.jar jsr305.jar jFormatString.jar commons-lang-2.6.jar plastic.jar
+Class-Path: bcel.jar dom4j-2.1.0.jar jaxen-1.1.6.jar asm-debug-all-6.0-SNAPSHOT.jar jsr305.jar jFormatString.jar commons-lang-2.6.jar plastic.jar

--- a/spotbugs/jnlp/core.jnlp
+++ b/spotbugs/jnlp/core.jnlp
@@ -15,7 +15,7 @@
   <resources> 
     <jar href="AppleJavaExtensions.jar"/>
     <jar href="bcel.jar"/>
-    <jar href="dom4j-1.6.1.jar"/>
+    <jar href="dom4j-2.1.0.jar"/>
     <jar href="asm-3.3.jar"/>
     <jar href="asm-tree-3.3.jar"/>
     <jar href="asm-commons-3.3.jar"/>

--- a/spotbugs/jnlp/findbugs.jnlp
+++ b/spotbugs/jnlp/findbugs.jnlp
@@ -20,7 +20,7 @@
     <jar href="findbugs.jar"/>
     <jar href="AppleJavaExtensions.jar"/>
     <jar href="bcel.jar"/>
-    <jar href="dom4j-1.6.1.jar"/>
+    <jar href="dom4j-2.1.0.jar"/>
     <jar href="asm-3.3.jar"/>
     <jar href="asm-tree-3.3.jar"/>
     <jar href="asm-commons-3.3.jar"/>

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/xml/XMLUtil.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/xml/XMLUtil.java
@@ -30,7 +30,7 @@ public class XMLUtil {
 
     @SuppressWarnings("unchecked")
     public static <T> List<T> selectNodes(Node node, String arg0) {
-        return node.selectNodes(arg0);
+        return (List<T>)node.selectNodes(arg0);
     }
 
 }

--- a/spotbugs/src/sampleXml/analysisResultsWithFilterAndUserAnnotations.xml
+++ b/spotbugs/src/sampleXml/analysisResultsWithFilterAndUserAnnotations.xml
@@ -7,7 +7,7 @@
     <AuxClasspathEntry>/Users/pugh/Documents/fb-trunk/findbugs/lib/findbugs.jar</AuxClasspathEntry>
     <AuxClasspathEntry>/Users/pugh/Documents/fb-trunk/findbugs/lib/jdepend-2.9.jar</AuxClasspathEntry>
     <AuxClasspathEntry>/Users/pugh/Documents/fb-trunk/findbugs/lib/bcel.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/Users/pugh/Documents/fb-trunk/findbugs/lib/dom4j-1.6.1.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/pugh/Documents/fb-trunk/findbugs/lib/dom4j-2.1.0.jar</AuxClasspathEntry>
     <AuxClasspathEntry>/Users/pugh/Documents/fb-trunk/findbugs/lib/AppleJavaExtensions.jar</AuxClasspathEntry>
     <AuxClasspathEntry>/Users/pugh/Documents/fb-trunk/findbugs/lib/junit.jar</AuxClasspathEntry>
     <AuxClasspathEntry>/Users/pugh/Documents/fb-trunk/findbugs/lib/asm-3.3.jar</AuxClasspathEntry>


### PR DESCRIPTION
When running spotbugs in Java 9 you get the following warning:

```
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.dom4j.io.SAXContentHandler (file:dom4j-1.6.1.jar) to method com.sun.org.apache.xerces.internal.parsers.AbstractSAXParser$LocatorProxy.getEncoding()
WARNING: Please consider reporting this to the maintainers of org.dom4j.io.SAXContentHandler
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
```

This has been fixed in the latest release of dom4j.

