### PR TITLE
Release 3.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased - 2017-??-??
+## 3.1.2 - 2018-02-24
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased - 2018-??-??
+
 ## 3.1.2 - 2018-02-24
 
 ### Added

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
   id 'org.sonarqube' version '2.5'
 }
 
-version = '3.1.2-SNAPSHOT'
+version = '3.1.2'
 
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/jacoco.gradle"

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
   id 'org.sonarqube' version '2.5'
 }
 
-version = '3.1.2'
+version = '3.1.3-SNAPSHOT'
 
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/jacoco.gradle"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,9 +17,9 @@ import os
 
 html_context = {
   'version' : '3.1',
-  'full_version' : '3.1.1',
-  'maven_plugin_version' : '3.1.0-RC7',
-  'gradle_plugin_version' : '1.6.0'
+  'full_version' : '3.1.2',
+  'maven_plugin_version' : '3.1.1',
+  'gradle_plugin_version' : '1.6.1'
 }
 
 # If extensions (or modules to document with autodoc) are in another directory,


### PR DESCRIPTION
After we merge this PR, tag a32a62f or its rebased commit then Travis CI will release 3.1.2 to Sonatype Staging Nexus.

Note that this is related with https://github.com/spotbugs/discuss/issues/32
and gradle plugin v1.6.1 will be released by https://github.com/spotbugs/spotbugs-gradle-plugin/pull/8

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
