### PR TITLE
Add test to trigger 'parameter must be non null' when using Precondit…

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/PreconditionsCheckNotNullNullableTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/PreconditionsCheckNotNullNullableTest.java
@@ -1,0 +1,37 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.BugCollection;
+import edu.umd.cs.findbugs.test.SpotBugsRule;
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.nio.file.Paths;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.collection.IsEmptyIterable.emptyIterable;
+import static org.junit.Assume.assumeThat;
+
+public class PreconditionsCheckNotNullNullableTest {
+    @Rule
+    public SpotBugsRule spotbugs = new SpotBugsRule();
+
+    @Before
+    public void setUp() {
+        String property = System.getProperty("AUX_CLASSPATH");
+        assumeThat(property, notNullValue());
+        for (String path : property.split(",")) {
+            spotbugs.addAuxClasspathEntry(Paths.get(path));
+        }
+    }
+
+    @Test
+    public void testNullableIsSanitizedByCheckNonNull() {
+        BugCollection bugCollection = spotbugs.performAnalysis(Paths.get("../spotbugsTestCases/build/classes/java/main/bugPatterns/NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE_Guava_Preconditions.class"));
+        Assert.assertThat(bugCollection, is(emptyIterable()));
+    }
+
+}

--- a/spotbugsTestCases/src/java/bugPatterns/NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE_Guava_Preconditions.java
+++ b/spotbugsTestCases/src/java/bugPatterns/NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE_Guava_Preconditions.java
@@ -1,0 +1,14 @@
+package bugPatterns;
+
+import com.google.common.base.Preconditions;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import javax.annotation.Nullable;
+
+public class NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE_Guava_Preconditions {
+    @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED")
+    public int method(@Nullable String param) {
+        Preconditions.checkNotNull(param);
+        return param.length();
+    }
+}


### PR DESCRIPTION
…ions.checkNotNull

----

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code

See issue #580 