### PR TITLE
Generate simple index.html for user using browser to visit site

### DIFF
--- a/eclipsePlugin/build.gradle
+++ b/eclipsePlugin/build.gradle
@@ -282,6 +282,45 @@ task featureDailyJar(type:Zip) {
   destinationDir = file("${buildDir}/site/eclipse-daily/features/")
 }
 
+task siteHtml(type:Copy) {
+  filter(tokens:[
+    'URL': 'https://spotbugs.github.io/eclipse/'
+  ] + siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
+  from 'plugin_site.html'
+  destinationDir = file("${buildDir}/site/eclipse")
+  rename { 'index.html' }
+  outputs.upToDateWhen {
+    // even if we have generated file, we should rerun this task to overwrite it.
+    false
+  }
+}
+
+task siteCandidateHtml(type:Copy) {
+  filter(tokens:[
+    'URL': 'https://spotbugs.github.io/eclipse-candidate/'
+  ] + siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
+  from 'plugin_site.html'
+  destinationDir = file("${buildDir}/site/eclipse-candidate")
+  rename { 'index.html' }
+  outputs.upToDateWhen {
+    // even if we have generated file, we should rerun this task to overwrite it.
+    false
+  }
+}
+
+task siteDailyHtml(type:Copy) {
+  filter(tokens:[
+    'URL': 'https://spotbugs.github.io/eclipse-latest/'
+  ] + siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
+  from 'plugin_site.html'
+  destinationDir = file("${buildDir}/site/eclipse-daily")
+  rename { 'index.html' }
+  outputs.upToDateWhen {
+    // even if we have generated file, we should rerun this task to overwrite it.
+    false
+  }
+}
+
 task siteXml(type:Copy) {
   filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
   from 'plugin_site.xml'
@@ -321,7 +360,7 @@ task generateP2Metadata(type:Exec) {
     project.delete "${buildDir}/site/eclipse/content.xml"
   }
   inputs.file 'local.properties'
-  dependsOn pluginJar, featureJar, siteXml
+  dependsOn pluginJar, featureJar, siteXml, siteHtml
   commandLine "${eclipseExecutable}", '-nosplash',
     '-application', 'org.eclipse.equinox.p2.publisher.UpdateSitePublisher',
     '-metadataRepository', "file:${buildDir}/site/eclipse", // TODO : May not work on Windows
@@ -335,7 +374,7 @@ task generateCandidateP2Metadata(type:Exec) {
     project.delete "${buildDir}/site/eclipse-candidate/content.xml"
   }
   inputs.file 'local.properties'
-  dependsOn pluginCandidateJar, featureCandidateJar, siteCandidateXml
+  dependsOn pluginCandidateJar, featureCandidateJar, siteCandidateXml, siteCandidateHtml
   commandLine "${eclipseExecutable}", '-nosplash',
     '-application', 'org.eclipse.equinox.p2.publisher.UpdateSitePublisher',
     '-metadataRepository', "file:${buildDir}/site/eclipse-candidate", // TODO : May not work on Windows
@@ -349,7 +388,7 @@ task generateP2MetadataDaily(type:Exec) {
     project.delete "${buildDir}/site/eclipse-daily/content.xml"
   }
   inputs.file 'local.properties'
-  dependsOn pluginDailyJar, featureDailyJar, siteDailyXml
+  dependsOn pluginDailyJar, featureDailyJar, siteDailyXml, siteDailyHtml
   commandLine "${eclipseExecutable}", '-nosplash',
     '-application', 'org.eclipse.equinox.p2.publisher.UpdateSitePublisher',
     '-metadataRepository', "file:${buildDir}/site/eclipse-daily", // TODO : May not work on Windows

--- a/eclipsePlugin/plugin_site.html
+++ b/eclipsePlugin/plugin_site.html
@@ -1,0 +1,44 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>SpotBugs Eclipse Plugin Update Site</title>
+  <!-- Search Engine -->
+  <meta name="description" content="Eclipse Plugin Update Site for SpotBugs Eclipse Plugin">
+  <meta name="image" content="https://spotbugs.github.io/images/logos/spotbugs_icon_only_zoom_256px.png">
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="SpotBugs Eclipse Plugin Update Site">
+  <meta name="twitter:description" content="Eclipse Plugin Update Site for SpotBugs Eclipse Plugin">
+  <meta name="twitter:image:src" content="https://spotbugs.github.io/images/logos/spotbugs_logo_600px.png">
+  <!-- Open Graph general (Facebook, Pinterest & Google+) -->
+  <meta name="og:title" content="SpotBugs Eclipse Plugin Update Site">
+  <meta name="og:description" content="Eclipse Plugin Update Site for SpotBugs Eclipse Plugin">
+  <meta name="og:image" content="https://spotbugs.github.io/images/logos/spotbugs_logo_600px.png">
+  <meta name="og:url" content="@URL@">
+  <meta name="og:site_name" content="SpotBugs Eclipse Plugin Update Site">
+  <meta name="og:locale" content="en">
+  <meta name="og:type" content="website">
+</head>
+<body>
+  <p>
+    This is Eclipse Plugin Update Site for SpotBugs Eclipse Plugin.
+    Use <a href="@URL@">this URL</a> to install plugin with the Eclipse Update Manager.
+  </p>
+  <dl>
+    <dt>Plugin ID</dt>
+    <dd>@PLUGIN_ID@</dd>
+    <dt>Version</dt>
+    <dd>@PLUGIN_VERSION@</dd>
+  </dl>
+  <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+    ga('create', 'UA-86930553-1', 'auto');
+    ga('send', 'pageview');
+  </script>
+</body>
+</html>


### PR DESCRIPTION
According to #510, #583 and #577, current our eclipse update sites are not intuitive enough.
By putting `index.html` to each update sites, we can avoid such confusion, I hope.

Here is built result for your reference: [update-site.zip](https://github.com/spotbugs/spotbugs/files/1801271/update-site.zip)

Note that metatags are generated by https://megatags.co/, and GA tracking code is copied from https://github.com/spotbugs/spotbugs.github.io/commit/60f4d612c9d6d60c7908ff7e134583f62209e184

@iloveeclipse I guess that Eclipse community has no recommended template for `index.html`, so I made this `plugin_site.html` from scratch. If you know recommended one, please let me know.
