### PR TITLE
Add CheckLogParamNum detector for slf4j. #587

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ## Unreleased - 2018-??-??
 
+* Add a detector to check if placeholder correct for slf4j. ([#587](https://github.com/spotbugs/spotbugs/issues/587))
+
 ## 3.1.2 - 2018-02-24
 
 ### Added

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/CheckLogParamNumTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/CheckLogParamNumTest.java
@@ -1,0 +1,37 @@
+package edu.umd.cs.findbugs.detect;
+
+import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeThat;
+
+import java.nio.file.Paths;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import edu.umd.cs.findbugs.BugCollection;
+import edu.umd.cs.findbugs.test.SpotBugsRule;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
+
+public class CheckLogParamNumTest extends AbstractIntegrationTest {
+    @Rule
+    public SpotBugsRule spotbugs = new SpotBugsRule();
+
+    @Test
+    public void test() {
+        String property = System.getProperty("AUX_CLASSPATH");
+        assumeThat(property, notNullValue());
+        for (String path : property.split(",")) {
+            spotbugs.addAuxClasspathEntry(Paths.get(path));
+        }
+
+        BugCollection bugCollection = spotbugs.performAnalysis(
+                Paths.get("../spotbugsTestCases/build/classes/java/main/WrongPlaceholderOfSlf4j.class"));
+        BugInstanceMatcher matcher = new BugInstanceMatcherBuilder().bugType("FS_LOG_PARAM_NUM").build();
+        assertThat(bugCollection, containsExactly(8, matcher));
+    }
+
+}

--- a/spotbugs/etc/findbugs.xml
+++ b/spotbugs/etc/findbugs.xml
@@ -644,6 +644,8 @@
                     reports="DM_DEFAULT_ENCODING"/>
           <Detector class="edu.umd.cs.findbugs.detect.CheckRelaxingNullnessAnnotation" speed="fast"
                     reports="NP_METHOD_RETURN_RELAXING_ANNOTATION,NP_METHOD_PARAMETER_TIGHTENS_ANNOTATION"/>
+          <Detector class="edu.umd.cs.findbugs.detect.CheckLogParamNum" speed="fast"
+                    reports="FS_LOG_PARAM_NUM" hidden="false"/>
 
             <!-- Bug Categories -->
            <BugCategory category="NOISE" hidden="true"/>
@@ -1038,6 +1040,7 @@
                     category="CORRECTNESS"/>
           <BugPattern abbrev="FS" type="VA_FORMAT_STRING_EXPECTED_MESSAGE_FORMAT_SUPPLIED"
                     category="CORRECTNESS"/>
+          <BugPattern abbrev="FS" type="FS_LOG_PARAM_NUM" category="CORRECTNESS"/>
           <BugPattern abbrev="EC" type="EC_UNRELATED_TYPES_USING_POINTER_EQUALITY"
                     category="CORRECTNESS"/>
           <BugPattern abbrev="EC" type="EC_UNRELATED_TYPES" category="CORRECTNESS"/>

--- a/spotbugs/etc/messages.xml
+++ b/spotbugs/etc/messages.xml
@@ -1003,6 +1003,13 @@ null.  It is a slow detector.</p>
 ]]>
     </Details>
   </Detector>
+  <Detector class="edu.umd.cs.findbugs.detect.CheckLogParamNum">
+    <Details>
+<![CDATA[
+<p> Use org.slf4j.Logger with wrong placeholder count.</p>
+]]>
+    </Details>
+  </Detector>
   <Detector class="edu.umd.cs.findbugs.detect.FindNullDerefsInvolvingNonShortCircuitEvaluation">
     <Details>
 <![CDATA[
@@ -2547,6 +2554,18 @@ dangerous methods in the Java libraries.</em> -- Joshua Bloch</p>
       <p>
       Unless the class must be compatible with JVMs predating Java 1.5,
       use either autoboxing or the <code>valueOf()</code> method when creating instances of <code>Double</code> and <code>Float</code>.
+      </p>
+      ]]>
+    </Details>
+  </BugPattern>
+  <BugPattern type="FS_LOG_PARAM_NUM">
+    <ShortDescription>Placeholder incorrect when calls org.slf4j.Logger.</ShortDescription>
+    <LongDescription>{1} calls org.slf4j.Logger.{3}, the count of braces placeholder is incorrect, need {2}.</LongDescription>
+    <Details>
+      <![CDATA[
+      <p>
+      The number of placeholders must be the same as the number of parameters. 
+      If the last parameter is 'Throwable', it does not need a placeholder.
       </p>
       ]]>
     </Details>

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/CheckLogParamNum.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/CheckLogParamNum.java
@@ -1,0 +1,198 @@
+/*
+ * FindBugs - Find bugs in Java programs
+ * Copyright (C) 2017-2018 Public
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+package edu.umd.cs.findbugs.detect;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.bcel.Const;
+import org.apache.bcel.classfile.Code;
+import org.apache.bcel.classfile.JavaClass;
+
+import edu.umd.cs.findbugs.BugInstance;
+import edu.umd.cs.findbugs.BugReporter;
+import edu.umd.cs.findbugs.OpcodeStack;
+import edu.umd.cs.findbugs.ba.XMethod;
+import edu.umd.cs.findbugs.bcel.OpcodeStackDetector;
+import edu.umd.cs.findbugs.classfile.MethodDescriptor;
+
+public class CheckLogParamNum extends OpcodeStackDetector {
+    private BugReporter bugReporter;
+
+    /** The last AASTORE value before INVOKEINTERFACE, is the last parameter if the method is varArgs. */
+    private OpcodeStack.Item lastAastoreItem = null;
+
+    private List<String> loggerMethods = Arrays.asList(new String[] { "error", "warn", "info", "debug", "trace" });
+
+    public CheckLogParamNum(BugReporter bugReporter) {
+        this.bugReporter = bugReporter;
+    }
+
+    /*
+     * Just called once one class file.
+     */
+    @Override
+    public void visit(Code obj) {
+        lastAastoreItem = null;
+        super.visit(obj);
+        lastAastoreItem = null;
+    }
+
+    /**
+     * @param seen
+     *            One op code of jvm
+     */
+    @Override
+    public void sawOpcode(int seen) {
+        if (seen == Const.AASTORE) {
+            lastAastoreItem = stack.getStackItem(0);
+        }
+
+        if (seen == Const.INVOKEINTERFACE) {
+            String className = getClassConstantOperand();
+            if ("org/slf4j/Logger".equals(className)) {
+                MethodDescriptor method = getMethodDescriptorOperand();
+                if ((method != null) && (loggerMethods.contains(method.getName()))) {
+                    BugInstance bug = checkPlaceholder();
+                    if (null != bug) {
+                        bug.addString(method.getName());
+                        bug.addSourceLine(this, getPC());
+                        bugReporter.reportBug(bug);
+                    }
+                }
+            }
+            lastAastoreItem = null;
+        }
+    }
+
+    /**
+     * Check if placeholder correct when call log.[info|error|warn|debug|trace].
+     * 
+     * @return When the first parameter is a formatted string, and the number of brace in it does not match the number
+     *         of parameters, it returns a bug, or else return null
+     */
+    private BugInstance checkPlaceholder() {
+        /*
+         * stack item(depth-1) is logger, item(depth-2) is formatter string; if no enough parameters, return null;
+         */
+        int depth = stack.getStackDepth();
+        if (depth < 2) {
+            return null;
+        }
+
+        /* If item(depth-2) is not an constant string, return null */
+        Object formatStr = stack.getStackItem(depth - 2).getConstant();
+        if (!(formatStr instanceof String)) {
+            return null;
+        }
+
+        int placeholderCount = countStr((String) formatStr, "{}");
+        boolean lastThrowable = false;
+        int needCount = 0;
+
+        if (depth == 2) {
+            /* If only have formatter string, no formatter parameter, needCount is 0. */
+            needCount = 0;
+        } else {
+            /* If have one or more formatter parameters, the parameters may be var args */
+            XMethod m = getXMethodOperand();
+            if (m.isVarArgs()) {
+                /* parameter is varArgs, need placeholder count is varArgs.len, except last Throwable */
+                OpcodeStack.Item varArgsItem = stack.getStackItem(0);
+                needCount = (Integer) (varArgsItem.getConstant());
+                if (isThrowable(lastAastoreItem)) {
+                    lastThrowable = true;
+                    needCount--;
+                }
+            } else {
+                /* Need placeholder count is parameter number, except last Throwable */
+                needCount = depth - 2;
+                OpcodeStack.Item param = stack.getStackItem(0);
+                if (isThrowable(param)) {
+                    needCount--;
+                    lastThrowable = true;
+                }
+            }
+        }
+
+        if (needCount == placeholderCount) {
+            return null;
+        }
+
+        int confidence = HIGH_PRIORITY;
+        if (lastThrowable && (placeholderCount == (needCount + 1))) {
+            confidence = NORMAL_PRIORITY;
+        }
+
+        BugInstance bug = new BugInstance(this, "FS_LOG_PARAM_NUM", confidence).addClassAndMethod(this)
+                .addInt(needCount);
+        return bug;
+    }
+
+    /**
+     * @param myClass
+     * @return
+     */
+    private static boolean isThrowable(OpcodeStack.Item param) {
+        if (null == param) {
+            return false;
+        }
+
+        JavaClass myClass;
+        try {
+            myClass = param.getJavaClass();
+        } catch (ClassNotFoundException e) {
+            myClass = null;
+        }
+
+        if (null == myClass) {
+            return false;
+        }
+        if ("java.lang.Throwable".equals(myClass.getClassName())) {
+            return true;
+        }
+
+        JavaClass[] superClasses;
+        try {
+            superClasses = myClass.getSuperClasses();
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+
+        for (final JavaClass oneSuper : superClasses) {
+            if ("java.lang.Throwable".equals(oneSuper.getClassName())) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static int countStr(String src, String sub) {
+        int counter = 0;
+        int index = -1;
+        while ((index = src.indexOf(sub)) != -1) {
+            counter++;
+            src = src.substring(index + sub.length());
+        }
+        return counter;
+    }
+
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/CheckLogParamNum.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/CheckLogParamNum.java
@@ -34,12 +34,13 @@ import edu.umd.cs.findbugs.bcel.OpcodeStackDetector;
 import edu.umd.cs.findbugs.classfile.MethodDescriptor;
 
 public class CheckLogParamNum extends OpcodeStackDetector {
-    private BugReporter bugReporter;
+    private final BugReporter bugReporter;
 
     /** The last AASTORE value before INVOKEINTERFACE, is the last parameter if the method is varArgs. */
     private OpcodeStack.Item lastAastoreItem = null;
 
-    private List<String> loggerMethods = Arrays.asList(new String[] { "error", "warn", "info", "debug", "trace" });
+    private final List<String> loggerMethods = Arrays
+            .asList(new String[] { "error", "warn", "info", "debug", "trace" });
 
     public CheckLogParamNum(BugReporter bugReporter) {
         this.bugReporter = bugReporter;
@@ -84,7 +85,7 @@ public class CheckLogParamNum extends OpcodeStackDetector {
 
     /**
      * Check if placeholder correct when call log.[info|error|warn|debug|trace].
-     * 
+     *
      * @return When the first parameter is a formatted string, and the number of brace in it does not match the number
      *         of parameters, it returns a bug, or else return null
      */
@@ -113,7 +114,7 @@ public class CheckLogParamNum extends OpcodeStackDetector {
         } else {
             /* If have one or more formatter parameters, the parameters may be var args */
             XMethod m = getXMethodOperand();
-            if (m.isVarArgs()) {
+            if (m != null && m.isVarArgs()) {
                 /* parameter is varArgs, need placeholder count is varArgs.len, except last Throwable */
                 OpcodeStack.Item varArgsItem = stack.getStackItem(0);
                 needCount = (Integer) (varArgsItem.getConstant());

--- a/spotbugsTestCases/build.gradle
+++ b/spotbugsTestCases/build.gradle
@@ -19,6 +19,7 @@ dependencies {
   compile 'joda-time:joda-time:2.9.9'
   compile 'net.jcip:jcip-annotations:1.0'
   compile 'org.springframework:spring-core:4.3.8.RELEASE'
+  compile 'org.slf4j:slf4j-api:1.7.25'
 
   compile 'junit:junit:4.12'
   compile 'org.testng:testng:6.11'

--- a/spotbugsTestCases/src/java/WrongPlaceholderOfSlf4j.java
+++ b/spotbugsTestCases/src/java/WrongPlaceholderOfSlf4j.java
@@ -1,0 +1,48 @@
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class WrongPlaceholderOfSlf4j {
+    public static void main(String[] args) {
+        Logger logger = LoggerFactory.getLogger(WrongPlaceholderOfSlf4j.class);
+
+        String strParam = logger.getName();
+        String[] arrayParam = new String[] { "1", "2", "3" };
+
+        /* Report a bug, have 2 placeholders but need 0 */
+        logger.warn("hello {} {}");
+
+        /* Report a bug, have 2 placeholders but need 1 */
+        logger.info("hello {} {}", strParam);
+
+        /*
+         * Report a bug, have 2 placeholders but need 0; the last 'Throwable' does not
+         * need a placeholder
+         */
+        logger.error("hello {} {}", new NullPointerException());
+
+        /* No bug */
+        logger.info("hello {} {}", strParam, strParam);
+
+        /* Report a bug, have 2 placeholders but need 1 */
+        logger.debug("hello {} {}", strParam, new NullPointerException());
+
+        /* No bug */
+        logger.info("hello {}", strParam, new Throwable());
+
+        /* Report a bug, have 2 placeholders but need 3 */
+        logger.trace("hello {} {}", strParam, strParam, strParam);
+
+        /* No bug */
+        logger.info("hello {} {}", strParam, strParam, new NullPointerException());
+
+        /* Report a bug, have 2 placeholders but need 4 */
+        logger.info("hello {} {}", strParam, strParam, strParam, strParam);
+
+        /* Report a bug, have 2 placeholders but need 3 */
+        logger.info("hello {} {}", strParam, strParam, strParam, new NullPointerException());
+
+        /* Report a bug, have 4 placeholders but need 5 */
+        logger.info("hello {} {} {} {}", strParam, strParam, strParam, strParam, arrayParam,
+                new NullPointerException());
+    }
+}


### PR DESCRIPTION
Add CheckLogParamNum detector for slf4j. #587 
Check if placeholder correct when call log.[info|error|warn|debug|trace].
When the first parameter is a formatted string, and the number of braces in it does not match the number of formatted parameters, report a bug.

---
This is the first time I submit my code on GitHub. If there is any mistake, I hope I can get your help.

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs  
