### PR TITLE
Fix resource leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ## Unreleased - 2018-??-??
 
+### Fixed
+
+* Close source file after analysis ([#591](https://github.com/spotbugs/spotbugs/issues/591))
+
 ## 3.1.2 - 2018-02-24
 
 ### Added

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/FindBugs2.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/FindBugs2.java
@@ -68,6 +68,7 @@ import edu.umd.cs.findbugs.config.AnalysisFeatureSetting;
 import edu.umd.cs.findbugs.config.UserPreferences;
 import edu.umd.cs.findbugs.detect.NoteSuppressedWarnings;
 import edu.umd.cs.findbugs.filter.FilterException;
+import edu.umd.cs.findbugs.io.IO;
 import edu.umd.cs.findbugs.log.Profiler;
 import edu.umd.cs.findbugs.plan.AnalysisPass;
 import edu.umd.cs.findbugs.plan.ExecutionPlan;
@@ -317,9 +318,7 @@ public class FindBugs2 implements IFindBugsEngine {
         // Make sure the codebases on the classpath are closed
         AnalysisContext.removeCurrentAnalysisContext();
         Global.removeAnalysisCacheForCurrentThread();
-        if (classPath != null) {
-            classPath.close();
-        }
+        IO.close(classPath);
     }
 
     /**
@@ -342,11 +341,13 @@ public class FindBugs2 implements IFindBugsEngine {
         analysisOptions.analysisFeatureSettingList = null;
         bugReporter = null;
         classFactory = null;
+        IO.close(classPath);
         classPath = null;
         classScreener = null;
         detectorFactoryCollection = null;
         executionPlan = null;
         progress = null;
+        IO.close(project);
         project = null;
         analysisOptions.userPreferences = null;
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/PluginLoader.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/PluginLoader.java
@@ -267,8 +267,8 @@ public class PluginLoader {
                 System.err.println(msg);
                 AnalysisContext.logError(msg);
 
-                for (Iterator<PluginLoader> i = partiallyInitialized.iterator(); i.hasNext();) {
-                    Plugin.removePlugin(i.next().loadedFromUri);
+                for (PluginLoader pluginLoader : partiallyInitialized) {
+                    Plugin.removePlugin(pluginLoader.loadedFromUri);
                 }
                 partiallyInitialized.clear();
             }
@@ -1590,9 +1590,7 @@ public class PluginLoader {
             throw new IllegalArgumentException(message);
         }
 
-        ZipFile zip = null;
-        try {
-            zip = new ZipFile(file);
+        try (ZipFile zip = new ZipFile(file)) {
             ZipEntry findbugsXML = zip.getEntry("findbugs.xml");
             if (findbugsXML == null) {
                 throw new IllegalArgumentException(
@@ -1623,8 +1621,6 @@ public class PluginLoader {
             throw new IllegalArgumentException(e);
         } catch (IOException e) {
             throw new IllegalArgumentException(e);
-        } finally {
-            Util.closeSilently(zip);
         }
     }
 
@@ -1639,4 +1635,3 @@ public class PluginLoader {
         }
     }
 }
-

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/Project.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/Project.java
@@ -63,6 +63,7 @@ import edu.umd.cs.findbugs.ba.URLClassPath;
 import edu.umd.cs.findbugs.charsets.UTF8;
 import edu.umd.cs.findbugs.config.UserPreferences;
 import edu.umd.cs.findbugs.filter.Filter;
+import edu.umd.cs.findbugs.io.IO;
 import edu.umd.cs.findbugs.util.Util;
 import edu.umd.cs.findbugs.xml.OutputStreamXMLOutput;
 import edu.umd.cs.findbugs.xml.XMLAttributeList;
@@ -83,7 +84,7 @@ import edu.umd.cs.findbugs.xml.XMLWriteable;
  *
  * @author David Hovemeyer
  */
-public class Project implements XMLWriteable {
+public class Project implements XMLWriteable, AutoCloseable {
     private static final boolean DEBUG = SystemProperties.getBoolean("findbugs.project.debug");
 
     private final List<File> currentWorkingDirectoryList;
@@ -273,7 +274,7 @@ public class Project implements XMLWriteable {
                 isNew = addToListInternal(srcDirList, dir) || isNew;
             }
         }
-
+        IO.close(sourceFinder);
         sourceFinder = new SourceFinder(this);
         return isNew;
     }
@@ -359,6 +360,7 @@ public class Project implements XMLWriteable {
      */
     public void removeSourceDir(int num) {
         srcDirList.remove(num);
+        IO.close(sourceFinder);
         sourceFinder = new SourceFinder(this);
         isModified = true;
     }
@@ -1121,5 +1123,10 @@ public class Project implements XMLWriteable {
 
         }
         return result;
+    }
+
+    @Override
+    public void close() {
+        IO.close(sourceFinder);
     }
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/AnalysisContext.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/AnalysisContext.java
@@ -67,6 +67,7 @@ import edu.umd.cs.findbugs.classfile.analysis.MethodInfo;
 import edu.umd.cs.findbugs.detect.UnreadFields;
 import edu.umd.cs.findbugs.detect.UnreadFieldsData;
 import edu.umd.cs.findbugs.internalAnnotations.DottedClassName;
+import edu.umd.cs.findbugs.io.IO;
 import edu.umd.cs.findbugs.util.ClassName;
 import net.jcip.annotations.NotThreadSafe;
 
@@ -85,7 +86,7 @@ import net.jcip.annotations.NotThreadSafe;
  * @see edu.umd.cs.findbugs.classfile.Global
  */
 @NotThreadSafe
-public class AnalysisContext {
+public class AnalysisContext implements AutoCloseable {
     public static final boolean DEBUG = SystemProperties.getBoolean("findbugs.analysiscontext.debug");
 
     public static final boolean IGNORE_BUILTIN_MODELS = SystemProperties.getBoolean("findbugs.ignoreBuiltinModels");
@@ -185,10 +186,14 @@ public class AnalysisContext {
         bridgeFrom = new IdentityHashMap<>();
     }
 
+    /**
+     * Clear cache and reference in this instances. Cleared {@link AnalysisContext} instance should not be reused.
+     */
     private void clear() {
         boolPropertySet = null;
         databaseInputDir = null;
         databaseOutputDir = null;
+        IO.close(project);
     }
 
     /**
@@ -1084,6 +1089,11 @@ public class AnalysisContext {
             Global.getAnalysisCache().getErrorLogger().reportSkippedAnalysis(method);
         }
 
+    }
+
+    @Override
+    public void close() {
+        clear();
     }
 
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/io/IO.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/io/IO.java
@@ -35,7 +35,6 @@ package edu.umd.cs.findbugs.io;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
-import java.io.Closeable;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -168,14 +167,14 @@ public class IO {
      * Close given InputStream, ignoring any resulting exception.
      *
      */
-    public static void close(@CheckForNull Closeable c) {
+    public static void close(@CheckForNull AutoCloseable c) {
         if (c == null) {
             return;
         }
 
         try {
             c.close();
-        } catch (IOException e) {
+        } catch (Exception e) {
             // Ignore
         }
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/RejarClassesForAnalysis.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/RejarClassesForAnalysis.java
@@ -648,9 +648,7 @@ public class RejarClassesForAnalysis {
             System.out.println("empty zip file: '" + f + "'");
             return false;
         }
-        ZipFile zipInputFile;
-        try {
-            zipInputFile = new ZipFile(f);
+        try (ZipFile zipInputFile = new ZipFile(f)) {
             for (Enumeration<? extends ZipEntry> e = zipInputFile.entries(); e.hasMoreElements();) {
                 ZipEntry ze = e.nextElement();
                 if (!ze.isDirectory() && ze.getName().endsWith(".class") && ze.getSize() != 0) {
@@ -658,7 +656,6 @@ public class RejarClassesForAnalysis {
                 }
 
             }
-            zipInputFile.close();
         } catch (ClassFileNameMismatch e) {
             return false;
         } catch (IOException e) {


### PR DESCRIPTION
Current implementation does not close `SourceFinder` even after analysis.
This PR also applies try-with-resources to handle zip files.

@iloveeclipse I'm not sure about the difference between `FindBugs2#dispose()` and `FindBugs2#clearCache()`, could you review? At least, can we destruct `project` instance by `clearCaches()` or not?