### PR TITLE
Fix 582: support error_prone's @CanIgnoreReturnValue with guava < 23.6-jre

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ## Unreleased - 2018-??-??
 
+### Added
+
+* Support for errorprone @CheckReturnValue annotation ([#592](https://github.com/spotbugs/spotbugs/issues/592))
+
+### Fixed
+
+* Handle annotation on `package-info.class` properly ([#592](https://github.com/spotbugs/spotbugs/issues/592))
+
 ## 3.1.2 - 2018-02-24
 
 ### Added

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue429Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue429Test.java
@@ -33,6 +33,6 @@ public class Issue429Test {
                 Paths.get("../spotbugsTestCases/build/classes/java/main/ghIssues/Issue429.class"));
         BugInstanceMatcher matcher = new BugInstanceMatcherBuilder().bugType("RV_RETURN_VALUE_IGNORED")
                 .build();
-        assertThat(bugCollection, containsExactly(1, matcher));
+        assertThat(bugCollection, containsExactly(0, matcher));
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue463Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue463Test.java
@@ -14,11 +14,24 @@ import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
  */
 public class Issue463Test extends AbstractIntegrationTest {
     @Test
-    public void test() {
+    public void testAnnotatedClass() {
         performAnalysis("ghIssues/Issue463.class");
         BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder().bugType("RV_RETURN_VALUE_IGNORED")
-                .build();
+                .atLine(37).build();
         assertThat(getBugCollection(), containsExactly(1, bugTypeMatcher));
     }
 
+    /**
+     * When package is annotated with {@code @CheckReturnValue} and method is not annotated with
+     * {@code @CanIgnoreReturnValue}, SpotBugs should report a bug for invocation which doesn't use returned value.
+     *
+     * @see <a href="https://github.com/spotbugs/spotbugs/issues/582">Issue 582</a>
+     */
+    @Test
+    public void testAnnotatedPackage() {
+        performAnalysis("ghIssues/issue463/Issue463.class", "ghIssues/issue463/package-info.class");
+        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder().bugType("RV_RETURN_VALUE_IGNORED")
+                .atLine(34).build();
+        assertThat(getBugCollection(), containsExactly(1, bugTypeMatcher));
+    }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue582Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue582Test.java
@@ -1,0 +1,35 @@
+package edu.umd.cs.findbugs.detect;
+
+import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
+
+/**
+ * SpotBugs should support both of {@code javax.annotation.CheckReturnValue} and
+ * {@code com.google.errorprone.annotations.CheckReturnValue} annotations.
+ *
+ * @see <a href="https://github.com/spotbugs/spotbugs/issues/582">GitHub issue</a>
+ * @since 3.1.3
+ */
+public class Issue582Test extends AbstractIntegrationTest {
+    @Test
+    public void testAnnnotatedClass() {
+        performAnalysis("ghIssues/Issue582.class");
+        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder().bugType("RV_RETURN_VALUE_IGNORED")
+                .atLine(35).build();
+        assertThat(getBugCollection(), containsExactly(1, bugTypeMatcher));
+    }
+
+    @Test
+    public void testAnnotatedPackage() {
+        performAnalysis("ghIssues/issue582/Issue582.class", "ghIssues/issue582/package-info.class");
+        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder().bugType("RV_RETURN_VALUE_IGNORED")
+                .atLine(34).build();
+        assertThat(getBugCollection(), containsExactly(1, bugTypeMatcher));
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/CheckReturnAnnotationDatabase.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/CheckReturnAnnotationDatabase.java
@@ -314,7 +314,6 @@ public class CheckReturnAnnotationDatabase extends AnnotationDatabase<CheckRetur
         }
 
         for (AnnotationEntry entry : clazz.getAnnotationEntries()) {
-            System.err.println(entry);
             String type = entry.getAnnotationType();
             if (type.equals(CHECK_RETURN_NULL_SPOTBUGS.getClassName())) {
                 for (ElementValuePair pair : entry.getElementValuePairs()) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/CheckReturnAnnotationDatabase.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/CheckReturnAnnotationDatabase.java
@@ -289,6 +289,8 @@ public class CheckReturnAnnotationDatabase extends AnnotationDatabase<CheckRetur
             .createClassDescriptor(CheckReturnValue.class);
     private static final ClassDescriptor CHECK_RETURN_NULL_JSR305 = DescriptorFactory
             .createClassDescriptor("javax/annotation/CheckReturnValue");
+    private static final ClassDescriptor CHECK_RETURN_NULL_ERRORPRONE = DescriptorFactory
+            .createClassDescriptor("com/google/errorprone/annotations/CheckReturnValue");
     private static final ClassDescriptor CAN_IGNORE_RETURN_VALUE = DescriptorFactory
             .createClassDescriptor("com/google/errorprone/annotations/CanIgnoreReturnValue");
 
@@ -332,6 +334,9 @@ public class CheckReturnAnnotationDatabase extends AnnotationDatabase<CheckRetur
                     return CheckReturnValueAnnotation.createFor(When.valueOf(pair.getValue().stringifyValue()));
                 }
                 // use default value
+                return CheckReturnValueAnnotation.createFor(When.ALWAYS);
+            }
+            if (type.equals(CHECK_RETURN_NULL_ERRORPRONE.getClassName())) {
                 return CheckReturnValueAnnotation.createFor(When.ALWAYS);
             }
             if (type.equals(CAN_IGNORE_RETURN_VALUE.getClassName())) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/CheckReturnAnnotationDatabase.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/CheckReturnAnnotationDatabase.java
@@ -274,18 +274,17 @@ public class CheckReturnAnnotationDatabase extends AnnotationDatabase<CheckRetur
                 && ("java.lang.StringBuffer".equals(m.getClassName()) || "java.lang.StringBuilder".equals(m.getClassName()))) {
             return CheckReturnValueAnnotation.CHECK_RETURN_VALUE_MEDIUM;
         }
-        if (!AnalysisContext.currentAnalysisContext().isApplicationClass(m.getClassDescriptor())) {
+        CheckReturnValueAnnotation annotationOnMethod = super.getResolvedAnnotation(o, getMinimal);
+        if (annotationOnMethod == null) {
             // https://github.com/spotbugs/spotbugs/issues/429
             // BuildCheckReturnAnnotationDatabase does not visit non-application classes,
             // so we need to check package info dynamically
 
-            CheckReturnValueAnnotation packageDefault = packageInfoCache.computeIfAbsent(m.getPackageName(),
+            CheckReturnValueAnnotation annotationOnPackage = packageInfoCache.computeIfAbsent(m.getPackageName(),
                     this::parsePackage);
-            if (packageDefault != null) {
-                return packageDefault;
-            }
+            return annotationOnPackage;
         }
-        return super.getResolvedAnnotation(o, getMinimal);
+        return annotationOnMethod;
     }
 
     private static final ClassDescriptor CHECK_RETURN_NULL_SPOTBUGS = DescriptorFactory

--- a/spotbugsTestCases/src/fakeAnnotations/com/google/errorprone/annotations/CheckReturnValue.java
+++ b/spotbugsTestCases/src/fakeAnnotations/com/google/errorprone/annotations/CheckReturnValue.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.annotations;
+
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PACKAGE;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that the return value of the annotated method must be checked. An error is triggered
+ * when one of these methods is called but the result is not used.
+ *
+ * <p>{@code @CheckReturnValue} may be applied to a class or package to indicate that all methods in
+ * that class or package must have their return values checked. For convenience, we provide an
+ * annotation, {@link CanIgnoreReturnValue}, to exempt specific methods or classes from this
+ * behavior.
+ */
+@Documented
+@Target({METHOD, CONSTRUCTOR, TYPE, PACKAGE})
+@Retention(RUNTIME)
+public @interface CheckReturnValue {}

--- a/spotbugsTestCases/src/java/ghIssues/Issue582.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue582.java
@@ -1,0 +1,38 @@
+package ghIssues;
+
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.errorprone.annotations.CheckReturnValue;
+/**
+ * @see <a href="https://github.com/spotbugs/spotbugs/issues/582">GitHub issue</a>
+ */
+@CheckReturnValue
+public class Issue582 {
+    private String value;
+
+    String getValue() {
+        return value;
+    }
+
+    @CanIgnoreReturnValue
+    String returnAValue(String newValue) {
+        value = newValue;
+        return newValue;
+    }
+
+    String returnAnotherValue(String newValue) {
+        value = newValue;
+        return newValue;
+    }
+
+    public static String testNoError() {
+        Issue582 i = new Issue582();
+        i.returnAValue("foobar");
+        return i.getValue();
+    }
+
+    public static String testWithError() {
+        Issue582 i = new Issue582();
+        i.returnAnotherValue("foobar");
+        return i.getValue();
+    }
+}

--- a/spotbugsTestCases/src/java/ghIssues/issue463/Issue463.java
+++ b/spotbugsTestCases/src/java/ghIssues/issue463/Issue463.java
@@ -1,13 +1,10 @@
-package ghIssues;
+package ghIssues.issue463;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
-
-import javax.annotation.CheckReturnValue;
 
 /**
  * @see <a href="https://github.com/spotbugs/spotbugs/issues/463">GitHub issue</a>
  */
-@CheckReturnValue
 public class Issue463 {
     private String value;
 

--- a/spotbugsTestCases/src/java/ghIssues/issue463/package-info.java
+++ b/spotbugsTestCases/src/java/ghIssues/issue463/package-info.java
@@ -1,0 +1,3 @@
+@CheckReturnValue
+package ghIssues.issue463;
+import javax.annotation.CheckReturnValue;

--- a/spotbugsTestCases/src/java/ghIssues/issue582/Issue582.java
+++ b/spotbugsTestCases/src/java/ghIssues/issue582/Issue582.java
@@ -1,0 +1,37 @@
+package ghIssues.issue582;
+
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+
+/**
+ * @see <a href="https://github.com/spotbugs/spotbugs/issues/582">GitHub issue</a>
+ */
+public class Issue582 {
+    private String value;
+
+    String getValue() {
+        return value;
+    }
+
+    @CanIgnoreReturnValue
+    String returnAValue(String newValue) {
+        value = newValue;
+        return newValue;
+    }
+
+    String returnAnotherValue(String newValue) {
+        value = newValue;
+        return newValue;
+    }
+
+    public static String testNoError() {
+        Issue582 i = new Issue582();
+        i.returnAValue("foobar");
+        return i.getValue();
+    }
+
+    public static String testWithError() {
+        Issue582 i = new Issue582();
+        i.returnAnotherValue("foobar");
+        return i.getValue();
+    }
+}

--- a/spotbugsTestCases/src/java/ghIssues/issue582/package-info.java
+++ b/spotbugsTestCases/src/java/ghIssues/issue582/package-info.java
@@ -1,0 +1,3 @@
+@CheckReturnValue
+package ghIssues.issue582;
+import com.google.errorprone.annotations.CheckReturnValue;


### PR DESCRIPTION
To fix #582, we need to fix two problems:

* error_prone's `@CheckReturnValue` annotation is not supported (this is feature improvement)
* `CheckReturnAnnotationDatabase` does not handle annotation on `package-info.class` (this is bugfix)
