### PR TITLE
Update ASM to 6.1 to support Java 10 class files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ## Unreleased - 2018-??-??
 
+### Fixed
+
+* Update asm to 6.1.1 to support Java 10
+
 ## 3.1.2 - 2018-02-24
 
 ### Added

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -5,7 +5,7 @@ tasks.withType(Test) {
     }
     doFirst {
       // http://openjdk.java.net/jeps/223
-      if (System.getProperty("java.specification.version") == "9") {
+      if (System.getProperty("java.specification.version") == "9" || System.getProperty("java.specification.version") == "10") {
         jvmArgs = [
           '--add-opens', 'java.base/java.lang=ALL-UNNAMED'
         ]

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -38,12 +38,12 @@ sourceSets {
 }
 
 dependencies {
-  compile 'org.ow2.asm:asm:6.0'
-  compile 'org.ow2.asm:asm-analysis:6.0'
-  compile 'org.ow2.asm:asm-commons:6.0'
-  compile 'org.ow2.asm:asm-tree:6.0'
-  compile 'org.ow2.asm:asm-util:6.0'
-  compile 'org.ow2.asm:asm-xml:6.0'
+  compile 'org.ow2.asm:asm:6.1.1'
+  compile 'org.ow2.asm:asm-analysis:6.1.1'
+  compile 'org.ow2.asm:asm-commons:6.1.1'
+  compile 'org.ow2.asm:asm-tree:6.1.1'
+  compile 'org.ow2.asm:asm-util:6.1.1'
+  compile 'org.ow2.asm:asm-xml:6.1.1'
   compile 'org.apache.bcel:bcel:6.1'
   compile 'net.jcip:jcip-annotations:1.0'
   compile 'org.dom4j:dom4j:2.1.0'

--- a/spotbugs/etc/MANIFEST-findbugs.MF
+++ b/spotbugs/etc/MANIFEST-findbugs.MF
@@ -1,3 +1,3 @@
 Manifest-Version: 1.0
 Main-Class: edu.umd.cs.findbugs.LaunchAppropriateUI
-Class-Path: bcel.jar dom4j-2.1.0.jar jaxen-1.1.6.jar asm-debug-all-6.0-SNAPSHOT.jar jsr305.jar jFormatString.jar commons-lang-2.6.jar
+Class-Path: bcel.jar dom4j-2.1.0.jar jaxen-1.1.6.jar asm-6.1.1.jar asm-analysis-6.1.1.jar asm-commons-6.1.1.jar asm-tree-6.1.1.jar asm-util-6.1.1.jar asm-xml-6.1.1.jar jsr305.jar jFormatString.jar commons-lang-2.6.jar

--- a/spotbugs/etc/MANIFEST-findbugsGUI.MF
+++ b/spotbugs/etc/MANIFEST-findbugsGUI.MF
@@ -1,3 +1,3 @@
 Manifest-Version: 1.0
 Main-Class: edu.umd.cs.findbugs.LaunchAppropriateUI
-Class-Path: bcel.jar dom4j-2.1.0.jar jaxen-1.1.6.jar asm-debug-all-6.0-SNAPSHOT.jar jsr305.jar jFormatString.jar commons-lang-2.6.jar plastic.jar
+Class-Path: bcel.jar dom4j-2.1.0.jar jaxen-1.1.6.jar asm-6.1.1.jar asm-analysis-6.1.1.jar asm-commons-6.1.1.jar asm-tree-6.1.1.jar asm-util-6.1.1.jar asm-xml-6.1.1.jar jsr305.jar jFormatString.jar commons-lang-2.6.jar plastic.jar

--- a/spotbugs/jnlp/findbugs.jnlp
+++ b/spotbugs/jnlp/findbugs.jnlp
@@ -1,29 +1,32 @@
-<?xml version="1.0" encoding="utf-8"?> 
-<jnlp 
-  spec="1.0+" 
-  codebase="http://findbugs.cs.umd.edu/demo/jnlp" 
+<?xml version="1.0" encoding="utf-8"?>
+<jnlp
+  spec="1.0+"
+  codebase="http://findbugs.cs.umd.edu/demo/jnlp"
   href="findbugs.jnlp">
-  <information> 
+  <information>
     <title>FindBugs</title>
-    <vendor>University of Maryland</vendor> 
-    <homepage href="http://findbugs.sourceforge.net"/> 
-    <description>Findbugs: Static Bug Finder</description> 
-    <description kind="short">Static analysis tool for defect detection</description> 
-    <icon href="buggy-sm.png"/> 
-    <offline-allowed/> 
-  </information> 
-  <security> 
-      <all-permissions/> 
-  </security> 
-  <resources> 
+    <vendor>University of Maryland</vendor>
+    <homepage href="http://findbugs.sourceforge.net"/>
+    <description>Findbugs: Static Bug Finder</description>
+    <description kind="short">Static analysis tool for defect detection</description>
+    <icon href="buggy-sm.png"/>
+    <offline-allowed/>
+  </information>
+  <security>
+      <all-permissions/>
+  </security>
+  <resources>
     <j2se version="1.5+" initial-heap-size="300m" max-heap-size="600m"/>
     <jar href="findbugs.jar"/>
     <jar href="AppleJavaExtensions.jar"/>
     <jar href="bcel.jar"/>
     <jar href="dom4j-2.1.0.jar"/>
-    <jar href="asm-3.3.jar"/>
-    <jar href="asm-tree-3.3.jar"/>
-    <jar href="asm-commons-3.3.jar"/>
+    <jar href="asm-6.1.1.jar"/>
+    <jar href="asm-analysis-6.1.1.jar"/>
+    <jar href="asm-commons-6.1.1.jar"/>
+    <jar href="asm-tree-6.1.1.jar"/>
+    <jar href="asm-util-6.1.1.jar"/>
+    <jar href="asm-xml-6.1.1.jar"/>
     <jar href="jaxen-1.1.6.jar"/>
     <jar href="jFormatString.jar"/>
     <jar href="commons-lang-2.6.jar"/>
@@ -31,7 +34,6 @@
     <property name="findbugs.jaws" value="true"/>
     <property name="findbugs.noSummary" value="true"/>
     <property name="apple.laf.useScreenMenuBar" value="true"/>
-  </resources> 
-  <application-desc main-class="edu.umd.cs.findbugs.gui2.Driver"/> 
-</jnlp> 
-
+  </resources>
+  <application-desc main-class="edu.umd.cs.findbugs.gui2.Driver"/>
+</jnlp>

--- a/spotbugs/src/sampleXml/analysisResultsWithFilterAndUserAnnotations.xml
+++ b/spotbugs/src/sampleXml/analysisResultsWithFilterAndUserAnnotations.xml
@@ -10,9 +10,12 @@
     <AuxClasspathEntry>/Users/pugh/Documents/fb-trunk/findbugs/lib/dom4j-2.1.0.jar</AuxClasspathEntry>
     <AuxClasspathEntry>/Users/pugh/Documents/fb-trunk/findbugs/lib/AppleJavaExtensions.jar</AuxClasspathEntry>
     <AuxClasspathEntry>/Users/pugh/Documents/fb-trunk/findbugs/lib/junit.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/Users/pugh/Documents/fb-trunk/findbugs/lib/asm-3.3.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/Users/pugh/Documents/fb-trunk/findbugs/lib/asm-commons-3.3.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/Users/pugh/Documents/fb-trunk/findbugs/lib/asm-tree-3.3.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/pugh/Documents/fb-trunk/findbugs/lib/asm-6.1.1.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/pugh/Documents/fb-trunk/findbugs/lib/asm-analysis-6.1.1.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/pugh/Documents/fb-trunk/findbugs/lib/asm-commons-6.1.1.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/pugh/Documents/fb-trunk/findbugs/lib/asm-tree-6.1.1.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/pugh/Documents/fb-trunk/findbugs/lib/asm-util-6.1.1.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/pugh/Documents/fb-trunk/findbugs/lib/asm-xml-6.1.1.jar</AuxClasspathEntry>
     <AuxClasspathEntry>/Users/pugh/Documents/fb-trunk/findbugs/lib/jaxen-1.1.6.jar</AuxClasspathEntry>
     <AuxClasspathEntry>/Users/pugh/Documents/fb-trunk/findbugs/lib/jsr305.jar</AuxClasspathEntry>
     <AuxClasspathEntry>/Users/pugh/Documents/fb-trunk/findbugs/lib/jFormatString.jar</AuxClasspathEntry>


### PR DESCRIPTION
Related to https://github.com/spotbugs/spotbugs/issues/593

Release Notes for ASM: http://asm.ow2.org/history.html

Significant update 
  - new V10 constant for Java 10 class files

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [ X] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
