### PR TITLE
Add test case for Issue 500

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue500Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue500Test.java
@@ -1,0 +1,27 @@
+package edu.umd.cs.findbugs.detect;
+
+import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeThat;
+
+import org.junit.Test;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
+
+/**
+ * @see <a href="https://github.com/spotbugs/spotbugs/issues/500">GitHub issue</a>
+ * @since 3.1
+ */
+public class Issue500Test extends AbstractIntegrationTest {
+  @Test
+  public void test() {
+    assumeThat(System.getProperty("java.specification.version"), is("9"));
+
+    performAnalysis("../java9/Issue500.class");
+    final BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder().build();
+    assertThat(getBugCollection(), containsExactly(0, bugTypeMatcher));
+  }
+}

--- a/spotbugsTestCases/src/java9/Issue500.java
+++ b/spotbugsTestCases/src/java9/Issue500.java
@@ -1,0 +1,19 @@
+import java.util.Map;
+
+class Issue500 {
+  String literalOK(Map<String, String> map) {
+    return map.get("const");
+  }
+
+  String refOK(Map<String, String> map, String key) {
+    return map.get(key);
+  }
+
+  String stringBuilderOK(Map<String, String> map, String key) {
+    return map.get(new StringBuilder(key).append("const").toString());
+  }
+
+  String nonConstConcatFails(Map<String, String> map, String key) {
+    return map.get(key + "const");
+  }
+}


### PR DESCRIPTION
I started to look into https://github.com/spotbugs/spotbugs/issues/500 but I can't figure out where in the TypeAnalysis the new `InvokeDynamic #0:makeConcatWithConstants` opcode should be adding the String to the Stack.  At least that's what I think is broken.

Here is the explanation about what was changed in Java 9 http://openjdk.java.net/jeps/280

This errror has come up about a dozen times in our code so far and the StringBuilder workaround is awkward.

@KengoTODA do you have time to look at this?  
----

Make sure these boxes are checked before submitting your PR -- thank you!

- [ ] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
