### PR TITLE
BUG-605:  Ignore unit test on windows

### DIFF
--- a/spotbugs/src/test/java/edu/umd/cs/findbugs/classfile/impl/ClassFactoryTest.java
+++ b/spotbugs/src/test/java/edu/umd/cs/findbugs/classfile/impl/ClassFactoryTest.java
@@ -22,6 +22,7 @@ package edu.umd.cs.findbugs.classfile.impl;
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assume.assumeFalse;
 
 import edu.umd.cs.findbugs.classfile.Global;
 import edu.umd.cs.findbugs.classfile.IScannableCodeBase;
@@ -59,6 +60,7 @@ public class ClassFactoryTest {
         File file = createZipFile();
         file.deleteOnExit();
         file.setReadable(false);
+        assumeFalse("File cannot be marked as unreadable, skipping test.", file.canRead());
         FilesystemCodeBaseLocator locator = buildLocator(file);
         assertHasNoCodeBase(ClassFactory.createFilesystemCodeBase(locator));
     }


### PR DESCRIPTION
Ignore unit test if the required file permissions can not be set.  Changing
file permissions will likely work on *nix systems and fail on windows
systems.



----

Make sure these boxes are checked before submitting your PR -- thank you!

- [ ] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
