### PR TITLE
Release 3.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased - 2018-??-??
+## 3.1.3 - 2018-04-18
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased - 2018-??-??
+
 ## 3.1.3 - 2018-04-18
 
 ### Added

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
   id 'org.sonarqube' version '2.5'
 }
 
-version = '3.1.3'
+version = '3.1.4-SNAPSHOT'
 
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/jacoco.gradle"

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
   id 'org.sonarqube' version '2.5'
 }
 
-version = '3.1.3-SNAPSHOT'
+version = '3.1.3'
 
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/jacoco.gradle"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,8 +17,8 @@ import os
 
 html_context = {
   'version' : '3.1',
-  'full_version' : '3.1.2',
-  'maven_plugin_version' : '3.1.1',
+  'full_version' : '3.1.3',
+  'maven_plugin_version' : '3.1.3',
   'gradle_plugin_version' : '1.6.1'
 }
 


### PR DESCRIPTION
After we merge these commits, we do:

1. Tag 2bb1d9b as `3.1.3` or its rebased commit then Travis CI will release 3.1.3 to Sonatype Staging Nexus.
2. Use Sonatype Nexus to release staging artifacts to Maven Central.
3. Make sure that Eclipse Update Site is successfully updated.