### PR TITLE
upload eclipsePlugin.zip to GitHub release page by Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,6 +90,13 @@ deploy:
       tags: true
       jdk: oraclejdk8
       condition: "$TRAVIS_TAG != *'_RC'*"
+  - provider: releases
+    api_key: $GITHUB_TOKEN
+    file: "eclipsePlugin/build/distributions/eclipsePlugin.zip"
+    skip_cleanup: true
+    on:
+      tags: true
+      jdk: oraclejdk8
   - provider: script
     skip_cleanup: true
     script: ./gradlew uploadArchives -PossrhUsername="$SONATYPE_USERNAME" -PossrhPassword="$SONATYPE_PASSWORD"

--- a/eclipsePlugin/build.gradle
+++ b/eclipsePlugin/build.gradle
@@ -400,9 +400,10 @@ task eclipseSite() {
   dependsOn generateP2Metadata, generateCandidateP2Metadata, generateP2MetadataDaily
 }
 
+// create zip file to upload to GitHub release page
 task eclipseSiteZip(type:Zip, dependsOn:eclipseSite) {
-  from("${buildDir}/site")
-  archiveName = "${eclipsePluginId}_site_${project.version}.zip"
+  from("${buildDir}/site/eclipse")
+  archiveName = "eclipsePlugin.zip"
 }
 
-tasks['assemble'].dependsOn eclipseSite
+tasks['assemble'].dependsOn eclipseSite, eclipseSiteZip


### PR DESCRIPTION
This change lets Travis CI uploads Eclipse Plugin zip file to GitHub Releases page like:

* https://github.com/spotbugs/spotbugs/releases/tag/3.1.3 (this is edited by manually, though)