### PR TITLE
Fix 603: inconsistent report for EI_EXPOSE_REP2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ## Unreleased - 2018-??-??
 
+### Fixed
+
+* Inconsistent reporting for EI_EXPOSE_REP2 ([#603](https://github.com/spotbugs/spotbugs/issues/603))
+
 ## 3.1.3 - 2018-04-18
 
 ### Added

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue603Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue603Test.java
@@ -1,0 +1,42 @@
+/*
+ * Contributions to SpotBugs
+ * Copyright (C) 2018, kengo
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+package edu.umd.cs.findbugs.detect;
+
+import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
+
+/**
+ * @see <a href="https://github.com/spotbugs/spotbugs/issues/603">GitHub issue</a>
+ */
+public class Issue603Test extends AbstractIntegrationTest {
+    @Test
+    public void test() {
+        performAnalysis("ghIssues/Issue603.class");
+        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
+                .bugType("EI_EXPOSE_REP2")
+                .build();
+        assertThat(getBugCollection(), containsExactly(3, bugTypeMatcher));
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/OpcodeStack.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/OpcodeStack.java
@@ -2747,6 +2747,18 @@ public class OpcodeStack implements Constants2 {
             push(i);
         }
 
+        if (seen == Const.INVOKESTATIC && topItem != null && topItem.isInitialParameter()
+                && isMethodThatReturnsGivenReference(clsName, methodName)) {
+            assert getStackDepth() > 0;
+            assert !getStackItem(0).isInitialParameter();
+            // keep returned StackItem as initial parameter
+            getStackItem(0).setInitialParameter(true);
+        }
+    }
+
+    private boolean isMethodThatReturnsGivenReference(String clsName, String methodName) {
+        return "java/util/Objects".equals(clsName) && "requireNonNull".equals(methodName)
+                || "com/google/common/base/Preconditions".equals(clsName) && "checkNotNull".equals(methodName);
     }
 
     private void processInvokeDynamic(DismantleBytecode dbc) {

--- a/spotbugsTestCases/src/java/ghIssues/Issue603.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue603.java
@@ -1,0 +1,25 @@
+package ghIssues;
+
+import java.util.Objects;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * @see <a href="https://github.com/spotbugs/spotbugs/issues/603">GitHub issue</a>
+ */
+public class Issue603 {
+    @SuppressWarnings("unused")
+    private byte[] bytes;
+
+    public void setBytes(byte[] bytes) {
+        this.bytes = bytes;
+    }
+
+    public void setBytesAfterCheck(byte[] bytes) {
+        this.bytes = Objects.requireNonNull(bytes);
+    }
+
+    public void setBytesAfterCheckWithGuava(byte[] bytes) {
+        this.bytes = Preconditions.checkNotNull(bytes);
+    }
+}


### PR DESCRIPTION
This change fixes reported issue #603. Currently it supports `Objects.requireNonnull()` and `Preconditions.checkNotNull()`.