### PR TITLE
Remove codes using deprecated BCEL's Constants

### DIFF
--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/Lookup.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/Lookup.java
@@ -35,9 +35,8 @@ import edu.umd.cs.findbugs.classfile.Global;
 import edu.umd.cs.findbugs.classfile.MissingClassException;
 import edu.umd.cs.findbugs.internalAnnotations.DottedClassName;
 import edu.umd.cs.findbugs.internalAnnotations.SlashedClassName;
-import edu.umd.cs.findbugs.visitclass.Constants2;
 
-public class Lookup implements Constants2 {
+public class Lookup {
 
     /*
     private static Subtypes2 subtypes2() {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/OpcodeStack.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/OpcodeStack.java
@@ -79,7 +79,6 @@ import edu.umd.cs.findbugs.internalAnnotations.SlashedClassName;
 import edu.umd.cs.findbugs.internalAnnotations.StaticConstant;
 import edu.umd.cs.findbugs.util.ClassName;
 import edu.umd.cs.findbugs.util.Util;
-import edu.umd.cs.findbugs.visitclass.Constants2;
 import edu.umd.cs.findbugs.visitclass.DismantleBytecode;
 import edu.umd.cs.findbugs.visitclass.LVTHelper;
 import edu.umd.cs.findbugs.visitclass.PreorderVisitor;
@@ -103,7 +102,7 @@ import edu.umd.cs.findbugs.visitclass.PreorderVisitor;
  * <li>wide</li>
  * </ul>
  */
-public class OpcodeStack implements Constants2 {
+public class OpcodeStack {
 
     /** You can put this annotation on a OpcodeStack detector
      * to indicate that it uses {@link OpcodeStack.Item#userValue},

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/AssertionMethods.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/AssertionMethods.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.StringTokenizer;
 
 import org.apache.bcel.Const;
-import org.apache.bcel.Constants;
 import org.apache.bcel.classfile.ClassFormatException;
 import org.apache.bcel.classfile.Constant;
 import org.apache.bcel.classfile.ConstantMethodref;
@@ -49,7 +48,7 @@ import edu.umd.cs.findbugs.SystemProperties;
  *
  * @author David Hovemeyer
  */
-public class AssertionMethods implements Constants {
+public class AssertionMethods {
 
     private static final boolean DEBUG = SystemProperties.getBoolean("assertionmethods.debug");
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/AssignedFieldMap.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/AssignedFieldMap.java
@@ -19,9 +19,7 @@
 
 package edu.umd.cs.findbugs.ba;
 
-import org.apache.bcel.Constants;
-
-public class AssignedFieldMap implements Constants {
+public class AssignedFieldMap {
     /*
      * private final Map<Method, Set<XField>> assignedFieldSetForMethodMap;
      * private final JavaClass myClass;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/bcp/FieldAccess.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/bcp/FieldAccess.java
@@ -36,7 +36,7 @@ import edu.umd.cs.findbugs.ba.vna.ValueNumberFrame;
  * @see Load
  * @see Store
  */
-public abstract class FieldAccess extends SingleInstruction implements org.apache.bcel.Constants {
+public abstract class FieldAccess extends SingleInstruction {
     private final String fieldVarName;
 
     private final String valueVarName;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/type/ExceptionObjectType.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/type/ExceptionObjectType.java
@@ -20,7 +20,6 @@
 package edu.umd.cs.findbugs.ba.type;
 
 import org.apache.bcel.Const;
-import org.apache.bcel.Constants;
 import org.apache.bcel.generic.ObjectType;
 import org.apache.bcel.generic.Type;
 
@@ -29,7 +28,7 @@ import org.apache.bcel.generic.Type;
  * track of the entire set of exceptions that can be caught, and whether they
  * are explicit or implicit.
  */
-public class ExceptionObjectType extends ObjectType implements Constants, ExtendedTypes {
+public class ExceptionObjectType extends ObjectType implements ExtendedTypes {
     /**
      *
      */

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/type/TypeFrameModelingVisitor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/type/TypeFrameModelingVisitor.java
@@ -31,7 +31,6 @@ import java.util.regex.Pattern;
 import javax.annotation.CheckForNull;
 
 import org.apache.bcel.Const;
-import org.apache.bcel.Constants;
 import org.apache.bcel.classfile.LocalVariable;
 import org.apache.bcel.classfile.LocalVariableTypeTable;
 import org.apache.bcel.generic.*;
@@ -73,7 +72,7 @@ import edu.umd.cs.findbugs.util.Util;
  * @see TypeFrame
  * @see TypeAnalysis
  */
-public class TypeFrameModelingVisitor extends AbstractFrameModelingVisitor<Type, TypeFrame> implements Constants, Debug {
+public class TypeFrameModelingVisitor extends AbstractFrameModelingVisitor<Type, TypeFrame> implements Debug {
 
     private ValueNumberDataflow valueNumberDataflow;
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/visitclass/PreorderVisitor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/visitclass/PreorderVisitor.java
@@ -95,7 +95,7 @@ import edu.umd.cs.findbugs.internalAnnotations.SlashedClassName;
  * @author <A HREF="http://www.inf.fu-berlin.de/~dahm">M. Dahm</A>
  * @version 970819
  */
-public class PreorderVisitor extends BetterVisitor implements Constants2 {
+public class PreorderVisitor extends BetterVisitor {
 
     // Available when visiting a class
     private ConstantPool constantPool;

--- a/spotbugs/src/tools/edu/umd/cs/findbugs/tools/FilterAndCombineBitfieldPropertyDatabase.java
+++ b/spotbugs/src/tools/edu/umd/cs/findbugs/tools/FilterAndCombineBitfieldPropertyDatabase.java
@@ -14,8 +14,6 @@ import java.util.regex.Pattern;
 
 import javax.annotation.WillClose;
 
-import org.apache.bcel.Constants;
-
 import edu.umd.cs.findbugs.internalAnnotations.DottedClassName;
 import edu.umd.cs.findbugs.util.Util;
 

--- a/spotbugs/src/tools/edu/umd/cs/findbugs/tools/FilterPropertyDatabase.java
+++ b/spotbugs/src/tools/edu/umd/cs/findbugs/tools/FilterPropertyDatabase.java
@@ -10,8 +10,6 @@ import java.util.regex.Pattern;
 
 import javax.annotation.WillClose;
 
-import org.apache.bcel.Constants;
-
 import edu.umd.cs.findbugs.tools.FilterAndCombineBitfieldPropertyDatabase.Status;
 import edu.umd.cs.findbugs.util.Util;
 


### PR DESCRIPTION

* `org.apache.bcel.Constants` is deprecated. so, I rewrite to codes which do not uses that. 
* `edu.umd.cs.findbugs.visitclass.Constants2` only implements `org.apache.bcel.Constants`.
  so, I rewrite to codes which do not uses `edu.umd.cs.findbugs.visitclass.Constants2`.
  but, I dont know why spotbugs have `edu.umd.cs.findbugs.visitclass.Constants2`...
 `edu.umd.cs.findbugs.visitclass.Constants2` is able to be removed?
 
----

Make sure these boxes are checked before submitting your PR -- thank you!

- [ ] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
