### PR TITLE
can ignore check not null return value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 * Close source file after analysis ([#591](https://github.com/spotbugs/spotbugs/issues/591))
 * Inconsistent reporting for EI_EXPOSE_REP2 ([#603](https://github.com/spotbugs/spotbugs/issues/603))
 * Update asm to 6.2 for better Java 11 support ([#648](https://github.com/spotbugs/spotbugs/issues/648))
+* False positive: 'return value ignored' on Guavas Preconditions.checkNotNull() ([#578](https://github.com/spotbugs/spotbugs/issues/578))
 
 ## 3.1.3 - 2018-04-18
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/PreconditionsCheckNotNullCanIgnoreReturnValueTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/PreconditionsCheckNotNullCanIgnoreReturnValueTest.java
@@ -1,0 +1,36 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.BugCollection;
+import edu.umd.cs.findbugs.test.SpotBugsRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.nio.file.Paths;
+
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.collection.IsEmptyIterable.emptyIterable;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeThat;
+
+public class PreconditionsCheckNotNullCanIgnoreReturnValueTest {
+    @Rule
+    public SpotBugsRule spotbugs = new SpotBugsRule();
+
+    @Before
+    public void setUp() {
+        String property = System.getProperty("AUX_CLASSPATH");
+        assumeThat(property, notNullValue());
+        for (String path : property.split(",")) {
+            spotbugs.addAuxClasspathEntry(Paths.get(path));
+        }
+    }
+
+    @Test
+    public void testDoNotWarnOnCanIgnoreReturnValue() {
+        BugCollection bugCollection = spotbugs.performAnalysis(Paths.get("../spotbugsTestCases/build/classes/java/main/bugPatterns/RV_RETURN_VALUE_IGNORED_Guava_Preconditions.class"));
+        assertThat(bugCollection, is(emptyIterable()));
+    }
+
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/CheckReturnAnnotationDatabase.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/CheckReturnAnnotationDatabase.java
@@ -202,6 +202,9 @@ public class CheckReturnAnnotationDatabase extends AnnotationDatabase<CheckRetur
         addMethodAnnotation("java.lang.ProcessBuilder", "redirectErrorStream", "()Z", false,
                 CheckReturnValueAnnotation.CHECK_RETURN_VALUE_MEDIUM);
 
+        addMethodAnnotation("com.google.common.base.Preconditions", "checkNotNull", "(Ljava/lang/Object;)Ljava/lang/Object;", true,
+                CheckReturnValueAnnotation.CHECK_RETURN_VALUE_IGNORE);
+
         addDefaultMethodAnnotation("jsr166z.forkjoin.ParallelArray", CheckReturnValueAnnotation.CHECK_RETURN_VALUE_MEDIUM);
         addDefaultMethodAnnotation("jsr166z.forkjoin.ParallelLongArray", CheckReturnValueAnnotation.CHECK_RETURN_VALUE_MEDIUM);
         addDefaultMethodAnnotation("jsr166z.forkjoin.ParallelDoubleArray", CheckReturnValueAnnotation.CHECK_RETURN_VALUE_MEDIUM);

--- a/spotbugsTestCases/src/java/bugPatterns/RV_RETURN_VALUE_IGNORED_Guava_Preconditions.java
+++ b/spotbugsTestCases/src/java/bugPatterns/RV_RETURN_VALUE_IGNORED_Guava_Preconditions.java
@@ -1,0 +1,10 @@
+package bugPatterns;
+
+import com.google.common.base.Preconditions;
+
+public class RV_RETURN_VALUE_IGNORED_Guava_Preconditions {
+    public int method(String param) {
+        Preconditions.checkNotNull(param);
+        return param.length();
+    }
+}


### PR DESCRIPTION
This PR is based on #579 made by @ewirch. I created a new branch in this repository, because I cannot push my code to his repository.

This fix treats `Preconditions.checkNotNull` as `CHECK_RETURN_VALUE_IGNORE` so SpotBugs will not alert even when code ignores returned value from it.