### PR TITLE
Remove unnecessary implements BCEL's Constants 2

### DIFF
--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/BytecodeScanner.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/BytecodeScanner.java
@@ -29,7 +29,7 @@ import edu.umd.cs.findbugs.SystemProperties;
  *
  * @author David Hovemeyer
  */
-public class BytecodeScanner implements org.apache.bcel.Constants {
+public class BytecodeScanner {
     private static final boolean DEBUG = SystemProperties.getBoolean("bs.debug");
 
     /**

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/type/StandardTypeMerger.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/type/StandardTypeMerger.java
@@ -43,7 +43,7 @@ import edu.umd.cs.findbugs.ba.generic.GenericUtilities;
  * @author David Hovemeyer
  * @see TypeMerger
  */
-public class StandardTypeMerger implements TypeMerger, Constants, ExtendedTypes {
+public class StandardTypeMerger implements TypeMerger, ExtendedTypes {
     private final RepositoryLookupFailureCallback lookupFailureCallback;
 
     private final ExceptionSetFactory exceptionSetFactory;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/type/StandardTypeMerger.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/type/StandardTypeMerger.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.bcel.Const;
-import org.apache.bcel.Constants;
 import org.apache.bcel.generic.ObjectType;
 import org.apache.bcel.generic.ReferenceType;
 import org.apache.bcel.generic.Type;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/visitclass/Constants2.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/visitclass/Constants2.java
@@ -19,7 +19,7 @@
 
 package edu.umd.cs.findbugs.visitclass;
 
-public interface Constants2 extends org.apache.bcel.Constants {
+public interface Constants2 {
 
     // Nothing defined here for now
 


### PR DESCRIPTION
## 

Related: #652 

* Remove unused `org.apache.bcel.Constants` imports 
* Remove unnecessary implementations `org.apache.bcel.Constants`
