### PR TITLE
Keep IO.close(Closeable) that was deleted by 3.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ## Unreleased - 2018-??-??
 
-## 3.1.4 - 2018-06-11
+### Fixed
+
+* Keep IO.close(Closeable) that was deleted by 3.1.4 ([#661](https://github.com/spotbugs/spotbugs/issues/661))
+
+## 3.1.4 - 2018-06-11 [YANKED]
 
 ### Fixed
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/io/IO.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/io/IO.java
@@ -188,15 +188,7 @@ public class IO {
      *
      */
     public static void close(@CheckForNull Closeable c) {
-        if (c == null) {
-            return;
-        }
-
-        try {
-            c.close();
-        } catch (Exception e) {
-            // Ignore
-        }
+        close((AutoCloseable) c);
     }
 
     /**

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/io/IO.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/io/IO.java
@@ -35,6 +35,7 @@ package edu.umd.cs.findbugs.io;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -167,10 +168,26 @@ public class IO {
     }
 
     /**
-     * Close given InputStream, ignoring any resulting exception.
+     * Close given AutoCloseable instance, ignoring any resulting exception.
      *
      */
     public static void close(@CheckForNull AutoCloseable c) {
+        if (c == null) {
+            return;
+        }
+
+        try {
+            c.close();
+        } catch (Exception e) {
+            // Ignore
+        }
+    }
+
+    /**
+     * Close given Closeable instance, ignoring any resulting exception.
+     *
+     */
+    public static void close(@CheckForNull Closeable c) {
         if (c == null) {
             return;
         }


### PR DESCRIPTION
This PR fixes #661, that makes 3.1.3 non backward compatible.
