### PR TITLE
release v3.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased - 2018-??-??
+## 3.1.5 - 2018-06-15
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased - 2018-??-??
+
 ## 3.1.5 - 2018-06-15
 
 ### Fixed

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
   id 'org.sonarqube' version '2.5'
 }
 
-version = '3.1.5'
+version = '3.1.6-SNAPSHOT'
 
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/jacoco.gradle"

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
   id 'org.sonarqube' version '2.5'
 }
 
-version = '3.1.5-SNAPSHOT'
+version = '3.1.5'
 
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/jacoco.gradle"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,7 @@ import os
 
 html_context = {
   'version' : '3.1',
-  'full_version' : '3.1.4',
+  'full_version' : '3.1.5',
   'maven_plugin_version' : '3.1.3.1',
   'gradle_plugin_version' : '1.6.2'
 }


### PR DESCRIPTION
After we merge these commits, we do:

1. Tag 2fccadc as `3.1.5` or its rebased commit then Travis CI will release 3.1.5 to Sonatype Staging Nexus.
2. Use Sonatype Nexus to release staging artifacts to Maven Central.
3. Make sure that Eclipse Update Site is successfully updated, and Eclipse plugin is successfully uploaded to release page.