### PR TITLE
Improve deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,6 +103,14 @@ deploy:
     # https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received
     script: travis_wait ./gradlew uploadArchives -PossrhUsername="$SONATYPE_USERNAME" -PossrhPassword="$SONATYPE_PASSWORD"
     on:
+      branch: release-3.1
+      jdk: oraclejdk8
+  - provider: script
+    skip_cleanup: true
+    # wait until uploading task finishes, because it may cost more than 10 minutes without any output
+    # https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received
+    script: travis_wait ./gradlew uploadArchives -PossrhUsername="$SONATYPE_USERNAME" -PossrhPassword="$SONATYPE_PASSWORD"
+    on:
       branch: master
       jdk: oraclejdk8
   - provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,13 +99,17 @@ deploy:
       jdk: oraclejdk8
   - provider: script
     skip_cleanup: true
-    script: ./gradlew uploadArchives -PossrhUsername="$SONATYPE_USERNAME" -PossrhPassword="$SONATYPE_PASSWORD"
+    # wait until uploading task finishes, because it may cost more than 10 minutes without any output
+    # https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received
+    script: travis_wait ./gradlew uploadArchives -PossrhUsername="$SONATYPE_USERNAME" -PossrhPassword="$SONATYPE_PASSWORD"
     on:
       branch: master
       jdk: oraclejdk8
   - provider: script
     skip_cleanup: true
-    script: ./gradlew uploadArchives -PossrhUsername="$SONATYPE_USERNAME" -PossrhPassword="$SONATYPE_PASSWORD" -Psigning.keyId="$SIGNING_KEY_ID" -Psigning.password="$SIGNING_PASSWORD" -Psigning.secretKeyRingFile="$TRAVIS_BUILD_DIR/secring.gpg"
+    # wait until uploading task finishes, because it may cost more than 10 minutes without any output
+    # https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received
+    script: travis_wait ./gradlew uploadArchives -PossrhUsername="$SONATYPE_USERNAME" -PossrhPassword="$SONATYPE_PASSWORD" -Psigning.keyId="$SIGNING_KEY_ID" -Psigning.password="$SIGNING_PASSWORD" -Psigning.secretKeyRingFile="$TRAVIS_BUILD_DIR/secring.gpg"
     on:
       tags: true
       jdk: oraclejdk8


### PR DESCRIPTION
Automatic deployment at Travis CI could be failed if `spotbugs:uploadArtifact` spends more than 10 minutes, due to limitation of Travis CI. To avoid this, we need to use `travis_wait` script.

And currently SNAPSHOT version from release-3.1 isn't deployed to Sonatype SNAPSHOT repository, it's better to deploy.

* https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received