### PR TITLE
Avoid NPE in AnalysisRunner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ## Unreleased - 2018-??-??
 
+### Fixed
+
+* Potential NPE in test-harness-core ([#671](https://github.com/spotbugs/spotbugs/issues/671))
+
 ## 3.1.5 - 2018-06-15
 
 ### Fixed

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/AbstractBugReporter.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/AbstractBugReporter.java
@@ -22,7 +22,6 @@ package edu.umd.cs.findbugs;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
@@ -35,6 +34,7 @@ import javax.annotation.WillClose;
 
 import org.dom4j.DocumentException;
 
+import edu.umd.cs.findbugs.annotations.Nullable;
 import edu.umd.cs.findbugs.ba.AnalysisContext;
 import edu.umd.cs.findbugs.ba.ClassNotFoundExceptionParser;
 import edu.umd.cs.findbugs.ba.MethodUnprofitableException;
@@ -57,13 +57,14 @@ public abstract class AbstractBugReporter implements BugReporter {
 
         private final String message;
 
+        @Nullable
         private final Throwable cause;
 
         public Error(int sequence, String message) {
             this(sequence, message, null);
         }
 
-        public Error(int sequence, String message, Throwable cause) {
+        public Error(int sequence, String message, @Nullable Throwable cause) {
             this.sequence = sequence;
             this.message = message;
             this.cause = cause;
@@ -77,6 +78,7 @@ public abstract class AbstractBugReporter implements BugReporter {
             return message;
         }
 
+        @CheckForNull
         public Throwable getCause() {
             return cause;
         }

--- a/test-harness-core/src/main/java/edu/umd/cs/findbugs/test/AnalysisRunner.java
+++ b/test-harness-core/src/main/java/edu/umd/cs/findbugs/test/AnalysisRunner.java
@@ -108,10 +108,9 @@ public class AnalysisRunner {
                 throw new AssertionError("Analysis failed with exception", e);
             }
             if (!bugReporter.getQueuedErrors().isEmpty()) {
-                AssertionError assertionError = new AssertionError(
-                        "Analysis failed with exception. Check stderr for detail.");
                 bugReporter.reportQueuedErrors();
-                throw assertionError;
+                throw new AssertionError(
+                        "Analysis failed with exception. Check stderr for detail.");
             }
             return bugReporter;
         }

--- a/test-harness-core/src/main/java/edu/umd/cs/findbugs/test/AnalysisRunner.java
+++ b/test-harness-core/src/main/java/edu/umd/cs/findbugs/test/AnalysisRunner.java
@@ -110,8 +110,7 @@ public class AnalysisRunner {
             if (!bugReporter.getQueuedErrors().isEmpty()) {
                 AssertionError assertionError = new AssertionError(
                         "Analysis failed with exception. Check stderr for detail.");
-                bugReporter.getQueuedErrors().stream().map(error -> error.getCause())
-                        .forEach(assertionError::addSuppressed);
+                bugReporter.reportQueuedErrors();
                 throw assertionError;
             }
             return bugReporter;


### PR DESCRIPTION
The `cause` field in `AbstractBugReporter.Error` is nullable, so we cannot use suppressed error that makes log readable. Instead, use `reportQueuedErrors()` method that supports `AbstractBugReporter.Error` without `cause`.