### PR TITLE
Adding ElementType.TYPE_USE to Spotbugs Null-Annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ## Unreleased - 2018-??-??
 
+### Added
+
+* Adding ElementType.TYPE_USE to Spotbugs Null-Annotations ([#470](https://github.com/spotbugs/spotbugs/issues/470))
+
 ## 3.1.5 - 2018-06-15
 
 ### Fixed

--- a/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/CheckForNull.java
+++ b/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/CheckForNull.java
@@ -35,7 +35,7 @@ import javax.annotation.meta.When;
  * value.
  **/
 @Documented
-@Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE })
+@Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.TYPE_USE })
 @Retention(RetentionPolicy.CLASS)
 @javax.annotation.Nonnull(when = When.MAYBE)
 @TypeQualifierNickname

--- a/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/NonNull.java
+++ b/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/NonNull.java
@@ -34,7 +34,7 @@ import javax.annotation.meta.When;
  * Annotated methods must have non-null return values.
  **/
 @Documented
-@Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE })
+@Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.TYPE_USE })
 @Retention(RetentionPolicy.CLASS)
 @javax.annotation.Nonnull(when = When.ALWAYS)
 @TypeQualifierNickname

--- a/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/Nullable.java
+++ b/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/Nullable.java
@@ -38,7 +38,7 @@ import javax.annotation.meta.When;
  * value.
  **/
 @Documented
-@Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE })
+@Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.TYPE_USE })
 @Retention(RetentionPolicy.CLASS)
 @javax.annotation.Nonnull(when = When.UNKNOWN)
 @TypeQualifierNickname

--- a/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/PossiblyNull.java
+++ b/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/PossiblyNull.java
@@ -39,7 +39,7 @@ import javax.annotation.meta.When;
  *             coding practice requires that the value be checked for null.
  **/
 @Documented
-@Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE })
+@Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.TYPE_USE })
 @Retention(RetentionPolicy.CLASS)
 @javax.annotation.Nonnull(when = When.MAYBE)
 @TypeQualifierNickname

--- a/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/UnknownNullness.java
+++ b/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/UnknownNullness.java
@@ -32,7 +32,7 @@ import javax.annotation.meta.When;
  * unknown ways in subclasses.
  **/
 @Documented
-@Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE })
+@Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.TYPE_USE })
 @Retention(RetentionPolicy.CLASS)
 @javax.annotation.Nonnull(when = When.UNKNOWN)
 @TypeQualifierNickname


### PR DESCRIPTION
Adding ElementType.TYPE_USE to Spotbugs Null-Annotations. This allows to place The Annotations as type arguments and - at least - allows for IDEs (testet in Eclipse) to recognize them.

I would love to have updated the spotbugs detectors but this requires Apache BCEL to have support for 
RuntimeVisibleTypeAnnotations and RuntimeInvisibleTypeAnnotations, which it currently doesn't have.