### PR TITLE
Issue a bug for BigDecimal(double) when the argument is not a constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 * Processing of "J" (long value constants) was not processed in `OpcodeStack.Item(OpcodeStack.Item, String)`
 * Processing of "Z" (boolean value constants) was not processed in `OpcodeStack.Item(OpcodeStack.Item, String)`
 * Processing of Box classes like `java.lang.Integer` was not processed in `OpcodeStack.Item(OpcodeStack.Item, String)`
+* DMI_BIGDECIMAL_CONSTRUCTED_FROM_DOUBLE was only reported when the double argument was a constant
 
 ## 3.1.5 - 2018-06-15
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue696Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue696Test.java
@@ -1,0 +1,43 @@
+/*
+ * Contributions to SpotBugs
+ * Copyright (C) 2018, cpfeiffer
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+package edu.umd.cs.findbugs.detect;
+
+import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
+
+/**
+ * @see <a href="https://github.com/spotbugs/spotbugs/issues/696">GitHub issue</a>
+ */
+public class Issue696Test extends AbstractIntegrationTest {
+
+    @Test
+    public void test() {
+        performAnalysis("ghIssues/Issue696.class");
+        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
+                .bugType("DMI_BIGDECIMAL_CONSTRUCTED_FROM_DOUBLE")
+                .build();
+        assertThat(getBugCollection(), containsExactly(1, bugTypeMatcher));
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DumbMethods.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DumbMethods.java
@@ -1398,6 +1398,12 @@ public class DumbMethods extends OpcodeStackDetector {
                                 .describe(MethodAnnotation.METHOD_ALTERNATIVE_TARGET).addString(dblString)
                                 .addString(bigDecimalString).addSourceLine(this));
                     }
+                } else {
+                    bugReporter.reportBug(new BugInstance(this, "DMI_BIGDECIMAL_CONSTRUCTED_FROM_DOUBLE",
+                            NORMAL_PRIORITY).addClassAndMethod(this).addCalledMethod(this)
+                            .addMethod("java.math.BigDecimal", "valueOf", "(D)Ljava/math/BigDecimal;", true)
+                            .describe(MethodAnnotation.METHOD_ALTERNATIVE_TARGET).addString(top.getSignature())
+                            .addSourceLine(this));
                 }
 
             }

--- a/spotbugsTestCases/src/java/ghIssues/Issue696.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue696.java
@@ -1,0 +1,18 @@
+package ghIssues;
+
+import java.math.BigDecimal;
+
+/**
+ * @see <a href="https://github.com/spotbugs/spotbugs/issues/696">GitHub issue</a>
+ */
+public class Issue696 {
+    @SuppressWarnings("unused")
+    public BigDecimal create() {
+        BigDecimal bd = new BigDecimal(getDoubleValue());
+        return bd;
+    }
+
+    private static double getDoubleValue() {
+        return 2.5d;
+    }
+}


### PR DESCRIPTION
The BigDecimal(double) detector only reported an issue when the argument
to the constructor was a constant whose value would cause rounding errors.
   
Now it also reports an issue if the value is *not* a constant.

- [x ] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code