### PR TITLE
Add management for source filter using full source path (if available).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ## Unreleased - 2018-??-??
 
+* Add management for source filter using full source path, if available ([#694](https://github.com/spotbugs/spotbugs/issues/694))
+
 ## 3.1.3 - 2018-04-18
 
 ### Added

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/SourceLineAnnotation.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/SourceLineAnnotation.java
@@ -51,6 +51,7 @@ import edu.umd.cs.findbugs.internalAnnotations.DottedClassName;
 import edu.umd.cs.findbugs.visitclass.PreorderVisitor;
 import edu.umd.cs.findbugs.xml.XMLAttributeList;
 import edu.umd.cs.findbugs.xml.XMLOutput;
+import javax.annotation.CheckReturnValue;
 
 /**
  * A BugAnnotation that records a range of source lines in a class.
@@ -944,6 +945,13 @@ public class SourceLineAnnotation implements BugAnnotation {
         return sourcePath;
     }
 
+    /**
+     * Returns the complete path of the source file the analyzed class has been generated from,
+     * if this information is available to the current AnalysisContext, otherwise falls back to getSourcePath().
+     *
+     * @return the complete path of the source file the analyzed class has been generated from,
+     * otherwise falls back to getSourcePath().
+     */
     public String getRealSourcePath() {
         if (isSourceFileKnown()) {
             SourceFinder sourceFinder = getSourceFinder();
@@ -962,7 +970,7 @@ public class SourceLineAnnotation implements BugAnnotation {
         return getSourcePath();
     }
 
-    private SourceFinder getSourceFinder() {
+    private @CheckReturnValue SourceFinder getSourceFinder() {
         Project project = myProject.get();
         if (project != null) {
             return project.getSourceFinder();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/SourceLineAnnotation.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/SourceLineAnnotation.java
@@ -946,30 +946,30 @@ public class SourceLineAnnotation implements BugAnnotation {
 
     public String getRealSourcePath() {
         if (isSourceFileKnown()) {
-            Project project = myProject.get();
-            if (project != null) {
+            SourceFinder sourceFinder = getSourceFinder();
+            if (sourceFinder != null)
+            {
                 try {
-                    SourceFinder mySourceFinder = project.getSourceFinder();
-                    return new File(mySourceFinder.findSourceFile(this).getFullFileName()).getCanonicalPath();
-
+                    return new File(sourceFinder.findSourceFile(this).getFullFileName()).getCanonicalPath();
                 } catch (IOException e) {
-                    assert true;
+                    AnalysisContext.logError("Error resolving Real SourcePath (only relative source path will be available) ", e);
                 }
             }
-            else {
-              AnalysisContext currentAnalysisContext = AnalysisContext.currentAnalysisContext();
-              if (currentAnalysisContext != null) {
-                try {
-                  SourceFinder sourceFinder = currentAnalysisContext.getSourceFinder();
-                  return new File(sourceFinder.findSourceFile(this).getFullFileName()).getCanonicalPath();
-                } catch (IOException e) {
-                  e.printStackTrace(System.out);
-                    assert true;
-                }
-              }
-            }
+            AnalysisContext.logError("No SourceFinder found (only relative source path will be available) ");
         }
         return getSourcePath();
+    }
+
+    private SourceFinder getSourceFinder() {
+        Project project = myProject.get();
+        if (project != null) {
+            return project.getSourceFinder();
+        }
+        AnalysisContext currentAnalysisContext = AnalysisContext.currentAnalysisContext();
+        if (currentAnalysisContext != null) {
+            return currentAnalysisContext.getSourceFinder();
+        }
+        return null;
     }
 
     public void setSynthetic(boolean synthetic) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/SourceLineAnnotation.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/SourceLineAnnotation.java
@@ -955,7 +955,9 @@ public class SourceLineAnnotation implements BugAnnotation {
                     AnalysisContext.logError("Error resolving Real SourcePath (only relative source path will be available) ", e);
                 }
             }
-            AnalysisContext.logError("No SourceFinder found (only relative source path will be available) ");
+            else {
+                AnalysisContext.logError("No SourceFinder found (only relative source path will be available) ");
+            }
         }
         return getSourcePath();
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/SourceLineAnnotation.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/SourceLineAnnotation.java
@@ -944,6 +944,34 @@ public class SourceLineAnnotation implements BugAnnotation {
         return sourcePath;
     }
 
+    public String getRealSourcePath() {
+        if (isSourceFileKnown()) {
+            Project project = myProject.get();
+            if (project != null) {
+                try {
+                    SourceFinder mySourceFinder = project.getSourceFinder();
+                    return new File(mySourceFinder.findSourceFile(this).getFullFileName()).getCanonicalPath();
+
+                } catch (IOException e) {
+                    assert true;
+                }
+            }
+            else {
+              AnalysisContext currentAnalysisContext = AnalysisContext.currentAnalysisContext();
+              if (currentAnalysisContext != null) {
+                try {
+                  SourceFinder sourceFinder = currentAnalysisContext.getSourceFinder();
+                  return new File(sourceFinder.findSourceFile(this).getFullFileName()).getCanonicalPath();
+                } catch (IOException e) {
+                  e.printStackTrace(System.out);
+                    assert true;
+                }
+              }
+            }
+        }
+        return getSourcePath();
+    }
+
     public void setSynthetic(boolean synthetic) {
         this.synthetic = synthetic;
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/filter/SourceMatcher.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/filter/SourceMatcher.java
@@ -62,7 +62,7 @@ public class SourceMatcher implements Matcher {
           String bugSourcePath = bugInstance.getPrimarySourceLineAnnotation().getRealSourcePath();
 
           if(bugSourcePath == null || bugSourcePath.isEmpty()){
-            return result;
+            return false;
           }
           result = fileName.match(bugSourcePath);
           if (DEBUG) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/filter/SourceMatcher.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/filter/SourceMatcher.java
@@ -57,6 +57,18 @@ public class SourceMatcher implements Matcher {
         if (DEBUG) {
             System.out.println("Matching " + bugFileName + " with " + fileName + ", result = " + result);
         }
+        if (!result
+                && bugInstance.getPrimarySourceLineAnnotation().isSourceFileKnown()) {
+          String bugSourcePath = bugInstance.getPrimarySourceLineAnnotation().getRealSourcePath();
+
+          if(bugSourcePath == null || bugSourcePath.isEmpty()){
+            return result;
+          }
+          result = fileName.match(bugSourcePath);
+          if (DEBUG) {
+              System.out.println("Matching Known source path " + bugSourcePath + " with " + fileName + ", result = " + result);
+          }
+        }
         return result;
     }
 


### PR DESCRIPTION
Initial PR for review to add support for full source paths on source filter (when available).

The primary bit I'm not sure about in this PR is the code in SourceLineAnnotation that retrieves an instance of the SourceFinder object.

Will also add a PR for the maven bit, these should probably be treated as a whole, and maybe support might be required also for other plugins.
----

Make sure these boxes are checked before submitting your PR -- thank you!

- [ ] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
