### PR TITLE
Release stable-latest Eclipse plugin to new update site

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,15 @@ deploy:
   - provider: pages
     skip_cleanup: true
     github_token: $GITHUB_TOKEN
+    local_dir: eclipsePlugin/build/site/eclipse-stable-latest
+    repo: spotbugs/eclipse-stable-latest
+    email: skypencil+spotbugs-bot@gmail.com
+    on:
+      branch: release-3.1
+      jdk: oraclejdk8
+  - provider: pages
+    skip_cleanup: true
+    github_token: $GITHUB_TOKEN
     local_dir: eclipsePlugin/build/site/eclipse-candidate
     repo: spotbugs/eclipse-candidate
     email: skypencil+spotbugs-bot@gmail.com

--- a/docs/eclipse.rst
+++ b/docs/eclipse.rst
@@ -25,6 +25,9 @@ https://spotbugs.github.io/eclipse-candidate/
 https://spotbugs.github.io/eclipse-latest/
   Provides latest SpotBugs Eclipse plugin built from master branch.
 
+https://spotbugs.github.io/eclipse-stable-latest/
+  Provides latest SpotBugs Eclipse plugin built from release-3.1 branch.
+
 Or just use `Eclipse marketplace <https://marketplace.eclipse.org/content/spotbugs-eclipse-plugin>`_ to install SpotBugs Eclipse plugin.
 
 Using the Plugin

--- a/docs/locale/ja/LC_MESSAGES/eclipse.po
+++ b/docs/locale/ja/LC_MESSAGES/eclipse.po
@@ -4,16 +4,17 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
 #
 msgid ""
-msgstr "Project-Id-Version: spotbugs 3.1\n"
+msgstr ""
+"Project-Id-Version: spotbugs 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-17 15:12+0900\n"
+"POT-Creation-Date: 2018-07-23 02:34+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.4.0\n"
+"Generated-By: Babel 1.3\n"
 
 #: ../../eclipse.rst:2
 msgid "Using the SpotBugs Eclipse plugin"
@@ -25,7 +26,10 @@ msgid ""
 " IDE. The SpotBugs Eclipse plugin was generously contributed by Peter "
 "Friese. Phil Crosby and Andrey Loskutov contributed major improvements to"
 " the plugin."
-msgstr "SpotBugs Eclipseプラグインを使用すると SpotBugs を Eclipse IDE 内で使用できます。SpotBugs Eclipseプラグインは，Peter Friese 氏の多大なる貢献によるものです。Phil Crosby 氏と Andrey Loskutov 氏は，プラグインの大幅な改善に貢献しました。"
+msgstr ""
+"SpotBugs Eclipseプラグインを使用すると SpotBugs を Eclipse IDE 内で使用できます。SpotBugs "
+"Eclipseプラグインは，Peter Friese 氏の多大なる貢献によるものです。Phil Crosby 氏と Andrey Loskutov"
+" 氏は，プラグインの大幅な改善に貢献しました。"
 
 #: ../../eclipse.rst:9
 msgid "Requirements"
@@ -46,7 +50,9 @@ msgid ""
 "We provide update sites that allow you to automatically install SpotBugs "
 "into Eclipse and also query and install updates. There are three "
 "different update sites:"
-msgstr "私たちは，SpotBugs を Eclipse に自動的にインストールしたり，アップデートを照会してインストールもできる更新サイトを提供しています。3 つの異なる更新サイトがあります。"
+msgstr ""
+"私たちは，SpotBugs を Eclipse "
+"に自動的にインストールしたり，アップデートを照会してインストールもできる更新サイトを提供しています。3 つの異なる更新サイトがあります。"
 
 #: ../../eclipse.rst:20
 msgid "https://spotbugs.github.io/eclipse/"
@@ -74,26 +80,39 @@ msgstr ""
 msgid "Provides latest SpotBugs Eclipse plugin built from master branch."
 msgstr "最新の SpotBugs Eclipse プラグインをマスターブランチからビルドします。"
 
-#: ../../eclipse.rst:28
+#: ../../eclipse.rst:29
+msgid "https://spotbugs.github.io/eclipse-stable-latest/"
+msgstr ""
+
+#: ../../eclipse.rst:29
+msgid "Provides latest SpotBugs Eclipse plugin built from release-3.1 branch."
+msgstr "最新で安定している SpotBugs Eclipse プラグインを release-3.1 ブランチからビルドします。"
+
+#: ../../eclipse.rst:31
 msgid ""
 "Or just use `Eclipse marketplace <https://marketplace.eclipse.org/content"
 "/spotbugs-eclipse-plugin>`_ to install SpotBugs Eclipse plugin."
-msgstr "または `Eclipse marketplace <https://marketplace.eclipse.org/content/spotbugs-eclipse-plugin>`_ を使って SpotBugs Eclipse プラグインをインストールします。"
+msgstr ""
+"または `Eclipse marketplace <https://marketplace.eclipse.org/content"
+"/spotbugs-eclipse-plugin>`_ を使って SpotBugs Eclipse プラグインをインストールします。"
 
-#: ../../eclipse.rst:31
+#: ../../eclipse.rst:34
 msgid "Using the Plugin"
 msgstr "プラグインの使い方"
 
-#: ../../eclipse.rst:33
+#: ../../eclipse.rst:36
 msgid ""
 "To get started, right click on a Java project in Package Explorer, and "
 "select the option labeled \"Spot Bugs\". SpotBugs will run, and problem "
 "markers (displayed in source windows, and also in the Eclipse Problems "
 "view) will point to locations in your code which have been identified as "
 "potential instances of bug patterns."
-msgstr "開始するには，パッケージエクスプローラで Java プロジェクトを右クリックして，「Spot Bugs」というラベルの付いたオプションを選択します。SpotBugs が実行され，問題マーカー (ソースウインドウと Eclipse の問題ビューに表示されます) は，バグパターンの潜在的なインスタンスとして特定されたコード内の場所を示します。"
+msgstr ""
+"開始するには，パッケージエクスプローラで Java プロジェクトを右クリックして，「Spot "
+"Bugs」というラベルの付いたオプションを選択します。SpotBugs が実行され，問題マーカー (ソースウインドウと Eclipse "
+"の問題ビューに表示されます) は，バグパターンの潜在的なインスタンスとして特定されたコード内の場所を示します。"
 
-#: ../../eclipse.rst:36
+#: ../../eclipse.rst:39
 msgid ""
 "You can also run SpotBugs on existing java archives (jar, ear, zip, war "
 "etc). Simply create an empty Java project and attach archives to the "
@@ -101,49 +120,61 @@ msgid ""
 "in Package Explorer and select the option labeled \"Spot Bugs\". If you "
 "additionally configure the source code locations for the binaries, "
 "SpotBugs will also link the generated warnings to the right source files."
-msgstr "既存の Java アーカイブ (jar，ear，zip，war など) で SpotBugs を実行できます。空の Java プロジェクトを作成し，プロジェクトのクラスパスにアーカイブを追加するだけです。これで，パッケージエクスプローラでアーカイブノードを右クリックして，「SpotBugs」というラベルの付いたオプションを選択できます。さらに，バイナリのソースコードの場所を設定すると，SpotBugs は生成された警告を正しいソースファイルにリンクします。"
+msgstr ""
+"既存の Java アーカイブ (jar，ear，zip，war など) で SpotBugs を実行できます。空の Java "
+"プロジェクトを作成し，プロジェクトのクラスパスにアーカイブを追加するだけです。これで，パッケージエクスプローラでアーカイブノードを右クリックして，「SpotBugs」というラベルの付いたオプションを選択できます。さらに，バイナリのソースコードの場所を設定すると，SpotBugs"
+" は生成された警告を正しいソースファイルにリンクします。"
 
-#: ../../eclipse.rst:41
+#: ../../eclipse.rst:44
 msgid ""
 "You may customize how SpotBugs runs by opening the Properties dialog for "
 "a Java project, and choosing the \"SpotBugs\" property page. Options you "
 "may choose include:"
-msgstr "SpotBugs の実行方法をカスタマイズするには，Java プロジェクトのプロパティダイアログを開き，「SpotBugs」プロパティページを選択します。選択できるオプションは次のとおりです。"
+msgstr ""
+"SpotBugs の実行方法をカスタマイズするには，Java "
+"プロジェクトのプロパティダイアログを開き，「SpotBugs」プロパティページを選択します。選択できるオプションは次のとおりです。"
 
-#: ../../eclipse.rst:44
+#: ../../eclipse.rst:47
 msgid ""
 "Enable or disable the \"Run SpotBugs Automatically\" checkbox. When "
 "enabled, SpotBugs will run every time you modify a Java class within the "
 "project."
-msgstr "「Run SpotBugs Automatically」チェックボックスを有効または無効にします。有効にすると，プロジェクト内の Java クラスを変更するたびに SpotBugs が実行されます。"
+msgstr ""
+"「Run SpotBugs Automatically」チェックボックスを有効または無効にします。有効にすると，プロジェクト内の Java "
+"クラスを変更するたびに SpotBugs が実行されます。"
 
-#: ../../eclipse.rst:46
+#: ../../eclipse.rst:49
 msgid ""
 "Choose minimum warning priority and enabled bug categories. These options"
 " will choose which warnings are shown. For example, if you select the "
 "\"Medium\" warning priority, only Medium and High priority warnings will "
 "be shown. Similarly, if you uncheck the \"Style\" checkbox, no warnings "
 "in the Style category will be displayed."
-msgstr "最低限の優先度を選択し，バグカテゴリを有効にします。これらのオプションは，表示される警告を選択します。たとえば，優先度で「Medium」を選択すると，優先度 (中) と優先度 (高) の警告だけが表示されます同様に，「Style」チェックボックスのチェックを外すと，Style カテゴリの警告は表示されません。"
+msgstr ""
+"最低限の優先度を選択し，バグカテゴリを有効にします。これらのオプションは，表示される警告を選択します。たとえば，優先度で「Medium」を選択すると，優先度"
+" (中) と優先度 (高) の警告だけが表示されます同様に，「Style」チェックボックスのチェックを外すと，Style "
+"カテゴリの警告は表示されません。"
 
-#: ../../eclipse.rst:48
+#: ../../eclipse.rst:51
 msgid ""
 "Select detectors. The table allows you to select which detectors you want"
 " to enable for your project."
 msgstr "ディテクタの選択。この表では，プロジェクトで有効にするディテクタを選択できます。"
 
-#: ../../eclipse.rst:51
+#: ../../eclipse.rst:54
 msgid "Extending the Eclipse Plugin (since 2.0.0)"
 msgstr "Eclipse プラグインの拡張 (2.0.0 以降)"
 
-#: ../../eclipse.rst:53
+#: ../../eclipse.rst:56
 msgid ""
 "Eclipse plugin supports contribution of custom SpotBugs detectors (see "
 "also AddingDetectors.txt for more information). There are two ways to "
 "contribute custom plugins to the Eclipse:"
-msgstr "Eclipse プラグインは，カスタム SpotBugs ディテクタの寄贈をサポートします (詳細については AddingDetectors.txt も参照してください)。カスタムプラグインを Eclipse に提供するには 2 つの方法があります。"
+msgstr ""
+"Eclipse プラグインは，カスタム SpotBugs ディテクタの寄贈をサポートします (詳細については "
+"AddingDetectors.txt も参照してください)。カスタムプラグインを Eclipse に提供するには 2 つの方法があります。"
 
-#: ../../eclipse.rst:55
+#: ../../eclipse.rst:58
 msgid ""
 "Existing standard SpotBugs detector packages can be configured via "
 "``Window → Preferences → Java → FindBugs → Misc. Settings → Custom "
@@ -153,15 +184,19 @@ msgid ""
 "quality of third party detectors. The drawback is that you have to apply "
 "this settings in each new Eclipse workspace, and this settings can't be "
 "shared between team members."
-msgstr "既存の標準 SpotBugs ディテクタパッケージは，``Window → Preferences → Java → FindBugs → Misc. Settings → Custom Detectors`` で設定できます。追加のプラグインの場所を指定するだけです。このソリューションの利点は，既存のディテクタパッケージを「そのまま」使用でき，サードパーティのディテクタの品質を迅速に検証できることです。欠点は，新しい Eclipse ワークスペースごとにこの設定を適用する必要があり，この設定をチームメンバ間で共有できないことです。"
+msgstr ""
+"既存の標準 SpotBugs ディテクタパッケージは，``Window → Preferences → Java → FindBugs → "
+"Misc. Settings → Custom Detectors`` "
+"で設定できます。追加のプラグインの場所を指定するだけです。このソリューションの利点は，既存のディテクタパッケージを「そのまま」使用でき，サードパーティのディテクタの品質を迅速に検証できることです。欠点は，新しい"
+" Eclipse ワークスペースごとにこの設定を適用する必要があり，この設定をチームメンバ間で共有できないことです。"
 
-#: ../../eclipse.rst:58
+#: ../../eclipse.rst:61
 msgid ""
 "It is possible to contribute custom detectors via standard Eclipse "
 "extensions mechanism."
 msgstr "標準の Eclipse 拡張機構を用いてカスタムディテクタを提供できます。"
 
-#: ../../eclipse.rst:60
+#: ../../eclipse.rst:63
 msgid ""
 "Please check the documentation of the "
 "``eclipsePlugin/schema/detectorPlugins.exsd`` extension point how to "
@@ -170,9 +205,14 @@ msgid ""
 "Usually you only need to add ``META-INF/MANIFEST.MF`` and ``plugin.xml`` "
 "to the jar and update your build scripts to not to override the "
 "``MANIFEST.MF`` during the build."
-msgstr "``eclipsePlugin/schema/detectorPlugins.exsd`` 拡張ポイントのドキュメントを参照して，plugin.xml の更新方法を確認してください。既存の SpotBugs ディテクタプラグインは，完全に機能する SpotBugs ディテクタプラグインになるように簡単に「拡張」できます。通常は，``META-INF/MANIFEST.MF`` と ``plugin.xml`` を jar ファイルに追加し，ビルド時に ``MANIFEST.MF`` を上書きしないようにビルドスクリプトを更新するだけです。"
+msgstr ""
+"``eclipsePlugin/schema/detectorPlugins.exsd`` "
+"拡張ポイントのドキュメントを参照して，plugin.xml の更新方法を確認してください。既存の SpotBugs "
+"ディテクタプラグインは，完全に機能する SpotBugs ディテクタプラグインになるように簡単に「拡張」できます。通常は，``META-"
+"INF/MANIFEST.MF`` と ``plugin.xml`` を jar ファイルに追加し，ビルド時に ``MANIFEST.MF`` "
+"を上書きしないようにビルドスクリプトを更新するだけです。"
 
-#: ../../eclipse.rst:64
+#: ../../eclipse.rst:67
 msgid ""
 "The benefit of this solution is that for given (shared) Eclipse "
 "installation each team member has exactly same detectors set, and there "
@@ -182,37 +222,48 @@ msgid ""
 "Another major differentiator is the ability to extend the default "
 "SpotBugs classpath at runtime with required third party libraries (see "
 "AddingDetectors.txt for more information)."
-msgstr "このソリューションの利点は，Eclipse インストールが共有されていれば，それぞれのチームメンバが正確に同じディテクタセットを持ち，何も設定する必要がないことです。(本当に小さな) 前提条件は，既存のディテクタパッケージを有効な Eclipse プラグインに変換しておくことです。サードパーティのディテクタでもこれを行うことができます。もうひとつの大きな違いは，実行時に必要なサードパーティのライブラリでデフォルトの SpotBugs クラスパスを拡張する能力です (詳細については AddingDetectors.txt を参照してください)。"
+msgstr ""
+"このソリューションの利点は，Eclipse "
+"インストールが共有されていれば，それぞれのチームメンバが正確に同じディテクタセットを持ち，何も設定する必要がないことです。(本当に小さな) "
+"前提条件は，既存のディテクタパッケージを有効な Eclipse "
+"プラグインに変換しておくことです。サードパーティのディテクタでもこれを行うことができます。もうひとつの大きな違いは，実行時に必要なサードパーティのライブラリでデフォルトの"
+" SpotBugs クラスパスを拡張する能力です (詳細については AddingDetectors.txt を参照してください)。"
 
-#: ../../eclipse.rst:69
+#: ../../eclipse.rst:72
 msgid "Troubleshooting"
 msgstr "トラブルシューティング"
 
-#: ../../eclipse.rst:71
+#: ../../eclipse.rst:74
 msgid ""
 "This section lists common problems with the plugin and (if known) how to "
 "resolve them."
 msgstr "この節では，プラグインの一般的な問題と (既知の) 問題を解決する方法について説明します。"
 
-#: ../../eclipse.rst:73
+#: ../../eclipse.rst:76
 msgid ""
 "If you see OutOfMemory error dialogs after starting SpotBugs analysis in "
 "Eclipse, please increase JVM available memory: change ``eclipse.ini`` and"
 " add the lines below to the end of the file:"
-msgstr "Eclipse で SpotBugs の解析を開始した後に OutOfMemory エラーダイアログが表示されるときは，JVM の使用可能なメモリを増やしてください。``eclipse.ini`` を変更し次の行をファイルの最後に追加してください。"
+msgstr ""
+"Eclipse で SpotBugs の解析を開始した後に OutOfMemory エラーダイアログが表示されるときは，JVM "
+"の使用可能なメモリを増やしてください。``eclipse.ini`` を変更し次の行をファイルの最後に追加してください。"
 
-#: ../../eclipse.rst:81
+#: ../../eclipse.rst:84
 msgid ""
 "Important: the configuration arguments starting with the line ``-vmargs``"
 " must be last lines in the ``eclipse.ini`` file, and only one argument "
 "per line is allowed!"
-msgstr "重要: ``-vmargs`` 行から始まる設定引数は ``eclipse.ini`` ファイルの最後でなければならず，1 行につき 1 つの引数しか許されません!"
+msgstr ""
+"重要: ``-vmargs`` 行から始まる設定引数は ``eclipse.ini`` ファイルの最後でなければならず，1 行につき 1 "
+"つの引数しか許されません!"
 
-#: ../../eclipse.rst:83
+#: ../../eclipse.rst:86
 msgid ""
 "If you do not see any SpotBugs problem markers (in your source windows or"
 " in the Problems View), you may need to change your ``Problems View`` "
 "filter settings. See `FAQ <faq.html#q6-the-eclipse-plugin-loads-but-"
 "doesn-t-work-correctly>`__ for more information."
-msgstr "SpotBugs の問題マーカーが (ソースファイルや問題ビューに) 表示されないときは，``問題ビュー`` のフィルタ設定を変更する必要があります。詳細は `FAQ <faq.html#q6-the-eclipse-plugin-loads-but-doesn-t-work-correctly>`__ を参照してください。"
-
+msgstr ""
+"SpotBugs の問題マーカーが (ソースファイルや問題ビューに) 表示されないときは，``問題ビュー`` "
+"のフィルタ設定を変更する必要があります。詳細は `FAQ <faq.html#q6-the-eclipse-plugin-loads-but-"
+"doesn-t-work-correctly>`__ を参照してください。"

--- a/eclipsePlugin/build.gradle
+++ b/eclipsePlugin/build.gradle
@@ -233,6 +233,11 @@ task pluginDailyJar(type:Copy, dependsOn:pluginJar) {
   into "${buildDir}/site/eclipse-daily/plugins/"
 }
 
+task pluginStableLatestJar(type:Copy, dependsOn:pluginJar) {
+  from pluginJar.outputs.files
+  into "${buildDir}/site/eclipse-stable-latest/plugins/"
+}
+
 def siteFilterTokens = [
   'PLUGIN_ID': eclipsePluginId,
   'PLUGIN_VERSION':"${project.version}".toString(),
@@ -282,6 +287,20 @@ task featureDailyJar(type:Zip) {
   destinationDir = file("${buildDir}/site/eclipse-daily/features/")
 }
 
+task featureStableLatestJar(type:Zip) {
+  archiveName = "${eclipsePluginId}_${project.version}.jar"
+  entryCompression = ZipEntryCompression.STORED // no compression, this is a jar with no manifest
+  from('plugin_feature-stable_latest.xml') {
+    filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
+    rename { 'feature.xml' }
+  }
+  from('feature_p2.inf') {
+    filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
+    rename { 'p2.inf' }
+  }
+  destinationDir = file("${buildDir}/site/eclipse-stable-latest/features/")
+}
+
 task siteHtml(type:Copy) {
   filter(tokens:[
     'URL': 'https://spotbugs.github.io/eclipse/'
@@ -321,6 +340,19 @@ task siteDailyHtml(type:Copy) {
   }
 }
 
+task siteStableLatestHtml(type:Copy) {
+  filter(tokens:[
+    'URL': 'https://spotbugs.github.io/eclipse-stable-latest/'
+  ] + siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
+  from 'plugin_site.html'
+  destinationDir = file("${buildDir}/site/eclipse-stable-latest")
+  rename { 'index.html' }
+  outputs.upToDateWhen {
+    // even if we have generated file, we should rerun this task to overwrite it.
+    false
+  }
+}
+
 task siteXml(type:Copy) {
   filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
   from 'plugin_site.xml'
@@ -347,6 +379,17 @@ task siteDailyXml(type:Copy) {
   filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
   from 'plugin_site-daily.xml'
   destinationDir = file("${buildDir}/site/eclipse-daily")
+  rename { 'site.xml' }
+  outputs.upToDateWhen {
+    // even if we have generated file, we should rerun this task to overwrite it.
+    false
+  }
+}
+
+task siteStableLatestXml(type:Copy) {
+  filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
+  from 'plugin_site-stable_latest.xml'
+  destinationDir = file("${buildDir}/site/eclipse-stable-latest")
   rename { 'site.xml' }
   outputs.upToDateWhen {
     // even if we have generated file, we should rerun this task to overwrite it.
@@ -396,8 +439,22 @@ task generateP2MetadataDaily(type:Exec) {
     '-source', "${buildDir}/site/eclipse-daily"
 }
 
+task generateP2MetadataStableLatest(type:Exec) {
+  doFirst {
+    project.delete "${buildDir}/site/eclipse-stable-latest/artifacts.xml"
+    project.delete "${buildDir}/site/eclipse-stable-latest/content.xml"
+  }
+  inputs.file 'local.properties'
+  dependsOn pluginStableLatestJar, featureStableLatestJar, siteStableLatestXml, siteStableLatestHtml
+  commandLine "${eclipseExecutable}", '-nosplash',
+    '-application', 'org.eclipse.equinox.p2.publisher.UpdateSitePublisher',
+    '-metadataRepository', "file:${buildDir}/site/eclipse-stable-latest", // TODO : May not work on Windows
+    '-artifactRepository', "file:${buildDir}/site/eclipse-stable-latest", // TODO : May not work on Windows
+    '-source', "${buildDir}/site/eclipse-stable-latest"
+}
+
 task eclipseSite() {
-  dependsOn generateP2Metadata, generateCandidateP2Metadata, generateP2MetadataDaily
+  dependsOn generateP2Metadata, generateCandidateP2Metadata, generateP2MetadataDaily, generateP2MetadataStableLatest
 }
 
 // create zip file to upload to GitHub release page

--- a/eclipsePlugin/plugin_feature-stable_latest.xml
+++ b/eclipsePlugin/plugin_feature-stable_latest.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="@FEATURE_ID@"
+      label="SpotBugs"
+      version="@FEATURE_VERSION@"
+      provider-name="SpotBugs Project"
+      plugin="@PLUGIN_ID@">
+
+   <description url="https://spotbugs.github.io/">
+      SpotBugs is a program which uses static analysis to look for bugs in Java code, a spiritual successor of FindBugs.
+   </description>
+
+   <copyright>
+      (c) 2017, SpotBugs Project
+      (c) 2006-2011, University of Maryland
+   </copyright>
+
+   <license url="https://opensource.org/licenses/LGPL-2.1">
+      SpotBugs is free software distributed under the terms of the Lesser GNU Public License.
+http://www.gnu.org/licenses/lgpl.html
+   </license>
+
+   <url>
+      <update label="SpotBugs stable-latest update site" url="https://spotbugs.github.io/eclipse-stable-latest/"/>
+   </url>
+
+   <requires>
+      <import plugin="org.eclipse.core.resources"/>
+      <import plugin="org.eclipse.core.runtime" version="3.12.0" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.jdt"/>
+      <import plugin="org.eclipse.jdt.core"/>
+      <import plugin="org.eclipse.jdt.launching"/>
+      <import plugin="org.eclipse.jdt.ui"/>
+      <import plugin="org.eclipse.jface.text"/>
+      <import plugin="org.eclipse.ui"/>
+      <import plugin="org.eclipse.ui.editors"/>
+      <import plugin="org.eclipse.ui.ide"/>
+      <import plugin="org.eclipse.ui.workbench.texteditor"/>
+   </requires>
+
+   <plugin
+         id="@PLUGIN_ID@"
+         download-size="5676"
+         install-size="5800"
+         version="@PLUGIN_VERSION@"/>
+
+</feature>

--- a/eclipsePlugin/plugin_site-stable_latest.xml
+++ b/eclipsePlugin/plugin_site-stable_latest.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<site>
+
+   <description url="https://spotbugs.github.io/eclipse-stable-latest">
+      Eclipse update site for SpotBugs.
+   </description>
+
+   <feature url="features/@FEATURE_ID@_@FEATURE_VERSION@.jar"
+            id="@FEATURE_ID@"
+            version="@FEATURE_VERSION@">
+      <category name="SpotBugs"/>
+   </feature>
+
+   <category-def name="SpotBugs" label="SpotBugs">
+      <description>
+         SpotBugs is a program which uses static analysis to look for bugs in Java code.
+      </description>
+   </category-def>
+
+</site>


### PR DESCRIPTION
URL of new update site will be: https://spotbugs.github.io/eclipse-stable-latest/
This change will close #701.