### PR TITLE
stop using absolute path at secretKeyRingFile 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -126,7 +126,7 @@ deploy:
     skip_cleanup: true
     # wait until uploading task finishes, because it may cost more than 10 minutes without any output
     # https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received
-    script: .travis/travis_wait "./gradlew uploadArchives -PossrhUsername='$SONATYPE_USERNAME' -PossrhPassword="$SONATYPE_PASSWORD" -Psigning.keyId="$SIGNING_KEY_ID" -Psigning.password='$SIGNING_PASSWORD' -Psigning.secretKeyRingFile='$TRAVIS_BUILD_DIR/secring.gpg'"
+    script: .travis/travis_wait "./gradlew uploadArchives -PossrhUsername='$SONATYPE_USERNAME' -PossrhPassword="$SONATYPE_PASSWORD" -Psigning.keyId="$SIGNING_KEY_ID" -Psigning.password='$SIGNING_PASSWORD' -Psigning.secretKeyRingFile=secring.gpg"
     on:
       tags: true
       jdk: oraclejdk8


### PR DESCRIPTION
When [we built 3.1.6 on Travis CI](https://travis-ci.org/spotbugs/spotbugs/jobs/405066182), we failed to publish artifacts to Sonatype repository. It is because Travis CI subprocess cannot find necessary file, even though we generated it in `before_install` phase:

> sh: 1: V90IfD -Psigning.keyId=EECF0E90 -Psigning.password='[secure]' -Psigning.secretKeyRingFile='/home/travis/build/spotbugs/spotbugs/secring.gpg': not found

One hypothesis is that, it isn't good to use absolute path: https://github.com/travis-ci/travis-ci/issues/9047
So this PR drops `$TRAVIS_BUILD_DIR` in `deploy` phase.