### PR TITLE
Make sure BugInstance hash is consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased - 2018-??-??
+* Make sure BugInstance hash is consistent
 
 ## 3.1.6 - 2018-07-18
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/BugInstance.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/BugInstance.java
@@ -552,7 +552,8 @@ public class BugInstance implements Comparable<BugInstance>, XMLWriteable, Clone
 
     private String getInstanceKeyNew() {
         StringBuilder buf = new StringBuilder(type);
-        for (BugAnnotation annotation : annotationList) {
+        Set<BugAnnotation> sortedAnnotationList = new TreeSet<>(annotationList);
+        for (BugAnnotation annotation : sortedAnnotationList) {
             if (annotation.isSignificant() || annotation instanceof IntAnnotation
                     || annotation instanceof LocalVariableAnnotation) {
                 buf.append(":");

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ExcludingHashesBugReporter.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ExcludingHashesBugReporter.java
@@ -62,8 +62,8 @@ public class ExcludingHashesBugReporter extends DelegatingBugReporter {
 
     @Override
     public void reportBug(@Nonnull BugInstance bugInstance) {
-        String instanceHash = bugInstance.getInstanceHash();
-        if (!excludedHashes.contains(instanceHash)) {
+        if (!excludedHashes.contains(bugInstance.getBrokenInstanceHashForBackwardCompatibility())
+                && !excludedHashes.contains(bugInstance.getInstanceHash())) {
             getDelegate().reportBug(bugInstance);
         }
     }

--- a/spotbugs/src/test/java/edu/umd/cs/findbugs/BugInstanceTest.java
+++ b/spotbugs/src/test/java/edu/umd/cs/findbugs/BugInstanceTest.java
@@ -7,6 +7,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+
 public class BugInstanceTest {
 
     private BugInstance b;
@@ -40,6 +42,19 @@ public class BugInstanceTest {
     public void testRemoveThroughIterator3() {
         removeThroughIterator(b.propertyIterator(), "C");
         checkPropertyIterator(b.propertyIterator(), new String[] { "A", "B" }, new String[] { "a", "b" });
+    }
+
+    @Test
+    public void testSameHashForMultipleRunsOfABugInstance() {
+        BugInstance firstRunBugInstance = new BugInstance("NP_NULL_ON_SOME_PATH", Priorities.NORMAL_PRIORITY);
+        firstRunBugInstance.addString("a");
+        firstRunBugInstance.addString("k");
+
+        BugInstance secondRunBugInstance = new BugInstance("NP_NULL_ON_SOME_PATH", Priorities.NORMAL_PRIORITY);
+        secondRunBugInstance.addString("k");
+        secondRunBugInstance.addString("a");
+
+        Assert.assertThat(firstRunBugInstance.getInstanceHash(), equalTo(secondRunBugInstance.getInstanceHash()));
     }
 
     @Test(expected = NoSuchElementException.class)


### PR DESCRIPTION
Why:
   Instance hash is used for excluding bugs from Baseline report. The hash creation is strongly dependent on the order in which  bug annotation are added to BugInstance. Some plugins like find-sec-bugs are adding bug annotation  in different Order for same BugInstance on different runs as they use HashSet to store the order before populating to BugInstance. The changes were made To make hash creation independent of the order in which bug annotiations  added to BugInstance.



----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
