### PR TITLE
runMain: Don't print exit code information when -quiet is passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ## Unreleased - 2018-??-??
 
+* Don't print exit code related output if '-quiet' is passed ([#714](https://github.com/spotbugs/spotbugs/pull/714))
+
 ## 3.1.6 - 2018-07-18
 
 ### Fixed

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/FindBugs.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/FindBugs.java
@@ -395,7 +395,7 @@ public abstract class FindBugs {
      */
     @SuppressFBWarnings("DM_EXIT")
     public static void runMain(IFindBugsEngine findBugs, TextUICommandLine commandLine) throws IOException {
-        boolean verbose = !commandLine.quiet() || commandLine.setExitCode();
+        boolean verbose = !commandLine.quiet();
 
         try {
             findBugs.execute();
@@ -415,7 +415,7 @@ public abstract class FindBugs {
         int missingClassCount = findBugs.getMissingClassCount();
         int errorCount = findBugs.getErrorCount();
 
-        if (verbose) {
+        if (verbose || commandLine.setExitCode()) {
             if (bugCount > 0) {
                 System.err.println("Warnings generated: " + bugCount);
             }
@@ -429,20 +429,30 @@ public abstract class FindBugs {
 
         if (commandLine.setExitCode()) {
             int exitCode = 0;
-            System.err.println("Calculating exit code...");
+            if (verbose) {
+                System.err.println("Calculating exit code...");
+            }
             if (errorCount > 0) {
                 exitCode |= ExitCodes.ERROR_FLAG;
-                System.err.println("Setting 'errors encountered' flag (" + ExitCodes.ERROR_FLAG + ")");
+                if (verbose) {
+                    System.err.println("Setting 'errors encountered' flag (" + ExitCodes.ERROR_FLAG + ")");
+                }
             }
             if (missingClassCount > 0) {
                 exitCode |= ExitCodes.MISSING_CLASS_FLAG;
-                System.err.println("Setting 'missing class' flag (" + ExitCodes.MISSING_CLASS_FLAG + ")");
+                if (verbose) {
+                    System.err.println("Setting 'missing class' flag (" + ExitCodes.MISSING_CLASS_FLAG + ")");
+                }
             }
             if (bugCount > 0) {
                 exitCode |= ExitCodes.BUGS_FOUND_FLAG;
-                System.err.println("Setting 'bugs found' flag (" + ExitCodes.BUGS_FOUND_FLAG + ")");
+                if (verbose) {
+                    System.err.println("Setting 'bugs found' flag (" + ExitCodes.BUGS_FOUND_FLAG + ")");
+                }
             }
-            System.err.println("Exit code set to: " + exitCode);
+            if (verbose) {
+                System.err.println("Exit code set to: " + exitCode);
+            }
 
             System.exit(exitCode);
         }


### PR DESCRIPTION
Today, it's impossible to run spotbugs where the exit code is set
and output is fully suppressed. It seems reasonable that -quiet
should suppress the exit code related output, which is not normally
very interesting.



----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
