### PR TITLE
upgrade archetype version from 0.1.0 to 0.2.1

### DIFF
--- a/docs/code-template/use-archetype.template
+++ b/docs/code-template/use-archetype.template
@@ -1,0 +1,4 @@
+$ mvn archetype:generate \
+      -DarchetypeArtifactId=spotbugs-archetype \
+      -DarchetypeGroupId=com.github.spotbugs \
+      -DarchetypeVersion=|archetype|

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,8 @@ html_context = {
   'version' : '3.1',
   'full_version' : '3.1.6',
   'maven_plugin_version' : '3.1.5',
-  'gradle_plugin_version' : '1.6.2'
+  'gradle_plugin_version' : '1.6.2',
+  'archetype_version' : '0.2.1'
 }
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/docs/extensions/code-template.py
+++ b/docs/extensions/code-template.py
@@ -4,11 +4,12 @@ def generate(config):
     release = config.release
     maven = config.html_context['maven_plugin_version']
     gradle = config.html_context['gradle_plugin_version']
+    archetype = config.html_context['archetype_version']
     for filename in os.listdir('code-template'):
         with open('code-template/' + filename, 'r') as template:
             data = template.read()
             with open('generated/' + filename + '.inc', 'w') as generated:
-                generated.write(data.replace('|release|', release).replace('|maven-plugin|', maven).replace('|gradle-plugin|', gradle))
+                generated.write(data.replace('|release|', release).replace('|maven-plugin|', maven).replace('|gradle-plugin|', gradle).replace('|archetype|', archetype))
 
 def setup(app):
     app.connect('builder-inited', lambda app: generate(app.config))

--- a/docs/implement-plugin.rst
+++ b/docs/implement-plugin.rst
@@ -7,12 +7,8 @@ Create Maven project
 Use `spotbugs-archetype <https://github.com/spotbugs/spotbugs-archetype>`_ to create Maven project.
 Then Maven archetype plugin will ask you to decide plugin's groupId, artifactId, package and initial version.
 
-.. code-block:: bash
-
-  $ mvn archetype:generate \
-        -DarchetypeArtifactId=spotbugs-archetype \
-        -DarchetypeGroupId=com.github.spotbugs \
-        -DarchetypeVersion=0.1.0
+.. literalinclude:: generated/use-archetype.template.inc
+    :language: bash
 
 Write java code to represent bug to find
 ----------------------------------------


### PR DESCRIPTION
Yesterday we've released spotbugs-archetype v0.2.1. This PR updates our documentation to use the latest version.

## screen shot

<img width="720" alt="screen shot 2018-08-03 at 9 47 51 am" src="https://user-images.githubusercontent.com/505751/43619864-65e9e894-9702-11e8-82d5-591db59d5e10.png">
