### PR TITLE
Close #500 - Add missing visitINVOKEDYNAMIC override in TypeFrameModelingVisitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ### Fixed
 * Don't print exit code related output if '-quiet' is passed ([#714](https://github.com/spotbugs/spotbugs/pull/714))
+* Don't underflow the stack at INVOKEDYNAMIC when modeling stack frame types ([#500](https://github.com/spotbugs/spotbugs/issues/500))
 
 ### CHANGED
 * ASM_VERSION=ASM7_EXPERIMENTAL by default to support Java 11

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue500Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue500Test.java
@@ -1,0 +1,42 @@
+/*
+ * Contributions to SpotBugs
+ * Copyright (C) 2018, William R. Price
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+package edu.umd.cs.findbugs.detect;
+
+import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
+
+/**
+ * @author William R. Price
+ */
+public class Issue500Test extends AbstractIntegrationTest {
+
+    @Test
+    public void test() {
+        performAnalysis("lambdas/Issue500.class");
+        BugInstanceMatcher bugMatcher = new BugInstanceMatcherBuilder().build();
+        assertThat(getBugCollection(), containsExactly(0, bugMatcher));
+    }
+
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/type/TypeFrameModelingVisitor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/type/TypeFrameModelingVisitor.java
@@ -443,6 +443,11 @@ public class TypeFrameModelingVisitor extends AbstractFrameModelingVisitor<Type,
         visitInvokeInstructionCommon(obj);
     }
 
+    @Override
+    public void visitINVOKEDYNAMIC(INVOKEDYNAMIC obj) {
+        visitInvokeInstructionCommon(obj);
+    }
+
     private boolean getResultTypeFromGenericType(TypeFrame frame, int index, int expectedParameters) {
         try {
             Type mapType = frame.getStackValue(0);

--- a/spotbugsTestCases/src/java/lambdas/Issue500.java
+++ b/spotbugsTestCases/src/java/lambdas/Issue500.java
@@ -1,0 +1,49 @@
+package lambdas;
+
+import java.util.Map;
+
+/**
+ * Return value of INVOKEDYNAMIC used as key to generic container such as a Map.
+ * See GitHub issue
+ * <a href="https://github.com/spotbugs/spotbugs/issues/500">#500</a>.
+ */
+public class Issue500 {
+
+    /**
+     * Realistic case from production code: using the result of string
+     * concatenation (performed within the method) to access a generic
+     * collection such as Map.  Won't trigger for code compiled with Java 8
+     * because those versions of javac emit a StringBuilder-based sequence.
+     * Java 9 javac switched to INVOKEDYNAMIC to choose optimal concatenation
+     * strategies at runtime, which revealed the bug.
+     */
+    Object mapGetFromConcatStr(Map<String, Object> map, String partialKey) {
+        String key = "myConstValue" + partialKey; // javac >= 9 uses INDY
+        return map.get(key);
+    }
+
+    /**
+     * To reproduce on Java 8 (where INDY string concatenation doesn't exist),
+     * attempt to fetch a value from the provided map by using the 'identity'
+     * of a lambda expression privately defined by this method.  It is unlikely
+     * that this convoluted construct is of much practical use in real-world
+     * code. Choosing to use {@link Runnable} below is completely arbitrary and
+     * is not relevant to the bug; it could be any {@code @FunctionalInterface}.
+     * 
+     * The important part is that the functional interface (FI) is provided by a
+     * lambda or a method reference, causing javac to emit INVOKEDYNAMIC, and it
+     * is that item that is then used as the key in a generic collection access.
+     * Using as a key a traditional reference to some object that implements the
+     * interface would not trigger the issue.
+     * 
+     * Sane code would probably invoke a method on the FI, like
+     * {@code Supplier.get()}, and then use that result to do the
+     * {@code Map.get()} call.  But that sequence won't trigger the bug,
+     * because then the Map generic container access is using the result of
+     * an INVOKEINTERFACE instruction. 
+     */
+    <T> Object mapGetIndyResult(Map<T, Object> map) {
+        Runnable funcInterface = System::gc; // gc() is not actually invoked
+        return map.get((T) funcInterface);
+    }
+}


### PR DESCRIPTION
Prevents underflowing the stack (reaching `<bottom>`) when encountering
INVOKEDYNAMIC.  Without the override, parent class logic was consuming
a stack frame but not pushing the return type from the INDY call.

Symptom was IllegalArgumentException ("Not a reference type: &lt;bottom&gt;")
from FindUnrelatedTypesInGenericContainer. See issue #500 



----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
