### PR TITLE
Added support for User Preferences exported from SpotBugs Eclipse Plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 ### CHANGED
 * ASM_VERSION=ASM7_EXPERIMENTAL by default to support Java 11
 * Removed dependency to jFormatString (GPL) code ([#725](https://github.com/spotbugs/spotbugs/issues/725))
+* Read User Preferences exported from SpotBugs Eclipse Plugin  ([#728](https://github.com/spotbugs/spotbugs/issues/728))
 
 ### ADDED
 * Set ASM_VERSION=ASM6 if system property spotbugs.experimental=false

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/config/UserPreferences.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/config/UserPreferences.java
@@ -199,7 +199,8 @@ public class UserPreferences implements Cloneable {
             if(e.getKey() instanceof String) {
                 String key = e.getKey().toString();
                 String value = e.getValue().toString();
-                prefixlessProperties.setProperty(key.replace("/instance/edu.umd.cs.findbugs.plugin.eclipse/", ""), value);
+                prefixlessProperties.setProperty(key.replace("/instance/edu.umd.cs.findbugs.plugin.eclipse/", "")
+                                                    .replace("/instance/com.github.spotbugs.plugin.eclipse/", ""), value);
             } else {
                 prefixlessProperties.put(e.getKey(), e.getValue());
             }

--- a/spotbugs/src/test/java/edu/umd/cs/findbugs/config/UserPreferencesTest.java
+++ b/spotbugs/src/test/java/edu/umd/cs/findbugs/config/UserPreferencesTest.java
@@ -1,5 +1,9 @@
 package edu.umd.cs.findbugs.config;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -13,5 +17,45 @@ public class UserPreferencesTest {
 
         Assert.assertEquals(sut, clone);
         Assert.assertEquals(sut.getClass(), clone.getClass());
+    }
+
+    @Test
+    public void testReadEffortNoPrefix() throws IOException {
+        String testPrefsString = "effort=max";
+
+        UserPreferences userPrefs = UserPreferences.createDefaultUserPreferences();
+
+        userPrefs.read(new ByteArrayInputStream(testPrefsString.getBytes(StandardCharsets.ISO_8859_1)));
+        Assert.assertEquals(UserPreferences.EFFORT_MAX, userPrefs.getEffort());
+    }
+
+    @Test
+    public void testReadEffortSpotBugsPrefix() throws IOException {
+        String testPrefsString = "/instance/com.github.spotbugs.plugin.eclipse/effort=max";
+
+        UserPreferences userPrefs = UserPreferences.createDefaultUserPreferences();
+
+        userPrefs.read(new ByteArrayInputStream(testPrefsString.getBytes(StandardCharsets.ISO_8859_1)));
+        Assert.assertEquals(UserPreferences.EFFORT_MAX, userPrefs.getEffort());
+    }
+
+    @Test
+    public void testReadEffortFindBugsPrefix() throws IOException {
+        String testPrefsString = "/instance/edu.umd.cs.findbugs.plugin.eclipse/effort=max";
+
+        UserPreferences userPrefs = UserPreferences.createDefaultUserPreferences();
+
+        userPrefs.read(new ByteArrayInputStream(testPrefsString.getBytes(StandardCharsets.ISO_8859_1)));
+        Assert.assertEquals(UserPreferences.EFFORT_MAX, userPrefs.getEffort());
+    }
+
+    @Test
+    public void testReadEffortUnknownPrefix() throws IOException {
+        String testPrefsString = "/instance/test.test.test.test.plugin.eclipse/effort=max";
+
+        UserPreferences userPrefs = UserPreferences.createDefaultUserPreferences();
+
+        userPrefs.read(new ByteArrayInputStream(testPrefsString.getBytes(StandardCharsets.ISO_8859_1)));
+        Assert.assertEquals(UserPreferences.EFFORT_DEFAULT, userPrefs.getEffort());
     }
 }


### PR DESCRIPTION
This should fix the issue #728.
UserPreferences now also replaces the prefix generated by the SpotBugs Eclipse Plugin when loading a userPrefs file.

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
