### PR TITLE
Update to Gradle 4.9 and spotbugs-maven-plugin 1.6.2 for jdk11 support

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-all.zip

--- a/spotbugs-ant/build.gradle
+++ b/spotbugs-ant/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.github.spotbugs" version "1.5"
+  id "com.github.spotbugs" version "1.6.2"
 }
 
 apply from: "$rootDir/gradle/checkstyle.gradle"

--- a/test-harness/build.gradle
+++ b/test-harness/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.github.spotbugs" version "1.5"
+  id "com.github.spotbugs" version "1.6.2"
 }
 
 apply from: "$rootDir/gradle/checkstyle.gradle"


### PR DESCRIPTION
Fixes `gradlew` invocation errors on jdk11
https://github.com/gradle/gradle/issues/4515
https://github.com/spotbugs/spotbugs-gradle-plugin/issues/22