### PR TITLE
Simplify hash code calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,14 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 ### CHANGED
 * Start migrating STDOUT/STDERR usage to a logging framework
 
+### Fixed
+* Fix hash code collision ([#751](https://github.com/spotbugs/spotbugs/pull/751))
+
 ## 3.1.7 - 2018-09-12
 
 ### Fixed
 * Don't print exit code related output if '-quiet' is passed ([#714](https://github.com/spotbugs/spotbugs/pull/714))
 * Don't underflow the stack at INVOKEDYNAMIC when modeling stack frame types ([#500](https://github.com/spotbugs/spotbugs/issues/500))
-* Fix hash code collision ([#751](https://github.com/spotbugs/spotbugs/pull/751))
 
 ### CHANGED
 * ASM_VERSION=ASM7_EXPERIMENTAL by default to support Java 11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 ### Fixed
 * Don't print exit code related output if '-quiet' is passed ([#714](https://github.com/spotbugs/spotbugs/pull/714))
 * Don't underflow the stack at INVOKEDYNAMIC when modeling stack frame types ([#500](https://github.com/spotbugs/spotbugs/issues/500))
+* Fix hash code collision ([#751](https://github.com/spotbugs/spotbugs/pull/751))
 
 ### CHANGED
 * ASM_VERSION=ASM7_EXPERIMENTAL by default to support Java 11

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/FieldOrMethodDescriptor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/FieldOrMethodDescriptor.java
@@ -19,6 +19,8 @@
 
 package edu.umd.cs.findbugs.classfile;
 
+import java.util.Objects;
+
 import edu.umd.cs.findbugs.internalAnnotations.SlashedClassName;
 
 /**
@@ -52,7 +54,7 @@ public abstract class FieldOrMethodDescriptor implements FieldOrMethodName {
     }
 
     public static int getNameSigHashCode(String name, String signature) {
-        return name.hashCode() * 3119 + signature.hashCode() * 131;
+        return Objects.hash(name, signature);
     }
 
     public int getNameSigHashCode() {
@@ -132,7 +134,7 @@ public abstract class FieldOrMethodDescriptor implements FieldOrMethodName {
     @Override
     public final int hashCode() {
         if (cachedHashCode == 0) {
-            cachedHashCode = slashedClassName.hashCode() * 7919 + nameSigHashCode + (isStatic ? 1 : 0);
+            cachedHashCode = Objects.hash(slashedClassName, nameSigHashCode, isStatic);
         }
         return cachedHashCode;
     }


### PR DESCRIPTION
I try to profile spotbugs running in gradle plugin.
I seem that hash code collision in FieldOrMethodDescriptor occurs frequently.
Because FieldOrMethodDescriptor.equals called from HashMap frequently.

after simplified, not called frequently.

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
