### PR TITLE
Introduce configuration for rtd-helper, a GitHub Probot for RTD

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,0 +1,2 @@
+rtd:
+  project: spotbugs


### PR DESCRIPTION
[rtd-helper](https://github.com/apps/rtd-helper) helps code review that updates document in our `/docs` directory. This PR introduces required configuration for this tool.