### PR TITLE
Release 3.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased - 2018-??-??
+## 3.1.8 - 2018-10-16
 
 ### Fixed
 * Update asm to 6.2.1 for better Java 12 support ([#741](https://github.com/spotbugs/spotbugs/issues/741))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased - 2018-??-??
+
 ## 3.1.8 - 2018-10-16
 
 ### Fixed

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
   id 'org.sonarqube' version '2.5'
 }
 
-version = '3.1.8'
+version = '3.1.9-SNAPSHOT'
 
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/jacoco.gradle"

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
   id 'org.sonarqube' version '2.5'
 }
 
-version = '3.1.8-SNAPSHOT'
+version = '3.1.8'
 
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/jacoco.gradle"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,9 +17,9 @@ import os
 
 html_context = {
   'version' : '3.1',
-  'full_version' : '3.1.7',
-  'maven_plugin_version' : '3.1.6',
-  'gradle_plugin_version' : '1.6.3',
+  'full_version' : '3.1.8',
+  'maven_plugin_version' : '3.1.7',
+  'gradle_plugin_version' : '1.6.4',
   'archetype_version' : '0.2.1'
 }
 


### PR DESCRIPTION
Better Java 12 support, and revert #688 to support non-Java JVM languages.

<!-- updated by rtd-bot -->
URL of RTD documents:
en: https://spotbugs.readthedocs.io/en/release-3.1.8/
ja: https://spotbugs.readthedocs.io/ja/release-3.1.8/


<!-- updated by rtd-bot -->
URL of RTD documents:
en: https://spotbugs.readthedocs.io/en/release-3.1.8/
ja: https://spotbugs.readthedocs.io/ja/release-3.1.8/
