### PR TITLE
deploy to Sonatype repo even from tag commit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -118,4 +118,4 @@ deploy:
     on:
       all_branches: true
       jdk: oraclejdk8
-      condition: (branch = master || branch = "release-3.1") && type = push
+      condition: (branch = master || branch = "release-3.1" || tag IS present) && type = push


### PR DESCRIPTION
Current Travis CI configuration does not deploy artifacts to Sonatype repo from build on tag.
So I'll add one more condition that is described in [official document](https://docs.travis-ci.com/user/conditions-v1).

Existing `branch = foobar` is still necessary, to deploy SNAPSHOT version.

refs #775