### PR TITLE
Allow parallel Eclipse builds with Spotbugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ## Unreleased - 2018-??-??
 
+### CHANGED
+* Allow parallel workspace builds in Eclipse with Spotbugs installed
+
 ## 3.1.8 - 2018-10-16
 
 ### Fixed

--- a/eclipsePlugin/src/de/tobject/findbugs/builder/FindBugsBuilder.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/builder/FindBugsBuilder.java
@@ -30,6 +30,7 @@ import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.jobs.ISchedulingRule;
 import org.eclipse.jface.preference.IPreferenceStore;
 
 import de.tobject.findbugs.FindBugsJob;
@@ -104,6 +105,12 @@ public class FindBugsBuilder extends IncrementalProjectBuilder {
     @Override
     protected void clean(IProgressMonitor monitor) throws CoreException {
         MarkerUtil.removeMarkers(getProject());
+    }
+    
+    @Override
+    public ISchedulingRule getRule(int kind, Map<String, String> args) {
+    	// lock only the current project during analysis, not the complete workspace. that allows other builders to run in parallel
+    	return getProject();
     }
 
     /**


### PR DESCRIPTION
Since Eclipse Photon users can enable parallel building of the
workspace. However, parallel building requires all existing project
builders to implement a useful scheduling rule. If builders don't
implement that method, they automatically lock the workspace root.

A simple and still safe implementation for spotbugs is to lock only
the currently analyzed project. That allows all other builders to run on
the remaining projects in parallel.

See https://de.slideshare.net/mickaelistria/parallel-builds-in-eclipse-ide-workspace
for more technical background.



----

Make sure these boxes are checked before submitting your PR -- thank you!

- [X] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
