### PR TITLE
Update ASM to 7.0 for full Java 11 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ### Fixed
 * Fix some out-of-bounds reports from LGTM
+* Update asm to 7.0 for better Java 11 support ([#785](https://github.com/spotbugs/spotbugs/pull/785))
 
 ### CHANGED
 * Allow parallel workspace builds in Eclipse with Spotbugs installed

--- a/spotbugs/META-INF/MANIFEST-TEMPLATE.MF
+++ b/spotbugs/META-INF/MANIFEST-TEMPLATE.MF
@@ -65,7 +65,6 @@ Export-Package: edu.umd.cs.findbugs,
  org.objectweb.asm.tree,
  org.objectweb.asm.tree.analysis,
  org.objectweb.asm.util,
- org.objectweb.asm.xml
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ManifestVersion: 2
 Bundle-Name: spotbugs

--- a/spotbugs/META-INF/MANIFEST-TEMPLATE.MF
+++ b/spotbugs/META-INF/MANIFEST-TEMPLATE.MF
@@ -64,7 +64,7 @@ Export-Package: edu.umd.cs.findbugs,
  org.objectweb.asm.signature,
  org.objectweb.asm.tree,
  org.objectweb.asm.tree.analysis,
- org.objectweb.asm.util,
+ org.objectweb.asm.util
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ManifestVersion: 2
 Bundle-Name: spotbugs

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -43,7 +43,6 @@ dependencies {
   compile 'org.ow2.asm:asm-commons:7.0'
   compile 'org.ow2.asm:asm-tree:7.0'
   compile 'org.ow2.asm:asm-util:7.0'
-  compile 'org.ow2.asm:asm-xml:7.0'
   compile 'org.apache.bcel:bcel:6.2'
   compile 'net.jcip:jcip-annotations:1.0'
   compile 'org.dom4j:dom4j:2.1.0'

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -38,12 +38,12 @@ sourceSets {
 }
 
 dependencies {
-  compile 'org.ow2.asm:asm:6.2.1'
-  compile 'org.ow2.asm:asm-analysis:6.2.1'
-  compile 'org.ow2.asm:asm-commons:6.2.1'
-  compile 'org.ow2.asm:asm-tree:6.2.1'
-  compile 'org.ow2.asm:asm-util:6.2.1'
-  compile 'org.ow2.asm:asm-xml:6.2.1'
+  compile 'org.ow2.asm:asm:7.0'
+  compile 'org.ow2.asm:asm-analysis:7.0'
+  compile 'org.ow2.asm:asm-commons:7.0'
+  compile 'org.ow2.asm:asm-tree:7.0'
+  compile 'org.ow2.asm:asm-util:7.0'
+  compile 'org.ow2.asm:asm-xml:7.0'
   compile 'org.apache.bcel:bcel:6.2'
   compile 'net.jcip:jcip-annotations:1.0'
   compile 'org.dom4j:dom4j:2.1.0'

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/asm/FindBugsASM.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/asm/FindBugsASM.java
@@ -28,6 +28,6 @@ public class FindBugsASM {
 
     private static final boolean USE_EXPERIMENTAL = Boolean.parseBoolean(System.getProperty("spotbugs.experimental", "true"));
 
-    public static final int ASM_VERSION = USE_EXPERIMENTAL ? Opcodes.ASM7_EXPERIMENTAL : Opcodes.ASM6;
+    public static final int ASM_VERSION = Opcodes.ASM7;
 
 }


### PR DESCRIPTION
* Removed dependency on `org.ow2.asm:asm-xml` which has been removed.
* Set ASM version to ASM7 unconditionally.
----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
