### PR TITLE
use welcome probot, to ask to share MCVE with us

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,2 +1,7 @@
 rtd:
   project: spotbugs
+newIssueWelcomeComment: >
+  Thanks for opening your first issue here! :smiley:
+
+  Please check [our contributing guideline](https://github.com/spotbugs/spotbugs/blob/release-3.1/.github/CONTRIBUTING.md).
+  Especially when you report problem, make sure you share [a Minimal, Complete, and Verifiable example](https://stackoverflow.com/help/mcve) to reproduce it in this issue.


### PR DESCRIPTION
Recently I manually ask issue authors to share MCVE, but it can be automated by [the welcome probot](https://probot.github.io/apps/welcome/). By this change, comment [like this](https://github.com/spotbugs/spotbugs/issues/791#issuecomment-436449521) will be added by bot.