### PR TITLE
Add missing "a" in bot message

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -4,4 +4,4 @@ newIssueWelcomeComment: >
   Thanks for opening your first issue here! :smiley:
 
   Please check [our contributing guideline](https://github.com/spotbugs/spotbugs/blob/release-3.1/.github/CONTRIBUTING.md).
-  Especially when you report problem, make sure you share [a Minimal, Complete, and Verifiable example](https://stackoverflow.com/help/mcve) to reproduce it in this issue.
+  Especially when you report a problem, make sure you share [a Minimal, Complete, and Verifiable example](https://stackoverflow.com/help/mcve) to reproduce it in this issue.


### PR DESCRIPTION
This PR adds a missing "a" that is pointed at #792.