### PR TITLE
Remove superfluous empty line from about dialog

### DIFF
--- a/eclipsePlugin/about.properties
+++ b/eclipsePlugin/about.properties
@@ -3,4 +3,4 @@ blurb=SpotBugs \n\
 Copyright (c) 2017 SpotBugs Project. All rights reserved.\n\
 Copyright 2003-2008 by the University of Maryland. \n\
 Licensed under the LGPL.\n\
-Visit https://spotbugs.github.io/\n\
+Visit https://spotbugs.github.io/


### PR DESCRIPTION
There is an unexpected empty line in the about dialog of the feature.
The properties file entry should not end with a line break nor with a line continuation escape character.
