### PR TITLE
Add log4j2.xml that has the default config into MANIFEST.MF

### DIFF
--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -147,7 +147,7 @@ jar {
   manifest {
     attributes 'Main-Class': 'edu.umd.cs.findbugs.LaunchAppropriateUI',
                'Bundle-Version': project.version,
-               'Class-Path': jarInClasspath.join(' ')
+               'Class-Path': jarInClasspath.join(' ') + ' config/'
   }
 }
 
@@ -233,6 +233,9 @@ distributions {
       }
       from([jar, project(':spotbugs-ant').jar]) {
         into 'lib'
+      }
+      from ('log4j2.xml') {
+        into 'lib/config'
       }
       from('src/xsl') {
         into 'src/xsl'

--- a/spotbugs/log4j2.xml
+++ b/spotbugs/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Root level="error">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+</Configuration>


### PR DESCRIPTION
This will remove error message when we launch spotbugs by `java -jar lib/spotbugs.jar` or `bin/spotbugs`.
See https://github.com/spotbugs/spotbugs/pull/790#issuecomment-438941763 about which error message we still have in the release-3.1 branch.