### PR TITLE
Release 3.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased - 2018-??-??
+## 3.1.9 - 2018-11-20
 
 ### Fixed
 * Fix some out-of-bounds reports from LGTM

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased - 2018-??-??
+
 ## 3.1.9 - 2018-11-20
 
 ### Fixed

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
   id 'org.sonarqube' version '2.6.2'
 }
 
-version = '3.1.9-SNAPSHOT'
+version = '3.1.9'
 
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/jacoco.gradle"

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
   id 'org.sonarqube' version '2.6.2'
 }
 
-version = '3.1.9'
+version = '3.1.10-SNAPSHOT'
 
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/jacoco.gradle"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,9 +17,9 @@ import os
 
 html_context = {
   'version' : '3.1',
-  'full_version' : '3.1.8',
-  'maven_plugin_version' : '3.1.7',
-  'gradle_plugin_version' : '1.6.4',
+  'full_version' : '3.1.9',
+  'maven_plugin_version' : '3.1.8',
+  'gradle_plugin_version' : '1.6.5',
   'archetype_version' : '0.2.1'
 }
 


### PR DESCRIPTION
This release will include following changes:

### Fixed
* Fix some out-of-bounds reports from LGTM
* Update asm to 7.0 for better Java 11 support ([#785](https://github.com/spotbugs/spotbugs/pull/785))
* Ignore @FXML annotated fields in UR\_UNIT\_READ ([#702](https://github.com/spotbugs/spotbugs/issues/702))

### CHANGED
* Allow parallel workspace builds in Eclipse with Spotbugs installed

This change will close #788 and close #702.

[//]: # (rtdbot-start)

URL of RTD documents:
en: https://spotbugs.readthedocs.io/en/release-3.1.9/
ja: https://spotbugs.readthedocs.io/ja/release-3.1.9/

[//]: # (rtdbot-end)
