### PR TITLE
Change OPCODE_NAMES[opcode] to getOpcodeName(opcode) in comments

### DIFF
--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/OpcodeStack.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/OpcodeStack.java
@@ -1308,7 +1308,7 @@ public class OpcodeStack {
         Item it, it2;
         Constant cons;
 
-        // System.out.printf("%3d %12s%s%n", dbc.getPC(), OPCODE_NAMES[seen],
+        // System.out.printf("%3d %12s%s%n", dbc.getPC(), Const.getOpcodeName(seen),
         // this);
         if (dbc.isRegisterStore()) {
             setLastUpdate(dbc.getRegisterOperand(), dbc.getPC());
@@ -1509,7 +1509,7 @@ public class OpcodeStack {
                     Item topItem = pop();
 
                     // System.out.printf("%4d %10s %s%n",
-                    // dbc.getPC(),OPCODE_NAMES[seen], topItem);
+                    // dbc.getPC(),Const.getOpcodeName(seen), topItem);
                     if (seen == Const.IFLT || seen == Const.IFLE) {
                         registerTestedFoundToBeNonnegative = topItem.registerNumber;
                     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/IsNullValueAnalysis.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/IsNullValueAnalysis.java
@@ -669,7 +669,7 @@ IsNullValueAnalysisFeatures {
             }
             short secondToLastOpcode = prev.getInstruction().getOpcode();
             // System.out.println("Second last opcode: " +
-            // Const.OPCODE_NAMES[secondToLastOpcode]);
+            // Const.Const.getOpcodeName(secondToLastOpcode));
             if (secondToLastOpcode != Const.INSTANCEOF) {
                 return null;
             }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DumbMethods.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DumbMethods.java
@@ -261,7 +261,7 @@ public class DumbMethods extends OpcodeStackDetector {
 
         @Override
         public void sawOpcode(int seen) {
-            // System.out.printf("%4d %s%n", getPC(), OPCODE_NAMES[seen]);
+            // System.out.printf("%4d %s%n", getPC(), Const.getOpcodeName(seen));
             switch(seen) {
             case Const.IALOAD:
             case Const.AALOAD:
@@ -778,7 +778,7 @@ public class DumbMethods extends OpcodeStackDetector {
             }
         }
 
-        // System.out.printf("%4d %10s: %s\n", getPC(), OPCODE_NAMES[seen],
+        // System.out.printf("%4d %10s: %s\n", getPC(), Const.getOpcodeName(seen),
         // stack);
         if (seen == Const.IFLT && stack.getStackDepth() > 0 && stack.getStackItem(0).getSpecialKind() == OpcodeStack.Item.SIGNED_BYTE) {
             sawCheckForNonNegativeSignedByte = getPC();
@@ -798,10 +798,10 @@ public class DumbMethods extends OpcodeStackDetector {
                 /*
                 if (false)
                     try {
-                        pendingAbsoluteValueBug.addString(OPCODE_NAMES[getPrevOpcode(1)] + ":" + OPCODE_NAMES[seen] + ":"
+                        pendingAbsoluteValueBug.addString(OPCODE_NAMES[getPrevOpcode(1)] + ":" + Const.getOpcodeName(seen) + ":"
                                 + OPCODE_NAMES[getNextOpcode()]);
                     } catch (Exception e) {
-                        pendingAbsoluteValueBug.addString(OPCODE_NAMES[getPrevOpcode(1)] + ":" + OPCODE_NAMES[seen]);
+                        pendingAbsoluteValueBug.addString(OPCODE_NAMES[getPrevOpcode(1)] + ":" + Const.getOpcodeName(seen));
 
                     }
                  */
@@ -1134,7 +1134,7 @@ public class DumbMethods extends OpcodeStackDetector {
             prevOpcodeWasReadLine = (seen == Const.INVOKEVIRTUAL || seen == Const.INVOKEINTERFACE)
                     && "readLine".equals(getNameConstantOperand()) && "()Ljava/lang/String;".equals(getSigConstantOperand());
 
-            // System.out.println(randomNextIntState + " " + OPCODE_NAMES[seen]
+            // System.out.println(randomNextIntState + " " + Const.getOpcodeName(seen)
             // + " " + getMethodName());
             switch (randomNextIntState) {
             case 0:

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNonShortCircuit.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNonShortCircuit.java
@@ -89,10 +89,10 @@ public class FindNonShortCircuit extends OpcodeStackDetector implements Stateles
 
     @Override
     public void sawOpcode(int seen) {
-        // System.out.println(getPC() + " " + OPCODE_NAMES[seen] + " " + stage1
+        // System.out.println(getPC() + " " + Const.getOpcodeName(seen) + " " + stage1
         // + " " + stage2);
         // System.out.println(stack);
-        // System.out.println(getPC() + " " + OPCODE_NAMES[seen] + " " +
+        // System.out.println(getPC() + " " + Const.getOpcodeName(seen) + " " +
         // sawMethodCall + " " + sawMethodCallOld + " " + stage1 + " " +
         // stage2);
         distance++;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindPuzzlers.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindPuzzlers.java
@@ -236,7 +236,7 @@ public class FindPuzzlers extends OpcodeStackDetector {
             bugReporter.reportBug(new BugInstance(this, "DLS_DEAD_LOCAL_STORE_IN_RETURN", priority).addClassAndMethod(this)
                     .addSourceLine(this));
         }
-        // System.out.println(getPC() + " " + OPCODE_NAMES[seen] + " " +
+        // System.out.println(getPC() + " " + Const.getOpcodeName(seen) + " " +
         // ternaryConversionState);
         if (seen == Const.IMUL) {
             if (imul_distance != 1) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindUninitializedGet.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindUninitializedGet.java
@@ -153,7 +153,7 @@ public class FindUninitializedGet extends BytecodeScanningDetector implements St
             if (nextOpcode != Const.POP && !initializedFields.contains(f) && declaredFields.contains(f) && !containerFields.contains(f)
                     && !unreadFields.isContainerField(xField)) {
                 // System.out.println("Next opcode: " +
-                // OPCODE_NAMES[nextOpcode]);
+                // Const.getOpcodeName(nextOpcode));
                 LocalVariableAnnotation possibleTarget = LocalVariableAnnotation.findMatchingIgnoredParameter(getClassContext(),
                         getMethod(), getNameConstantOperand(), xField.getSignature());
                 if (possibleTarget == null) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FormatStringChecker.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FormatStringChecker.java
@@ -64,7 +64,7 @@ public class FormatStringChecker extends OpcodeStackDetector {
      */
     @Override
     public void sawOpcode(int seen) {
-        // System.out.println(getPC() + " " + OPCODE_NAMES[seen] + " " + state);
+        // System.out.println(getPC() + " " + Const.getOpcodeName(seen) + " " + state);
 
         if (stack.getStackDepth() < stackDepth) {
             state = FormatState.NONE;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MutableStaticFields.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MutableStaticFields.java
@@ -165,7 +165,7 @@ public class MutableStaticFields extends BytecodeScanningDetector {
 
     @Override
     public void sawOpcode(int seen) {
-        // System.out.println("saw\t" + OPCODE_NAMES[seen] + "\t" + zeroOnTOS);
+        // System.out.println("saw\t" + Const.getOpcodeName(seen) + "\t" + zeroOnTOS);
         switch (seen) {
         case Const.GETSTATIC:
         case Const.PUTSTATIC:

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/OverridingEqualsNotSymmetrical.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/OverridingEqualsNotSymmetrical.java
@@ -207,7 +207,7 @@ public class OverridingEqualsNotSymmetrical extends OpcodeStackDetector implemen
     @Override
     public void sawOpcode(int seen) {
         if (getPC() == 2 && seen != Const.IF_ACMPEQ && seen != Const.IF_ACMPNE) {
-            // System.out.println(OPCODE_NAMES[seen]);
+            // System.out.println(Const.getOpcodeName(seen));
             sawInitialIdentityCheck = false;
         }
         if (getPC() == 2

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SynchronizeAndNullCheckField.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SynchronizeAndNullCheckField.java
@@ -58,7 +58,7 @@ public class SynchronizeAndNullCheckField extends BytecodeScanningDetector {
 
     @Override
     public void sawOpcode(int seen) {
-        // System.out.println(getPC() + " " + OPCODE_NAMES[seen] + " " +
+        // System.out.println(getPC() + " " + Const.getOpcodeName(seen) + " " +
         // currState);
         switch (currState) {
         case 0:

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SynchronizingOnContentsOfFieldToProtectField.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SynchronizingOnContentsOfFieldToProtectField.java
@@ -62,7 +62,7 @@ public class SynchronizingOnContentsOfFieldToProtectField extends OpcodeStackDet
 
     @Override
     public void sawOpcode(int seen) {
-        // System.out.println(state + " " + getPC() + " " + OPCODE_NAMES[seen]);
+        // System.out.println(state + " " + getPC() + " " + Const.getOpcodeName(seen));
         if (countDown == 2 && seen == Const.GOTO) {
             CodeException tryBlock = getSurroundingTryBlock(getPC());
             if (tryBlock != null && tryBlock.getEndPC() == getPC()) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/visitclass/DismantleBytecode.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/visitclass/DismantleBytecode.java
@@ -562,7 +562,7 @@ abstract public class DismantleBytecode extends AnnotationVisitor {
                 }
                 prevOpcode[currentPosInPrevOpcodeBuffer] = opcode;
                 i++;
-                // System.out.println(OPCODE_NAMES[opCode]);
+                // System.out.println(Const.getOpcodeName(opCode));
                 int byteStreamArgCount = Const.getNoOfOperands(opcode);
                 if (byteStreamArgCount == Const.UNPREDICTABLE) {
 


### PR DESCRIPTION
This saves time if there is a need to locally re-enable these debugging
statements, and makes it easier to base code off of these methods.

There is no expected impact - These are all commented out and the constant doesn't exist any more.

I'm not sure which target branch to use (checked CONTRIBUTING.md) - is 3.1 correct?

----

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code (only comments were changed)
