### PR TITLE
Detect method parameter type annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ### CHANGED
 * Allow parallel workspace builds in Eclipse with Spotbugs installed
+* Detect method parameter type annotations ([#743](https://github.com/spotbugs/spotbugs/issues/592))
 
 ## 3.1.8 - 2018-10-16
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/ClassParserUsingASM.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/ClassParserUsingASM.java
@@ -34,6 +34,8 @@ import org.objectweb.asm.Handle;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.TypePath;
+import org.objectweb.asm.TypeReference;
 
 import edu.umd.cs.findbugs.ba.SignatureParser;
 import edu.umd.cs.findbugs.classfile.ClassDescriptor;
@@ -489,6 +491,19 @@ public class ClassParserUsingASM implements ClassParserInterface {
             AnnotationValue value = new AnnotationValue(desc);
             mBuilder.addParameterAnnotation(parameter, desc, value);
             return value.getAnnotationVisitor();
+        }
+
+        @Override
+        public org.objectweb.asm.AnnotationVisitor visitTypeAnnotation(int typeRef, TypePath typePath,
+                String desc, boolean visible) {
+            TypeReference typeRefObject = new TypeReference(typeRef);
+            if (typeRefObject.getSort() == TypeReference.METHOD_FORMAL_PARAMETER) {
+                // treat as parameter annotation
+                AnnotationValue value = new AnnotationValue(desc);
+                mBuilder.addParameterAnnotation(typeRefObject.getFormalParameterIndex(), desc, value);
+                return value.getAnnotationVisitor();
+            }
+            return null;
         }
     }
 


### PR DESCRIPTION
This change causes Spotbugs to treat type annotations on formal method parameters just like parameter annotations. The main purpose is to get Spotbugs to see @Nullable and @NonNull annotations in code compiled under Java 8, where the compiler slots them as type annotations.

This might not be a "correct" way of handling the issue, because it doesn't make Spotbugs understand type annotations. So, feel free to reject for that reason (or others!) or use as a basis for some better way. It does at least illuminate, for example, how moving to newer Guava libraries causes false positives - Guava started being built under Java 8.

Should fix issues #470 in some aspects, #616, #643 in some aspects, and #743.
----

Make sure these boxes are checked before submitting your PR -- thank you!

- [X] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
