### PR TITLE
Fix the path of secret key, by using absolute path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ install:
   - echo "ossrhPassword=${SONATYPE_PASSWORD}" >> gradle.properties
   - echo "signing.keyId=${SIGNING_KEY_ID}" >> gradle.properties
   - echo "signing.password=${SIGNING_PASSWORD}" >> gradle.properties
-  - echo signing.secretKeyRingFile=secring.gpg >> gradle.properties
+  - echo signing.secretKeyRingFile=${TRAVIS_BUILD_DIR}/secring.gpg >> gradle.properties
   - echo "keystorepass=${KEYSTORE_PASS}" >> gradle.properties
 
 script:


### PR DESCRIPTION
Our build job is failing because it cannot find the secret key to sign archives by GPG.

* https://travis-ci.org/spotbugs/spotbugs/jobs/463217362

Previously it worked; Gradle resolved relative path based on project base directory.
I guess behaviour of Gradle or its plugins has been changed.

By using absolute path instead of relative path, we can avoid this trouble.