### PR TITLE
Release 3.1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased - 2019-??-??
+
 ## 3.1.10 - 2018-12-19
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased - 2018-??-??
+## 3.1.10 - 2018-12-19
 
 ### Fixed
 * Fix bug that enhanced xml options not recognized as textui mode

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
   id 'org.sonarqube' version '2.6.2'
 }
 
-version = '3.1.10-SNAPSHOT'
+version = '3.1.10'
 
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/jacoco.gradle"

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
   id 'org.sonarqube' version '2.6.2'
 }
 
-version = '3.1.10'
+version = '3.1.11-SNAPSHOT'
 
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/jacoco.gradle"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,7 @@ import os
 
 html_context = {
   'version' : '3.1',
-  'full_version' : '3.1.9',
+  'full_version' : '3.1.10',
   'maven_plugin_version' : '3.1.9',
   'gradle_plugin_version' : '1.6.6',
   'archetype_version' : '0.2.2'


### PR DESCRIPTION
This will release the next patch version 3.1.10, you can see its CHANGELOG at here:

https://github.com/spotbugs/spotbugs/blob/ae95e5595222662e34bac89e98907089eee1810a/CHANGELOG.md#3110---2018-12-19

[//]: # (rtdbot-start)

URL of RTD documents:
en: https://spotbugs.readthedocs.io/en/release-3.1.10/
ja: https://spotbugs.readthedocs.io/ja/release-3.1.10/

[//]: # (rtdbot-end)
