### PR TITLE
Treat annotations on synthetic parameter properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ## Unreleased - 2019-??-??
 
+### Fixed
+* False positive: parameter must be non-null in inner class constructor ([#772](https://github.com/spotbugs/spotbugs/issues/772))
+
 ## 3.1.10 - 2018-12-19
 
 ### Fixed

--- a/spotbugsTestCases/src/java/nullnessAnnotations/NonNullParameterOfInnerClassConstructor.java
+++ b/spotbugsTestCases/src/java/nullnessAnnotations/NonNullParameterOfInnerClassConstructor.java
@@ -1,0 +1,23 @@
+package nullnessAnnotations;
+
+import edu.umd.cs.findbugs.annotations.NoWarning;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * Reproducer for https://github.com/spotbugs/spotbugs/issues/772
+ */
+public class NonNullParameterOfInnerClassConstructor {
+
+  private class Inner {
+    private final String a;
+    private final Object b;
+
+    @NoWarning("NP")
+    Inner(@NonNull String a, @Nullable Object b) {
+      this.a = a.toLowerCase();
+      this.b = b;
+    }
+
+  }
+}


### PR DESCRIPTION
Currently `ClassParserUsingASM` uses parameter index that doesn't consider the synthetic parameter like the reference from non-static inner class to outer class. This means that, SpotBugs treats annotation on the 1st parameter __in source code__ (`String` in the test case) as annotation on the 1st parameter __in bytecode__ (`NonNullParameterOfInnerClassConstructor` in the test case).

Unfortunately at the timing of `visitParameterAnnotation()`, the `mBuilder` doesn't know that the parameter is synthetic or not. So we need to count the number of synthetic parameters by `number of actual parameters - number of annotatable parameters` dynamically.

This PR fixes #772. It also closes #773.

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
