### PR TITLE
Update 3.0 to 3.1 migration doc

### DIFF
--- a/docs/code-template/migration-findbugs-gradle-plugin.template
+++ b/docs/code-template/migration-findbugs-gradle-plugin.template
@@ -7,8 +7,6 @@ spotbugs {
 
 // To generate an HTML report instead of XML
 tasks.withType(com.github.spotbugs.SpotBugsTask) {
-  reports {
-    xml.enabled = false
-    html.enabled = true
-  }
+  reports.xml.enabled = false
+  reports.html.enabled = true
 }


### PR DESCRIPTION
Gradle 5.x won't support constructions like `reports { a=b }` anymore
so the update proposes a compilable version of the same code in docs.
Why is this important?
- Gradle 5.0 is officially released stable
- spotbugs docs page is the first in google index `spotbugs report html`

Also, please correct me/consider reworking the idea/promote further if needed.

----

- [ ] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
- [ ] Added an entry into `gradlePlugin/CHANGELOG.md` if you have changed Gradle plugin code
