### PR TITLE
Issue #829: fix compile issues in Eclipse

### DIFF
--- a/spotbugs/META-INF/MANIFEST-TEMPLATE.MF
+++ b/spotbugs/META-INF/MANIFEST-TEMPLATE.MF
@@ -1,6 +1,5 @@
 Manifest-Version: 1.0
 Export-Package: edu.umd.cs.findbugs,
- edu.umd.cs.findbugs.architecture,
  edu.umd.cs.findbugs.asm,
  edu.umd.cs.findbugs.ba,
  edu.umd.cs.findbugs.ba.bcp,

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -47,6 +47,11 @@ sourceSets {
       include '**/*.png'
     }
   }
+  test {
+    java {
+      srcDirs = ['src/test/java','src/gui/test/java']
+    }
+  }
 }
 
 dependencies {
@@ -70,6 +75,7 @@ dependencies {
   testCompile 'junit:junit:4.12'
   testCompile 'org.apache.ant:ant:1.9.4'
   testCompile 'org.apache.logging.log4j:log4j-slf4j18-impl:2.11.1'
+  testCompile sourceSets.gui.output
 
   // TODO : Some of these can be extracted to actual dependencies
   compile fileTree(dir: 'lib', include: '*.jar')
@@ -96,6 +102,11 @@ tasks.withType(Jar).all {
   //destinationDir = file("$projectDir/lib")
 }
 
+eclipse.classpath {
+  plusConfigurations += [ configurations.compileOnly ]
+  plusConfigurations += [ configurations.guiCompileOnly ]
+  plusConfigurations += [ configurations.testCompile ]
+}
 
 eclipse.classpath.file {
     whenMerged {
@@ -103,7 +114,8 @@ eclipse.classpath.file {
          classpath.entries.removeAll { entry -> entry.kind == 'lib' && entry.path.contains('xml-apis')}
          classpath.entries.forEach {
              entry ->
-               if(entry.kind == 'lib' && !entry.path.contains('spotbugs-annotations')) {
+               if(entry.kind == 'lib' && !entry.path.contains('spotbugs-annotations')
+                   && !java.nio.file.Files.isDirectory(java.nio.file.Paths.get(entry.path))) {
                    entry.path = ".libs/" + java.nio.file.Paths.get(entry.path).getFileName().toString()
                    entry.exported = true
                }
@@ -127,6 +139,10 @@ task copyLibsForEclipse (type: Copy) {
     include "*.jar"
 
     from configurations.compileOnly.files
+    into ".libs"
+    include "*.jar"
+
+    from configurations.guiCompileOnly.files
     into ".libs"
     include "*.jar"
 }

--- a/spotbugs/build.properties
+++ b/spotbugs/build.properties
@@ -1,9 +1,13 @@
 source.spotbugs.jar = src/main/java/,\
-                      src/gui/,\
+                      src/gui/main/,\
+                      src/gui/test/java/,\
                       src/test/java/,\
                       src/xsl/,\
                       etc
 bin.includes = .libs/,\
                META-INF/
 jars.compile.order = spotbugs.jar
+output.spotbugs.jar = bin/main/,\
+                      bin/gui/,\
+                      bin/test
 


### PR DESCRIPTION
- fixed not existing package in manifest
- fixed AppleJavaExtensions-1.4.jar missing in generated .classpath