### PR TITLE
Update documentation tools

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -4,14 +4,19 @@
 
 FROM ubuntu:xenial
 
+# Necessary to build documents with Python3
+# https://click.palletsprojects.com/en/7.x/python3/
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+
 RUN mkdir documents
 RUN apt-get update && \
-    apt-get install -y texlive texlive-latex-extra pandoc build-essential curl && \
+    apt-get install -y texlive texlive-latex-extra pandoc build-essential curl make python3 && \
     apt-get autoremove && \
     apt-get clean
-RUN curl -kL https://bootstrap.pypa.io/get-pip.py | python
+RUN curl -kL https://bootstrap.pypa.io/get-pip.py | python3
 
-RUN pip install sphinx sphinx-intl sphinx_rtd_theme
+RUN pip3 install sphinx sphinx-intl sphinx_rtd_theme
 
 WORKDIR /documents/docs
 VOLUME /documents

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -5,8 +5,10 @@
 FROM ubuntu:xenial
 
 RUN mkdir documents
-RUN apt-get update
-RUN apt-get install -y python-sphinx texlive texlive-latex-extra pandoc build-essential curl
+RUN apt-get update && \
+    apt-get install -y python-sphinx texlive texlive-latex-extra pandoc build-essential curl && \
+    apt-get autoremove && \
+    apt-get clean
 RUN curl -kL https://bootstrap.pypa.io/get-pip.py | python
 
 RUN pip install sphinx-intl

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -6,12 +6,12 @@ FROM ubuntu:xenial
 
 RUN mkdir documents
 RUN apt-get update && \
-    apt-get install -y python-sphinx texlive texlive-latex-extra pandoc build-essential curl && \
+    apt-get install -y texlive texlive-latex-extra pandoc build-essential curl && \
     apt-get autoremove && \
     apt-get clean
 RUN curl -kL https://bootstrap.pypa.io/get-pip.py | python
 
-RUN pip install sphinx-intl
+RUN pip install sphinx sphinx-intl
 
 WORKDIR /documents/docs
 VOLUME /documents

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -3,7 +3,6 @@
 # and run `docker run -it -v $(pwd):/documents spotbugs-sphinx make html` to generate documents.
 
 FROM ubuntu:xenial
-ENV DEBIAN_FRONTEND noninteractive
 
 RUN mkdir documents
 RUN apt-get update

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
     apt-get clean
 RUN curl -kL https://bootstrap.pypa.io/get-pip.py | python
 
-RUN pip install sphinx sphinx-intl
+RUN pip install sphinx sphinx-intl sphinx_rtd_theme
 
 WORKDIR /documents/docs
 VOLUME /documents


### PR DESCRIPTION
To prepare for Sphinx 2.0 that will be released at this spring, bump up the version of python from 2 to 3.
Also update `docs/Dockerfile` to make build image more small and stable.