### PR TITLE
modify test data to prove issue #259 is not solved yet

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/nullness/Issue259Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/nullness/Issue259Test.java
@@ -21,7 +21,9 @@ public class Issue259Test {
     @Test
     public void test() {
         BugCollection bugCollection = spotbugs.performAnalysis(
-                Paths.get("../spotbugsTestCases/build/classes/java/main/ghIssues/Issue259.class"));
+                Paths.get("../spotbugsTestCases/build/classes/java/main/ghIssues/Issue259.class"),
+                Paths.get("../spotbugsTestCases/build/classes/java/main/ghIssues/Issue259$X.class")
+        );
         assertThat(bugCollection, emptyIterable());
     }
 }

--- a/spotbugsTestCases/src/java/ghIssues/Issue259.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue259.java
@@ -8,8 +8,12 @@ public class Issue259 {
     }
 
     private static class X implements AutoCloseable {
+
+        Object state = new Object();
+
         @Override
         public void close() {
+            state = null;
         }
     }
 }


### PR DESCRIPTION
As a continuation to discussions of issue #259 regarding false positives for try-with-resources statements. Two important points that were missing:
- First of all, compiled class for static nested class was not included for analysis
- Empty close() method does not raise the issue, instead there should be some action inside the method which is quite normal and expected. I think there is some kind of compiler optimization for empty methods.

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [ ] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code - **N/A**
- [ ] Added an entry into `gradlePlugin/CHANGELOG.md` if you have changed Gradle plugin code - **N/A**