### PR TITLE
fix FindNonShortCircuit#reportBug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,41 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased - 2018-??-??
-* Start migrating STDOUT/STDERR usage to a logging framework
+## Unreleased - 2019-??-??
+
+### Changed
+* Bump up Apache Commons BCEL to [the version 6.3](http://mail-archives.apache.org/mod_mbox/commons-user/201901.mbox/%3CCACZkXPy3VgLmD2jppzEPwOqVDJYMM2QG%2BtWQCyzfKmZrDwem6A%40mail.gmail.com%3E)
+
+### Fixed
 * Fixed bug priority calculation logic in FindNonShortCircuit#reportBug
+
+### Security
+* Update dom4j to 2.1.1 to fix security vulnerability. ([#864](https://github.com/spotbugs/spotbugs/issues/864))
+
+## 3.1.11 - 2019-01-18
+
+### Fixed
+* False positive: parameter must be non-null in inner class constructor ([#772](https://github.com/spotbugs/spotbugs/issues/772))
+
+## 3.1.10 - 2018-12-19
+
+### Fixed
+* Fix bug that enhanced xml options not recognized as textui mode
+* Dataflow generates too much log ([#601](https://github.com/spotbugs/spotbugs/issues/601))
+* Delete redundant put plugin ([#720](https://github.com/spotbugs/spotbugs/pull/720))
+
+### Added
+* Add new detector IRA\_INEFFICIENT\_REPLACEALL for detecting usage of String.replaceAll where no regex is being used ([#705](https://github.com/spotbugs/spotbugs/issues/705))
+
+### Changed
+* Eclipse plugin is now signed to establish validity ([#779](https://github.com/spotbugs/spotbugs/issues/779))
+* edu.umd.cs.findbugs.util.ClassName#assertIsDotted return type is changed to void
+* edu.umd.cs.findbugs.util.ClassName#assertIsSlashed return type is changed to void
+* Detect method parameter type annotations ([#743](https://github.com/spotbugs/spotbugs/issues/743))
+
+### Deprecated
+* edu.umd.cs.findbugs.classfile.ClassDescriptor#toDottedClassName() is depricated and getDottedClassName() can be used instead.
+
 ## 3.1.9 - 2018-11-20
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ## Unreleased - 2018-??-??
 * Start migrating STDOUT/STDERR usage to a logging framework
-
+* Fixed bug priority calculation logic in FindNonShortCircuit#reportBug
 ## 3.1.9 - 2018-11-20
 
 ### Fixed

--- a/docs/links.rst
+++ b/docs/links.rst
@@ -3,6 +3,12 @@ SpotBugs Links
 
 This page contains links to related projects, including tools that are similar to SpotBugs.
 
+IDE Integration
+---------------
+
+`m2e-code-quality <https://github.com/m2e-code-quality/m2e-code-quality/>`_
+  An Eclipse plugin which configures the FindBugs/SpotBugs Eclipse plugin to match the FindBugs/SpotBugs Maven plugin.
+
 SpotBugs Plugins
 ----------------
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNonShortCircuit.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNonShortCircuit.java
@@ -195,8 +195,7 @@ public class FindNonShortCircuit extends OpcodeStackDetector implements Stateles
         if (sawDangerOld) {
             if (sawNullTestVeryOld) {
                 priority = HIGH_PRIORITY;
-            }
-            if (sawMethodCallOld || sawNumericTestVeryOld && sawArrayDangerOld) {
+            } else if (sawMethodCallOld || sawNumericTestVeryOld && sawArrayDangerOld) {
                 priority = HIGH_PRIORITY;
                 pattern = "NS_DANGEROUS_NON_SHORT_CIRCUIT";
             } else {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNonShortCircuit.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNonShortCircuit.java
@@ -32,6 +32,10 @@ import edu.umd.cs.findbugs.bcel.OpcodeStackDetector;
 
 public class FindNonShortCircuit extends OpcodeStackDetector implements StatelessDetector {
 
+    public static final String NS_NON_SHORT_CIRCUIT = "NS_NON_SHORT_CIRCUIT";
+
+    public static final String NS_DANGEROUS_NON_SHORT_CIRCUIT = "NS_DANGEROUS_NON_SHORT_CIRCUIT";
+
     int stage1 = 0;
 
     int stage2 = 0;
@@ -189,21 +193,24 @@ public class FindNonShortCircuit extends OpcodeStackDetector implements Stateles
     }
 
     private void reportBug() {
+        bugAccumulator.accumulateBug(getBugInstance().addClassAndMethod(this), this);
+    }
+
+    BugInstance getBugInstance() {
         int priority = LOW_PRIORITY;
-        String pattern = "NS_NON_SHORT_CIRCUIT";
+        String pattern = NS_NON_SHORT_CIRCUIT;
 
         if (sawDangerOld) {
             if (sawNullTestVeryOld) {
                 priority = HIGH_PRIORITY;
             } else if (sawMethodCallOld || sawNumericTestVeryOld && sawArrayDangerOld) {
                 priority = HIGH_PRIORITY;
-                pattern = "NS_DANGEROUS_NON_SHORT_CIRCUIT";
+                pattern = NS_DANGEROUS_NON_SHORT_CIRCUIT;
             } else {
                 priority = NORMAL_PRIORITY;
             }
         }
-
-        bugAccumulator.accumulateBug(new BugInstance(this, pattern, priority).addClassAndMethod(this), this);
+        return new BugInstance(this, pattern, priority);
     }
 
     private void scanForBooleanValue(int seen) {

--- a/spotbugs/src/test/java/edu/umd/cs/findbugs/detect/FindNonShortCircuitTest.java
+++ b/spotbugs/src/test/java/edu/umd/cs/findbugs/detect/FindNonShortCircuitTest.java
@@ -1,0 +1,46 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.BugInstance;
+import edu.umd.cs.findbugs.PrintingBugReporter;
+import edu.umd.cs.findbugs.Priorities;
+import edu.umd.cs.findbugs.Project;
+import edu.umd.cs.findbugs.ba.AnalysisContext;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class FindNonShortCircuitTest {
+
+    @Test
+    public void testBugTypeAndPriority() {
+        PrintingBugReporter bugReporter = new PrintingBugReporter();
+        AnalysisContext ctx = AnalysisContext.currentAnalysisContext();
+        try {
+            if (ctx == null) {
+                AnalysisContext.setCurrentAnalysisContext(new AnalysisContext(new Project()));
+            }
+            FindNonShortCircuit check = new FindNonShortCircuit(bugReporter);
+            BugInstance bug = check.getBugInstance();
+            assertEquals(FindNonShortCircuit.NS_NON_SHORT_CIRCUIT, bug.getType());
+            assertEquals(Priorities.LOW_PRIORITY, bug.getPriority());
+
+            check.sawDangerOld = true;
+            bug = check.getBugInstance();
+            assertEquals(FindNonShortCircuit.NS_NON_SHORT_CIRCUIT, bug.getType());
+            assertEquals(Priorities.NORMAL_PRIORITY, bug.getPriority());
+
+            check.sawNullTestVeryOld = true;
+            bug = check.getBugInstance();
+            assertEquals(FindNonShortCircuit.NS_NON_SHORT_CIRCUIT, bug.getType());
+            assertEquals(Priorities.HIGH_PRIORITY, bug.getPriority());
+
+            check.sawNullTestVeryOld = false;
+            check.sawMethodCallOld = true;
+            bug = check.getBugInstance();
+            assertEquals(FindNonShortCircuit.NS_DANGEROUS_NON_SHORT_CIRCUIT, bug.getType());
+            assertEquals(Priorities.HIGH_PRIORITY, bug.getPriority());
+        } finally {
+            AnalysisContext.setCurrentAnalysisContext(ctx);
+        }
+    }
+}


### PR DESCRIPTION
Fixed `FindNonShortCircuit#reportBug` method based on [static analysis finding](https://www.viva64.com/en/b/0603/#ID0E61EK). `sawNullTestVeryOld` variable had no impact on `priority`.


----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
