### PR TITLE
Bump up Apache Commons BCEL to 6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ## Unreleased - 2019-??-??
 
+### Changed
+* Bump up Apache Commons BCEL to [the version 6.3](http://mail-archives.apache.org/mod_mbox/commons-user/201901.mbox/%3CCACZkXPy3VgLmD2jppzEPwOqVDJYMM2QG%2BtWQCyzfKmZrDwem6A%40mail.gmail.com%3E)
+
 ## 3.1.11 - 2019-01-18
 
 ### Fixed

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -60,7 +60,7 @@ dependencies {
   compile 'org.ow2.asm:asm-commons:7.0'
   compile 'org.ow2.asm:asm-tree:7.0'
   compile 'org.ow2.asm:asm-util:7.0'
-  compile 'org.apache.bcel:bcel:6.2'
+  compile 'org.apache.bcel:bcel:6.3'
   compile 'net.jcip:jcip-annotations:1.0'
   compile 'org.dom4j:dom4j:2.1.0'
   compile 'jaxen:jaxen:1.1.6' // only transitive through dom4j:dom4j:1.6.1, which has an *optional* dependency on jaxen:jaxen.


### PR DESCRIPTION
Bump up Apache Commons BCEL to [the version 6.3](http://mail-archives.apache.org/mod_mbox/commons-user/201901.mbox/%3CCACZkXPy3VgLmD2jppzEPwOqVDJYMM2QG%2BtWQCyzfKmZrDwem6A%40mail.gmail.com%3E).

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
