### PR TITLE
Bump up dom4j to the latest version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ## Unreleased - 2019-??-??
 
+### Security
+* Update dom4j to 2.1.1 to fix security vulnerability. ([#864](https://github.com/spotbugs/spotbugs/issues/864))
+
 ## 3.1.11 - 2019-01-18
 
 ### Fixed

--- a/eclipsePlugin/doc/installing_findbugsplugin.txt
+++ b/eclipsePlugin/doc/installing_findbugsplugin.txt
@@ -25,7 +25,7 @@ Install the plug-in
             |     asm-tree-3.3.jar
             |     bcel.jar
             |     commons-lang-2.6.jar
-            |     dom4j-2.1.0.jar
+            |     dom4j-2.1.1.jar
             |     jaxen-1.1.6.jar
             |     jsr305.jar
             |

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -62,7 +62,7 @@ dependencies {
   compile 'org.ow2.asm:asm-util:7.0'
   compile 'org.apache.bcel:bcel:6.2'
   compile 'net.jcip:jcip-annotations:1.0'
-  compile 'org.dom4j:dom4j:2.1.0'
+  compile 'org.dom4j:dom4j:2.1.1'
   compile 'jaxen:jaxen:1.1.6' // only transitive through dom4j:dom4j:1.6.1, which has an *optional* dependency on jaxen:jaxen.
   compile 'commons-lang:commons-lang:2.6'
   compile 'org.slf4j:slf4j-api:1.8.0-beta2'

--- a/spotbugs/etc/MANIFEST-findbugs.MF
+++ b/spotbugs/etc/MANIFEST-findbugs.MF
@@ -1,3 +1,3 @@
 Manifest-Version: 1.0
 Main-Class: edu.umd.cs.findbugs.LaunchAppropriateUI
-Class-Path: bcel.jar dom4j-2.1.0.jar jaxen-1.1.6.jar asm-6.2.1.jar asm-analysis-6.2.1.jar asm-commons-6.2.1.jar asm-tree-6.2.1.jar asm-util-6.2.1.jar asm-xml-6.2.1.jar jsr305.jar commons-lang-2.6.jar
+Class-Path: bcel.jar dom4j-2.1.1.jar jaxen-1.1.6.jar asm-6.2.1.jar asm-analysis-6.2.1.jar asm-commons-6.2.1.jar asm-tree-6.2.1.jar asm-util-6.2.1.jar asm-xml-6.2.1.jar jsr305.jar commons-lang-2.6.jar

--- a/spotbugs/etc/MANIFEST-findbugsGUI.MF
+++ b/spotbugs/etc/MANIFEST-findbugsGUI.MF
@@ -1,3 +1,3 @@
 Manifest-Version: 1.0
 Main-Class: edu.umd.cs.findbugs.LaunchAppropriateUI
-Class-Path: bcel.jar dom4j-2.1.0.jar jaxen-1.1.6.jar asm-6.2.1.jar asm-analysis-6.2.1.jar asm-commons-6.2.1.jar asm-tree-6.2.1.jar asm-util-6.2.1.jar asm-xml-6.2.1.jar jsr305.jar commons-lang-2.6.jar plastic.jar
+Class-Path: bcel.jar dom4j-2.1.1.jar jaxen-1.1.6.jar asm-6.2.1.jar asm-analysis-6.2.1.jar asm-commons-6.2.1.jar asm-tree-6.2.1.jar asm-util-6.2.1.jar asm-xml-6.2.1.jar jsr305.jar commons-lang-2.6.jar plastic.jar

--- a/spotbugs/jnlp/core.jnlp
+++ b/spotbugs/jnlp/core.jnlp
@@ -15,7 +15,7 @@
   <resources>
     <jar href="AppleJavaExtensions.jar"/>
     <jar href="bcel.jar"/>
-    <jar href="dom4j-2.1.0.jar"/>
+    <jar href="dom4j-2.1.1.jar"/>
     <jar href="asm-3.3.jar"/>
     <jar href="asm-tree-3.3.jar"/>
     <jar href="asm-commons-3.3.jar"/>
@@ -25,6 +25,3 @@
   </resources>
   <component-desc />
 </jnlp>
-
-
-

--- a/spotbugs/jnlp/findbugs.jnlp
+++ b/spotbugs/jnlp/findbugs.jnlp
@@ -20,7 +20,7 @@
     <jar href="findbugs.jar"/>
     <jar href="AppleJavaExtensions.jar"/>
     <jar href="bcel.jar"/>
-    <jar href="dom4j-2.1.0.jar"/>
+    <jar href="dom4j-2.1.1.jar"/>
     <jar href="asm-6.2.1.jar"/>
     <jar href="asm-analysis-6.2.1.jar"/>
     <jar href="asm-commons-6.2.1.jar"/>

--- a/spotbugs/src/sampleXml/analysisResultsWithFilterAndUserAnnotations.xml
+++ b/spotbugs/src/sampleXml/analysisResultsWithFilterAndUserAnnotations.xml
@@ -7,7 +7,7 @@
     <AuxClasspathEntry>/Users/pugh/Documents/fb-trunk/findbugs/lib/findbugs.jar</AuxClasspathEntry>
     <AuxClasspathEntry>/Users/pugh/Documents/fb-trunk/findbugs/lib/jdepend-2.9.jar</AuxClasspathEntry>
     <AuxClasspathEntry>/Users/pugh/Documents/fb-trunk/findbugs/lib/bcel.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/Users/pugh/Documents/fb-trunk/findbugs/lib/dom4j-2.1.0.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/pugh/Documents/fb-trunk/findbugs/lib/dom4j-2.1.1.jar</AuxClasspathEntry>
     <AuxClasspathEntry>/Users/pugh/Documents/fb-trunk/findbugs/lib/AppleJavaExtensions.jar</AuxClasspathEntry>
     <AuxClasspathEntry>/Users/pugh/Documents/fb-trunk/findbugs/lib/junit.jar</AuxClasspathEntry>
     <AuxClasspathEntry>/Users/pugh/Documents/fb-trunk/findbugs/lib/asm-6.2.1.jar</AuxClasspathEntry>


### PR DESCRIPTION
As reported at #864, currently dom4j has a XML Injection vulnerability. Better to fix in the next release.

This PR close #864.