### PR TITLE
chore: replace old properties with new one

### DIFF
--- a/gradle/sonar.gradle
+++ b/gradle/sonar.gradle
@@ -36,7 +36,7 @@ if (isPullRequest) {
             // https://docs.sonarqube.org/7.6/analysis/pull-request/
             // https://github.com/travis-ci/travis-build/blob/6af6dd723bd6b364dc29ad74af7f22438a16494d/lib/travis/build/addons/sonarcloud.rb#L123-L127
             property 'sonar.pullrequest.key', System.env.TRAVIS_PULL_REQUEST
-            property 'sonar.pullrequest.branch' System.env.TRAVIS_PULL_REQUEST_SLUG
+            property 'sonar.pullrequest.branch', System.env.TRAVIS_PULL_REQUEST_SLUG
             property 'sonar.pullrequest.base', System.env.TRAVIS_BRANCH
             property 'sonar.pullrequest.provider', 'GitHub'
             property 'sonar.pullrequest.github.repository', System.env.TRAVIS_REPO_SLUG

--- a/gradle/sonar.gradle
+++ b/gradle/sonar.gradle
@@ -33,10 +33,13 @@ sonarqube {
 if (isPullRequest) {
     sonarqube {
         properties {
-            property 'sonar.analysis.mode', 'preview'
-            property 'sonar.github.oauth', System.env.GITHUB_TOKEN
-            property 'sonar.github.pullRequest', System.env.TRAVIS_PULL_REQUEST
-            property 'sonar.github.repository', System.env.TRAVIS_REPO_SLUG
+            // https://docs.sonarqube.org/7.6/analysis/pull-request/
+            // https://github.com/travis-ci/travis-build/blob/6af6dd723bd6b364dc29ad74af7f22438a16494d/lib/travis/build/addons/sonarcloud.rb#L123-L127
+            property 'sonar.pullrequest.key', System.env.TRAVIS_PULL_REQUEST
+            property 'sonar.pullrequest.branch' System.env.TRAVIS_PULL_REQUEST_SLUG
+            property 'sonar.pullrequest.base', System.env.TRAVIS_BRANCH
+            property 'sonar.pullrequest.provider', 'GitHub'
+            property 'sonar.pullrequest.github.repository', System.env.TRAVIS_REPO_SLUG
         }
     }
 }

--- a/gradle/sonar.gradle
+++ b/gradle/sonar.gradle
@@ -25,8 +25,6 @@ sonarqube {
         property 'sonar.projectName', 'SpotBugs'
         property 'sonar.projectVersion', rootProject.version
         property 'sonar.organization', 'spotbugs'
-        // https://docs.sonarqube.org/display/PLUG/Branch+Plugin
-        property 'sonar.branch.name', System.env.TRAVIS_BRANCH
     }
 }
 
@@ -40,6 +38,13 @@ if (isPullRequest) {
             property 'sonar.pullrequest.base', System.env.TRAVIS_BRANCH
             property 'sonar.pullrequest.provider', 'GitHub'
             property 'sonar.pullrequest.github.repository', System.env.TRAVIS_REPO_SLUG
+        }
+    }
+} else {
+    sonarqube {
+        properties {
+            // https://docs.sonarqube.org/display/PLUG/Branch+Plugin
+            property 'sonar.branch.name', System.env.TRAVIS_BRANCH
         }
     }
 }


### PR DESCRIPTION
This PR fixes the following error [in `release-3.1` branch](https://travis-ci.org/spotbugs/spotbugs/jobs/496961561):

```
Execution failed for task ':sonarqube'.
> The preview mode, along with the 'sonar.analysis.mode' parameter, is no more supported. You should stop using this parameter.
```

This is because [the new setting for PR analysis](https://docs.sonarqube.org/7.6/analysis/pull-request/) replaced old one completely. So we need to use new configuration and [new app](https://github.com/apps/sonarcloud) instead of old one.