### PR TITLE
Release 3.1.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased - 2019-??-??
+## 3.1.12 - 2019-02-28
 
 ### Added
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
   id 'org.sonarqube' version '2.6.2'
 }
 
-version = '3.1.12-SNAPSHOT'
+version = '3.1.12'
 
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/jacoco.gradle"

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
   id 'org.sonarqube' version '2.6.2'
 }
 
-version = '3.1.12'
+version = '3.1.13-SNAPSHOT'
 
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/jacoco.gradle"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,9 +17,9 @@ import os
 
 html_context = {
   'version' : '3.1',
-  'full_version' : '3.1.11',
-  'maven_plugin_version' : '3.1.10',
-  'gradle_plugin_version' : '1.6.9',
+  'full_version' : '3.1.12',
+  'maven_plugin_version' : '3.1.11',
+  'gradle_plugin_version' : '1.6.10',
   'archetype_version' : '0.2.2'
 }
 


### PR DESCRIPTION
This is the last minor release for 3.1. We'll use `master` as working branch from the next release.


[//]: # (rtdbot-start)

URL of RTD documents:
en: https://spotbugs.readthedocs.io/en/release-3.1.12/
ja: https://spotbugs.readthedocs.io/ja/release-3.1.12/

[//]: # (rtdbot-end)
