### PR TITLE
Merge 3.1.12 to master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 ## Unreleased - 2019-??-??
 * Start migrating STDOUT/STDERR usage to a logging framework
 
+### Added
+
+* Make TypeQualifierResolver recognize androidx.annotation.NonNull and Nullable ([#880](https://github.com/spotbugs/spotbugs/pull/880))
+
 ### Changed
 * Bump up Apache Commons BCEL to [the version 6.3](http://mail-archives.apache.org/mod_mbox/commons-user/201901.mbox/%3CCACZkXPy3VgLmD2jppzEPwOqVDJYMM2QG%2BtWQCyzfKmZrDwem6A%40mail.gmail.com%3E)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
+
 ## Unreleased - 2019-??-??
 * Start migrating STDOUT/STDERR usage to a logging framework
+
+## 3.1.12 - 2019-02-28
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 ## Unreleased - 2019-??-??
 * Start migrating STDOUT/STDERR usage to a logging framework
 
+### Changed
+* Bump up Apache Commons BCEL to [the version 6.3](http://mail-archives.apache.org/mod_mbox/commons-user/201901.mbox/%3CCACZkXPy3VgLmD2jppzEPwOqVDJYMM2QG%2BtWQCyzfKmZrDwem6A%40mail.gmail.com%3E)
+
 ### Security
 * Update dom4j to 2.1.1 to fix security vulnerability. ([#864](https://github.com/spotbugs/spotbugs/issues/864))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 ## Unreleased - 2019-??-??
 * Start migrating STDOUT/STDERR usage to a logging framework
 
+### Security
+* Update dom4j to 2.1.1 to fix security vulnerability. ([#864](https://github.com/spotbugs/spotbugs/issues/864))
+
 ## 3.1.11 - 2019-01-18
 
 ### Fixed

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,9 +17,9 @@ import os
 
 html_context = {
   'version' : '3.1',
-  'full_version' : '3.1.11',
-  'maven_plugin_version' : '3.1.10',
-  'gradle_plugin_version' : '1.6.9',
+  'full_version' : '3.1.12',
+  'maven_plugin_version' : '3.1.11',
+  'gradle_plugin_version' : '1.6.10',
   'archetype_version' : '0.2.2'
 }
 

--- a/eclipsePlugin/doc/installing_findbugsplugin.txt
+++ b/eclipsePlugin/doc/installing_findbugsplugin.txt
@@ -25,7 +25,7 @@ Install the plug-in
             |     asm-tree-3.3.jar
             |     bcel.jar
             |     commons-lang-2.6.jar
-            |     dom4j-2.1.0.jar
+            |     dom4j-2.1.1.jar
             |     jaxen-1.1.6.jar
             |     jsr305.jar
             |

--- a/gradle/sonar.gradle
+++ b/gradle/sonar.gradle
@@ -25,18 +25,26 @@ sonarqube {
         property 'sonar.projectName', 'SpotBugs'
         property 'sonar.projectVersion', rootProject.version
         property 'sonar.organization', 'spotbugs'
-        // https://docs.sonarqube.org/display/PLUG/Branch+Plugin
-        property 'sonar.branch.name', System.env.TRAVIS_BRANCH
     }
 }
 
 if (isPullRequest) {
     sonarqube {
         properties {
-            property 'sonar.analysis.mode', 'preview'
-            property 'sonar.github.oauth', System.env.GITHUB_TOKEN
-            property 'sonar.github.pullRequest', System.env.TRAVIS_PULL_REQUEST
-            property 'sonar.github.repository', System.env.TRAVIS_REPO_SLUG
+            // https://docs.sonarqube.org/7.6/analysis/pull-request/
+            // https://github.com/travis-ci/travis-build/blob/6af6dd723bd6b364dc29ad74af7f22438a16494d/lib/travis/build/addons/sonarcloud.rb#L123-L127
+            property 'sonar.pullrequest.key', System.env.TRAVIS_PULL_REQUEST
+            property 'sonar.pullrequest.branch', System.env.TRAVIS_PULL_REQUEST_SLUG
+            property 'sonar.pullrequest.base', System.env.TRAVIS_BRANCH
+            property 'sonar.pullrequest.provider', 'GitHub'
+            property 'sonar.pullrequest.github.repository', System.env.TRAVIS_REPO_SLUG
+        }
+    }
+} else {
+    sonarqube {
+        properties {
+            // https://docs.sonarqube.org/display/PLUG/Branch+Plugin
+            property 'sonar.branch.name', System.env.TRAVIS_BRANCH
         }
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/nullness/AndroidNullabilityTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/nullness/AndroidNullabilityTest.java
@@ -31,9 +31,24 @@ public class AndroidNullabilityTest {
     }
 
     @Test
+    public void objectForNonNullParam2_isOk() {
+        BugCollection bugCollection = spotbugs.performAnalysis(
+                Paths.get("../spotbugsTestCases/build/classes/java/main/androidAnnotations/ObjectForNonNullParam2.class"));
+        assertThat(bugCollection, emptyIterable());
+    }
+
+    @Test
     public void nullForNonNullParam_isDetected() {
         BugCollection bugCollection = spotbugs.performAnalysis(
                 Paths.get("../spotbugsTestCases/build/classes/java/main/androidAnnotations/NullForNonNullParam.class"));
+
+        assertThat(bugCollection, containsExactly(1, bug("NP_NONNULL_PARAM_VIOLATION")));
+    }
+
+    @Test
+    public void nullForNonNullParam2_isDetected() {
+        BugCollection bugCollection = spotbugs.performAnalysis(
+                Paths.get("../spotbugsTestCases/build/classes/java/main/androidAnnotations/NullForNonNullParam2.class"));
 
         assertThat(bugCollection, containsExactly(1, bug("NP_NONNULL_PARAM_VIOLATION")));
     }
@@ -46,9 +61,24 @@ public class AndroidNullabilityTest {
     }
 
     @Test
+    public void checkedNullableReturn2_isOk() {
+        BugCollection bugCollection = spotbugs.performAnalysis(
+                Paths.get("../spotbugsTestCases/build/classes/java/main/androidAnnotations/CheckedNullableReturn2.class"));
+        assertThat(bugCollection, emptyIterable());
+    }
+
+    @Test
     public void uncheckedNullableReturn_isDetected() {
         BugCollection bugCollection = spotbugs.performAnalysis(
                 Paths.get("../spotbugsTestCases/build/classes/java/main/androidAnnotations/UncheckedNullableReturn.class"));
+
+        assertThat(bugCollection, containsExactly(1, bug("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")));
+    }
+
+    @Test
+    public void uncheckedNullableReturn2_isDetected() {
+        BugCollection bugCollection = spotbugs.performAnalysis(
+                Paths.get("../spotbugsTestCases/build/classes/java/main/androidAnnotations/UncheckedNullableReturn2.class"));
 
         assertThat(bugCollection, containsExactly(1, bug("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")));
     }

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -60,7 +60,7 @@ dependencies {
   compile 'org.ow2.asm:asm-commons:7.0'
   compile 'org.ow2.asm:asm-tree:7.0'
   compile 'org.ow2.asm:asm-util:7.0'
-  compile 'org.apache.bcel:bcel:6.2'
+  compile 'org.apache.bcel:bcel:6.3'
   compile 'net.jcip:jcip-annotations:1.0'
   compile 'org.dom4j:dom4j:2.1.1'
   compile 'jaxen:jaxen:1.1.6' // only transitive through dom4j:dom4j:1.6.1, which has an *optional* dependency on jaxen:jaxen.

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -62,7 +62,7 @@ dependencies {
   compile 'org.ow2.asm:asm-util:7.0'
   compile 'org.apache.bcel:bcel:6.2'
   compile 'net.jcip:jcip-annotations:1.0'
-  compile 'org.dom4j:dom4j:2.1.0'
+  compile 'org.dom4j:dom4j:2.1.1'
   compile 'jaxen:jaxen:1.1.6' // only transitive through dom4j:dom4j:1.6.1, which has an *optional* dependency on jaxen:jaxen.
   compile 'commons-lang:commons-lang:2.6'
   compile 'org.slf4j:slf4j-api:1.8.0-beta2'

--- a/spotbugs/etc/MANIFEST-findbugs.MF
+++ b/spotbugs/etc/MANIFEST-findbugs.MF
@@ -1,3 +1,3 @@
 Manifest-Version: 1.0
 Main-Class: edu.umd.cs.findbugs.LaunchAppropriateUI
-Class-Path: bcel.jar dom4j-2.1.0.jar jaxen-1.1.6.jar asm-6.2.1.jar asm-analysis-6.2.1.jar asm-commons-6.2.1.jar asm-tree-6.2.1.jar asm-util-6.2.1.jar asm-xml-6.2.1.jar jsr305.jar commons-lang-2.6.jar
+Class-Path: bcel.jar dom4j-2.1.1.jar jaxen-1.1.6.jar asm-6.2.1.jar asm-analysis-6.2.1.jar asm-commons-6.2.1.jar asm-tree-6.2.1.jar asm-util-6.2.1.jar asm-xml-6.2.1.jar jsr305.jar commons-lang-2.6.jar

--- a/spotbugs/etc/MANIFEST-findbugsGUI.MF
+++ b/spotbugs/etc/MANIFEST-findbugsGUI.MF
@@ -1,3 +1,3 @@
 Manifest-Version: 1.0
 Main-Class: edu.umd.cs.findbugs.LaunchAppropriateUI
-Class-Path: bcel.jar dom4j-2.1.0.jar jaxen-1.1.6.jar asm-6.2.1.jar asm-analysis-6.2.1.jar asm-commons-6.2.1.jar asm-tree-6.2.1.jar asm-util-6.2.1.jar asm-xml-6.2.1.jar jsr305.jar commons-lang-2.6.jar plastic.jar
+Class-Path: bcel.jar dom4j-2.1.1.jar jaxen-1.1.6.jar asm-6.2.1.jar asm-analysis-6.2.1.jar asm-commons-6.2.1.jar asm-tree-6.2.1.jar asm-util-6.2.1.jar asm-xml-6.2.1.jar jsr305.jar commons-lang-2.6.jar plastic.jar

--- a/spotbugs/jnlp/core.jnlp
+++ b/spotbugs/jnlp/core.jnlp
@@ -15,7 +15,7 @@
   <resources>
     <jar href="AppleJavaExtensions.jar"/>
     <jar href="bcel.jar"/>
-    <jar href="dom4j-2.1.0.jar"/>
+    <jar href="dom4j-2.1.1.jar"/>
     <jar href="asm-3.3.jar"/>
     <jar href="asm-tree-3.3.jar"/>
     <jar href="asm-commons-3.3.jar"/>
@@ -25,6 +25,3 @@
   </resources>
   <component-desc />
 </jnlp>
-
-
-

--- a/spotbugs/jnlp/findbugs.jnlp
+++ b/spotbugs/jnlp/findbugs.jnlp
@@ -20,7 +20,7 @@
     <jar href="findbugs.jar"/>
     <jar href="AppleJavaExtensions.jar"/>
     <jar href="bcel.jar"/>
-    <jar href="dom4j-2.1.0.jar"/>
+    <jar href="dom4j-2.1.1.jar"/>
     <jar href="asm-6.2.1.jar"/>
     <jar href="asm-analysis-6.2.1.jar"/>
     <jar href="asm-commons-6.2.1.jar"/>

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/NullnessAnnotation.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/NullnessAnnotation.java
@@ -37,6 +37,7 @@ public class NullnessAnnotation extends AnnotationEnumeration<NullnessAnnotation
         @Override
         boolean match(@DottedClassName String className) {
             return "android.support.annotation.Nullable".equals(className)
+                    || "androidx.annotation.Nullable".equals(className)
                     || "com.google.common.base.Nullable".equals(className)
                     || "org.eclipse.jdt.annotation.Nullable".equals(className)
                     || "org.jetbrains.annotations.Nullable".equals(className)

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/TypeQualifierResolver.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/TypeQualifierResolver.java
@@ -55,6 +55,10 @@ public class TypeQualifierResolver {
 
     static final ClassDescriptor androidNonNull = DescriptorFactory.createClassDescriptor("android/support/annotation/NonNull");
 
+    static final ClassDescriptor androidxNullable = DescriptorFactory.createClassDescriptor("androidx/annotation/Nullable");
+
+    static final ClassDescriptor androidxNonNull = DescriptorFactory.createClassDescriptor("androidx/annotation/NonNull");
+
     static final ClassDescriptor googleNullable = DescriptorFactory.createClassDescriptor("com/google/common/base/Nullable");
 
     static final ClassDescriptor intellijNullable = DescriptorFactory.createClassDescriptor("org/jetbrains/annotations/Nullable");
@@ -133,6 +137,7 @@ public class TypeQualifierResolver {
 
             try {
                 if (annotationClass.equals(androidNullable)
+                        || annotationClass.equals(androidxNullable)
                         || annotationClass.equals(googleNullable)
                         || annotationClass.equals(eclipseNullable)
                         || annotationClass.equals(intellijNullable)
@@ -142,6 +147,7 @@ public class TypeQualifierResolver {
                     return;
                 }
                 if (annotationClass.equals(androidNonNull)
+                        || annotationClass.equals(androidxNonNull)
                         || annotationClass.equals(eclipseNonNull)
                         || annotationClass.equals(eclipseNonNullByDefault)
                         || annotationClass.equals(intellijNotNull)) {

--- a/spotbugs/src/sampleXml/analysisResultsWithFilterAndUserAnnotations.xml
+++ b/spotbugs/src/sampleXml/analysisResultsWithFilterAndUserAnnotations.xml
@@ -7,7 +7,7 @@
     <AuxClasspathEntry>/Users/pugh/Documents/fb-trunk/findbugs/lib/findbugs.jar</AuxClasspathEntry>
     <AuxClasspathEntry>/Users/pugh/Documents/fb-trunk/findbugs/lib/jdepend-2.9.jar</AuxClasspathEntry>
     <AuxClasspathEntry>/Users/pugh/Documents/fb-trunk/findbugs/lib/bcel.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/Users/pugh/Documents/fb-trunk/findbugs/lib/dom4j-2.1.0.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/pugh/Documents/fb-trunk/findbugs/lib/dom4j-2.1.1.jar</AuxClasspathEntry>
     <AuxClasspathEntry>/Users/pugh/Documents/fb-trunk/findbugs/lib/AppleJavaExtensions.jar</AuxClasspathEntry>
     <AuxClasspathEntry>/Users/pugh/Documents/fb-trunk/findbugs/lib/junit.jar</AuxClasspathEntry>
     <AuxClasspathEntry>/Users/pugh/Documents/fb-trunk/findbugs/lib/asm-6.2.1.jar</AuxClasspathEntry>

--- a/spotbugsTestCases/src/fakeAnnotations/androidx/annotation/NonNull.java
+++ b/spotbugsTestCases/src/fakeAnnotations/androidx/annotation/NonNull.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2013 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.annotation;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.LOCAL_VARIABLE;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PACKAGE;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Denotes that a parameter, field or method return value can never be null.
+ * <p>
+ * This is a marker annotation and it has no specific attributes.
+ */
+@Documented
+@Retention(CLASS)
+@Target({METHOD, PARAMETER, FIELD, LOCAL_VARIABLE, ANNOTATION_TYPE, PACKAGE})
+public @interface NonNull {
+}

--- a/spotbugsTestCases/src/fakeAnnotations/androidx/annotation/Nullable.java
+++ b/spotbugsTestCases/src/fakeAnnotations/androidx/annotation/Nullable.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2013 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.annotation;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.LOCAL_VARIABLE;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PACKAGE;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Denotes that a parameter, field or method return value can be null.
+ * <p>
+ * When decorating a method call parameter, this denotes that the parameter can
+ * legitimately be null and the method will gracefully deal with it. Typically
+ * used on optional parameters.
+ * <p>
+ * When decorating a method, this denotes the method might legitimately return
+ * null.
+ * <p>
+ * This is a marker annotation and it has no specific attributes.
+ */
+@Documented
+@Retention(CLASS)
+@Target({METHOD, PARAMETER, FIELD, LOCAL_VARIABLE, ANNOTATION_TYPE, PACKAGE})
+public @interface Nullable {
+}

--- a/spotbugsTestCases/src/java/androidAnnotations/CheckedNullableReturn2.java
+++ b/spotbugsTestCases/src/java/androidAnnotations/CheckedNullableReturn2.java
@@ -1,0 +1,17 @@
+package androidAnnotations;
+
+import androidx.annotation.Nullable;
+
+public class CheckedNullableReturn2 {
+    @Nullable
+    String foo() {
+        return null;
+    }
+
+    void bar() {
+        String foo = foo();
+        if (foo != null) {
+            System.out.println(foo.hashCode());
+        }
+    }
+}

--- a/spotbugsTestCases/src/java/androidAnnotations/NullForNonNullParam2.java
+++ b/spotbugsTestCases/src/java/androidAnnotations/NullForNonNullParam2.java
@@ -1,0 +1,12 @@
+package androidAnnotations;
+
+import androidx.annotation.NonNull;
+
+public class NullForNonNullParam2 {
+    static void foo(@NonNull Object o) {
+    }
+
+    static void bar() {
+        foo(null);
+    }
+}

--- a/spotbugsTestCases/src/java/androidAnnotations/ObjectForNonNullParam2.java
+++ b/spotbugsTestCases/src/java/androidAnnotations/ObjectForNonNullParam2.java
@@ -1,0 +1,12 @@
+package androidAnnotations;
+
+import androidx.annotation.NonNull;
+
+public class ObjectForNonNullParam2 {
+    static void foo(@NonNull Object o) {
+    }
+
+    static void bar() {
+        foo(new Object());
+    }
+}

--- a/spotbugsTestCases/src/java/androidAnnotations/UncheckedNullableReturn2.java
+++ b/spotbugsTestCases/src/java/androidAnnotations/UncheckedNullableReturn2.java
@@ -1,0 +1,14 @@
+package androidAnnotations;
+
+import androidx.annotation.Nullable;
+
+public class UncheckedNullableReturn2 {
+    @Nullable
+    String foo() {
+        return null;
+    }
+
+    void bar() {
+        System.out.println(foo().hashCode());
+    }
+}


### PR DESCRIPTION
This PR reflects all changes in `release-3.1` to `master`. This is necessary to use `master` as default branch, and focus on v4.0 development.