### PR TITLE
Upgrade asm to 7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ## Unreleased - 2019-??-??
 
+### Added
+
+* update ASM to 7.1 that supports Java 13
+
 ### Removed
 
 * non thread-safe implementation in `OpcodeStack.Item` ([#28](https://github.com/spotbugs/spotbugs/issues/28))

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -55,11 +55,11 @@ sourceSets {
 }
 
 dependencies {
-  compile 'org.ow2.asm:asm:7.0'
-  compile 'org.ow2.asm:asm-analysis:7.0'
-  compile 'org.ow2.asm:asm-commons:7.0'
-  compile 'org.ow2.asm:asm-tree:7.0'
-  compile 'org.ow2.asm:asm-util:7.0'
+  compile 'org.ow2.asm:asm:7.1'
+  compile 'org.ow2.asm:asm-analysis:7.1'
+  compile 'org.ow2.asm:asm-commons:7.1'
+  compile 'org.ow2.asm:asm-tree:7.1'
+  compile 'org.ow2.asm:asm-util:7.1'
   compile 'org.apache.bcel:bcel:6.3'
   compile 'net.jcip:jcip-annotations:1.0'
   compile 'org.dom4j:dom4j:2.1.1'


### PR DESCRIPTION
ASM released version 7.1, that supports Java 13. Visit following URL for detail:

https://asm.ow2.io/versions.html#7.1
