### PR TITLE
chore: remove needless checkbox in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,4 +5,3 @@
 Make sure these boxes are checked before submitting your PR -- thank you!
 
 - [ ] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
-- [ ] Added an entry into `gradlePlugin/CHANGELOG.md` if you have changed Gradle plugin code


### PR DESCRIPTION
Gradle plugin is moved to another Git project, then this checkbox is needless anymore.