### PR TITLE
Util#getXMLType refactoring

### DIFF
--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/Util.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/Util.java
@@ -385,14 +385,11 @@ public class Util {
         }
 
         in.mark(5000);
-        BufferedReader r = null;
         try {
-            r = new BufferedReader(Util.getReader(in), 2000);
+            BufferedReader r = new BufferedReader(Util.getReader(in), 2000);
 
-            String s;
-            int count = 0;
-            while (count < 4) {
-                s = r.readLine();
+            while (true) {
+                String s = r.readLine();
                 if (s == null) {
                     break;
                 }


### PR DESCRIPTION
This is a reincarnation of #853.

Refactored `Util#getXMLType` method based on [static analysis finding](https://www.viva64.com/en/b/0603/#ID0E5LDK). `counter` variable had no chance to be equal to or greater than 4 anyway.

Since this code worked unchanged since initial commit 70bd1096fd325c44eaad92e5e6a9c029d183c4aa in 2007, I think there is no point in 'correcting' it by actually limiting the search of opening tag by 4 lines. 'Limited search' will not work, e.g. in case of extensive comment or just empty lines in the beginning of the file.

Since this is not changing the code behaviour, do we need changelog entry?


----

Make sure these boxes are checked before submitting your PR -- thank you!

- [ ] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code

