### PR TITLE
fixed FindNonShortCircuit#reportBug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 * Start migrating STDOUT/STDERR usage to a logging framework
 
+### Fixed
+
+* Fixed bug priority calculation logic in FindNonShortCircuit#reportBug
+
 ## 3.1.12 - 2019-02-28
 
 ### Added

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNonShortCircuit.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNonShortCircuit.java
@@ -32,9 +32,9 @@ import edu.umd.cs.findbugs.bcel.OpcodeStackDetector;
 
 public class FindNonShortCircuit extends OpcodeStackDetector implements StatelessDetector {
 
-    public static final String NS_NON_SHORT_CIRCUIT = "NS_NON_SHORT_CIRCUIT";
+    static final String NS_NON_SHORT_CIRCUIT = "NS_NON_SHORT_CIRCUIT";
 
-    public static final String NS_DANGEROUS_NON_SHORT_CIRCUIT = "NS_DANGEROUS_NON_SHORT_CIRCUIT";
+    static final String NS_DANGEROUS_NON_SHORT_CIRCUIT = "NS_DANGEROUS_NON_SHORT_CIRCUIT";
 
     int stage1 = 0;
 
@@ -193,10 +193,10 @@ public class FindNonShortCircuit extends OpcodeStackDetector implements Stateles
     }
 
     private void reportBug() {
-        bugAccumulator.accumulateBug(getBugInstance().addClassAndMethod(this), this);
+        bugAccumulator.accumulateBug(createBugInstance().addClassAndMethod(this), this);
     }
 
-    BugInstance getBugInstance() {
+    BugInstance createBugInstance() {
         int priority = LOW_PRIORITY;
         String pattern = NS_NON_SHORT_CIRCUIT;
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNonShortCircuit.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNonShortCircuit.java
@@ -32,6 +32,10 @@ import edu.umd.cs.findbugs.bcel.OpcodeStackDetector;
 
 public class FindNonShortCircuit extends OpcodeStackDetector implements StatelessDetector {
 
+    public static final String NS_NON_SHORT_CIRCUIT = "NS_NON_SHORT_CIRCUIT";
+
+    public static final String NS_DANGEROUS_NON_SHORT_CIRCUIT = "NS_DANGEROUS_NON_SHORT_CIRCUIT";
+
     int stage1 = 0;
 
     int stage2 = 0;
@@ -189,22 +193,24 @@ public class FindNonShortCircuit extends OpcodeStackDetector implements Stateles
     }
 
     private void reportBug() {
+        bugAccumulator.accumulateBug(getBugInstance().addClassAndMethod(this), this);
+    }
+
+    BugInstance getBugInstance() {
         int priority = LOW_PRIORITY;
-        String pattern = "NS_NON_SHORT_CIRCUIT";
+        String pattern = NS_NON_SHORT_CIRCUIT;
 
         if (sawDangerOld) {
             if (sawNullTestVeryOld) {
                 priority = HIGH_PRIORITY;
-            }
-            if (sawMethodCallOld || sawNumericTestVeryOld && sawArrayDangerOld) {
+            } else if (sawMethodCallOld || sawNumericTestVeryOld && sawArrayDangerOld) {
                 priority = HIGH_PRIORITY;
-                pattern = "NS_DANGEROUS_NON_SHORT_CIRCUIT";
+                pattern = NS_DANGEROUS_NON_SHORT_CIRCUIT;
             } else {
                 priority = NORMAL_PRIORITY;
             }
         }
-
-        bugAccumulator.accumulateBug(new BugInstance(this, pattern, priority).addClassAndMethod(this), this);
+        return new BugInstance(this, pattern, priority);
     }
 
     private void scanForBooleanValue(int seen) {

--- a/spotbugs/src/test/java/edu/umd/cs/findbugs/detect/FindNonShortCircuitTest.java
+++ b/spotbugs/src/test/java/edu/umd/cs/findbugs/detect/FindNonShortCircuitTest.java
@@ -20,23 +20,23 @@ public class FindNonShortCircuitTest {
                 AnalysisContext.setCurrentAnalysisContext(new AnalysisContext(new Project()));
             }
             FindNonShortCircuit check = new FindNonShortCircuit(bugReporter);
-            BugInstance bug = check.getBugInstance();
+            BugInstance bug = check.createBugInstance();
             assertEquals(FindNonShortCircuit.NS_NON_SHORT_CIRCUIT, bug.getType());
             assertEquals(Priorities.LOW_PRIORITY, bug.getPriority());
 
             check.sawDangerOld = true;
-            bug = check.getBugInstance();
+            bug = check.createBugInstance();
             assertEquals(FindNonShortCircuit.NS_NON_SHORT_CIRCUIT, bug.getType());
             assertEquals(Priorities.NORMAL_PRIORITY, bug.getPriority());
 
             check.sawNullTestVeryOld = true;
-            bug = check.getBugInstance();
+            bug = check.createBugInstance();
             assertEquals(FindNonShortCircuit.NS_NON_SHORT_CIRCUIT, bug.getType());
             assertEquals(Priorities.HIGH_PRIORITY, bug.getPriority());
 
             check.sawNullTestVeryOld = false;
             check.sawMethodCallOld = true;
-            bug = check.getBugInstance();
+            bug = check.createBugInstance();
             assertEquals(FindNonShortCircuit.NS_DANGEROUS_NON_SHORT_CIRCUIT, bug.getType());
             assertEquals(Priorities.HIGH_PRIORITY, bug.getPriority());
         } finally {

--- a/spotbugs/src/test/java/edu/umd/cs/findbugs/detect/FindNonShortCircuitTest.java
+++ b/spotbugs/src/test/java/edu/umd/cs/findbugs/detect/FindNonShortCircuitTest.java
@@ -1,0 +1,46 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.BugInstance;
+import edu.umd.cs.findbugs.PrintingBugReporter;
+import edu.umd.cs.findbugs.Priorities;
+import edu.umd.cs.findbugs.Project;
+import edu.umd.cs.findbugs.ba.AnalysisContext;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class FindNonShortCircuitTest {
+
+    @Test
+    public void testBugTypeAndPriority() {
+        PrintingBugReporter bugReporter = new PrintingBugReporter();
+        AnalysisContext ctx = AnalysisContext.currentAnalysisContext();
+        try {
+            if (ctx == null) {
+                AnalysisContext.setCurrentAnalysisContext(new AnalysisContext(new Project()));
+            }
+            FindNonShortCircuit check = new FindNonShortCircuit(bugReporter);
+            BugInstance bug = check.getBugInstance();
+            assertEquals(FindNonShortCircuit.NS_NON_SHORT_CIRCUIT, bug.getType());
+            assertEquals(Priorities.LOW_PRIORITY, bug.getPriority());
+
+            check.sawDangerOld = true;
+            bug = check.getBugInstance();
+            assertEquals(FindNonShortCircuit.NS_NON_SHORT_CIRCUIT, bug.getType());
+            assertEquals(Priorities.NORMAL_PRIORITY, bug.getPriority());
+
+            check.sawNullTestVeryOld = true;
+            bug = check.getBugInstance();
+            assertEquals(FindNonShortCircuit.NS_NON_SHORT_CIRCUIT, bug.getType());
+            assertEquals(Priorities.HIGH_PRIORITY, bug.getPriority());
+
+            check.sawNullTestVeryOld = false;
+            check.sawMethodCallOld = true;
+            bug = check.getBugInstance();
+            assertEquals(FindNonShortCircuit.NS_DANGEROUS_NON_SHORT_CIRCUIT, bug.getType());
+            assertEquals(Priorities.HIGH_PRIORITY, bug.getPriority());
+        } finally {
+            AnalysisContext.setCurrentAnalysisContext(ctx);
+        }
+    }
+}

--- a/spotbugs/src/test/java/edu/umd/cs/findbugs/detect/FindNonShortCircuitTest.java
+++ b/spotbugs/src/test/java/edu/umd/cs/findbugs/detect/FindNonShortCircuitTest.java
@@ -5,42 +5,61 @@ import edu.umd.cs.findbugs.PrintingBugReporter;
 import edu.umd.cs.findbugs.Priorities;
 import edu.umd.cs.findbugs.Project;
 import edu.umd.cs.findbugs.ba.AnalysisContext;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
 
 public class FindNonShortCircuitTest {
+    private AnalysisContext ctx;
+    private FindNonShortCircuit check;
+
+    @Before
+    public void setup() {
+        PrintingBugReporter bugReporter = new PrintingBugReporter();
+        ctx = AnalysisContext.currentAnalysisContext();
+        if (ctx == null) {
+            AnalysisContext.setCurrentAnalysisContext(new AnalysisContext(new Project()));
+        }
+        check = new FindNonShortCircuit(bugReporter);
+    }
+
+    @After
+    public void tearDown() {
+        AnalysisContext.setCurrentAnalysisContext(ctx);
+    }
 
     @Test
-    public void testBugTypeAndPriority() {
-        PrintingBugReporter bugReporter = new PrintingBugReporter();
-        AnalysisContext ctx = AnalysisContext.currentAnalysisContext();
-        try {
-            if (ctx == null) {
-                AnalysisContext.setCurrentAnalysisContext(new AnalysisContext(new Project()));
-            }
-            FindNonShortCircuit check = new FindNonShortCircuit(bugReporter);
-            BugInstance bug = check.createBugInstance();
-            assertEquals(FindNonShortCircuit.NS_NON_SHORT_CIRCUIT, bug.getType());
-            assertEquals(Priorities.LOW_PRIORITY, bug.getPriority());
+    public void testDefaultBugTypeAndPriority() {
+        BugInstance bug = check.createBugInstance();
+        assertEquals(FindNonShortCircuit.NS_NON_SHORT_CIRCUIT, bug.getType());
+        assertEquals(Priorities.LOW_PRIORITY, bug.getPriority());
+    }
 
-            check.sawDangerOld = true;
-            bug = check.createBugInstance();
-            assertEquals(FindNonShortCircuit.NS_NON_SHORT_CIRCUIT, bug.getType());
-            assertEquals(Priorities.NORMAL_PRIORITY, bug.getPriority());
+    @Test
+    public void testBugTypeAndPriorityDangerOld() {
+        check.sawDangerOld = true;
+        BugInstance bug = check.createBugInstance();
+        assertEquals(FindNonShortCircuit.NS_NON_SHORT_CIRCUIT, bug.getType());
+        assertEquals(Priorities.NORMAL_PRIORITY, bug.getPriority());
+    }
 
-            check.sawNullTestVeryOld = true;
-            bug = check.createBugInstance();
-            assertEquals(FindNonShortCircuit.NS_NON_SHORT_CIRCUIT, bug.getType());
-            assertEquals(Priorities.HIGH_PRIORITY, bug.getPriority());
+    @Test
+    public void testBugTypeAndPriorityNullTestOld() {
+        check.sawDangerOld = true;
+        check.sawNullTestVeryOld = true;
+        BugInstance bug = check.createBugInstance();
+        assertEquals(FindNonShortCircuit.NS_NON_SHORT_CIRCUIT, bug.getType());
+        assertEquals(Priorities.HIGH_PRIORITY, bug.getPriority());
+    }
 
-            check.sawNullTestVeryOld = false;
-            check.sawMethodCallOld = true;
-            bug = check.createBugInstance();
-            assertEquals(FindNonShortCircuit.NS_DANGEROUS_NON_SHORT_CIRCUIT, bug.getType());
-            assertEquals(Priorities.HIGH_PRIORITY, bug.getPriority());
-        } finally {
-            AnalysisContext.setCurrentAnalysisContext(ctx);
-        }
+    @Test
+    public void testBugTypeAndPriorityMethodCallOld() {
+        check.sawDangerOld = true;
+        check.sawMethodCallOld = true;
+        BugInstance bug = check.createBugInstance();
+        assertEquals(FindNonShortCircuit.NS_DANGEROUS_NON_SHORT_CIRCUIT, bug.getType());
+        assertEquals(Priorities.HIGH_PRIORITY, bug.getPriority());
     }
 }


### PR DESCRIPTION
This is a reincarnation of #854.

Fixed `FindNonShortCircuit#reportBug` method based on [static analysis finding](https://www.viva64.com/en/b/0603/#ID0E61EK). `sawNullTestVeryOld` variable had no impact on `priority`.


----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
