### PR TITLE
Tell which feature is deprecated in 4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 * Start migrating STDOUT/STDERR usage to a logging framework
 * Improvements and bug-fixes for fancy-hist.xsl
 
+### Deprecated
+
+* SQL files
+* JNLP files
+* `speed` attribute of `Detector` element in `findbugs.xml`
+
 ## 3.1.12 - 2019-02-28
 
 ### Added

--- a/spotbugs/jnlp/README.md
+++ b/spotbugs/jnlp/README.md
@@ -1,0 +1,1 @@
+JNLP files in this directory is deprecated and not maintained. It will be removed in future release.

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/DetectorFactory.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/DetectorFactory.java
@@ -122,6 +122,10 @@ public class DetectorFactory {
 
     private final boolean defEnabled;
 
+    /**
+     * @deprecated This attribute is not used actively, and could be removed in future release
+     */
+    @Deprecated
     private final String speed;
 
     private final String reports;
@@ -320,6 +324,7 @@ public class DetectorFactory {
 
     /**
      * Get the speed of the Detector produced by this factory.
+     * @deprecated This attribute is not used actively, and could be removed in future release
      */
     @Deprecated
     public String getSpeed() {

--- a/spotbugs/src/sql/README.md
+++ b/spotbugs/src/sql/README.md
@@ -1,0 +1,1 @@
+SQL files in this directory is deprecated and not maintained. It will be removed in future release.


### PR DESCRIPTION
Mark SQL, JNLP and speed attribute as deprecated. This is because:

1. Applet and Java Web Start (depends on JNLP) is deprecated in Java SE 9 and removed in Java SE 11.
2. Not sure about the usage of these SQL files.
3. Not sure how to decide value of speed attribute (e.g. when we can say a detector is "fast").
4. According to [this RFC issue](https://github.com/spotbugs/discuss/issues/65), JNLP, SQL and speed attributes are not used frequently. 