### PR TITLE
Configure build scan plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,10 +55,10 @@ install:
 
 script:
   - jdk_switcher use oraclejdk8
-  - ./gradlew classes testClasses -S
+  - ./gradlew classes testClasses -S --scan
   - if [[ $TRAVIS_JDK_VERSION == "oraclejdk11" ]]; then export JAVA_HOME=$HOME/oraclejdk11; fi
   - ./gradlew -v --no-daemon
-  - ./gradlew build smoketest -x signArchives -S --no-daemon
+  - ./gradlew build smoketest -x signArchives -S --no-daemon --scan
   - jdk_switcher use oraclejdk8
   - if [[ $TRAVIS_JDK_VERSION == "oraclejdk8" ]]; then ./gradlew sonarqube -S; fi
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,11 @@
 plugins {
+  id 'com.gradle.build-scan' version '2.2.1'
   id 'org.sonarqube' version '2.6.2'
+}
+
+buildScan {
+  termsOfServiceUrl = 'https://gradle.com/terms-of-service'
+  apply from: 'gradle/build-scans.gradle'
 }
 
 version = '4.0.0-SNAPSHOT'

--- a/gradle/build-scans.gradle
+++ b/gradle/build-scans.gradle
@@ -1,0 +1,41 @@
+File acceptFile = new File(gradle.gradleUserHomeDir, "build-scans/spotbugs/gradle-scans-license-agree.txt")
+acceptFile.parentFile.mkdirs()
+def env = System.getenv()
+boolean isCI = env.CI || env.TRAVIS
+boolean hasAccepted = isCI || env.SPOTBUGS_GRADLE_SCANS_ACCEPT=='yes' || acceptFile.exists() && acceptFile.text.trim() == 'yes'
+boolean hasRefused = env.SPOTBUGS_GRADLE_SCANS_ACCEPT=='no' || acceptFile.exists() && acceptFile.text.trim() == 'no'
+
+buildScan {
+    if (hasAccepted) {
+        termsOfServiceAgree = 'yes'
+    } else if (!hasRefused) {
+        gradle.buildFinished {
+            println """
+This build uses Gradle Build Scans to gather statistics, share information about 
+failures, environmental issues, dependencies resolved during the build and more.
+Build scans will be published after each build, if you accept the terms of 
+service, and in particular the privacy policy.
+
+Please read 
+   
+    https://gradle.com/terms-of-service 
+    https://gradle.com/legal/privacy
+
+and then:
+
+  - set the `SPOTBUGS_GRADLE_SCANS_ACCEPT` to `yes`/`no` if you agree with/refuse the TOS
+  - or create the ${acceptFile} file with `yes`/`no` in it if you agree with/refuse
+
+
+    echo 'yes' >> ${acceptFile}
+
+    or
+
+    echo 'no' >> ${acceptFile}
+
+And we'll not bother you again. Note that build scans are only made public if 
+you share the URL at the end of the build.
+"""
+        }
+    }
+}


### PR DESCRIPTION
This small PR configures the `build-scan` Gradle plugin (https://guides.gradle.org/creating-build-scans/) which yields further insight into the build, allowing the team to make informed decisions on where and when the build may be tweaked to get faster, more performant builds.

Sample scan: https://gradle.com/s/h3256mn2lqrnw

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [ ] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
