### PR TITLE
bump up Apache BCEL to 6.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 * Start migrating STDOUT/STDERR usage to a logging framework
 * Improvements and bug-fixes for fancy-hist.xsl
+* Bump up Apache Commons BCEL to the version 6.3.1
 
 ### Deprecated
 

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -60,7 +60,7 @@ dependencies {
   compile 'org.ow2.asm:asm-commons:7.1'
   compile 'org.ow2.asm:asm-tree:7.1'
   compile 'org.ow2.asm:asm-util:7.1'
-  compile 'org.apache.bcel:bcel:6.3'
+  compile 'org.apache.bcel:bcel:6.3.1'
   compile 'net.jcip:jcip-annotations:1.0'
   compile 'org.dom4j:dom4j:2.1.1'
   compile 'jaxen:jaxen:1.1.6' // only transitive through dom4j:dom4j:1.6.1, which has an *optional* dependency on jaxen:jaxen.


### PR DESCRIPTION
Here I will quote [the changelog for this release](https://www.apache.org/dist/commons/bcel/RELEASE-NOTES.txt). It's bug fix release and all of our test cases pass with this version.

```
FIXED BUGS:
===========

o BCEL-267: Race conditions on static fields in BranchHandle and
InstructionHandle. Thanks to Stephan Herrmann, Sebb, Gary Gregory, Torsten
Curdt.
o BCEL-297: Possible NPE in override implementation of Object.equals (#20)
Thanks to Mark Roberts, mingleizhang.
o BCEL-315: NullPointerException at
org.apache.bcel.classfile.FieldOrMethod.dump(). Thanks to Gary Gregory.

CHANGES:
========

o BCEL-298: Add some files to .gitignore (#19) Thanks to mingleizhang.
```

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
