### PR TITLE
Fix build script to avoid releasing to spotbugs/eclipse in beta version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,15 +85,6 @@ deploy:
   - provider: pages
     skip_cleanup: true
     github_token: $GITHUB_TOKEN
-    local_dir: eclipsePlugin/build/site/eclipse-stable-latest
-    repo: spotbugs/eclipse-stable-latest
-    email: skypencil+spotbugs-bot@gmail.com
-    on:
-      branch: release-3.1
-      jdk: oraclejdk8
-  - provider: pages
-    skip_cleanup: true
-    github_token: $GITHUB_TOKEN
     local_dir: eclipsePlugin/build/site/eclipse-candidate
     repo: spotbugs/eclipse-candidate
     email: skypencil+spotbugs-bot@gmail.com
@@ -125,14 +116,6 @@ deploy:
     on:
       jdk: oraclejdk8
       branch: master
-  - provider: script
-    skip_cleanup: true
-    # wait until uploading task finishes, because it may cost more than 10 minutes without any output
-    # https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received
-    script: .travis/travis_wait "./gradlew uploadArchives"
-    on:
-      jdk: oraclejdk8
-      branch: release-3.1
   - provider: script
     skip_cleanup: true
     # wait until uploading task finishes, because it may cost more than 10 minutes without any output

--- a/.travis.yml
+++ b/.travis.yml
@@ -100,7 +100,7 @@ deploy:
     on:
       tags: true
       jdk: oraclejdk8
-      condition: "$TRAVIS_TAG != *'_RC'*"
+      condition: "$TRAVIS_TAG != *'_RC'* && $TRAVIS_TAG != *'_beta'*"
   - provider: releases
     api_key: $GITHUB_TOKEN
     file: "eclipsePlugin/build/distributions/eclipsePlugin.zip"

--- a/eclipsePlugin/build.gradle
+++ b/eclipsePlugin/build.gradle
@@ -17,6 +17,9 @@ if (version.endsWith('-SNAPSHOT')) {
 } else if (version.contains('-RC')) {
   // eclipse doesn't like the `-RC`, so we timestamp uniquely
   version = version.substring(0, version.lastIndexOf('-RC')) + '.' + new Date().format('yyyyMMddHHmm') + '-' + readLastCommitHash()
+} else if (version.contains('-beta')) {
+  // eclipse doesn't like the `-beta`, so we timestamp uniquely
+  version = version.substring(0, version.lastIndexOf('-beta')) + '.' + new Date().format('yyyyMMddHHmm') + '-' + readLastCommitHash()
 } else {
   // A release build version like 3.0.0 without qualifier will always be smaller
   // then nightly build 3.0.0.20171023-1508734123102, but to update from nightlies


### PR DESCRIPTION
note: this build script (and gradle wrapper) still has two known issues: https://github.com/gradle/gradle/issues/888 https://github.com/gradle/gradle/issues/8213

To avoid it, we need to downgrade Gradle to 5.0. I will fix this problem later.