### PR TITLE
Debug reset on exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 * Start migrating STDOUT/STDERR usage to a logging framework
 * Improvements and bug-fixes for fancy-hist.xsl
 * Bump up Apache Commons BCEL to the version 6.3.1
+* Reset DataAnalysis.DEBUG back when analysis reaches MAX_ITER
 
 ### Deprecated
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/Dataflow.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/Dataflow.java
@@ -185,6 +185,8 @@ public class Dataflow<Fact, AnalysisType extends DataflowAnalysis<Fact>> {
             }
 
             if (numIterations >= MAX_ITERS + 9) {
+                DEBUG = debugWas;
+
                 throw new DataflowAnalysisException("Too many iterations (" + numIterations + ") in dataflow when analyzing "
                         + getFullyQualifiedMethodName());
             }


### PR DESCRIPTION
Hello,

there's a problem with static DataAnalysis.DEBUG flag that is turned on when data analysis reaches MAX_ITERS iterations. In the end an exception is thrown which doesn't reset back the flag and ongoing analysis generates tons of data.

Reached the problem during aspectj-weaver.jar analysis (`Too many iterations TaintAnalysis on org.aspectj.weaver.AjcMemberMaker.interConstructor(org.aspectj.weaver.ResolvedType, org.aspectj.weaver.ResolvedMember, org.aspectj.weaver.UnresolvedType)`).

This fix is to reset the DEBUG back to it's original value when terminating the method analysis so other methods analyses have again DEBUG disabled.

Thank you.

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [X] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
