### PR TITLE
Rejuvenate log levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ## Unreleased - 2019-??-??
 
+### Changed
+
+* Rejuvenated log levels.
+
 ## 4.0.0-beta1 - 2019-03-27
 
 ### Added

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/FindBugs.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/FindBugs.java
@@ -406,27 +406,27 @@ public abstract class FindBugs {
         int errorCount = findBugs.getErrorCount();
 
         if (verbose || commandLine.setExitCode()) {
-            LOG.log(FINE, "Warnings generated: {0}", bugCount);
-            LOG.log(FINE, "Missing classes: {0}", missingClassCount);
-            LOG.log(FINE, "Analysis errors: {0}", errorCount);
+            LOG.log(FINEST, "Warnings generated: {0}", bugCount);
+            LOG.log(FINEST, "Missing classes: {0}", missingClassCount);
+            LOG.log(FINEST, "Analysis errors: {0}", errorCount);
         }
 
         if (commandLine.setExitCode()) {
             int exitCode = 0;
-            LOG.info("Calculating exit code...");
+            LOG.finest("Calculating exit code...");
             if (errorCount > 0) {
                 exitCode |= ExitCodes.ERROR_FLAG;
                 LOG.log(FINE, "Setting 'errors encountered' flag ({0})", ExitCodes.ERROR_FLAG);
             }
             if (missingClassCount > 0) {
                 exitCode |= ExitCodes.MISSING_CLASS_FLAG;
-                LOG.log(FINE, "Setting 'missing class' flag ({0})", ExitCodes.MISSING_CLASS_FLAG);
+                LOG.log(FINEST, "Setting 'missing class' flag ({0})", ExitCodes.MISSING_CLASS_FLAG);
             }
             if (bugCount > 0) {
                 exitCode |= ExitCodes.BUGS_FOUND_FLAG;
-                LOG.log(FINE, "Setting 'bugs found' flag ({0})", ExitCodes.BUGS_FOUND_FLAG);
+                LOG.log(FINEST, "Setting 'bugs found' flag ({0})", ExitCodes.BUGS_FOUND_FLAG);
             }
-            LOG.log(FINE, "Exit code set to: {0}", exitCode);
+            LOG.log(FINEST, "Exit code set to: {0}", exitCode);
 
             System.exit(exitCode);
         }

--- a/spotbugsTestCases/src/java/bugIdeas/Ideas_2009_05_06.java
+++ b/spotbugsTestCases/src/java/bugIdeas/Ideas_2009_05_06.java
@@ -65,7 +65,7 @@ public class Ideas_2009_05_06 {
     public static void main(String[] args) throws Exception {
         initLogging(); // adds a file handler to the logger
         System.gc(); // logger configuration lost
-        Logger.getLogger("com.google.gse").info("Some message"); // this isn't
+        Logger.getLogger("com.google.gse").finest("Some message"); // this isn't
                                                                  // logged to
                                                                  // the file as
                                                                  // expected


### PR DESCRIPTION
## Introduction

We are in the process of evaluating our [research prototype Eclipse plug-in](https://github.com/ponder-lab/Logging-Level-Evolution-Plugin) that "rejuvenates" log statement levels based on how "interesting" the enclosing methods are to the developers. We hypothesize that portions of a system that are worked on more and more recently should have higher log levels (e.g., `INFO` as compared to `FINEST`) and vice-versa. This places event logs related to tasks that are currently more important to the forefront while pushing event logs pertaining to tasks worked on in the past to the background. The goal is to reduce information overload, bring more relevant events to developers' attention, and alleviate developers from manually making log level changes.

The transformation decision is made by analyzing the "degree of interest" (DOI) values of enclosing methods for logging invocations. DOI value is a kind of real number for a program element which shows how developers are interested in it. It is computed from the interaction events between developer and program elements, such as edits. In this project, we calculate the DOI using the project's git history.

## Feedback Request

We are looking for feedback on our tool from developers. If you can, we would appreciate if you can comment on *each* of the transformations (if possible) in the case that this PR is not accepted. If there there are too many transformations to review, letting us know where you left off would be helpful. Of course, we would also love to contribute to your project if you wish.

## Settings

We have several analysis settings. We can vary these settings and rerun if you desire. The settings we are using in this pull request are:

1. Treat CONFIG levels as a category and not a traditional level, i.e., our tool ignores these log levels.
1. Never lower the logging level of logging statements within catch blocks.
1. Avoid log wrapping by disregarding logging statements contained in if statements mentioning log levels.
1. The greatest number of commits evaluated: 1000.

The head at time of analysis was: 89bc8138dc675d9b1fe58761d0e5326f0f7d6f7a

----

- [X] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code