### PR TITLE
Fix usage of IdentityHashMaps

### DIFF
--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/Location.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/Location.java
@@ -125,7 +125,7 @@ public class Location implements Comparable<Location> {
     @Override
     public int hashCode() {
         if (hash == 0) {
-            return hash = System.identityHashCode(basicBlock) + handle.getPosition();
+            return hash = Objects.hash(basicBlock.getLabel(), handle.getPosition());
         }
         return hash;
     }
@@ -136,7 +136,8 @@ public class Location implements Comparable<Location> {
             return false;
         }
         Location other = (Location) o;
-        return basicBlock == other.basicBlock && handle == other.handle;
+        return basicBlock.getLabel() == other.basicBlock.getLabel()
+                && handle.getPosition() == other.handle.getPosition();
     }
 
     @Override

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/vna/ValueNumberAnalysis.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/vna/ValueNumberAnalysis.java
@@ -20,7 +20,6 @@
 package edu.umd.cs.findbugs.ba.vna;
 
 import java.util.HashMap;
-import java.util.IdentityHashMap;
 import java.util.Iterator;
 
 import javax.annotation.CheckForNull;
@@ -69,7 +68,7 @@ public class ValueNumberAnalysis extends FrameDataflowAnalysis<ValueNumber, Valu
 
     private final ValueNumber[] entryLocalValueList;
 
-    private final IdentityHashMap<BasicBlock, ValueNumber> exceptionHandlerValueNumberMap;
+    private final HashMap<Integer, ValueNumber> exceptionHandlerValueNumberMap;
 
     private ValueNumber thisValue;
 
@@ -94,7 +93,7 @@ public class ValueNumberAnalysis extends FrameDataflowAnalysis<ValueNumber, Valu
             this.entryLocalValueList[i] = factory.createFreshValue();
         }
 
-        this.exceptionHandlerValueNumberMap = new IdentityHashMap<>();
+        this.exceptionHandlerValueNumberMap = new HashMap<>();
 
         // For non-static methods, keep track of which value represents the
         // "this" reference
@@ -452,10 +451,11 @@ public class ValueNumberAnalysis extends FrameDataflowAnalysis<ValueNumber, Valu
     // }
 
     private ValueNumber getExceptionValueNumber(BasicBlock handlerBlock) {
-        ValueNumber valueNumber = exceptionHandlerValueNumberMap.get(handlerBlock);
+        Integer handlerBlockLabel = handlerBlock.getLabel();
+        ValueNumber valueNumber = exceptionHandlerValueNumberMap.get(handlerBlockLabel);
         if (valueNumber == null) {
             valueNumber = factory.createFreshValue();
-            exceptionHandlerValueNumberMap.put(handlerBlock, valueNumber);
+            exceptionHandlerValueNumberMap.put(handlerBlockLabel, valueNumber);
         }
         return valueNumber;
     }


### PR DESCRIPTION
Change all IdentityHashMaps to the usual HashMaps and fix work with blocks after cache clearing.
Now correctly works on huge projects.
Changes are invented by @bugaevc.
Don't introduce tests because the error can't be reproduced on small examples.
Fixes #955 
