### PR TITLE
close #953: stop putting `jar` into `artifacts` block

### DIFF
--- a/eclipsePlugin-test/build.gradle
+++ b/eclipsePlugin-test/build.gradle
@@ -45,7 +45,7 @@ task sourcesJar(type: Jar) {
 }
 
 artifacts {
-  archives jar, sourcesJar
+  archives sourcesJar
 }
 
 jacocoTestReport {

--- a/spotbugs-annotations/build.gradle
+++ b/spotbugs-annotations/build.gradle
@@ -64,7 +64,7 @@ task sourcesJar(type: Jar) {
 }
 
 artifacts {
-  archives jar, javadocJar, sourcesJar
+  archives javadocJar, sourcesJar
 }
 
 uploadArchives {

--- a/spotbugs-ant/build.gradle
+++ b/spotbugs-ant/build.gradle
@@ -34,7 +34,7 @@ task sourcesJar(type: Jar) {
 }
 
 artifacts {
-  archives jar, javadocJar, sourcesJar
+  archives javadocJar, sourcesJar
 }
 
 uploadArchives {

--- a/spotbugs-tests/build.gradle
+++ b/spotbugs-tests/build.gradle
@@ -28,5 +28,5 @@ task sourcesJar(type: Jar) {
 }
 
 artifacts {
-  archives jar, sourcesJar
+  archives sourcesJar
 }

--- a/test-harness-core/build.gradle
+++ b/test-harness-core/build.gradle
@@ -17,7 +17,7 @@ task sourcesJar(type: Jar) {
 }
 
 artifacts {
-  archives jar, javadocJar, sourcesJar
+  archives javadocJar, sourcesJar
 }
 
 uploadArchives {

--- a/test-harness-jupiter/build.gradle
+++ b/test-harness-jupiter/build.gradle
@@ -39,7 +39,7 @@ task sourcesJar(type: Jar) {
 }
 
 artifacts {
-  archives jar, javadocJar, sourcesJar
+  archives javadocJar, sourcesJar
 }
 
 uploadArchives {

--- a/test-harness/build.gradle
+++ b/test-harness/build.gradle
@@ -23,7 +23,7 @@ task sourcesJar(type: Jar) {
 }
 
 artifacts {
-  archives jar, javadocJar, sourcesJar
+  archives javadocJar, sourcesJar
 }
 
 uploadArchives {


### PR DESCRIPTION
even after this change, we can install the target jar files into
local maven repo by `./gradlew install` so deployment should not be
affected.
