### PR TITLE
Provide better support for CheckerFramework annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ## Unreleased - 2019-??-??
 
+### Added
+
+* Provide support for CheckerFramework @NonNull annotation
+* Recognize CheckerFramework type annotations on method return values ([#960](https://github.com/spotbugs/spotbugs/pull/960))
+
 ## 4.0.0-beta2 - 2019-05-21
 
 ### Fixed

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/nullness/TestCheckerFrameworkTypeAnnotations.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/nullness/TestCheckerFrameworkTypeAnnotations.java
@@ -1,0 +1,26 @@
+package edu.umd.cs.findbugs.nullness;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
+import org.junit.Test;
+
+import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Checks the effect of CheckerFramework @NonNull annotation on method return value
+ */
+public class TestCheckerFrameworkTypeAnnotations extends AbstractIntegrationTest {
+
+    @Test
+    public void test() {
+        performAnalysis("type/annotation/CheckerFrameworkTypeAnnotations.class");
+        final BugInstanceMatcher matcher = new BugInstanceMatcherBuilder()
+                .bugType("NP_NONNULL_RETURN_VIOLATION")
+                .build();
+
+        assertThat(getBugCollection(), containsExactly(1, matcher));
+    }
+
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/TypeQualifierResolver.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/TypeQualifierResolver.java
@@ -73,6 +73,10 @@ public class TypeQualifierResolver {
 
     static final ClassDescriptor checkerFrameworkNullableDecl = DescriptorFactory.createClassDescriptor("org/checkerframework/checker/nullness/compatqual/NullableDecl");
 
+    static final ClassDescriptor checkerFrameworkNonNull = DescriptorFactory.createClassDescriptor("org/checkerframework/checker/nullness/qual/NonNull");
+
+    static final ClassDescriptor checkerFrameworkNonNullDecl = DescriptorFactory.createClassDescriptor("org/checkerframework/checker/nullness/compatqual/NonNullDecl");
+
     // javax.annotations.ParametersAreNonnullByDefault ?
     static final ClassDescriptor eclipseNonNullByDefault = DescriptorFactory.createClassDescriptor("org/eclipse/jdt/annotation/NonNullByDefault");
 
@@ -150,7 +154,9 @@ public class TypeQualifierResolver {
                         || annotationClass.equals(androidxNonNull)
                         || annotationClass.equals(eclipseNonNull)
                         || annotationClass.equals(eclipseNonNullByDefault)
-                        || annotationClass.equals(intellijNotNull)) {
+                        || annotationClass.equals(intellijNotNull)
+                        || annotationClass.equals(checkerFrameworkNonNull)
+                        || annotationClass.equals(checkerFrameworkNonNullDecl)) {
                     resolveTypeQualifierNicknames(new AnnotationValue(JSR305NullnessAnnotations.NONNULL), result, onStack);
                     return;
                 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/ClassParserUsingASM.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/ClassParserUsingASM.java
@@ -517,6 +517,12 @@ public class ClassParserUsingASM implements ClassParserInterface {
                 mBuilder.addParameterAnnotation(typeRefObject.getFormalParameterIndex(), desc, value);
                 return value.getAnnotationVisitor();
             }
+            if (typeRefObject.getSort() == TypeReference.METHOD_RETURN) {
+                // treat as method annotation
+                AnnotationValue value = new AnnotationValue(desc);
+                mBuilder.addAnnotation(desc, value);
+                return value.getAnnotationVisitor();
+            }
             return null;
         }
     }

--- a/spotbugsTestCases/build.gradle
+++ b/spotbugsTestCases/build.gradle
@@ -20,6 +20,7 @@ dependencies {
   compile 'net.jcip:jcip-annotations:1.0'
   compile 'org.springframework:spring-core:4.3.8.RELEASE'
   compileOnly 'javax.annotation:javax.annotation-api:1.3.2'
+  compile 'org.checkerframework:checker-qual:2.8.1'
 
   compile 'junit:junit:4.12'
   compile 'org.testng:testng:6.11'

--- a/spotbugsTestCases/src/java/type/annotation/CheckerFrameworkTypeAnnotations.java
+++ b/spotbugsTestCases/src/java/type/annotation/CheckerFrameworkTypeAnnotations.java
@@ -1,0 +1,13 @@
+package type.annotation;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+public class CheckerFrameworkTypeAnnotations {
+
+    // Expecting NP_NONNULL_RETURN_VIOLATION to be thrown here
+    @NonNull
+    public String foo() {
+        return null;
+    }
+
+}


### PR DESCRIPTION
Spotbugs doesn't recognize TYPE_USE annotations on method return values. In other words, if you use CheckerFramework annotation in the following context, the annotation is ignored on class parsing phase.

```java
@Nullable
String foo() {
  return null;
}
```

This PR adds a clause to the bytecode parser to check type annotations on method return types. It is done in the same way as similar change for method formal parameters [here](https://github.com/spotbugs/spotbugs/pull/816)

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
