### PR TITLE
Fixing 'Inefficient use of String.indexOf(String)' in BugInfoView

### DIFF
--- a/eclipsePlugin/src/de/tobject/findbugs/view/BugInfoView.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/view/BugInfoView.java
@@ -395,10 +395,10 @@ public class BugInfoView extends AbstractFindbugsView {
     }
 
     private static String toSafeHtml(String s) {
-        if (s.indexOf(">") >= 0) {
+        if (s.indexOf('>') >= 0) {
             s = s.replace(">", "&gt;");
         }
-        if (s.indexOf("<") >= 0) {
+        if (s.indexOf('<') >= 0) {
             s = s.replace("<", "&lt;");
         }
         return s;


### PR DESCRIPTION
Hello,

I found two instances of **IIO_INEFFICIENT_INDEX_OF** in `BugInfoView`. Fortunately, the fix is very easy!

----

Should I add an entry into the changelog for this?

- [ ] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
