### PR TITLE
Experimental multi threading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 * Provide support for CheckerFramework @NonNull annotation
 * Recognize CheckerFramework type annotations on method return values ([#960](https://github.com/spotbugs/spotbugs/pull/960))
+* The feature toggle `spotbugs.experimental.multiThread` for experimental multi-thread analysis
 
 ## 4.0.0-beta2 - 2019-05-21
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/AnalysisLocal.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/AnalysisLocal.java
@@ -22,6 +22,13 @@ import java.util.Map;
 
 import edu.umd.cs.findbugs.classfile.Global;
 
+/**
+ * @deprecated This class is not necessary to realize multi-thread model in SpotBugs 4.0. Each detector instance will
+ *             not run on multiple threads, then only database (or other classes shared by detectors) needs
+ *             synchronization and they can use normal Java synchronization instead.
+ *
+ */
+@Deprecated
 public class AnalysisLocal<T> {
     protected T initialValue() {
         return null;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/CurrentThreadExecutorService.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/CurrentThreadExecutorService.java
@@ -1,0 +1,87 @@
+/*
+ * Contributions to SpotBugs
+ * Copyright (C) 2019, kengo
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+package edu.umd.cs.findbugs;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * <p>
+ * An {@link ExecutorService} implementation that runs command in the current thread. Instance of this class is not
+ * thread safe, do not share it among multiple threads. SpotBugs uses this class to keep backward compatibility
+ * (SpotBugs 3.1 run analysis on the main/current thread).
+ * </p>
+ *
+ * @since 4.0
+ */
+@NotThreadSafe
+class CurrentThreadExecutorService extends AbstractExecutorService {
+    private static final Logger LOG = LoggerFactory.getLogger(CurrentThreadExecutorService.class);
+
+    private boolean isShutdown = false;
+
+    @Override
+    public void shutdown() {
+        if (isShutdown) {
+            throw new IllegalStateException("CurrentThreadExecutorService is closed again");
+        }
+
+        isShutdown = true;
+        LOG.debug("CurrentThreadExecutorService is closed, do nothing");
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        shutdown();
+        return Collections.emptyList();
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return isShutdown;
+    }
+
+    @Override
+    public boolean isTerminated() {
+        // this ExecutorService implementation does not keep commands, then
+        // we can immediately terminate it after the shutdown
+        return isShutdown;
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) {
+        if (!isShutdown) {
+            throw new IllegalStateException("awaitTermination() should be called after the shutdown");
+        }
+        return true;
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        command.run();
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/FindBugs2.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/FindBugs2.java
@@ -1237,6 +1237,8 @@ public class FindBugs2 implements IFindBugsEngine, AutoCloseable {
             // Away we go!
 
             FindBugs.runMain(findBugs, commandLine);
+        } finally {
+            service.shutdown();
         }
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/FindBugs2.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/FindBugs2.java
@@ -1096,8 +1096,8 @@ public class FindBugs2 implements IFindBugsEngine, AutoCloseable {
                     currentAnalysisContext.setClassBeingAnalyzed(classDescriptor);
 
                     try {
-                        Collection<Callable<Void>> tasks = Arrays.stream(detectorList).map(detector -> {
-                            return (Callable<Void>) () -> {
+                        Collection<Callable<Void>> tasks = Arrays.stream(detectorList).map(detector ->
+                            (Callable<Void>) () -> {
                                 if (Thread.interrupted()) {
                                     throw new InterruptedException();
                                 }
@@ -1122,8 +1122,8 @@ public class FindBugs2 implements IFindBugsEngine, AutoCloseable {
                                     profiler.end(detector.getClass());
                                 }
                                 return null;
-                            };
-                        }).collect(Collectors.toList());
+                            }
+                        ).collect(Collectors.toList());
                         service.invokeAll(tasks).forEach(future -> {
                             try {
                                 future.get();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/FindBugs2.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/FindBugs2.java
@@ -1129,7 +1129,7 @@ public class FindBugs2 implements IFindBugsEngine, AutoCloseable {
                                 future.get();
                             } catch (InterruptedException e) {
                                 LOG.warn("Thread interrupted during analysis", e);
-                                Thread.interrupted();
+                                Thread.currentThread().interrupt();
                             } catch (ExecutionException e) {
                                 throw new AnalysisException("Exeption was thrown during analysis", e);
                             }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/FindBugs2.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/FindBugs2.java
@@ -22,6 +22,7 @@ package edu.umd.cs.findbugs;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -31,16 +32,26 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
 import org.apache.bcel.classfile.ClassFormatException;
 import org.dom4j.DocumentException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.asm.FBClassReader;
 import edu.umd.cs.findbugs.ba.AnalysisContext;
+import edu.umd.cs.findbugs.ba.AnalysisException;
 import edu.umd.cs.findbugs.ba.AnalysisFeatures;
 import edu.umd.cs.findbugs.ba.ObjectTypeFactory;
 import edu.umd.cs.findbugs.ba.SourceInfoMap;
@@ -83,6 +94,8 @@ import edu.umd.cs.findbugs.util.TopologicalSort.OutEdges;
  * @author David Hovemeyer
  */
 public class FindBugs2 implements IFindBugsEngine, AutoCloseable {
+    private static final Logger LOG = LoggerFactory.getLogger(FindBugs2.class);
+
     private static final boolean LIST_ORDER = SystemProperties.getBoolean("findbugs.listOrder");
 
     private static final boolean VERBOSE = SystemProperties.getBoolean("findbugs.verbose");
@@ -92,6 +105,8 @@ public class FindBugs2 implements IFindBugsEngine, AutoCloseable {
     public static final boolean PROGRESS = DEBUG || SystemProperties.getBoolean("findbugs.progress");
 
     private static final boolean SCREEN_FIRST_PASS_CLASSES = SystemProperties.getBoolean("findbugs.screenFirstPass");
+
+    public static final boolean MULTI_THREAD = SystemProperties.getBoolean("spotbugs.experimental.multiThread");
 
     public static final String PROP_FINDBUGS_HOST_APP = "findbugs.hostApp";
     public static final String PROP_FINDBUGS_HOST_APP_VERSION = "findbugs.hostAppVersion";
@@ -126,10 +141,25 @@ public class FindBugs2 implements IFindBugsEngine, AutoCloseable {
 
     private final AnalysisOptions analysisOptions = new AnalysisOptions(true);
 
+    private final ExecutorService service;
+
     /**
-     * Constructor.
+     * Constructor that uses {@link CurrentThreadExecutorService} to keep backward compatibility with SpotBugs 3.1.
+     *
+     * @since 3.1
      */
     public FindBugs2() {
+        this(new CurrentThreadExecutorService());
+    }
+
+    /**
+     * @param service
+     *            The non-null {@link ExecutorService} instance to execute analysis. Caller is responsible to shutdown
+     *            it.
+     * @since 4.0
+     */
+    public FindBugs2(@NonNull ExecutorService service) {
+        this.service = Objects.requireNonNull(service, "Given ExecutorService cannot be null.");
         this.classObserverList = new LinkedList<>();
         this.analysisOptions.analysisFeatureSettingList = FindBugs.DEFAULT_EFFORT;
         this.progressReporter = new NoOpFindBugsProgress();
@@ -322,8 +352,12 @@ public class FindBugs2 implements IFindBugsEngine, AutoCloseable {
     }
 
     /**
-     * To avoid cyclic cross-references and allow GC after engine is not more
-     * needed. (used by Eclipse plugin)
+     * <p>
+     * To avoid cyclic cross-references and allow GC after engine is not more needed. (used by Eclipse plugin)
+     * </p>
+     * <p>
+     * Caller probably need to shutdown the {@link ExecutorService} instance provided at constructor.
+     * </p>
      */
     public void dispose() {
         if (executionPlan != null) {
@@ -1062,33 +1096,46 @@ public class FindBugs2 implements IFindBugsEngine, AutoCloseable {
                     currentAnalysisContext.setClassBeingAnalyzed(classDescriptor);
 
                     try {
-                        for (Detector2 detector : detectorList) {
-                            if (Thread.interrupted()) {
-                                throw new InterruptedException();
-                            }
-                            if (isHuge && !FirstPassDetector.class.isAssignableFrom(detector.getClass())) {
-                                continue;
-                            }
-                            if (DEBUG) {
-                                System.out.println("Applying " + detector.getDetectorClassName() + " to " + classDescriptor);
-                                // System.out.println("foo: " +
-                                // NonReportingDetector.class.isAssignableFrom(detector.getClass())
-                                // + ", bar: " + detector.getClass().getName());
-                            }
+                        Collection<Callable<Void>> tasks = Arrays.stream(detectorList).map(detector -> {
+                            return (Callable<Void>) () -> {
+                                if (Thread.interrupted()) {
+                                    throw new InterruptedException();
+                                }
+                                if (isHuge && !FirstPassDetector.class.isAssignableFrom(detector.getClass())) {
+                                    return null;
+                                }
+                                if (DEBUG) {
+                                    System.out.println("Applying " + detector.getDetectorClassName() + " to " + classDescriptor);
+                                }
+                                try {
+                                    profiler.start(detector.getClass());
+                                    detector.visitClass(classDescriptor);
+                                } catch (ClassFormatException e) {
+                                    logRecoverableException(classDescriptor, detector, e);
+                                } catch (MissingClassException e) {
+                                    Global.getAnalysisCache().getErrorLogger().reportMissingClass(e.getClassDescriptor());
+                                } catch (CheckedAnalysisException e) {
+                                    logRecoverableException(classDescriptor, detector, e);
+                                } catch (RuntimeException e) {
+                                    logRecoverableException(classDescriptor, detector, e);
+                                } finally {
+                                    profiler.end(detector.getClass());
+                                }
+                                return null;
+                            };
+                        }).collect(Collectors.toList());
+                        service.invokeAll(tasks).forEach(future -> {
                             try {
-                                profiler.start(detector.getClass());
-                                detector.visitClass(classDescriptor);
-                            } catch (ClassFormatException e) {
-                                logRecoverableException(classDescriptor, detector, e);
-                            } catch (MissingClassException e) {
-                                Global.getAnalysisCache().getErrorLogger().reportMissingClass(e.getClassDescriptor());
-                            } catch (CheckedAnalysisException e) {
-                                logRecoverableException(classDescriptor, detector, e);
-                            } catch (RuntimeException e) {
-                                logRecoverableException(classDescriptor, detector, e);
-                            } finally {
-                                profiler.end(detector.getClass());
+                                future.get();
+                            } catch (InterruptedException e) {
+                                LOG.warn("Thread interrupted during analysis", e);
+                                Thread.interrupted();
+                            } catch (ExecutionException e) {
+                                throw new AnalysisException("Exeption was thrown during analysis", e);
                             }
+                        });
+                        if (Thread.interrupted()) {
+                            throw new InterruptedException();
                         }
                     } finally {
 
@@ -1168,8 +1215,15 @@ public class FindBugs2 implements IFindBugsEngine, AutoCloseable {
             System.exit(1);
         }
 
+        final ExecutorService service;
+        if (MULTI_THREAD) {
+            LOG.warn("Multi-thread analysis is still experimental!");
+            service = Executors.newCachedThreadPool();
+        } else {
+            service = new CurrentThreadExecutorService();
+        }
         // Create FindBugs2 engine
-        try (FindBugs2 findBugs = new FindBugs2()) {
+        try (FindBugs2 findBugs = new FindBugs2(service)) {
             // Parse command line and configure the engine
             TextUICommandLine commandLine = new TextUICommandLine();
             FindBugs.processCommandLine(commandLine, args, findBugs);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/IAnalysisCache.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/IAnalysisCache.java
@@ -203,7 +203,11 @@ public interface IAnalysisCache {
 
     /**
      * Get map of analysis-local objects.
+     *
+     * @deprecated This method is not necessary to realize multi-thread model in SpotBugs 4.0. See
+     *             {@link edu.umd.cs.findbugs.AnalysisLocal AnalysisLocal} for detail.
      */
+    @Deprecated
     public Map<?, ?> getAnalysisLocals();
 
     /**

--- a/spotbugs/src/test/java/edu/umd/cs/findbugs/CurrentThreadExecutorServiceTest.java
+++ b/spotbugs/src/test/java/edu/umd/cs/findbugs/CurrentThreadExecutorServiceTest.java
@@ -1,0 +1,47 @@
+/*
+ * Contributions to SpotBugs
+ * Copyright (C) 2019, kengo
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+package edu.umd.cs.findbugs;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Test;
+
+public class CurrentThreadExecutorServiceTest {
+
+    @Test
+    public void test() {
+        Thread currentThread = Thread.currentThread();
+        ExecutorService executorService = new CurrentThreadExecutorService();
+        AtomicBoolean isCalled = new AtomicBoolean();
+        try {
+            executorService.execute(() -> {
+                assertEquals(currentThread, Thread.currentThread());
+                isCalled.set(true);
+            });
+            assertTrue(isCalled.get());
+        } finally {
+            executorService.shutdown();
+        }
+    }
+
+}


### PR DESCRIPTION
Related with #249. This PR adds an experimental multi-thread analysis. It's deactivated by default because I already know many problems in current implementation such as:

1. `Profiler`, `ClassContext`, `BugReporter` and more classes are not thread-safe.
2. Some default detectors (`LoadOfKnownNullValue`, `Dataflow` and more) expect it runs right after other detector (so we cannot run them at the same time).
3. BCEL is not thread-safe.
4. Dependency among classes are complicated (f93c21a983bd6b8a3c87a59ab1eb7b613c268b09).

This PR just make it possible to run in parallel, to ease debugging.

## Basic approach

I follow the existing `ExecutionPlan` mechanism that orders detectors within each `AnalysisPass` based on ordering constraints specified in the plugin descriptor(s). For detail:

a. Each detector run on a single thread (so detector does not have to be thread-safe).
b. Run detectors in one `AnalysisPass` in parallel, to run database construction before running detectors.
c. Detectors that belongs to another `AnalysisPass` won't run at the same time.

## Remaining TODOs

I will work on following tasks in different PRs:

- [ ] Make `Profiler`, `ClassContext` and others thread-safe, or stop sharing them among threads (to solve 1). 8f332523e5107dc1e8fa2e554b8a6d2e9e98ba0e is rough but not complete idea.
- [ ] Update plugin descriptor to solve existing detector dependency issue (to solve 2).

I hope the problem number 3 (BCEL issue) cannot be blocker, because we do not use BCEL's `Repository` directly. We use an adapter named `AnalysisCacheToRepositoryAdapter` so we can take a lock in this class.

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
