### PR TITLE
ci: Remove warning in SonarQube analysis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: java
 dist: trusty
-
+git:
+  depth: false
 jdk:
   - openjdk8
   - openjdk11

--- a/build.gradle
+++ b/build.gradle
@@ -38,9 +38,11 @@ wrapper {
 // https://discuss.gradle.org/t/merge-jacoco-coverage-reports-for-multiproject-setups/12100/6
 task jacocoRootReport(type: JacocoReport) {
   description = 'Merge all coverage reports before submit to SonarQube'
+  dependsOn(subprojects.test)
 
-  executionData project(':spotbugs').file('build/jacoco/test.exec')
+  executionData = files(subprojects.jacocoTestReport.executionData)
   sourceDirectories = files(subprojects.sourceSets.main.allSource.srcDirs)
+  classDirectories = files(subprojects.sourceSets.main.output)
 
   // Only enable class directories related to non-test project
   classDirectories = files(subprojects.sourceSets.main.output).filter {
@@ -48,7 +50,13 @@ task jacocoRootReport(type: JacocoReport) {
   }
 
   reports {
+    // JaCoCo SonarQube plugin needs a XML file to parse
+    // https://docs.sonarqube.org/display/PLUG/JaCoCo+Plugin
     xml.enabled = true
+  }
+
+  doFirst {
+    executionData = files(executionData.findAll { it.exists() })
   }
 }
 tasks.sonarqube.dependsOn jacocoRootReport

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id 'org.sonarqube' version '2.6.2'
+  id 'org.sonarqube' version '2.7.1'
 }
 
 version = '4.0.0-SNAPSHOT'

--- a/build.gradle
+++ b/build.gradle
@@ -38,14 +38,13 @@ wrapper {
 // https://discuss.gradle.org/t/merge-jacoco-coverage-reports-for-multiproject-setups/12100/6
 task jacocoRootReport(type: JacocoReport) {
   description = 'Merge all coverage reports before submit to SonarQube'
-  dependsOn(subprojects.test)
+  dependsOn(subprojects.jacocoTestReport)
 
   executionData = files(subprojects.jacocoTestReport.executionData)
-  sourceDirectories = files(subprojects.sourceSets.main.allSource.srcDirs)
-  classDirectories = files(subprojects.sourceSets.main.output)
+  sourceDirectories = files(subprojects.jacocoTestReport.sourceDirectories)
 
   // Only enable class directories related to non-test project
-  classDirectories = files(subprojects.sourceSets.main.output).filter {
+  classDirectories = files(subprojects.jacocoTestReport.classDirectories).filter {
     !it.toString().contains("-test") && !it.toString().contains("Test") && !it.toString().contains("junit")
   }
 

--- a/gradle/jacoco.gradle
+++ b/gradle/jacoco.gradle
@@ -12,7 +12,6 @@ jacocoTestReport {
 
 test {
   jacoco {
-    destinationFile = project(':spotbugs').file('build/jacoco/test.exec')
     includeNoLocationClasses = true
     // https://github.com/gradle/gradle/issues/5184#issuecomment-391982009
     excludes = ['jdk.internal.*']

--- a/gradle/sonar.gradle
+++ b/gradle/sonar.gradle
@@ -25,6 +25,7 @@ sonarqube {
         property 'sonar.projectName', 'SpotBugs'
         property 'sonar.projectVersion', rootProject.version
         property 'sonar.organization', 'spotbugs'
+        property 'sonar.coverage.jacoco.xmlReportPaths', "${rootProject.buildDir}/reports/jacoco/jacocoRootReport/jacocoRootReport.xml"
     }
 }
 

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -49,7 +49,12 @@ sourceSets {
   }
   test {
     java {
-      srcDirs = ['src/test/java','src/gui/test/java']
+      srcDirs = ['src/test/java']
+    }
+  }
+  guiTest {
+    java {
+      srcDirs = ['src/gui/test/java']
     }
   }
 }
@@ -81,11 +86,14 @@ dependencies {
   // TODO : Some of these can be extracted to actual dependencies
   compile fileTree(dir: 'lib', include: '*.jar')
 
-  guiCompile sourceSets.main.output
+  guiCompile sourceSets.main.runtimeClasspath
   guiCompile 'commons-lang:commons-lang:2.6'
   guiCompile 'org.dom4j:dom4j:2.1.0'
   guiCompileOnly 'com.apple:AppleJavaExtensions:1.4'
   guiCompileOnly project(':spotbugs-annotations')
+  guiTestCompile sourceSets.gui.runtimeClasspath
+  guiTestCompile 'junit:junit:4.12'
+  guiTestCompileOnly project(':spotbugs-annotations')
 }
 
 // spotbugs {
@@ -333,6 +341,18 @@ uploadArchives {
 // http://blog.joda.org/2017/04/java-se-9-jpms-module-naming.html
 ext.moduleName = 'com.github.spotbugs.spotbugs'
 apply from: "$rootDir/gradle/jigsaw.gradle"
+
+task guiTest(type: Test) {
+  classpath = project.sourceSets.guiTest.runtimeClasspath
+  testClassesDirs = project.sourceSets.guiTest.output.classesDirs
+}
+
+jacocoTestReport {
+  dependsOn(test, guiTest)
+  executionData = files("$buildDir/jacoco/test.exec", "$buildDir/jacoco/guiTest.exec")
+  sourceDirectories = files(sourceSets.main.java.srcDirs, sourceSets.gui.java.srcDirs)
+  classDirectories = files(sourceSets.main.output, sourceSets.gui.output)
+}
 
 // TODO : generatemanual (we should decide what to do with the manual)
 // TODO : generatepdfmanual


### PR DESCRIPTION
In the latest SonarQube analysis, we can find two warnings:

> Property 'sonar.jacoco.reportPaths' is deprecated (JaCoCo binary format). 'sonar.coverage.jacoco.xmlReportPaths' should be used instead (JaCoCo XML format).
> Shallow clone detected during the analysis. Some files will miss SCM information. This will affect features like auto-assignment of issues. Please configure your build to disable shallow clone.

To solve them, this PR configures Travis CI and Gradle.
