### PR TITLE
Release 4.0.0 beta3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased - 2019-??-??
+
 ## 4.0.0-beta3 - 2019-06-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased - 2019-??-??
+## 4.0.0-beta3 - 2019-06-24
 
 ### Added
 
-* Provide support for CheckerFramework @NonNull annotation
+* Provide support for CheckerFramework `@NonNull` annotation
 * Recognize CheckerFramework type annotations on method return values ([#960](https://github.com/spotbugs/spotbugs/pull/960))
 * The feature toggle `spotbugs.experimental.multiThread` for experimental multi-thread analysis
 * Add management for source filter using full source path, if available and simple filename does not already match ([#694](https://github.com/spotbugs/spotbugs/issues/694))

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
   id 'org.sonarqube' version '2.7.1'
 }
 
-version = '4.0.0-SNAPSHOT'
+version = '4.0.0-beta3'
 
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/jacoco.gradle"

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
   id 'org.sonarqube' version '2.7.1'
 }
 
-version = '4.0.0-beta3'
+version = '4.0.0-SNAPSHOT'
 
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/jacoco.gradle"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,8 +17,8 @@ import os
 
 html_context = {
   'version' : '4.0',
-  'full_version' : '4.0.0-beta2',
-  'maven_plugin_version' : '3.1.11',
+  'full_version' : '4.0.0-beta3',
+  'maven_plugin_version' : '3.1.12',
   'gradle_plugin_version' : '2.0.0',
   'archetype_version' : '0.2.2'
 }


### PR DESCRIPTION
This PR will release SpotBugs version `4.0.0-beta3` to Maven Central.

[//]: # (rtdbot-start)

URL of RTD documents:
en: https://spotbugs.readthedocs.io/en/release-4.0.0_beta3/
ja: https://spotbugs.readthedocs.io/ja/release-4.0.0_beta3/

[//]: # (rtdbot-end)
