### PR TITLE
Fixed spotless build error on Windows

### DIFF
--- a/gradle/spotless.gradle
+++ b/gradle/spotless.gradle
@@ -5,5 +5,6 @@ spotless {
     removeUnusedImports()
     eclipse().configFile "${rootProject.projectDir}/gradle/eclipse-formatter.xml"
     endWithNewline()
+    lineEndings 'UNIX'
   }
 }


### PR DESCRIPTION
Enforce LF line endings via spotless config by default, independently on
the current OS. This fixes #994.



----

Make sure these boxes are checked before submitting your PR -- thank you!

- [ ] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
