### PR TITLE
Add checksum-dependency-plugin for verification of plugin/dependency checksums

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,13 +55,13 @@ install:
 
 script:
   - jdk_switcher use openjdk8
-  - ./gradlew classes testClasses -S
+  - ./gradlew classes testClasses -S -PchecksumPrint -PchecksumFailOn=build_finish
   - if [[ $TRAVIS_JDK_VERSION == "openjdk11" ]]; then export JAVA_HOME=$HOME/openjdk11; fi
-  - ./gradlew -v --no-daemon
-  - ./gradlew build smoketest -x signArchives -S --no-daemon
+  - ./gradlew -v --no-daemon -PchecksumPrint -PchecksumFailOn=build_finish
+  - ./gradlew build smoketest -x signArchives -S --no-daemon -PchecksumPrint -PchecksumFailOn=build_finish
   - jdk_switcher use openjdk8
-  - if [[ $TRAVIS_JDK_VERSION == "openjdk8" ]]; then ./gradlew sonarqube -S; fi
-  - if [[ $TRAVIS_JDK_VERSION == "openjdk8" ]]; then ./gradlew spotlessCheck -S; fi
+  - if [[ $TRAVIS_JDK_VERSION == "openjdk8" ]]; then ./gradlew sonarqube -S -PchecksumPrint -PchecksumFailOn=build_finish; fi
+  - if [[ $TRAVIS_JDK_VERSION == "openjdk8" ]]; then ./gradlew spotlessCheck -S -PchecksumPrint -PchecksumFailOn=build_finish; fi
 
 before_cache:
   - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/checksum.xml
+++ b/checksum.xml
@@ -1,0 +1,136 @@
+<?xml version='1.0' encoding='utf-8'?>
+<dependency-verification version='1'>
+  <trust-requirement pgp='GROUP' checksum='NONE' />
+  <ignored-keys />
+  <trusted-keys>
+    <trusted-key id='2d6641c6af88103e' group='com.apple' />
+    <trusted-key id='5ad66315fc018797' group='com.beust' />
+    <trusted-key id='379ce192d401ab61' group='com.diffplug.durian' />
+    <trusted-key id='379ce192d401ab61' group='com.diffplug.spotless' />
+    <trusted-key id='1756b920eecf0e90' group='com.github.spotbugs' />
+    <trusted-key id='9c6404ebce3e4464' group='com.github.zafarkhaja' />
+    <trusted-key id='353a436e043e3145' group='com.google.code.findbugs' />
+    <trusted-key id='59a252fb1199d873' group='com.google.code.findbugs' />
+    <trusted-key id='7a01b0f236e5430f' group='com.google.code.gson' />
+    <trusted-key id='9a259c7ee636c5ed' group='com.google.errorprone' />
+    <trusted-key id='bf935c771a8474f8' group='com.google.errorprone' />
+    <trusted-key id='9a259c7ee636c5ed' group='com.google.googlejavaformat' />
+    <trusted-key id='abe9f3126bb741c1' group='com.google.guava' />
+    <trusted-key id='f6d4a1d411e9d1ae' group='com.google.guava' />
+    <trusted-key id='f0df21d1d0a3c384' group='com.google.inject' />
+    <trusted-key id='f0df21d1d0a3c384' group='com.google.inject.extensions' />
+    <trusted-key id='29579f18fa8fd93b' group='com.google.j2objc' />
+    <trusted-key id='bac30622339994c4' group='com.google.truth' />
+    <trusted-key id='7eb97d110dfadd60' group='com.googlecode.concurrent-trees' />
+    <trusted-key id='72475fd306b9cab7' group='com.googlecode.javaewah' />
+    <trusted-key id='44ce7bf2825ea2cd' group='com.ibm.icu' />
+    <trusted-key id='a50569c7ca7fa1f0' group='com.jcraft' />
+    <trusted-key id='1063fe98bcecb758' group='com.puppycrawl.tools' />
+    <trusted-key id='411063a3a0ffd119' group='commons-beanutils' />
+    <trusted-key id='9daadc1c9fcc82d0' group='commons-cli' />
+    <trusted-key id='86fdc7e2a11262cb' group='commons-codec' />
+    <trusted-key id='a41f13c999945293' group='commons-collections' />
+    <trusted-key id='1861c322c56014b2' group='commons-lang' />
+    <trusted-key id='a41f13c999945293' group='commons-logging' />
+    <trusted-key id='6425559c47cc79c4' group='javax.annotation' />
+    <trusted-key id='4044edf1bb73efea' group='jaxen' />
+    <trusted-key id='72385ff0af338d52' group='joda-time' />
+    <trusted-key id='efe8086f9e93774e' group='junit' />
+    <trusted-key id='bb2914c1fa0811c3' group='net.bytebuddy' />
+    <trusted-key id='75bf031b7c94e183' group='net.java.dev.jna' />
+    <trusted-key id='1d185615d0a84648' group='net.sf.saxon' />
+    <trusted-key id='c84125c13bf6f2f2' group='org.ajoberstar' />
+    <trusted-key id='6b1b008864323b92' group='org.antlr' />
+    <trusted-key id='5efad9fe82a7fbcd' group='org.apache.ant' />
+    <trusted-key id='86fdc7e2a11262cb' group='org.apache.bcel' />
+    <trusted-key id='7c25280eae63ebe5' group='org.apache.httpcomponents' />
+    <trusted-key id='3595395eb3d8e1ba' group='org.apache.logging.log4j' />
+    <trusted-key id='164bd2247b936711' group='org.apiguardian' />
+    <trusted-key id='b16698a4adf4d638' group='org.checkerframework' />
+    <trusted-key id='41321490758aad6f' group='org.codehaus.groovy' />
+    <trusted-key id='6525fd70cc303655' group='org.codehaus.mojo' />
+    <trusted-key id='873a8e86b4372146' group='org.codehaus.mojo' />
+    <trusted-key id='79e193516be7998f' group='org.dom4j' />
+    <trusted-key id='5fec689ca7e7b6bd' group='org.eclipse.jdt' />
+    <trusted-key id='5b05ccde140c2876' group='org.eclipse.jgit' />
+    <trusted-key id='700e4f39bc05364b' group='org.eclipse.platform' />
+    <trusted-key id='a6adfc93ef34893e' group='org.hamcrest' />
+    <trusted-key id='cb43338e060cf9fa' group='org.jacoco' />
+    <trusted-key id='164bd2247b936711' group='org.junit.jupiter' />
+    <trusted-key id='164bd2247b936711' group='org.junit.platform' />
+    <trusted-key id='a1b4460d8ba7b9af' group='org.mockito' />
+    <trusted-key id='7c7d8456294423ba' group='org.objenesis' />
+    <trusted-key id='164bd2247b936711' group='org.opentest4j' />
+    <trusted-key id='2c7b12f2a511e325' group='org.slf4j' />
+    <trusted-key id='cfca4a29d26468de' group='org.sonarsource.scanner.api' />
+    <trusted-key id='cfca4a29d26468de' group='org.sonarsource.scanner.gradle' />
+    <trusted-key id='379ce192d401ab61' group='org.springframework' />
+    <trusted-key id='5ad66315fc018797' group='org.testng' />
+    <trusted-key id='55c7e5e701832382' group='org.yaml' />
+  </trusted-keys>
+  <dependencies>
+    <dependency group='antlr' module='antlr' version='2.7.7'>
+      <sha512>311C3115F9F6651D1711C52D1739E25A70F25456CACB9A2CDDE7627498C30B13D721133CC75B39462AD18812A82472EF1B3B9D64FAB5ABB0377C12BF82043A74</sha512>
+    </dependency>
+    <dependency group='aopalliance' module='aopalliance' version='1.0'>
+      <sha512>3F44A932D8C00CFEEE2EB057BCD7C301A2D029063E0A916E1E20B3AEC4877D19D67A2FD8AAF58FA2D5A00133D1602128A7F50912FFB6CABC7B0FDC7FBDA3F8A1</sha512>
+    </dependency>
+    <dependency group='com.diffplug.spotless' module='spotless-plugin-gradle' version='3.23.0'>
+      <sha512>3156088983703A4AF551155174A82735942BC86142C8EA50C2609B37803A56BEF8FB26B5E7F8120D07776DE857B2070AFF1F62FC90C23198045669D6A22037C2</sha512>
+    </dependency>
+    <dependency group='gradle.plugin.com.github.spotbugs' module='spotbugs-gradle-plugin' version='1.6.5'>
+      <sha512>E8DCCF6086D03CC311CF0E7069741E1A1082E2459AE0E943EB8F3CB40D2F591A5566F5F21B3A12579AC18FE916DFD541FC13C18DADCEF3D84B7AE47E6F84EA35</sha512>
+    </dependency>
+    <dependency group='javax.inject' module='javax.inject' version='1'>
+      <sha512>E126B7CCF3E42FD1984A0BEEF1004A7269A337C202E59E04E8E2AF714280D2F2D8D2BA5E6F59481B8DCD34AAF35C966A688D0B48EC7E96F102C274DC0D3B381E</sha512>
+    </dependency>
+    <dependency group='net.jcip' module='jcip-annotations' version='1.0'>
+      <sha512>CB312B3F571D91EF183C119D878F50464FFD97F853B7311CBA386463F295E8B7B3A5A89ED4269A045CACD5AA7CB4C803D4882854A0FDDEFA9BBC28C72AA6C786</sha512>
+    </dependency>
+    <dependency group='org.ow2.asm' module='asm-analysis' version='6.2'>
+      <sha512>B2EE54095D0451BD503AC9CE0C0AC447FD292A926E6C0E129043A1DFAA1BD1A28D37F7CB2C56D87A2386DBAADAB319DD760CE2441403D46067FDCE3C6A7F1C10</sha512>
+    </dependency>
+    <dependency group='org.ow2.asm' module='asm-analysis' version='6.2.1'>
+      <sha512>BE273F8E886BBCFDA81180917145996AB8FD26A17264EBEB5E1FC2337950A309D64DC8CBD373220009728622A8CBF56B8578E960B5561C22EA66848D296AE44E</sha512>
+    </dependency>
+    <dependency group='org.ow2.asm' module='asm-analysis' version='7.1'>
+      <sha512>D74FD51F49A8278545EAAAAF808692D69F7140FA73F4CF1EEC01A21D5D2A378356A5D74FADC2F6983EE023CDF6E06851F9F37A084BE547120300AC97D9CC6BBA</sha512>
+    </dependency>
+    <dependency group='org.ow2.asm' module='asm-commons' version='6.2'>
+      <sha512>E884F2DCE3D203B00970C61AC956199DC1C168D8364DE9B561D2305A31778BA1A8786BCFCA5C59DBAC0B08414D9C8ED1D7FB53EBB75F8604F532C2950AD5A6B1</sha512>
+    </dependency>
+    <dependency group='org.ow2.asm' module='asm-commons' version='6.2.1'>
+      <sha512>CDF7DDB8E865B1C22C7532FFF68380FE4EC49A00C6FF3188BF265C4769E49E793B51621FC80A39B5BA2D49E703F100BDB7FC9CFF8F488C5153A9339334371411</sha512>
+    </dependency>
+    <dependency group='org.ow2.asm' module='asm-commons' version='7.1'>
+      <sha512>2879AE5E7B796F0777B4730FB3F21B8D42CBDBF3A090ACADF2CE52082F1EA030059B0067D9A3B4D2C4B4680519A8EE9B2CF1563901931645245A973B9F60B1C2</sha512>
+    </dependency>
+    <dependency group='org.ow2.asm' module='asm-tree' version='6.2'>
+      <sha512>2492FB82610FBED9DF0DED5825CC6BCC106A1EC8D1F362ACDFC9712766618DBE39B78C5A80D2D6D79E876D86677C48BACBCF6BE020472A30E3785050D2F931C3</sha512>
+    </dependency>
+    <dependency group='org.ow2.asm' module='asm-tree' version='6.2.1'>
+      <sha512>20FE687C2F494717CCEB33C97704FAB7C1867EEA1A0F79B70C68BCAA72E7818F34921B6FBA7A3C1ECBBC7256E1D8E1A538F9EC5B4BD3B2A255D412D2BC2CAA4C</sha512>
+    </dependency>
+    <dependency group='org.ow2.asm' module='asm-tree' version='7.1'>
+      <sha512>7C285E6DE13CED1FD6110C616F9F38120D5D37DA9E39BE1B6FC16224595F54F645C675313F75ED819AE27E66D84E9BC378A6FB42DF2F4DD2819ED745767A79AC</sha512>
+    </dependency>
+    <dependency group='org.ow2.asm' module='asm-util' version='6.2'>
+      <sha512>72289F8DCAA203675747EBA75ACE7D2650BFBFB353A1DC1574B6665FF500C4ACF9BB94DCD43708F09BC2FE25B03ABEC5FB3A4F96EBD3AD30B70B11AE24D03F97</sha512>
+    </dependency>
+    <dependency group='org.ow2.asm' module='asm-util' version='7.1'>
+      <sha512>F8F693C0EFDEDB244EC09D0FD1E32E2C3DD392C464468ABBAD1D730C80FB2FDAC889719C57911D5EECCAA9E20EA4FBB47452FA24B6AFE31B07E7BBDF70F25466</sha512>
+    </dependency>
+    <dependency group='org.ow2.asm' module='asm-xml' version='6.2'>
+      <sha512>BD9BA7C230EAB1F752A1CB204DB1CC6914A033540A184DBBFAA9199281C28ABF34FF12C3BF4CC63722ECB03597E4C5B1D794A2979190F0FF9C88CC243F99794E</sha512>
+    </dependency>
+    <dependency group='org.ow2.asm' module='asm' version='6.2'>
+      <sha512>1E819B65D6DD55DA6E325B4D223F661CF25C04F1A8B3B52E766DAB8C9ADD91DDEC816703CCC6196A7E7B46995B7F6463F18A2E50BF6598D034B04786790CCDA1</sha512>
+    </dependency>
+    <dependency group='org.ow2.asm' module='asm' version='6.2.1'>
+      <sha512>C8D0AB865B628CB5A71C2B8C5FC8AACDA3E286B14662C3287CE50A96E91990E959F1447D439BD7190D9088E69E4368EFBFF5890FA539F98776F514A262D6DA8C</sha512>
+    </dependency>
+    <dependency group='org.ow2.asm' module='asm' version='7.1'>
+      <sha512>7EBA7097109389F48FA9142BF22D225F5D3104D68013D3B8E0A6D4054A8CD0EF64614372BDCB38987D68ADB6D33A3804E98DDF112BA84DBB09D448CE702DACC4</sha512>
+    </dependency>
+  </dependencies>
+</dependency-verification>

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,3 +7,56 @@ if (new File(rootDir, eclipseFile).exists()) {
 }
 
 include ':test-harness-core', ':test-harness-jupiter'
+
+// See https://github.com/vlsi/vlsi-release-plugins
+// It is a  plugin that verifies checksums of all the resolved files (plugins, dependencies, ...)
+// By default the plugin generates an updated checksums to $rootDir/build/checksum/checksum.xml,
+// and you can make it update rootDir/checksum.xml by adding -PchecksumUpdate
+buildscript {
+  dependencies {
+    classpath('com.github.vlsi.gradle:checksum-dependency-plugin:1.28.0') {
+      // Gradle ships kotlin-stdlib which is good enough
+      exclude(group: "org.jetbrains.kotlin", module:"kotlin-stdlib")
+    }
+  }
+  repositories {
+    gradlePluginPortal()
+  }
+}
+
+// Note: we need to verify the checksum for checksum-dependency-plugin itself
+def expectedSha512 = [
+  "43BC9061DFDECA0C421EDF4A76E380413920E788EF01751C81BDC004BD28761FBD4A3F23EA9146ECEDF10C0F85B7BE9A857E9D489A95476525565152E0314B5B":
+    "bcpg-jdk15on-1.62.jar",
+  "2BA6A5DEC9C8DAC2EB427A65815EB3A9ADAF4D42D476B136F37CD57E6D013BF4E9140394ABEEA81E42FBDB8FC59228C7B85C549ED294123BF898A7D048B3BD95":
+    "bcprov-jdk15on-1.62.jar",
+  "17DAAF511BE98F99007D7C6B3762C9F73ADD99EAB1D222985018B0258EFBE12841BBFB8F213A78AA5300F7A3618ACF252F2EEAD196DF3F8115B9F5ED888FE827":
+    "okhttp-4.1.0.jar",
+  "93E7A41BE44CC17FB500EA5CD84D515204C180AEC934491D11FC6A71DAEA761FB0EECEF865D6FD5C3D88AAF55DCE3C2C424BE5BA5D43BEBF48D05F1FA63FA8A7":
+    "okio-2.2.2.jar",
+  "2ABC83FF0675D69697D4530D4853411761FE947E57EB8D68F6590DC2BFF0436906ADE619822EEE5F80B0DA28285FBE75FDCB50B67421DB7BF78B34CF6A613714":
+    "checksum-dependency-plugin-1.28.0.jar"
+]
+
+def sha512(File file) {
+  def md = java.security.MessageDigest.getInstance('SHA-512')
+  file.eachByte(8192) { buffer, length ->
+     md.update(buffer, 0, length)
+  }
+  new BigInteger(1, md.digest()).toString(16).toUpperCase()
+}
+
+def violations =
+  buildscript.configurations.classpath
+    .resolve()
+    .sort { it.name }
+    .collectEntries { [(it): sha512(it)] }
+    .findAll { !expectedSha512.containsKey(it.value) }
+    .collect { file, sha512 ->  "SHA-512(${file.name}) = $sha512 ($file)" }
+    .join("\n  ")
+
+if (!violations.isEmpty()) {
+  throw new GradleException("Buildscript classpath has non-whitelisted files:\n  $violations")
+}
+
+apply plugin: 'com.github.vlsi.checksum-dependency'


### PR DESCRIPTION
`checksum-dependency-plugin` is a superset of `gradle-witness`, and it enables to increase the level of security.

See https://github.com/vlsi/vlsi-release-plugins#checksum-dependency-plugin
See https://medium.com/@vladimirsitniko/dependency-verification-checksum-vs-pgp-582e76207019?sk=7485298b76eaf9f935b899b002f4c3b5

Note: upcoming versions of ASM would publish PGP signatures. See https://gitlab.ow2.org/asm/asm/issues/317878
