### PR TITLE
Replace maven plugin with maven-publish plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ script:
   - ./gradlew classes testClasses -S
   - if [[ $TRAVIS_JDK_VERSION == "openjdk11" ]]; then export JAVA_HOME=$HOME/openjdk11; fi
   - ./gradlew -v --no-daemon
-  - ./gradlew build smoketest -x signArchives -S --no-daemon
+  - ./gradlew build smoketest -S --no-daemon
   - jdk_switcher use openjdk8
   - if [[ $TRAVIS_JDK_VERSION == "openjdk8" ]]; then ./gradlew sonarqube -S; fi
   - if [[ $TRAVIS_JDK_VERSION == "openjdk8" ]]; then ./gradlew spotlessCheck -S; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -113,7 +113,7 @@ deploy:
     skip_cleanup: true
     # wait until uploading task finishes, because it may cost more than 10 minutes without any output
     # https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received
-    script: .travis/travis_wait "./gradlew uploadArchives"
+    script: .travis/travis_wait "./gradlew publish"
     on:
       jdk: openjdk8
       branch: master
@@ -121,7 +121,7 @@ deploy:
     skip_cleanup: true
     # wait until uploading task finishes, because it may cost more than 10 minutes without any output
     # https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received
-    script: .travis/travis_wait "./gradlew uploadArchives"
+    script: .travis/travis_wait "./gradlew publish"
     on:
       tags: true
       jdk: openjdk8

--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -2,13 +2,6 @@ apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT") && /* for Eclipse plugin */ !version.contains("-SNAPSHOT.")
-signing {
-  required { isReleaseVersion && gradle.taskGraph.hasTask(":${project.name}:uploadArchives") }
-  sign publishing.publications.maven
-}
-tasks.withType(Sign) {
-  onlyIf { isReleaseVersion }
-}
 
 publishing {
   repositories {
@@ -83,4 +76,13 @@ publishing {
       }
     }
   }
+}
+
+signing {
+  required { isReleaseVersion && gradle.taskGraph.hasTask(":${project.name}:publish") }
+  sign publishing.publications.maven
+}
+
+tasks.withType(Sign) {
+  onlyIf { isReleaseVersion }
 }

--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -1,88 +1,83 @@
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT") && /* for Eclipse plugin */ !version.contains("-SNAPSHOT.")
 signing {
   required { isReleaseVersion && gradle.taskGraph.hasTask(":${project.name}:uploadArchives") }
-  sign configurations.archives
+  sign publishing.publications.maven
 }
 tasks.withType(Sign) {
   onlyIf { isReleaseVersion }
 }
 
-uploadArchives {
+publishing {
   repositories {
-    mavenDeployer {
-      def username = project.hasProperty('ossrhUsername') ? ossrhUsername : "Unknown user"
-      def password = project.hasProperty('ossrhPassword') ? ossrhPassword : "Unknown password"
-      beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
-
-      repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-        authentication(userName: username, password: password)
+    maven {
+      url isReleaseVersion ? "https://oss.sonatype.org/service/local/staging/deploy/maven2/" : "https://oss.sonatype.org/content/repositories/snapshots/"
+      credentials {
+        username = project.hasProperty('ossrhUsername') ? ossrhUsername : "Unknown user"
+        password = project.hasProperty('ossrhPassword') ? ossrhPassword : "Unknown password"
       }
-
-      snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
-        authentication(userName: username, password: password)
-      }
-
-      pom.project {
-        url 'https://spotbugs.github.io/'
-
+    }
+  }
+  publications {
+    maven(MavenPublication) {
+      from components.java
+      pom {
+        url = 'https://spotbugs.github.io/'
         scm {
-          connection 'scm:git:git@github.com:spotbugs/spotbugs.git'
-          developerConnection 'scm:git:git@github.com:spotbugs/spotbugs.git'
-          url 'https://github.com/spotbugs/spotbugs/'
+          connection = 'scm:git:git@github.com:spotbugs/spotbugs.git'
+          developerConnection = 'scm:git:git@github.com:spotbugs/spotbugs.git'
+          url = 'https://github.com/spotbugs/spotbugs/'
         }
-
         licenses {
           license {
-            name 'GNU LESSER GENERAL PUBLIC LICENSE, Version 2.1'
-            url 'https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html'
+            name = 'GNU LESSER GENERAL PUBLIC LICENSE, Version 2.1'
+            url = 'https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html'
           }
         }
-
         developers {
           developer {
-            id 'jsotuyod'
-            name 'Juan Martín Sotuyo Dodero'
-            url 'https://github.com/jsotuyod'
-            timezone '-3'
+            id = 'jsotuyod'
+            name = 'Juan Martín Sotuyo Dodero'
+            url = 'https://github.com/jsotuyod'
+            timezone = '-3'
           }
           developer {
-            id 'mebigfatguy'
-            name 'Dave Brosius'
-            email 'dbrosius@mebigfatguy.com'
-            url 'http://www.jroller.com/dbrosius/'
-            timezone '-5'
+            id = 'mebigfatguy'
+            name = 'Dave Brosius'
+            email = 'dbrosius@mebigfatguy.com'
+            url = 'http://www.jroller.com/dbrosius/'
+            timezone = '-5'
           }
           developer {
-            id 'henrik242'
-            url 'https://github.com/henrik242'
+            id = 'henrik242'
+            url = 'https://github.com/henrik242'
           }
           developer {
-            id 'KengoTODA'
-            name 'Kengo TODA'
-            email 'skypencil@gmail.com'
-            url 'https://github.com/KengoTODA/'
-            timezone '+8'
+            id = 'KengoTODA'
+            name = 'Kengo TODA'
+            email = 'skypencil@gmail.com'
+            url = 'https://github.com/KengoTODA/'
+            timezone = '+8'
           }
           developer {
-            id 'iloveeclipse'
-            name 'Andrey Loskutov'
-            email 'loskutov@gmx.de'
-            url 'https://plus.google.com/+AndreyLoskutov'
-            timezone '+2'
+            id = 'iloveeclipse'
+            name = 'Andrey Loskutov'
+            email = 'loskutov@gmx.de'
+            url = 'https://plus.google.com/+AndreyLoskutov'
+            timezone = '+2'
           }
           developer {
-            id 'ThrawnCA'
-            url 'https://github.com/ThrawnCA'
+            id = 'ThrawnCA'
+            url = 'https://github.com/ThrawnCA'
           }
           developer {
-            id 'sewe'
-            name 'Andreas Sewe'
-            email 'andreas.sewe@codetrails.com'
-            url 'https://github.com/sewe'
-            timezone '+1'
+            id = 'sewe'
+            name = 'Andreas Sewe'
+            email = 'andreas.sewe@codetrails.com'
+            url = 'https://github.com/sewe'
+            timezone = '+1'
           }
         }
       }

--- a/spotbugs-annotations/build.gradle
+++ b/spotbugs-annotations/build.gradle
@@ -63,18 +63,12 @@ task sourcesJar(type: Jar) {
   from sourceSets.main.allSource
 }
 
-artifacts {
-  archives javadocJar, sourcesJar
-}
-
-uploadArchives {
-  repositories {
-    mavenDeployer {
-      pom.project {
-        name 'SpotBugs Annotations'
-        description 'Annotations the SpotBugs tool supports'
-      }
-    }
+publishing.publications.maven {
+  artifact javadocJar
+  artifact sourcesJar
+  pom {
+    name = 'SpotBugs Annotations'
+    description = 'Annotations the SpotBugs tool supports'
   }
 }
 

--- a/spotbugs-ant/build.gradle
+++ b/spotbugs-ant/build.gradle
@@ -33,18 +33,12 @@ task sourcesJar(type: Jar) {
   from sourceSets.main.allSource
 }
 
-artifacts {
-  archives javadocJar, sourcesJar
-}
-
-uploadArchives {
-  repositories {
-    mavenDeployer {
-      pom.project {
-        name 'SpotBugs Ant Task'
-        description 'Ant Task to run SpotBugs'
-      }
-    }
+publishing.publications.maven {
+  artifact javadocJar
+  artifact sourcesJar
+  pom {
+    name = 'SpotBugs Ant Task'
+    description = 'Ant Task to run SpotBugs'
   }
 }
 

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -245,11 +245,6 @@ task sourcesJar(type: Jar, dependsOn: classes) {
   from sourceSets.main.allSource
 }
 
-artifacts {
-  archives javadocJar
-  archives sourcesJar
-}
-
 apply plugin: 'distribution'
 distributions {
   main {
@@ -326,14 +321,12 @@ task smokeTest {
   }
 }
 
-uploadArchives {
-  repositories {
-    mavenDeployer {
-      pom.project {
-        name 'SpotBugs'
-        description "SpotBugs: Because it's easy!"
-      }
-    }
+publishing.publications.maven {
+  artifact javadocJar
+  artifact sourcesJar
+  pom {
+    name = 'SpotBugs'
+    description = "SpotBugs: Because it's easy!"
   }
 }
 

--- a/test-harness-core/build.gradle
+++ b/test-harness-core/build.gradle
@@ -16,18 +16,12 @@ task sourcesJar(type: Jar) {
   from sourceSets.main.allSource
 }
 
-artifacts {
-  archives javadocJar, sourcesJar
-}
-
-uploadArchives {
-  repositories {
-    mavenDeployer {
-      pom.project {
-        name 'Core of Test Harness for SpotBugs Plugin'
-        description 'Core feature to support unit test for SpotBugs Plugin'
-      }
-    }
+publishing.publications.maven {
+  artifact javadocJar
+  artifact sourcesJar
+  pom {
+    name = 'Core of Test Harness for SpotBugs Plugin'
+    description = 'Core feature to support unit test for SpotBugs Plugin'
   }
 }
 

--- a/test-harness-jupiter/build.gradle
+++ b/test-harness-jupiter/build.gradle
@@ -38,18 +38,12 @@ task sourcesJar(type: Jar) {
   from sourceSets.main.allSource
 }
 
-artifacts {
-  archives javadocJar, sourcesJar
-}
-
-uploadArchives {
-  repositories {
-    mavenDeployer {
-      pom.project {
-        name 'JUnit 5 Test Harness for SpotBugs Plugin'
-        description 'A test harness library for SpotBugs plugin developers to test on JUnit 5'
-      }
-    }
+publishing.publications.maven {
+  artifact javadocJar
+  artifact sourcesJar
+  pom {
+    name = 'JUnit 5 Test Harness for SpotBugs Plugin'
+    description = 'A test harness library for SpotBugs plugin developers to test on JUnit 5'
   }
 }
 

--- a/test-harness/build.gradle
+++ b/test-harness/build.gradle
@@ -22,18 +22,12 @@ task sourcesJar(type: Jar) {
   from sourceSets.main.allSource
 }
 
-artifacts {
-  archives javadocJar, sourcesJar
-}
-
-uploadArchives {
-  repositories {
-    mavenDeployer {
-      pom.project {
-        name 'JUnit 4 Test Harness for SpotBugs Plugin'
-        description 'A test harness library for SpotBugs plugin developers to test on JUnit4'
-      }
-    }
+publishing.publications.maven {
+  artifact javadocJar
+  artifact sourcesJar
+  pom {
+    name = 'JUnit 4 Test Harness for SpotBugs Plugin'
+    description = 'A test harness library for SpotBugs plugin developers to test on JUnit4'
   }
 }
 


### PR DESCRIPTION
[according to this info](https://github.com/spotbugs/spotbugs-gradle-plugin/pull/159/files#diff08aeba2871118ca65285e0a3cfceab9fR3), Gradle 7 will remove maven plugin that is already deprecated.

This PR replaces it with preferred maven-publish plugin.