### PR TITLE
chore: bump up Apache BCEL to 6.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ### Changed
 
-* Bump up Apache Commons BCEL to the version 6.4.0
+* Bump up Apache Commons BCEL to the version 6.4.1
 * update ASM to 7.2 that supports Java 14
 
 ## 4.0.0-beta4 - 2019-08-20

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -65,7 +65,7 @@ dependencies {
   compile 'org.ow2.asm:asm-commons:7.2'
   compile 'org.ow2.asm:asm-tree:7.2'
   compile 'org.ow2.asm:asm-util:7.2'
-  compile 'org.apache.bcel:bcel:6.4.0'
+  compile 'org.apache.bcel:bcel:6.4.1'
   compile 'net.jcip:jcip-annotations:1.0'
   compile 'org.dom4j:dom4j:2.1.1'
   compile 'jaxen:jaxen:1.1.6' // only transitive through dom4j:dom4j:1.6.1, which has an *optional* dependency on jaxen:jaxen.


### PR DESCRIPTION
This version contains bug fix, see https://www.apache.org/dist/commons/bcel/RELEASE-NOTES.txt for detail