### PR TITLE
Introduce reproducible-builds

### DIFF
--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -6,3 +6,11 @@ tasks.withType(JavaCompile) {
 tasks.withType(Javadoc) {
     options.encoding = 'UTF-8'
 }
+
+// make the build reproducible https://reproducible-builds.org/
+tasks.withType(AbstractArchiveTask) {
+  preserveFileTimestamps = false
+  reproducibleFileOrder = true
+  dirMode = 0775
+  fileMode = 0664
+}


### PR DESCRIPTION
This change introduces [reproducible builds](https://reproducible-builds.org/) and stabilizes  distribution files (zip, tgz). For instance, in this branch the md5 hash of `spotbugs/build/distributions/spotbugs-4.0.0-SNAPSHOT.zip` is always 1d00579fbd62cf5c13959e7657f2e4c1. I've confirmed it in my macOS, and will check even in Windows and Ubuntu.

This change lets third-party verify that our official distribution is not cracked and secure.