### PR TITLE
WIP: Introduce Gradle Build Cache

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 org.gradle.jvmargs=-XX:+CMSClassUnloadingEnabled -XX:+HeapDumpOnOutOfMemoryError -Xmx1G
+org.gradle.caching=true

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,3 +7,18 @@ if (new File(rootDir, eclipseFile).exists()) {
 }
 
 include ':test-harness-core', ':test-harness-jupiter'
+
+boolean isCiServer = System.getenv().containsKey("CI")
+buildCache {
+  remote(HttpBuildCache) {
+    url = 'https://spotbugs.kengo-toda.jp/cache/'
+    push = isCiServer
+    if (isCiServer) {
+      print "Connecting to Gradle Build-Cache with write access..."
+      credentials {
+        username = 'travis'
+        password = System.getenv('GRADLE_BUILD_CACHE_PASSWORD')
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR introduces [the Gradle Build Cache](https://docs.gradle.org/current/userguide/build_cache.html). It helps developers to shorten time to build in local, by reusing the build result at CI server.

I'm still a beginner of this feature, please feedback to me if you're facing any problem.