### PR TITLE
Suppress warnings in getRealSourcePath(). Fixes #1009.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ## Unreleased - 2019-??-??
 
+### Fixed
+
+* Suppress `Error resolving Real SourcePath (only relative source path will be available)` warning. [#1009](https://github.com/spotbugs/spotbugs/issues/1009)
+
 ### Changed
 
 * Bump up Apache Commons BCEL to the version 6.4.1

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/SourceLineAnnotation.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/SourceLineAnnotation.java
@@ -52,6 +52,9 @@ import edu.umd.cs.findbugs.internalAnnotations.DottedClassName;
 import edu.umd.cs.findbugs.visitclass.PreorderVisitor;
 import edu.umd.cs.findbugs.xml.XMLAttributeList;
 import edu.umd.cs.findbugs.xml.XMLOutput;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.annotation.CheckReturnValue;
 
 /**
@@ -62,6 +65,8 @@ import javax.annotation.CheckReturnValue;
  */
 public class SourceLineAnnotation implements BugAnnotation {
     private static final long serialVersionUID = 1L;
+
+    private static final Logger LOG = LoggerFactory.getLogger(SourceLineAnnotation.class);
 
     public static final String DEFAULT_ROLE = "SOURCE_LINE_DEFAULT";
 
@@ -960,7 +965,7 @@ public class SourceLineAnnotation implements BugAnnotation {
                 try {
                     return new File(sourceFinder.findSourceFile(this).getFullFileName()).getCanonicalPath();
                 } catch (IOException e) {
-                    AnalysisContext.logError("Error resolving Real SourcePath (only relative source path will be available) ", e);
+                    LOG.debug("Error resolving Real SourcePath (only relative source path will be available) ", e);
                 }
             } else {
                 AnalysisContext.logError("No SourceFinder found (only relative source path will be available) ");

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/SourceFinder.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/SourceFinder.java
@@ -36,6 +36,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
+import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 import java.util.zip.ZipEntry;
@@ -512,7 +513,11 @@ public class SourceFinder implements AutoCloseable {
             }
         }
 
-        throw new FileNotFoundException("Can't find source file " + fileName);
+        String sourceRepositories = repositoryList.stream()
+                .map(Object::toString)
+                .collect(Collectors.joining(", "));
+        throw new FileNotFoundException("Can't find source file " + fileName + " (source repositories="
+                + sourceRepositories + ")");
     }
 
     public static String getPlatformName(String packageName, String fileName) {


### PR DESCRIPTION
If the user uses java code generation like Avro or kotlin, the source finder
can't find the original source code.
`Error resolving Real SourcePath (only relative source path will be available)` warning is
meaningless in most cases.
