### PR TITLE
Issue641: reporting useless @SuppressFBWarnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ## Unreleased - 2019-??-??
 
+### Added
+
+* Reporting useless `@SuppressFBWarnings` annotations
+
 ### Fixed
 
 * Suppress `Error resolving Real SourcePath (only relative source path will be available)` warning. [#1009](https://github.com/spotbugs/spotbugs/issues/1009)

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue641Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue641Test.java
@@ -1,0 +1,45 @@
+package edu.umd.cs.findbugs.ba;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import edu.umd.cs.findbugs.SortedBugCollection;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
+
+import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
+import static org.junit.Assert.assertThat;
+
+public class Issue641Test extends AbstractIntegrationTest {
+
+    @Test
+    public void testUselessSuppression() {
+
+        performAnalysis("/suppression/Issue641.class");
+        SortedBugCollection bugCollection = (SortedBugCollection) getBugCollection();
+
+        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
+                .bugType("US_USELESS_SUPPRESSION_ON_FIELD")
+                .inClass("suppression.Issue641")
+                .atField("field")
+                .build();
+        assertThat(bugCollection, containsExactly(1, bugTypeMatcher));
+
+        bugTypeMatcher = new BugInstanceMatcherBuilder()
+                .bugType("US_USELESS_SUPPRESSION_ON_CLASS")
+                .inClass("suppression.Issue641")
+                .build();
+        assertThat(bugCollection, containsExactly(1, bugTypeMatcher));
+
+        bugTypeMatcher = new BugInstanceMatcherBuilder()
+                .bugType("US_USELESS_SUPPRESSION_ON_METHOD_PARAMETER")
+                .inClass("suppression.Issue641")
+                .inMethod("setField")
+                .build();
+        assertThat(bugCollection, containsExactly(1, bugTypeMatcher));
+
+        assertThat("Expected three warnings",
+                bugCollection.getCollection().size(),
+                CoreMatchers.equalTo(3));
+    }
+}

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -79,6 +79,7 @@ dependencies {
   compile project(':spotbugs-annotations')
 
   testCompile 'junit:junit:4.12'
+  testCompile 'org.mockito:mockito-core:3.2.4'
   testCompile 'org.apache.ant:ant:1.9.4'
   testCompile 'org.apache.logging.log4j:log4j-slf4j18-impl:2.11.1'
   testCompile sourceSets.gui.output

--- a/spotbugs/etc/findbugs.xml
+++ b/spotbugs/etc/findbugs.xml
@@ -295,7 +295,7 @@
           <Detector class="edu.umd.cs.findbugs.detect.FunctionsThatMightBeMistakenForProcedures" speed="fast"
                     reports="" hidden="true"/>
           <Detector class="edu.umd.cs.findbugs.detect.NoteSuppressedWarnings" speed="fast"
-                    reports="US_USELESS_SUPPRESSION,US_USELESS_SUPPRESSION_ON_CLASS,US_USELESS_SUPPRESSION_ON_FIELD,US_USELESS_SUPPRESSION_ON_METHOD,US_USELESS_SUPPRESSION_ON_METHOD_PARAMETER,US_USELESS_SUPPRESSION_ON_PACKAGE"
+                    reports="US_USELESS_SUPPRESSION_ON_CLASS,US_USELESS_SUPPRESSION_ON_FIELD,US_USELESS_SUPPRESSION_ON_METHOD,US_USELESS_SUPPRESSION_ON_METHOD_PARAMETER,US_USELESS_SUPPRESSION_ON_PACKAGE"
                     hidden="true"/>
           <Detector class="edu.umd.cs.findbugs.detect.NoteAnnotationRetention" speed="fast"
                     reports="" hidden="true"/>
@@ -1241,9 +1241,9 @@
           <BugPattern abbrev="NP" type="NP_METHOD_RETURN_RELAXING_ANNOTATION" category="STYLE" />
           <BugPattern abbrev="NP" type="NP_METHOD_PARAMETER_TIGHTENS_ANNOTATION" category="STYLE" />
           <BugPattern abbrev="NP" type="NP_METHOD_PARAMETER_RELAXING_ANNOTATION" category="STYLE" deprecated="true" />
-          <BugPattern abbrev="US" type="US_USELESS_SUPPRESSION" category="CORRECTNESS"/>
-          <BugPattern abbrev="US" type="US_USELESS_SUPPRESSION_ON_FIELD" category="CORRECTNESS"/>
-          <BugPattern abbrev="US" type="US_USELESS_SUPPRESSION_ON_CLASS" category="CORRECTNESS"/>
-          <BugPattern abbrev="US" type="US_USELESS_SUPPRESSION_ON_METHOD" category="CORRECTNESS"/>
-          <BugPattern abbrev="US" type="US_USELESS_SUPPRESSION_ON_METHOD_PARAMETER" category="CORRECTNESS"/>
+          <BugPattern abbrev="US" type="US_USELESS_SUPPRESSION_ON_FIELD" category="STYLE"/>
+          <BugPattern abbrev="US" type="US_USELESS_SUPPRESSION_ON_CLASS" category="STYLE"/>
+          <BugPattern abbrev="US" type="US_USELESS_SUPPRESSION_ON_METHOD" category="STYLE"/>
+          <BugPattern abbrev="US" type="US_USELESS_SUPPRESSION_ON_METHOD_PARAMETER" category="STYLE"/>
+          <BugPattern abbrev="US" type="US_USELESS_SUPPRESSION_ON_PACKAGE" category="STYLE"/>
 </FindbugsPlugin>

--- a/spotbugs/etc/findbugs.xml
+++ b/spotbugs/etc/findbugs.xml
@@ -295,7 +295,8 @@
           <Detector class="edu.umd.cs.findbugs.detect.FunctionsThatMightBeMistakenForProcedures" speed="fast"
                     reports="" hidden="true"/>
           <Detector class="edu.umd.cs.findbugs.detect.NoteSuppressedWarnings" speed="fast"
-                    reports="" hidden="true"/>
+                    reports="US_USELESS_SUPPRESSION,US_USELESS_SUPPRESSION_ON_CLASS,US_USELESS_SUPPRESSION_ON_FIELD,US_USELESS_SUPPRESSION_ON_METHOD,US_USELESS_SUPPRESSION_ON_METHOD_PARAMETER,US_USELESS_SUPPRESSION_ON_PACKAGE"
+                    hidden="true"/>
           <Detector class="edu.umd.cs.findbugs.detect.NoteAnnotationRetention" speed="fast"
                     reports="" hidden="true"/>
           <Detector class="edu.umd.cs.findbugs.detect.NoteDirectlyRelevantTypeQualifiers"
@@ -1240,4 +1241,9 @@
           <BugPattern abbrev="NP" type="NP_METHOD_RETURN_RELAXING_ANNOTATION" category="STYLE" />
           <BugPattern abbrev="NP" type="NP_METHOD_PARAMETER_TIGHTENS_ANNOTATION" category="STYLE" />
           <BugPattern abbrev="NP" type="NP_METHOD_PARAMETER_RELAXING_ANNOTATION" category="STYLE" deprecated="true" />
+          <BugPattern abbrev="US" type="US_USELESS_SUPPRESSION" category="CORRECTNESS"/>
+          <BugPattern abbrev="US" type="US_USELESS_SUPPRESSION_ON_FIELD" category="CORRECTNESS"/>
+          <BugPattern abbrev="US" type="US_USELESS_SUPPRESSION_ON_CLASS" category="CORRECTNESS"/>
+          <BugPattern abbrev="US" type="US_USELESS_SUPPRESSION_ON_METHOD" category="CORRECTNESS"/>
+          <BugPattern abbrev="US" type="US_USELESS_SUPPRESSION_ON_METHOD_PARAMETER" category="CORRECTNESS"/>
 </FindbugsPlugin>

--- a/spotbugs/etc/messages.xml
+++ b/spotbugs/etc/messages.xml
@@ -8351,19 +8351,8 @@ after the call to initLogging, the logger configuration is lost
       </Details>
   </BugPattern>
 
-  <BugPattern type="US_USELESS_SUPPRESSION">
-    <ShortDescription>Useless suppression</ShortDescription>
-    <LongDescription>Suppressing annotation is unnecessary</LongDescription>
-    <Details>
-      <![CDATA[<p>
-      Suppressing annotations should be removed from the source code as soon as they are no more needed.
-      Leaving them may result in accidental warnings suppression.
-      </p>]]>
-    </Details>
-  </BugPattern>
-
   <BugPattern type="US_USELESS_SUPPRESSION_ON_CLASS">
-    <ShortDescription>Useless suppression</ShortDescription>
+    <ShortDescription>Useless suppression on a class</ShortDescription>
     <LongDescription>Suppressing annotation on the class {0} is unnecessary</LongDescription>
     <Details>
       <![CDATA[<p>
@@ -8374,7 +8363,7 @@ after the call to initLogging, the logger configuration is lost
   </BugPattern>
 
   <BugPattern type="US_USELESS_SUPPRESSION_ON_FIELD">
-    <ShortDescription>Useless suppression</ShortDescription>
+    <ShortDescription>Useless suppression on a field</ShortDescription>
     <LongDescription>Suppressing annotation on the field {1} is unnecessary</LongDescription>
     <Details>
       <![CDATA[<p>
@@ -8385,7 +8374,7 @@ after the call to initLogging, the logger configuration is lost
   </BugPattern>
 
   <BugPattern type="US_USELESS_SUPPRESSION_ON_METHOD">
-    <ShortDescription>Useless suppression</ShortDescription>
+    <ShortDescription>Useless suppression on a method</ShortDescription>
     <LongDescription>Suppressing annotation on the method {1} is unnecessary</LongDescription>
     <Details>
       <![CDATA[<p>
@@ -8396,7 +8385,7 @@ after the call to initLogging, the logger configuration is lost
   </BugPattern>
 
   <BugPattern type="US_USELESS_SUPPRESSION_ON_METHOD_PARAMETER">
-    <ShortDescription>Useless suppression</ShortDescription>
+    <ShortDescription>Useless suppression on a method parameter</ShortDescription>
     <LongDescription>Suppressing annotation on the parameter {2} of the method {1} is unnecessary</LongDescription>
     <Details>
       <![CDATA[<p>
@@ -8407,7 +8396,7 @@ after the call to initLogging, the logger configuration is lost
   </BugPattern>
 
   <BugPattern type="US_USELESS_SUPPRESSION_ON_PACKAGE">
-    <ShortDescription>Useless suppression</ShortDescription>
+    <ShortDescription>Useless suppression on a package</ShortDescription>
     <LongDescription>Suppressing annotation on the package {0} is unnecessary</LongDescription>
     <Details>
       <![CDATA[<p>

--- a/spotbugs/etc/messages.xml
+++ b/spotbugs/etc/messages.xml
@@ -8350,6 +8350,72 @@ after the call to initLogging, the logger configuration is lost
         </p>]]>
       </Details>
   </BugPattern>
+
+  <BugPattern type="US_USELESS_SUPPRESSION">
+    <ShortDescription>Useless suppression</ShortDescription>
+    <LongDescription>Suppressing annotation is unnecessary</LongDescription>
+    <Details>
+      <![CDATA[<p>
+      Suppressing annotations should be removed from the source code as soon as they are no more needed.
+      Leaving them may result in accidental warnings suppression.
+      </p>]]>
+    </Details>
+  </BugPattern>
+
+  <BugPattern type="US_USELESS_SUPPRESSION_ON_CLASS">
+    <ShortDescription>Useless suppression</ShortDescription>
+    <LongDescription>Suppressing annotation on the class {0} is unnecessary</LongDescription>
+    <Details>
+      <![CDATA[<p>
+      Suppressing annotations should be removed from the source code as soon as they are no more needed.
+      Leaving them may result in accidental warnings suppression.
+      </p>]]>
+    </Details>
+  </BugPattern>
+
+  <BugPattern type="US_USELESS_SUPPRESSION_ON_FIELD">
+    <ShortDescription>Useless suppression</ShortDescription>
+    <LongDescription>Suppressing annotation on the field {1} is unnecessary</LongDescription>
+    <Details>
+      <![CDATA[<p>
+      Suppressing annotations should be removed from the source code as soon as they are no more needed.
+      Leaving them may result in accidental warnings suppression.
+      </p>]]>
+    </Details>
+  </BugPattern>
+
+  <BugPattern type="US_USELESS_SUPPRESSION_ON_METHOD">
+    <ShortDescription>Useless suppression</ShortDescription>
+    <LongDescription>Suppressing annotation on the method {1} is unnecessary</LongDescription>
+    <Details>
+      <![CDATA[<p>
+      Suppressing annotations should be removed from the source code as soon as they are no more needed.
+      Leaving them may result in accidental warnings suppression.
+      </p>]]>
+    </Details>
+  </BugPattern>
+
+  <BugPattern type="US_USELESS_SUPPRESSION_ON_METHOD_PARAMETER">
+    <ShortDescription>Useless suppression</ShortDescription>
+    <LongDescription>Suppressing annotation on the parameter {2} of the method {1} is unnecessary</LongDescription>
+    <Details>
+      <![CDATA[<p>
+      Suppressing annotations should be removed from the source code as soon as they are no more needed.
+      Leaving them may result in accidental warnings suppression.
+      </p>]]>
+    </Details>
+  </BugPattern>
+
+  <BugPattern type="US_USELESS_SUPPRESSION_ON_PACKAGE">
+    <ShortDescription>Useless suppression</ShortDescription>
+    <LongDescription>Suppressing annotation on the package {0} is unnecessary</LongDescription>
+    <Details>
+      <![CDATA[<p>
+      Suppressing annotations should be removed from the source code as soon as they are no more needed.
+      Leaving them may result in accidental warnings suppression.
+      </p>]]>
+    </Details>
+  </BugPattern>
   <!--
   **********************************************************************
    BugCodes
@@ -8493,4 +8559,5 @@ after the call to initLogging, the logger configuration is lost
   <BugCode abbrev="OBL">Unsatisfied obligation to clean up stream or resource</BugCode>
   <BugCode abbrev="FB">SpotBugs did not produce the expected warnings on a method</BugCode>
   <BugCode abbrev="DL">Unintended contention or possible deadlock due to locking on shared objects</BugCode>
+  <BugCode abbrev="US">Useless suppression</BugCode>
 </MessageCollection>

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ClassWarningSuppressor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ClassWarningSuppressor.java
@@ -2,6 +2,8 @@ package edu.umd.cs.findbugs;
 
 public class ClassWarningSuppressor extends WarningSuppressor {
 
+    private final static String BUG_TYPE = "US_USELESS_SUPPRESSION_ON_CLASS";
+
     ClassAnnotation clazz;
 
     public ClassWarningSuppressor(String bugPattern, ClassAnnotation clazz) {
@@ -14,6 +16,12 @@ public class ClassWarningSuppressor extends WarningSuppressor {
 
     public ClassAnnotation getClassAnnotation() {
         return clazz;
+    }
+
+    @Override
+    public BugInstance buildUselessSuppressionBugInstance() {
+        return new BugInstance(BUG_TYPE, PRIORITY)
+                .addClass(clazz.getClassDescriptor());
     }
 
     @Override

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/FieldWarningSuppressor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/FieldWarningSuppressor.java
@@ -2,6 +2,8 @@ package edu.umd.cs.findbugs;
 
 public class FieldWarningSuppressor extends ClassWarningSuppressor {
 
+    private final static String BUG_TYPE = "US_USELESS_SUPPRESSION_ON_FIELD";
+
     FieldAnnotation field;
 
     public FieldWarningSuppressor(String bugPattern, ClassAnnotation clazz, FieldAnnotation field) {
@@ -30,5 +32,12 @@ public class FieldWarningSuppressor extends ClassWarningSuppressor {
             System.out.println("Suppressing " + bugInstance);
         }
         return true;
+    }
+
+    @Override
+    public BugInstance buildUselessSuppressionBugInstance() {
+        return new BugInstance(BUG_TYPE, PRIORITY)
+                .addClass(clazz.getClassDescriptor())
+                .addField(field);
     }
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/FindBugs2.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/FindBugs2.java
@@ -291,7 +291,7 @@ public class FindBugs2 implements IFindBugsEngine, AutoCloseable {
 
                 if (executionPlan.isActive(NoteSuppressedWarnings.class)) {
                     SuppressionMatcher m = AnalysisContext.currentAnalysisContext().getSuppressionMatcher();
-                    bugReporter = new FilterBugReporter(bugReporter, m, false);
+                    bugReporter = new SuppressionMatcherBugReporter(bugReporter, m);
                 }
 
                 if (appClassList.size() == 0) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/MethodWarningSuppressor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/MethodWarningSuppressor.java
@@ -2,6 +2,8 @@ package edu.umd.cs.findbugs;
 
 public class MethodWarningSuppressor extends ClassWarningSuppressor {
 
+    private final static String BUG_TYPE = "US_USELESS_SUPPRESSION_ON_METHOD";
+
     MethodAnnotation method;
 
     public MethodWarningSuppressor(String bugPattern, ClassAnnotation clazz, MethodAnnotation method) {
@@ -24,5 +26,12 @@ public class MethodWarningSuppressor extends ClassWarningSuppressor {
             System.out.println("Suppressing " + bugInstance);
         }
         return true;
+    }
+
+    @Override
+    public BugInstance buildUselessSuppressionBugInstance() {
+        return new BugInstance(BUG_TYPE, PRIORITY)
+                .addClass(clazz.getClassDescriptor())
+                .addMethod(method);
     }
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/PackageWarningSuppressor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/PackageWarningSuppressor.java
@@ -2,6 +2,8 @@ package edu.umd.cs.findbugs;
 
 public class PackageWarningSuppressor extends WarningSuppressor {
 
+    private final static String BUG_TYPE = "US_USELESS_SUPPRESSION_ON_PACKAGE";
+
     String packageName;
 
     public PackageWarningSuppressor(String bugPattern, String packageName) {
@@ -28,5 +30,10 @@ public class PackageWarningSuppressor extends WarningSuppressor {
         String className = primaryClassAnnotation.getClassName();
 
         return className.startsWith(packageName);
+    }
+
+    @Override
+    public BugInstance buildUselessSuppressionBugInstance() {
+        return new BugInstance(BUG_TYPE, PRIORITY).addClass(packageName);
     }
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ParameterWarningSuppressor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ParameterWarningSuppressor.java
@@ -2,6 +2,8 @@ package edu.umd.cs.findbugs;
 
 public class ParameterWarningSuppressor extends ClassWarningSuppressor {
 
+    private final static String BUG_TYPE = "US_USELESS_SUPPRESSION_ON_METHOD_PARAMETER";
+
     final MethodAnnotation method;
 
     final int register;
@@ -31,5 +33,13 @@ public class ParameterWarningSuppressor extends ClassWarningSuppressor {
             System.out.println("Suppressing " + bugInstance);
         }
         return true;
+    }
+
+    @Override
+    public BugInstance buildUselessSuppressionBugInstance() {
+        return new BugInstance(BUG_TYPE, PRIORITY)
+                .addClass(clazz.getClassDescriptor())
+                .addMethod(method)
+                .addParameterAnnotation(register, LocalVariableAnnotation.PARAMETER_ROLE);
     }
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/SuppressionMatcher.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/SuppressionMatcher.java
@@ -22,8 +22,11 @@ package edu.umd.cs.findbugs;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
 
 import edu.umd.cs.findbugs.filter.Matcher;
 import edu.umd.cs.findbugs.xml.XMLOutput;
@@ -32,6 +35,8 @@ public class SuppressionMatcher implements Matcher {
     private final Map<ClassAnnotation, Collection<WarningSuppressor>> suppressedWarnings = new HashMap<>();
 
     private final Map<String, Collection<WarningSuppressor>> suppressedPackageWarnings = new HashMap<>();
+
+    private final Set<WarningSuppressor> matched = new HashSet<>();
 
     int count = 0;
 
@@ -55,13 +60,17 @@ public class SuppressionMatcher implements Matcher {
 
     @Override
     public boolean match(BugInstance b) {
-        ClassAnnotation clazz = b.getPrimaryClass().getTopLevelClass();
-        Collection<WarningSuppressor> c = suppressedWarnings.get(clazz);
-        if (c != null) {
-            for (WarningSuppressor w : c) {
-                if (w.match(b)) {
-                    count++;
-                    return true;
+        ClassAnnotation primaryClazz = b.getPrimaryClass();
+        if (primaryClazz != null) {
+            ClassAnnotation clazz = b.getPrimaryClass().getTopLevelClass();
+            Collection<WarningSuppressor> c = suppressedWarnings.get(clazz);
+            if (c != null) {
+                for (WarningSuppressor w : c) {
+                    if (w.match(b)) {
+                        count++;
+                        matched.add(w);
+                        return true;
+                    }
                 }
             }
         }
@@ -69,11 +78,20 @@ public class SuppressionMatcher implements Matcher {
             for (WarningSuppressor w : c2) {
                 if (w.match(b)) {
                     count++;
+                    matched.add(w);
                     return true;
                 }
             }
         }
         return false;
+    }
+
+    public void validateSuppressionUsage(BugReporter bugReporter) {
+        Stream.concat(suppressedWarnings.values().stream(), suppressedPackageWarnings.values().stream())
+                .flatMap(Collection::stream)
+                .filter(w -> !matched.contains(w))
+                .map(WarningSuppressor::buildUselessSuppressionBugInstance)
+                .forEach(bugReporter::reportBug);
     }
 
     @Override

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/SuppressionMatcherBugReporter.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/SuppressionMatcherBugReporter.java
@@ -1,0 +1,17 @@
+package edu.umd.cs.findbugs;
+
+public class SuppressionMatcherBugReporter extends FilterBugReporter {
+
+    private final SuppressionMatcher suppressionMatcher;
+
+    public SuppressionMatcherBugReporter(BugReporter realBugReporter, SuppressionMatcher suppressionMatcher) {
+        super(realBugReporter, suppressionMatcher, false);
+        this.suppressionMatcher = suppressionMatcher;
+    }
+
+    @Override
+    public void finish() {
+        suppressionMatcher.validateSuppressionUsage(this);
+        super.finish();
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/WarningSuppressor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/WarningSuppressor.java
@@ -7,6 +7,9 @@ import edu.umd.cs.findbugs.xml.XMLOutput;
 
 abstract public class WarningSuppressor implements Matcher {
 
+    protected final static String USELESS_SUPPRESSION_ABB = "US";
+    protected static final int PRIORITY = Priorities.NORMAL_PRIORITY;
+
     final static boolean DEBUG = SystemProperties.getBoolean("warning.suppressor");
 
     String bugPattern;
@@ -27,6 +30,9 @@ abstract public class WarningSuppressor implements Matcher {
             System.out.println(" against: " + bugPattern);
 
         }
+        if (USELESS_SUPPRESSION_ABB.equals(bugInstance.getAbbrev())) {
+            return false;
+        }
         if (!(bugPattern == null || bugInstance.getType().startsWith(bugPattern)
                 || bugInstance.getBugPattern().getCategory().equalsIgnoreCase(bugPattern) || bugInstance.getBugPattern()
                         .getAbbrev().equalsIgnoreCase(bugPattern))) {
@@ -37,6 +43,8 @@ abstract public class WarningSuppressor implements Matcher {
         }
         return true;
     }
+
+    public abstract BugInstance buildUselessSuppressionBugInstance();
 
     @Override
     public void writeXML(XMLOutput xmlOutput, boolean disabled) throws IOException {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/NoteSuppressedWarnings.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/NoteSuppressedWarnings.java
@@ -44,7 +44,6 @@ import edu.umd.cs.findbugs.ba.ClassContext;
 import edu.umd.cs.findbugs.bcel.BCELUtil;
 import edu.umd.cs.findbugs.internalAnnotations.DottedClassName;
 import edu.umd.cs.findbugs.visitclass.AnnotationVisitor;
-import org.apache.bcel.classfile.LineNumberTable;
 
 public class NoteSuppressedWarnings extends AnnotationVisitor implements Detector, NonReportingDetector {
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/NoteSuppressedWarnings.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/NoteSuppressedWarnings.java
@@ -44,6 +44,7 @@ import edu.umd.cs.findbugs.ba.ClassContext;
 import edu.umd.cs.findbugs.bcel.BCELUtil;
 import edu.umd.cs.findbugs.internalAnnotations.DottedClassName;
 import edu.umd.cs.findbugs.visitclass.AnnotationVisitor;
+import org.apache.bcel.classfile.LineNumberTable;
 
 public class NoteSuppressedWarnings extends AnnotationVisitor implements Detector, NonReportingDetector {
 

--- a/spotbugs/src/test/java/edu/umd/cs/findbugs/SuppressionMatcherBugReporterTest.java
+++ b/spotbugs/src/test/java/edu/umd/cs/findbugs/SuppressionMatcherBugReporterTest.java
@@ -1,0 +1,55 @@
+package edu.umd.cs.findbugs;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SuppressionMatcherBugReporterTest {
+
+    @Mock
+    private SuppressionMatcher matcher;
+
+    @Mock
+    private BugReporter upstreamReporter;
+
+    @InjectMocks
+    SuppressionMatcherBugReporter reporter;
+
+    @Test
+    public void shouldNotCallUpstreamReporterIfBugSuppressed() {
+        // given
+        BugInstance suppressed = mock(BugInstance.class);
+        when(matcher.match(suppressed)).thenReturn(true);
+        // when
+        reporter.reportBug(suppressed);
+        // then
+        verify(matcher).match(suppressed);
+        verifyNoInteractions(upstreamReporter);
+    }
+
+    @Test
+    public void shouldCallUpstreamReporterIfBugNotSuppressed() {
+        // given
+        BugInstance reported = mock(BugInstance.class);
+        when(matcher.match(reported)).thenReturn(false);
+        // when
+        reporter.reportBug(reported);
+        // then
+        verify(matcher).match(reported);
+        verify(upstreamReporter).reportBug(reported);
+    }
+
+    @Test
+    public void shouldCallMatcherAndUpstreamReporterOnFinish() {
+        // when
+        reporter.finish();
+        // then
+        verify(matcher).validateSuppressionUsage(reporter);
+        verify(upstreamReporter).finish();
+    }
+}

--- a/spotbugs/src/test/java/edu/umd/cs/findbugs/SuppressionMatcherMockedTest.java
+++ b/spotbugs/src/test/java/edu/umd/cs/findbugs/SuppressionMatcherMockedTest.java
@@ -1,0 +1,69 @@
+package edu.umd.cs.findbugs;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SuppressionMatcherMockedTest {
+
+    @Mock
+    private ClassAnnotation classAnnotation;
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private ClassWarningSuppressor suppressor;
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private BugInstance bugInstance;
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private BugInstance uselessSuppressionBugInstance;
+
+    @Mock
+    private BugReporter bugReporter;
+
+    @Before
+    public void init() {
+        when(suppressor.getClassAnnotation().getTopLevelClass()).thenReturn(classAnnotation);
+        when(bugInstance.getPrimaryClass().getTopLevelClass()).thenReturn(classAnnotation);
+    }
+
+    @Test
+    public void shouldMatchBugInstance() {
+        // given
+        when(suppressor.match(bugInstance)).thenReturn(true);
+        SuppressionMatcher matcher = new SuppressionMatcher();
+        // when
+        matcher.addSuppressor(suppressor);
+        // then
+        assertTrue("Should match BugInstance", matcher.match(bugInstance));
+        // and when
+        matcher.validateSuppressionUsage(bugReporter);
+        // then
+        verifyNoInteractions(bugReporter);
+    }
+
+    @Test
+    public void shouldNotMatchBugInstance() {
+        // given
+        when(suppressor.match(bugInstance)).thenReturn(false);
+        when(suppressor.buildUselessSuppressionBugInstance()).thenReturn(uselessSuppressionBugInstance);
+        SuppressionMatcher matcher = new SuppressionMatcher();
+        // when
+        matcher.addSuppressor(suppressor);
+        // then
+        assertFalse("Should match BugInstance", matcher.match(bugInstance));
+        // and when
+        matcher.validateSuppressionUsage(bugReporter);
+        // then
+        verify(suppressor).buildUselessSuppressionBugInstance();
+        verify(bugReporter).reportBug(uselessSuppressionBugInstance);
+    }
+}

--- a/spotbugs/src/test/java/edu/umd/cs/findbugs/SuppressionMatcherTest.java
+++ b/spotbugs/src/test/java/edu/umd/cs/findbugs/SuppressionMatcherTest.java
@@ -1,0 +1,149 @@
+package edu.umd.cs.findbugs;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class SuppressionMatcherTest {
+
+    private static final String PACKAGE_NAME = "com.example";
+    private static final String CLASS_NAME = PACKAGE_NAME + ".Test";
+    private static final ClassAnnotation CLASS_ANNOTATION = new ClassAnnotation(CLASS_NAME);
+
+    private SuppressionMatcher matcher;
+    private BugReporter bugReporter;
+    private ArgumentCaptor<BugInstance> bugCaptor;
+
+    @Before
+    public void init() {
+        matcher = new SuppressionMatcher();
+        bugReporter = mock(BugReporter.class);
+        bugCaptor = ArgumentCaptor.forClass(BugInstance.class);
+    }
+
+    @After
+    public void validate() {
+        Mockito.validateMockitoUsage();
+    }
+
+    @Test
+    public void shouldMatchClassLevelSuppression() {
+        // given
+        matcher.addSuppressor(new ClassWarningSuppressor("UUF_UNUSED_FIELD", CLASS_ANNOTATION));
+        BugInstance bug = new BugInstance("UUF_UNUSED_FIELD", 1).addClass(CLASS_NAME);
+        // when
+        boolean matched = matcher.match(bug);
+        // then
+        assertThat("Should match the bug", matched, is(true));
+    }
+
+    @Test
+    public void shouldMatchPackageLevelSuppressor() {
+        // given
+        BugInstance bug = new BugInstance("UUF_UNUSED_FIELD", 1).addClass(CLASS_NAME);
+        matcher.addPackageSuppressor(new PackageWarningSuppressor("UUF_UNUSED_FIELD", PACKAGE_NAME));
+        // when
+        boolean matched = matcher.match(bug);
+        // then
+        assertThat("Should match the bug", matched, is(true));
+    }
+
+    @Test
+    public void shouldMatchMethodLevelSuppressor() {
+        // given
+        MethodAnnotation method = new MethodAnnotation(CLASS_NAME, "test", "bool test()", false);
+        BugInstance bug = new BugInstance("UUF_UNUSED_FIELD", 1).addClass(CLASS_NAME).addMethod(method);
+        matcher.addSuppressor(new MethodWarningSuppressor("UUF_UNUSED_FIELD", CLASS_ANNOTATION, method));
+        // when
+        boolean matched = matcher.match(bug);
+        // then
+        assertThat("Should match the bug", matched, is(true));
+    }
+
+    @Test
+    public void shouldMatchParameterLevelSuppressor() {
+        // given
+        MethodAnnotation method = new MethodAnnotation(CLASS_NAME, "test", "bool test()", false);
+        BugInstance bug = new BugInstance("UUF_UNUSED_FIELD", 1)
+                .addClass(CLASS_NAME).addMethod(method)
+                .addAnnotations(Collections.singletonList(new LocalVariableAnnotation("?", 2, 0, 0)));
+        matcher.addSuppressor(new ParameterWarningSuppressor("UUF_UNUSED_FIELD", CLASS_ANNOTATION, method, 2));
+        // when
+        boolean matched = matcher.match(bug);
+        // then
+        assertThat("Should match the bug", matched, is(true));
+    }
+
+    @Test
+    public void shouldMatchFieldLevelSuppressor() {
+        // given
+        FieldAnnotation field = new FieldAnnotation(CLASS_NAME, "test", "bool test", false);
+        BugInstance bug = new BugInstance("UUF_UNUSED_FIELD", 1).addClass(CLASS_NAME).addField(field);
+        matcher.addSuppressor(new FieldWarningSuppressor("UUF_UNUSED_FIELD", CLASS_ANNOTATION, field));
+        // when
+        boolean matched = matcher.match(bug);
+        // then
+        assertThat("Should match the bug", matched, is(true));
+    }
+
+    @Test
+    public void shouldNotMatchBugsWithDifferentType() {
+        // given
+        matcher.addSuppressor(new ClassWarningSuppressor("UUF_UNUSED_FIELD", CLASS_ANNOTATION));
+        BugInstance bug = new BugInstance("UWF_NULL_FIELD", 1).addClass(CLASS_NAME);
+        // when
+        boolean matched = matcher.match(bug);
+        // then
+        assertThat("Should not match the bug", matched, is(false));
+    }
+
+    @Test
+    public void shouldNotBreakOnMissingPrimaryClass() {
+        // given
+        BugInstance bug = new BugInstance("UUF_UNUSED_FIELD", 1);
+        matcher.addSuppressor(new ClassWarningSuppressor("UUF_UNUSED_FIELD", CLASS_ANNOTATION));
+        // when
+        boolean matched = matcher.match(bug);
+        // then
+        assertThat("Should not match the bug", matched, is(false));
+    }
+
+    @Test
+    public void shouldMatchFieldSuppressorBeforeClass() {
+        // given
+        FieldAnnotation field = new FieldAnnotation(CLASS_NAME, "test", "bool test", false);
+        BugInstance bug = new BugInstance("UUF_UNUSED_FIELD", 1).addClass(CLASS_NAME).addField(field);
+        matcher.addSuppressor(new FieldWarningSuppressor("UUF_UNUSED_FIELD", CLASS_ANNOTATION, field));
+        matcher.addSuppressor(new ClassWarningSuppressor("UUF_UNUSED_FIELD", CLASS_ANNOTATION));
+        // when
+        matcher.match(bug);
+        matcher.validateSuppressionUsage(bugReporter);
+        // then
+        verify(bugReporter).reportBug(bugCaptor.capture());
+        assertThat("Bug type", bugCaptor.getValue().getBugPattern().getType(), startsWith("US_USELESS_SUPPRESSION_ON_CLASS"));
+    }
+
+    @Test
+    public void shouldReportUselessSuppressor() {
+        // given
+        BugInstance bug = new BugInstance("UUF_UNUSED_FIELD", 1).addClass(CLASS_NAME);
+        matcher.addSuppressor(new ClassWarningSuppressor("UUF_UNUSED_FIELD", CLASS_ANNOTATION));
+        matcher.addSuppressor(new ClassWarningSuppressor("UWF_NULL_FIELD", CLASS_ANNOTATION));
+        // when
+        matcher.match(bug);
+        matcher.validateSuppressionUsage(bugReporter);
+        // then
+        verify(bugReporter).reportBug(bugCaptor.capture());
+        assertThat("Bug type", bugCaptor.getValue().getBugPattern().getType(), startsWith("US_USELESS_SUPPRESSION"));
+    }
+}

--- a/spotbugsTestCases/src/java/suppression/Issue641.java
+++ b/spotbugsTestCases/src/java/suppression/Issue641.java
@@ -1,0 +1,21 @@
+package suppression;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+@SuppressFBWarnings(value = "UUF_UNUSED_FIELD") // <- useless suppression
+public class Issue641 {
+
+    @SuppressFBWarnings(value = "UUF_UNUSED_FIELD") // <- useless suppression
+    private String field;
+
+    @SuppressFBWarnings(value = "UUF_UNUSED_FIELD") // <- valid suppression
+    private String field2;
+
+    public String getField() {
+        return field;
+    }
+
+    public void setField(/* useless suppression -> */ @SuppressFBWarnings(value = "UUF_UNUSED_FIELD") String val) {
+        field = val;
+    }
+}


### PR DESCRIPTION
Implementation of the ticket #641, or more precisely of the first half it:
reporting `@SuppressFBWarnings` annotations which are not "hit" by any bugs.

Test class:
```java
@SuppressFBWarnings(value = "UUF_UNUSED_FIELD") // <- useless suppression
public class Issue641 {

    @SuppressFBWarnings(value = "UUF_UNUSED_FIELD") // <- useless suppression
    private String field;

    @SuppressFBWarnings(value = "UUF_UNUSED_FIELD") // <- valid suppression
    private String field2;

    public String getField() {
        return field;
    }

    public void setField(/* useless suppression -> */ @SuppressFBWarnings(value = "UUF_UNUSED_FIELD") String val) {
        field = val;
    }
}
```
Output:
```
[INFO] BugInstance size is 3
[INFO] Error size is 0
[INFO] Total bugs: 3
[ERROR] Suppressing annotation on the class com.chaosonic.Issue641 is unnecessary [com.chaosonic.Issue641] At Issue641.java:[lines 6-20] US_USELESS_SUPPRESSION_ON_CLASS
[ERROR] Suppressing annotation on the field com.chaosonic.Issue641.field is unnecessary [com.chaosonic.Issue641] In Issue641.java US_USELESS_SUPPRESSION_ON_FIELD
[ERROR] Suppressing annotation on the parameter 2 of the method com.chaosonic.Issue641.setField(String) is unnecessary [com.chaosonic.Issue641] At Issue641.java:[lines 19-20] US_USELESS_SUPPRESSION_ON_METHOD_PARAMETER
[INFO]
```
----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
