### PR TITLE
fix: wrong build order after update to gradle 6

### DIFF
--- a/eclipsePlugin/build.gradle
+++ b/eclipsePlugin/build.gradle
@@ -93,7 +93,6 @@ javadoc {
 }
 
 task copyLibsForEclipse(type: Copy) {
-    dependsOn project(':spotbugs').configurations.runtimeClasspath
     from ('../spotbugs/.libs') {
       include "*.jar"
       exclude "*xml-apis*.jar"
@@ -147,6 +146,8 @@ task updateManifest {
     props.store(file('build.properties').newWriter(), null)
   }
 }
+
+tasks['compileJava'].dependsOn ':spotbugs:jar'
 
 // create manifest when importing to eclipse
 tasks.eclipse.dependsOn copyLibsForEclipse, updateManifest

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -271,6 +271,7 @@ distributions {
 
 distTar.compression = Compression.GZIP
 tasks['assemble'].dependsOn tasks['assembleDist']
+tasks['jar'].dependsOn tasks['updateManifest']
 
 task distSrcZip(type:Exec) {
   commandLine 'git', 'archive', '-o', "${buildDir}/distributions/spotbugs-${project.version}-source.zip",


### PR DESCRIPTION
Make sure Eclipse plugin compilation starts after spotbugs jar task, and
spotbugs jar task depends on updateManifest task.

This fixes issue #1067



----

Make sure these boxes are checked before submitting your PR -- thank you!

- [ ] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
