### PR TITLE
Upload distributions onto GitHub Releases too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,7 +104,9 @@ deploy:
       condition: "$TRAVIS_TAG != *'_RC'* && $TRAVIS_TAG != *'_beta'*"
   - provider: releases
     api_key: $GITHUB_TOKEN
-    file: "eclipsePlugin/build/distributions/eclipsePlugin.zip"
+    file:
+      - "eclipsePlugin/build/distributions/eclipsePlugin.zip"
+      - "spotbugs/build/distributions/*"
     skip_cleanup: true
     on:
       tags: true

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -283,5 +283,5 @@ extensions += ['code-template']
 # URL to distribute SpotBugs package
 # http://www.sphinx-doc.org/en/stable/ext/extlinks.html
 extensions += ['sphinx.ext.extlinks']
-tag = release.replace('-', '_')
+tag = release.replace('-', '_').lower()
 extlinks = {'dist': ('https://github.com/spotbugs/spotbugs/releases/download/' + tag + '/spotbugs-' + release + '.%s', '')}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -283,4 +283,5 @@ extensions += ['code-template']
 # URL to distribute SpotBugs package
 # http://www.sphinx-doc.org/en/stable/ext/extlinks.html
 extensions += ['sphinx.ext.extlinks']
-extlinks = {'dist': ('https://repo.maven.apache.org/maven2/com/github/spotbugs/spotbugs/' + release + '/spotbugs-' + release + '.%s', '')}
+tag = release.replace('-', '_')
+extlinks = {'dist': ('https://github.com/spotbugs/spotbugs/releases/download/' + tag + '/spotbugs-' + release + '.%s', '')}


### PR DESCRIPTION
close #1075

This change does not affect SpotBugs binary, so we need no CHANGELOG entry for it.

[//]: # (rtdbot-start)

URL of RTD documents:
en: https://spotbugs.readthedocs.io/en/issue-1075/
ja: https://spotbugs.readthedocs.io/ja/issue-1075/

[//]: # (rtdbot-end)
