### PR TITLE
Replace Travis CI with GitHub Actions for stable deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@722adc6
+      - name: Set up JDK 11
+        uses: actions/setup-java@081536e
+        with:
+          java-version: '8.0.x'
+      - uses: actions/cache@cffae95
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: Build
+        run: |
+          echo $GPG_PRIV_KEY > secring.text
+          gpg --import --batch secring.text
+          echo ossrhUsername=eller86 >> gradle.properties
+          echo "ossrhPassword=${SONATYPE_PASSWORD}" >> gradle.properties
+          echo "signing.keyId=${SIGNING_KEY_ID}" >> gradle.properties
+          echo "signing.password=${SIGNING_PASSWORD}" >> gradle.properties
+          ./gradlew publish --no-daemon
+        env:
+          GPG_PRIV_KEY: ${{ secrets.GPG_PRIV_KEY }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -111,19 +111,3 @@ deploy:
     on:
       tags: true
       jdk: openjdk8
-  - provider: script
-    skip_cleanup: true
-    # wait until uploading task finishes, because it may cost more than 10 minutes without any output
-    # https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received
-    script: .travis/travis_wait "./gradlew publish"
-    on:
-      jdk: openjdk8
-      branch: master
-  - provider: script
-    skip_cleanup: true
-    # wait until uploading task finishes, because it may cost more than 10 minutes without any output
-    # https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received
-    script: .travis/travis_wait "./gradlew publish"
-    on:
-      tags: true
-      jdk: openjdk8

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.jvmargs=-XX:+CMSClassUnloadingEnabled -XX:+HeapDumpOnOutOfMemoryError -Xmx1G
 
 # https://issues.sonatype.org/browse/MVNCENTRAL-5548
-org.gradle.internal.publish.checksums.insecure=true
+systemProp.org.gradle.internal.publish.checksums.insecure=true


### PR DESCRIPTION
Recently the publish task from Travis CI is quite unstable, it makes 4~5 staging registries and sometimes lack necessary files on Sonatype Central Nexus.

When I use a node on Google Cloud the publish task usually becomes stable, so hope that using another cloud service solves the problem.