### PR TITLE
Relese 4.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ on:
     branches:
       - master
     tags:
-      - '*'
+      - '**'
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased - 2020-??-??
+
 ## 4.0.0 - 2020-02-15
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased - 2020-??-??
+## 4.0.0 - 2020-02-15
+
+### Fixed
+
+* [Duplicated word in bug descriptions](https://github.com/spotbugs/spotbugs/commit/0d50f0056d7b34e09b472079120bf5ea2abddc45)
 
 ## 4.0.0-RC3 - 2020-02-04
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
   id "com.diffplug.gradle.spotless" version "3.27.1"
 }
 
-version = '4.0.0'
+version = '4.0.1-SNAPSHOT'
 
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/jacoco.gradle"

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
   id "com.diffplug.gradle.spotless" version "3.27.1"
 }
 
-version = '4.0.0-SNAPSHOT'
+version = '4.0.0'
 
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/jacoco.gradle"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,7 @@ import os
 
 html_context = {
   'version' : '4.0',
-  'full_version' : '4.0.0-RC3',
+  'full_version' : '4.0.0',
   'maven_plugin_version' : '3.1.12.2',
   'gradle_plugin_version' : '3.0.0',
   'archetype_version' : '0.2.2'


### PR DESCRIPTION
`4.0.0-RC3` got no bug report during the last week, so ship the stable 4.0.0.

The migration guide is already published at [the official document hosted by Read The Docs](https://spotbugs.readthedocs.io/en/latest/migration.html#guide-for-migration-from-spotbugs-3-1-to-4-0).