### PR TITLE
Correct XSL variable declaration & assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ## Unreleased - 2020-??-??
 
+### Fixed
+
+* Resolved Saxon warning ([#1077](https://github.com/spotbugs/spotbugs/issues/1077))
+
 ## 4.0.0 - 2020-02-15
 
 ### Fixed

--- a/spotbugs/src/xsl/default.xsl
+++ b/spotbugs/src/xsl/default.xsl
@@ -345,13 +345,10 @@
 						</xsl:choose>
 					</td>
 				</tr>
-				<xsl:variable name="totalClass" select="tablerow0"/>
 			</xsl:when>
-			<xsl:otherwise>
-				<xsl:variable name="totalClass" select="tablerow1"/>
-			</xsl:otherwise>
 		</xsl:choose>
 
+		<xsl:variable name = "totalClass" select="if (@priority_3) then 'tablerow0' else 'tablerow1'"/>
 		<tr class="$totalClass">
 			<td><b>Total Warnings</b></td>
 			<td align="right"><b><xsl:value-of select="@total_bugs"/></b></td>

--- a/spotbugs/src/xsl/plain.xsl
+++ b/spotbugs/src/xsl/plain.xsl
@@ -274,13 +274,10 @@
 			        </xsl:choose>
 				</td>
 			</tr>
-			<xsl:variable name="totalClass" select="tablerow0"/>
 		</xsl:when>
-		<xsl:otherwise>
-		    <xsl:variable name="totalClass" select="tablerow1"/>
-		</xsl:otherwise>
 	</xsl:choose>
 
+		<xsl:variable name = "totalClass" select="if (@priority_3) then 'tablerow0' else 'tablerow1'"/>
 		<tr class="$totalClass">
 			<td><b>Total Warnings</b></td>
 			<td align="right"><b><xsl:value-of select="@total_bugs"/></b></td>


### PR DESCRIPTION
Resolves Saxon warning `SXWN9001: A variable with no following sibling instructions has no effect`

----

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
