### PR TITLE
Be precise about required Ctor accessibility

### DIFF
--- a/spotbugs/etc/messages.xml
+++ b/spotbugs/etc/messages.xml
@@ -4360,8 +4360,8 @@ deserialized instance of the class.
     <Details>
 <![CDATA[
   <p> This class implements the <code>Externalizable</code> interface, but does
-  not define a void constructor. When Externalizable objects are deserialized,
-   they first need to be constructed by invoking the void
+  not define a public void constructor. When Externalizable objects are deserialized,
+   they first need to be constructed by invoking the public void
    constructor. Since this class does not have one,
    serialization and deserialization will fail at runtime.</p>
 ]]>


### PR DESCRIPTION
[Externalizable](https://docs.oracle.com/javase/8/docs/api/java/io/Externalizable.html):
> When an Externalizable object is reconstructed, an instance is created using the **public no-arg constructor**, then the readExternal method called.

I forgot that bit, and was fighting with [NO_S*_C*_F*_E*](https://spotbugs.readthedocs.io/en/stable/bugDescriptions.html#se-class-is-externalizable-but-doesn-t-define-a-void-constructor-se-no-suitable-constructor-for-externalization) violation, by adding private, then protected Ctor (fine for `Serializable`s). All for nothing :wink:

<sup>Only then I wrote the test and finally read API... :flushed: </sup>