### PR TITLE
Allow any ant task or command-line user to specify large values or many arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 * Resolved Saxon warning ([#1077](https://github.com/spotbugs/spotbugs/issues/1077))
 * Unclear message of `SE_NO_SUITABLE_CONSTRUCTOR_FOR_EXTERNALIZATION` ([#1091](https://github.com/spotbugs/spotbugs/pull/1091))
+* Allow any ant task or command-line user to specify large values or many arguments ([#1098](https://github.com/spotbugs/spotbugs/pull/1098))
 
 ## 4.0.0 - 2020-02-15
 

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -247,10 +247,17 @@ These options are only accepted by the Text User Interface.
 -userPrefs *edu.umd.cs.findbugs.core.prefs*:
   Set the path of the user preferences file to use, which might override some of the options above.
   Specifying userPrefs as first argument would mean some later options will override them, as last argument would mean they will override some previous options).
-  This rationale behind this option is to reuse SpotBugs Eclipse project settings for command line execution.
+  The rationale behind this option is to reuse SpotBugs Eclipse project settings for command line execution.
 
 -showPlugins:
   Show list of available detector plugins.
+
+-parseStdinAsOptions:
+    Read additional options from from standard input, with each new line as a separate argument.
+    This option is incompatible with other arguments using standard input,
+    such as -auxclasspathFromInput and reading files or data from standard input.
+    -auxclasspathFromInput can be replaced with -auxclasspath followed by a classpath line.
+    The rationale behind this option is to bypass the inherent operating systme limit on the size and number of provided command line arguments.
 
 Output options
 **************

--- a/spotbugs-ant/src/main/java/edu/umd/cs/findbugs/anttask/AbstractFindBugsTask.java
+++ b/spotbugs-ant/src/main/java/edu/umd/cs/findbugs/anttask/AbstractFindBugsTask.java
@@ -95,6 +95,8 @@ public abstract class AbstractFindBugsTask extends Task {
 
     public String execResultProperty = "edu.umd.cs.findbugs.anttask.AbstractFindBugsTask" + "." + RESULT_PROPERTY_SUFFIX;
 
+    private StringBuilder inputStringBuilder = null;
+
     /**
      * Constructor.
      */
@@ -388,8 +390,23 @@ public abstract class AbstractFindBugsTask extends Task {
      * Sets the given string to be piped to standard input of the FindBugs JVM
      * upon launching.
      */
+    protected void appendToInputString(String input) {
+        if (null == inputStringBuilder) {
+            inputStringBuilder = new StringBuilder();
+        }
+        inputStringBuilder.append(input);
+    }
+
+    protected void appendToInputString(char input) {
+        if (null == inputStringBuilder) {
+            inputStringBuilder = new StringBuilder();
+        }
+        inputStringBuilder.append(input);
+    }
+
     protected void setInputString(String input) {
-        findbugsEngine.setInputString(input);
+        inputStringBuilder = new StringBuilder();
+        inputStringBuilder.append(input);
     }
 
     /**
@@ -404,6 +421,10 @@ public abstract class AbstractFindBugsTask extends Task {
         configureFindbugsEngine();
 
         beforeExecuteJavaProcess();
+
+        if (null != inputStringBuilder) {
+            findbugsEngine.setInputString(inputStringBuilder.toString());
+        }
 
         if (getDebug()) {
             log(getFindbugsEngine().getCommandLine().describeCommand());

--- a/spotbugs-ant/src/main/java/edu/umd/cs/findbugs/anttask/FindBugsTask.java
+++ b/spotbugs-ant/src/main/java/edu/umd/cs/findbugs/anttask/FindBugsTask.java
@@ -901,10 +901,24 @@ public class FindBugsTask extends AbstractFindBugsTask {
             addArg(excludeFile.getPath());
         }
         if (excludePath != null) {
-            String[] result = excludePath.toString().split(java.io.File.pathSeparator);
-            for (String element : result) {
-                addArg("-exclude");
-                addArg(element);
+            String excludePathValue = excludePath.toString();
+            if (!excludePathValue.isEmpty()) {
+                if (excludePathValue.length() > 100) {
+                    addArg("-parseStdinAsOptions");
+                    String[] result = excludePathValue.split(java.io.File.pathSeparator);
+                    for (int x = 0; x < result.length; x++) {
+                        appendToInputString("-exclude");
+                        appendToInputString('\n');
+                        appendToInputString(result[x]);
+                        appendToInputString('\n');
+                    }
+                } else {
+                    String[] result = excludePathValue.split(java.io.File.pathSeparator);
+                    for (int x = 0; x < result.length; x++) {
+                        addArg("-exclude");
+                        addArg(result[x]);
+                    }
+                }
             }
         }
         if (includeFile != null) {
@@ -912,10 +926,24 @@ public class FindBugsTask extends AbstractFindBugsTask {
             addArg(includeFile.getPath());
         }
         if (includePath != null) {
-            String[] result = includePath.toString().split(java.io.File.pathSeparator);
-            for (String element : result) {
-                addArg("-include");
-                addArg(element);
+            String includePathValue = includePath.toString();
+            if (!includePathValue.isEmpty()) {
+                if (includePathValue.length() > 100) {
+                    addArg("-parseStdinAsOptions");
+                    String[] result = includePathValue.split(java.io.File.pathSeparator);
+                    for (int x = 0; x < result.length; x++) {
+                        appendToInputString("-include");
+                        appendToInputString('\n');
+                        appendToInputString(result[x]);
+                        appendToInputString('\n');
+                    }
+                } else {
+                    String[] result = includePathValue.split(java.io.File.pathSeparator);
+                    for (int x = 0; x < result.length; x++) {
+                        addArg("-include");
+                        addArg(result[x]);
+                    }
+                }
             }
         }
         if (visitors != null) {

--- a/spotbugs-ant/src/main/java/edu/umd/cs/findbugs/anttask/FindBugsTask.java
+++ b/spotbugs-ant/src/main/java/edu/umd/cs/findbugs/anttask/FindBugsTask.java
@@ -101,6 +101,11 @@ import edu.umd.cs.findbugs.ExitCodes;
 
 public class FindBugsTask extends AbstractFindBugsTask {
 
+    /**
+     * Arguments longer than this value will be passed via STDIN
+     */
+    private static final int MAXIMUM_DIRECTLY_PASSED_ARGUMENT_LENGTH = 100;
+
     private String effort;
 
     private boolean conserveSpace;
@@ -903,7 +908,7 @@ public class FindBugsTask extends AbstractFindBugsTask {
         if (excludePath != null) {
             String excludePathValue = excludePath.toString();
             if (!excludePathValue.isEmpty()) {
-                if (excludePathValue.length() > 100) {
+                if (excludePathValue.length() > MAXIMUM_DIRECTLY_PASSED_ARGUMENT_LENGTH) {
                     addArg("-parseStdinAsOptions");
                     String[] result = excludePathValue.split(java.io.File.pathSeparator);
                     for (int x = 0; x < result.length; x++) {
@@ -928,7 +933,7 @@ public class FindBugsTask extends AbstractFindBugsTask {
         if (includePath != null) {
             String includePathValue = includePath.toString();
             if (!includePathValue.isEmpty()) {
-                if (includePathValue.length() > 100) {
+                if (includePathValue.length() > MAXIMUM_DIRECTLY_PASSED_ARGUMENT_LENGTH) {
                     addArg("-parseStdinAsOptions");
                     String[] result = includePathValue.split(java.io.File.pathSeparator);
                     for (int x = 0; x < result.length; x++) {
@@ -969,9 +974,13 @@ public class FindBugsTask extends AbstractFindBugsTask {
                 String unreadReference = auxClasspath.toString();
                 String auxClasspathString = auxClasspath.toString();
                 if (!auxClasspathString.isEmpty()) {
-                    if (auxClasspathString.length() > 100) {
-                        addArg("-auxclasspathFromInput");
-                        setInputString(auxClasspathString);
+                    if (auxClasspathString.length() > MAXIMUM_DIRECTLY_PASSED_ARGUMENT_LENGTH) {
+                        addArg("-parseStdinAsOptions");
+
+                        appendToInputString("-auxclasspath");
+                        appendToInputString('\n');
+                        appendToInputString(auxClasspathString);
+                        appendToInputString('\n');
                     } else {
                         addArg("-auxclasspath");
                         addArg(auxClasspathString);
@@ -982,8 +991,20 @@ public class FindBugsTask extends AbstractFindBugsTask {
             }
         }
         if (sourcePath != null) {
-            addArg("-sourcepath");
-            addArg(sourcePath.toString());
+            String sourcePathValue = sourcePath.toString();
+            if (!sourcePathValue.isEmpty()) {
+                if (sourcePathValue.length() > MAXIMUM_DIRECTLY_PASSED_ARGUMENT_LENGTH) {
+                    addArg("-parseStdinAsOptions");
+
+                    appendToInputString("-sourcepath");
+                    appendToInputString('\n');
+                    appendToInputString(sourcePathValue);
+                    appendToInputString('\n');
+                } else {
+                    addArg("-sourcepath");
+                    addArg(sourcePathValue);
+                }
+            }
         }
         if (outputFileName != null) {
             addArg("-outputFile");

--- a/spotbugs/src/doc/manual.xml
+++ b/spotbugs/src/doc/manual.xml
@@ -928,6 +928,18 @@ These options are only accepted by the Text User Interface.
   </varlistentry>
 
   <varlistentry>
+  <term><command>-parseStdinAsOptions</command> </term>
+  <listitem>
+    <para>
+    Read additional options from from standard input, with each new line as a separate argument.
+    This option is incompatible with other arguments using standard input,
+    such as -auxclasspathFromInput and reading files or data from standard input.
+    -auxclasspathFromInput can be replaced with -auxclasspath followed by a classpath line.
+    </para>
+  </listitem>
+  </varlistentry>
+
+  <varlistentry>
   <term><command>-auxclasspath</command> <replaceable>classpath</replaceable></term>
   <listitem>
     <para>

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/TextUICommandLine.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/TextUICommandLine.java
@@ -211,6 +211,7 @@ public class TextUICommandLine extends FindBugsCommandLine {
         addOption("-adjustPriority", "v1=(raise|lower)[,...]", "raise/lower priority of warnings for given visitor(s)");
 
         startOptionGroup("Project configuration options:");
+        addSwitch("-parseStdinAsOptions", "read additional options from standard input, one argument per line");
         addOption("-auxclasspath", "classpath", "set aux classpath for analysis");
         addSwitch("-auxclasspathFromInput", "read aux classpath from standard input");
         addOption("-auxclasspathFromFile", "filepath", "read aux classpaths from a designated file");


### PR DESCRIPTION
Originally submitted as

Ant task parses stdin as argv
https://github.com/findbugsproject/findbugs/pull/61

Here's a maintainable way forward to allow any findbugs ant task (or command-line user) to specify large values or many arguments. I started with the idea used by -auxclasspathFromInput and expanded it to be more generic so that it could work for any option. Options are parsed from the command-line and if -parseStdinAsOptions is specified, options are then parsed from standard input, which each line considered as a separate argument. Since sourcePath was the option which was not working for me in the findbugs ant task, I updated both it and auxClasspath to use this new mechanism from the ant task. It is a simple matter to apply the same change to other options. Candidates could include class, visitors, and my proposed excludePath and includePath elements. This change maintains backward compatibility although the use of -parseStdinAsOptions will be incompatible with anything else using standard input.


