### PR TITLE
Add missing ant task documentation for includePath and excludePath

### DIFF
--- a/docs/ant.rst
+++ b/docs/ant.rst
@@ -158,8 +158,14 @@ chooseVisitors
 excludeFilter
   Optional attribute. It specifies the filename of a filter specifying bugs to exclude from being reported. See :doc:`filter`.
 
+excludePath
+  An optional nested element. It specifies a path containing filters specifying bugs to exclude from being reported. See :doc:`filter`.
+
 includeFilter
   Optional attribute. It specifies the filename of a filter specifying which bugs are reported. See :doc:`filter`.
+
+includePath
+  An optional nested element. It specifies a path containing filters specifying which bugs are reported. See :doc:`filter`.
 
 projectFile
   Optional attribute. It specifies the name of a project file.


### PR DESCRIPTION
 Add missing ant task documentation for includePath and excludePath from old manual to new docs.