### PR TITLE
Resolved XPathException generating html report if BugInstance contains multiple Class elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 ### Fixed
 
 * Resolved Saxon warning ([#1077](https://github.com/spotbugs/spotbugs/issues/1077))
+* Resolved fatal exception in html report if BugInstance contains multiple Class elements ([#1025](https://github.com/spotbugs/spotbugs/issues/1025))
 * Unclear message of `SE_NO_SUITABLE_CONSTRUCTOR_FOR_EXTERNALIZATION` ((#1091)[https://github.com/spotbugs/spotbugs/pull/1091])
 
 ## 4.0.0 - 2020-02-15

--- a/spotbugs/src/xsl/default.xsl
+++ b/spotbugs/src/xsl/default.xsl
@@ -282,7 +282,7 @@
 		<xsl:copy-of select="$bugTableHeader"/>
 		<xsl:apply-templates select="$warningSet">
 			<xsl:sort select="@abbrev"/>
-			<xsl:sort select="Class/@classname"/>
+			<xsl:sort select="Class[1]/@classname"/>
 		</xsl:apply-templates>
 	</table>
 </xsl:template>


### PR DESCRIPTION
Resolved XPathException generating html report if BugInstance contains multiple Class elements reported in issue #1025 

net.sf.saxon.trans.XPathException: A sequence of more than one item is not allowed as the @select attribute of xsl:sort (@ClassName=...)

Found a solution on stackoverflow which explicitly sets the first child node match to be used in the sort, which seems reasonable.
https://stackoverflow.com/questions/45601621/what-does-1-mean-in-an-xslt-sort

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
