### PR TITLE
Deprecated since jdk9 replacing usage of XMLReaderFactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 * Upgraded log4j2 to 2.13.1
 * Upgraded from commons-lang2 to commons-lang3 3.10
 * Added commons-text 1.8 due to items deprecated in commons-lang3 and moved to this project
+* replaced usage of org.xml.sax.helpers.XMLReaderFactory (deprecated since jdk9) with javax.xml.parsers.SAXParserFactory
 
 ## 4.0.1 - 2020-03-19
 

--- a/spotbugs/src/gui/main/edu/umd/cs/findbugs/gui2/BugLoader.java
+++ b/spotbugs/src/gui/main/edu/umd/cs/findbugs/gui2/BugLoader.java
@@ -34,6 +34,7 @@ import javax.swing.JFileChooser;
 import javax.swing.JOptionPane;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
+import javax.xml.parsers.ParserConfigurationException;
 
 import org.dom4j.DocumentException;
 import org.xml.sax.SAXException;
@@ -207,7 +208,7 @@ public class BugLoader {
             return project;
         } catch (IOException e) {
             JOptionPane.showMessageDialog(mainFrame, "Could not read " + f + "; " + e.getMessage());
-        } catch (SAXException e) {
+        } catch (SAXException | ParserConfigurationException e) {
             JOptionPane.showMessageDialog(mainFrame, "Could not read  project from " + f + "; " + e.getMessage());
         }
         return null;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/Project.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/Project.java
@@ -54,13 +54,18 @@ import java.util.jar.Manifest;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+import javax.xml.stream.XMLInputFactory;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
 import org.xml.sax.XMLReader;
-import org.xml.sax.helpers.XMLReaderFactory;
 
 import edu.umd.cs.findbugs.ba.SourceFinder;
 import edu.umd.cs.findbugs.ba.URLClassPath;
@@ -666,7 +671,7 @@ public class Project implements XMLWriteable, AutoCloseable {
         isModified = false;
     }
 
-    public static Project readXML(File f) throws IOException, SAXException {
+    public static Project readXML(File f) throws IOException, SAXException, ParserConfigurationException {
         @SuppressWarnings("resource") // will be closed by caller
         Project project = new Project();
 
@@ -682,7 +687,14 @@ public class Project implements XMLWriteable, AutoCloseable {
                 throw new IOException("Can't load a project from a " + tag + " file");
             }
 
-            XMLReader xr = XMLReaderFactory.createXMLReader();
+            SAXParserFactory parserFactory = SAXParserFactory.newInstance();
+            parserFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, Boolean.TRUE);
+            parserFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl",  Boolean.TRUE);
+            parserFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd",  Boolean.FALSE);
+            parserFactory.setFeature("http://xml.org/sax/features/external-general-entities", Boolean.FALSE);
+            parserFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", Boolean.FALSE);
+            SAXParser parser = parserFactory.newSAXParser();
+            XMLReader xr = parser.getXMLReader();
 
             xr.setContentHandler(handler);
             xr.setErrorHandler(handler);
@@ -690,7 +702,7 @@ public class Project implements XMLWriteable, AutoCloseable {
             try (Reader reader = Util.getReader(in)) {
                 xr.parse(new InputSource(reader));
             }
-        } catch (IOException | SAXException e) {
+        } catch (IOException | SAXException | ParserConfigurationException e) {
             project.close();
             throw e;
         }
@@ -727,9 +739,8 @@ public class Project implements XMLWriteable, AutoCloseable {
         if (projectFileName.endsWith(".xml") || projectFileName.endsWith(".fbp")) {
             try {
                 return Project.readXML(projectFile);
-            } catch (SAXException e) {
-                IOException ioe = new IOException("Couldn't read saved FindBugs project");
-                ioe.initCause(e);
+            } catch (SAXException | ParserConfigurationException e) {
+                IOException ioe = new IOException("Couldn't read saved FindBugs project",e);
                 throw ioe;
             }
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/SortedBugCollection.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/SortedBugCollection.java
@@ -54,6 +54,11 @@ import java.util.zip.GZIPOutputStream;
 import javax.annotation.CheckForNull;
 import javax.annotation.WillClose;
 import javax.annotation.WillNotClose;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+import javax.xml.stream.XMLInputFactory;
 import javax.xml.transform.TransformerException;
 
 import org.dom4j.Document;
@@ -349,8 +354,15 @@ public class SortedBugCollection implements BugCollection {
 
             XMLReader xr;
             try {
-                xr = XMLReaderFactory.createXMLReader();
-            } catch (SAXException e) {
+                SAXParserFactory parserFactory = SAXParserFactory.newInstance();
+                parserFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, Boolean.TRUE);
+                parserFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl",  Boolean.TRUE);
+                parserFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd",  Boolean.FALSE);
+                parserFactory.setFeature("http://xml.org/sax/features/external-general-entities", Boolean.FALSE);
+                parserFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", Boolean.FALSE);
+                SAXParser parser = parserFactory.newSAXParser();
+                xr = parser.getXMLReader();
+            } catch (SAXException | ParserConfigurationException e) {
                 AnalysisContext.logError("Couldn't create XMLReaderFactory", e);
                 throw new DocumentException("Sax error ", e);
             }


### PR DESCRIPTION
replacing usage of org.xml.sax.helpers.XMLReaderFactory with javax.xml.parsers.SAXParserFactory

Ref:
https://docs.oracle.com/javase/9/docs/api/org/xml/sax/helpers/XMLReaderFactory.html
https://docs.oracle.com/javase/tutorial/jaxp/properties/scope.html

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
