### PR TITLE
Release SpotBugs 4.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ### Changed
 
+* Upgrade ASM to 8.0.1 which supports Java14
 * Upgraded junit4 to 4.13
 * Upgraded ant to 1.10.7
 * Upgraded log4j2 to 2.13.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased - 2020-??-??
+## 4.0.2 - 2020-04-15
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased - 2020-??-??
+
 ## 4.0.2 - 2020-04-15
 
 ### Fixed

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
   id "com.diffplug.gradle.spotless" version "3.27.1"
 }
 
-version = '4.0.2'
+version = '4.0.3-SNAPSHOT'
 
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/jacoco.gradle"

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
   id "com.diffplug.gradle.spotless" version "3.27.1"
 }
 
-version = '4.0.2-SNAPSHOT'
+version = '4.0.2'
 
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/jacoco.gradle"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,9 +17,9 @@ import os
 
 html_context = {
   'version' : '4.0',
-  'full_version' : '4.0.1',
+  'full_version' : '4.0.2',
   'maven_plugin_version' : '4.0.0',
-  'gradle_plugin_version' : '4.0.4',
+  'gradle_plugin_version' : '4.0.5',
   'archetype_version' : '0.2.3'
 }
 

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -56,11 +56,11 @@ sourceSets {
 }
 
 dependencies {
-  api 'org.ow2.asm:asm:7.3.1'
-  api 'org.ow2.asm:asm-analysis:7.3.1'
-  api 'org.ow2.asm:asm-commons:7.3.1'
-  api 'org.ow2.asm:asm-tree:7.3.1'
-  api 'org.ow2.asm:asm-util:7.3.1'
+  api 'org.ow2.asm:asm:8.0.1'
+  api 'org.ow2.asm:asm-analysis:8.0.1'
+  api 'org.ow2.asm:asm-commons:8.0.1'
+  api 'org.ow2.asm:asm-tree:8.0.1'
+  api 'org.ow2.asm:asm-util:8.0.1'
   api 'org.apache.bcel:bcel:6.4.1'
   api 'net.jcip:jcip-annotations:1.0'
   api 'org.dom4j:dom4j:2.1.1'

--- a/spotbugs/etc/MANIFEST-findbugs.MF
+++ b/spotbugs/etc/MANIFEST-findbugs.MF
@@ -1,3 +1,3 @@
 Manifest-Version: 1.0
 Main-Class: edu.umd.cs.findbugs.LaunchAppropriateUI
-Class-Path: bcel.jar dom4j-2.1.1.jar jaxen-1.1.6.jar asm-7.3.1.jar asm-analysis-7.3.1.jar asm-commons-7.3.1.jar asm-tree-7.3.1.jar asm-util-7.3.1.jar asm-xml-7.3.1.jar jsr305.jar commons-lang3-3.10.jar commons-text-1.8.jar
+Class-Path: bcel.jar dom4j-2.1.1.jar jaxen-1.1.6.jar asm-8.0.1.jar asm-analysis-8.0.1.jar asm-commons-8.0.1.jar asm-tree-8.0.1.jar asm-util-8.0.1.jar asm-xml-8.0.1.jar jsr305.jar commons-lang3-3.10.jar commons-text-1.8.jar

--- a/spotbugs/etc/MANIFEST-findbugsGUI.MF
+++ b/spotbugs/etc/MANIFEST-findbugsGUI.MF
@@ -1,3 +1,3 @@
 Manifest-Version: 1.0
 Main-Class: edu.umd.cs.findbugs.LaunchAppropriateUI
-Class-Path: bcel.jar dom4j-2.1.1.jar jaxen-1.1.6.jar asm-7.3.1.jar asm-analysis-7.3.1.jar asm-commons-7.3.1.jar asm-tree-7.3.1.jar asm-util-7.3.1.jar asm-xml-7.3.1.jar jsr305.jar commons-lang3-3.10.jar commons-text-1.8.jar plastic.jar
+Class-Path: bcel.jar dom4j-2.1.1.jar jaxen-1.1.6.jar asm-8.0.1.jar asm-analysis-8.0.1.jar asm-commons-8.0.1.jar asm-tree-8.0.1.jar asm-util-8.0.1.jar asm-xml-8.0.1.jar jsr305.jar commons-lang3-3.10.jar commons-text-1.8.jar plastic.jar


### PR DESCRIPTION
Release SpotBugs v4.0.2 with upgrading ASM to [8.0.1 with Java14 support](https://asm.ow2.io/versions.html).

[//]: # (rtdbot-start)

URL of RTD documents:
en: https://spotbugs.readthedocs.io/en/spotbugs-4.0.2/
ja: https://spotbugs.readthedocs.io/ja/spotbugs-4.0.2/

[//]: # (rtdbot-end)
