### PR TITLE
Make the build failed when the code is unexpectedly formatted

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ install:
 
 script:
   - jdk_switcher use openjdk8
-  - ./gradlew classes testClasses -S
+  - ./gradlew spotlessCheck classes testClasses -S
   - if [[ $TRAVIS_JDK_VERSION == "openjdk11" ]]; then export JAVA_HOME=$HOME/openjdk11; fi
   - ./gradlew -v --no-daemon
   - ./gradlew build smoketest -S --no-daemon

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/Project.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/Project.java
@@ -58,13 +58,11 @@ import javax.xml.XMLConstants;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
-import javax.xml.stream.XMLInputFactory;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
-import org.xml.sax.SAXParseException;
 import org.xml.sax.XMLReader;
 
 import edu.umd.cs.findbugs.ba.SourceFinder;
@@ -689,8 +687,8 @@ public class Project implements XMLWriteable, AutoCloseable {
 
             SAXParserFactory parserFactory = SAXParserFactory.newInstance();
             parserFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, Boolean.TRUE);
-            parserFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl",  Boolean.TRUE);
-            parserFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd",  Boolean.FALSE);
+            parserFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", Boolean.TRUE);
+            parserFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", Boolean.FALSE);
             parserFactory.setFeature("http://xml.org/sax/features/external-general-entities", Boolean.FALSE);
             parserFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", Boolean.FALSE);
             SAXParser parser = parserFactory.newSAXParser();
@@ -740,7 +738,7 @@ public class Project implements XMLWriteable, AutoCloseable {
             try {
                 return Project.readXML(projectFile);
             } catch (SAXException | ParserConfigurationException e) {
-                IOException ioe = new IOException("Couldn't read saved FindBugs project",e);
+                IOException ioe = new IOException("Couldn't read saved FindBugs project", e);
                 throw ioe;
             }
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/SortedBugCollection.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/SortedBugCollection.java
@@ -58,7 +58,6 @@ import javax.xml.XMLConstants;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
-import javax.xml.stream.XMLInputFactory;
 import javax.xml.transform.TransformerException;
 
 import org.dom4j.Document;
@@ -68,7 +67,6 @@ import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 import org.xml.sax.XMLReader;
-import org.xml.sax.helpers.XMLReaderFactory;
 
 import edu.umd.cs.findbugs.ba.AnalysisContext;
 import edu.umd.cs.findbugs.ba.MissingClassException;
@@ -356,8 +354,8 @@ public class SortedBugCollection implements BugCollection {
             try {
                 SAXParserFactory parserFactory = SAXParserFactory.newInstance();
                 parserFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, Boolean.TRUE);
-                parserFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl",  Boolean.TRUE);
-                parserFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd",  Boolean.FALSE);
+                parserFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", Boolean.TRUE);
+                parserFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", Boolean.FALSE);
                 parserFactory.setFeature("http://xml.org/sax/features/external-general-entities", Boolean.FALSE);
                 parserFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", Boolean.FALSE);
                 SAXParser parser = parserFactory.newSAXParser();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/filter/Filter.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/filter/Filter.java
@@ -33,12 +33,10 @@ import javax.xml.XMLConstants;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
-import javax.xml.stream.XMLInputFactory;
 
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
-import org.xml.sax.helpers.XMLReaderFactory;
 
 import edu.umd.cs.findbugs.BugInstance;
 import edu.umd.cs.findbugs.SAXBugCollectionHandler;
@@ -224,8 +222,8 @@ public class Filter extends OrMatcher {
             SAXBugCollectionHandler handler = new SAXBugCollectionHandler(this, new File(fileName));
             SAXParserFactory parserFactory = SAXParserFactory.newInstance();
             parserFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, Boolean.TRUE);
-            parserFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl",  Boolean.TRUE);
-            parserFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd",  Boolean.FALSE);
+            parserFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", Boolean.TRUE);
+            parserFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", Boolean.FALSE);
             parserFactory.setFeature("http://xml.org/sax/features/external-general-entities", Boolean.FALSE);
             parserFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", Boolean.FALSE);
             SAXParser parser = parserFactory.newSAXParser();


### PR DESCRIPTION
#1115 introduced unexpectedly formatted code, so the release build is failed on the Travis.
This is why [the Eclipse update site](https://github.com/spotbugs/eclipse) isn't updated at this timing.

This PR will make the build failed when the code is unexpectedly formatted, and
format all the code in the repository by `./gradlew spotlessApply`.

Note that the `spotlessApply` runs when we simply execute `./gradlew` in local.