### PR TITLE
Avoid setting the custom SecurityManager when running under IntelliJ IDEA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ## Unreleased - 2020-??-??
 
+### Fixed
+
+* Avoid changing the SecurityManager when launched as an IntelliJ IDEA plugin. 
+
 ## 4.0.2 - 2020-04-15
 
 ### Fixed

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/SystemProperties.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/SystemProperties.java
@@ -42,8 +42,15 @@ public class SystemProperties {
 
     public final static boolean ASSERTIONS_ENABLED;
 
-    public final static boolean RUNNING_IN_ECLIPSE = SystemProperties.class.getClassLoader().getClass().getCanonicalName()
-            .startsWith("org.eclipse.osgi");
+    public final static boolean RUNNING_IN_ECLIPSE;
+
+    public final static boolean RUNNING_AS_IDE_PLUGIN;
+
+    static {
+        String name = SystemProperties.class.getClassLoader().getClass().getCanonicalName();
+        RUNNING_IN_ECLIPSE = name.startsWith("org.eclipse.osgi");
+        RUNNING_AS_IDE_PLUGIN = RUNNING_IN_ECLIPSE || name.startsWith("com.intellij.ide.");
+    }
 
     final static String OS_NAME;
     static {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/TypeQualifierValue.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/TypeQualifierValue.java
@@ -137,10 +137,13 @@ public class TypeQualifierValue<A extends Annotation> {
         if (xclass != null) {
             ClassDescriptor checkerName = DescriptorFactory.createClassDescriptor(typeQualifier.getClassName() + "$Checker");
 
-            if (!SystemProperties.RUNNING_IN_ECLIPSE) {
-                /**   don't do this if running in Eclipse; check below is the quick
-                fix for bug 3599258 (Random obscure Eclipse failures during
-                 analysis) */
+            if (!SystemProperties.RUNNING_AS_IDE_PLUGIN) {
+                /* don't do this if running in Eclipse; check below is the quick
+                   fix for bug 3599258 (Random obscure Eclipse failures during analysis)
+                   
+                   Also don't do this if running in IntelliJ IDEA. This causes weird issues
+                   either (see IDEA-230268) 
+                 */
 
                 try {
                     Global.getAnalysisCache().getClassAnalysis(ClassData.class, checkerName);


### PR DESCRIPTION
When SpotBugs is launched under IDEA plugin changing the SecurityManager affects the whole IntelliJ IDEA caused strange issues. See:
https://github.com/JetBrains/spotbugs-intellij-plugin/issues/10
https://youtrack.jetbrains.com/issue/IDEA-230268

This functionality is already excluded for the Eclipse plugin. This patch extends the exclusion to IntelliJ IDEA plugin as well. I don't see how we can fix this without patching SpotBugs itself. The only possibility is to update reflectively static final field, but this is too dirty.