### PR TITLE
Fix the XML External Entity (XXE) Injection Vulnerability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased - 2020-??-??
+### Security
+
+* Update dom4j to 2.1.3 to fix security vulnerability. ([#1122](https://github.com/spotbugs/spotbugs/issues/1122))
 
 ## 4.0.3 - 2020-05-13
 

--- a/eclipsePlugin/doc/installing_findbugsplugin.txt
+++ b/eclipsePlugin/doc/installing_findbugsplugin.txt
@@ -25,7 +25,7 @@ Install the plug-in
             |     asm-tree-3.3.jar
             |     bcel.jar
             |     commons-lang-2.6.jar
-            |     dom4j-2.1.1.jar
+            |     dom4j-2.1.3.jar
             |     jaxen-1.1.6.jar
             |     jsr305.jar
             |

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -63,7 +63,17 @@ dependencies {
   api 'org.ow2.asm:asm-util:8.0.1'
   api 'org.apache.bcel:bcel:6.4.1'
   api 'net.jcip:jcip-annotations:1.0'
-  api 'org.dom4j:dom4j:2.1.3'
+  api('org.dom4j:dom4j:2.1.3') {
+    // exclude transitive dependencies to keep compatible with dom4j 2.1.1
+    // https://github.com/dom4j/dom4j/issues/85
+    // https://docs.gradle.org/current/userguide/dependency_downgrade_and_exclude.html#sec:excluding-transitive-deps
+    exclude group: 'jaxen',            module: 'jaxen'
+    exclude group: 'javax.xml.stream', module: 'stax-api'
+    exclude group: 'net.java.dev.msv', module: 'xsdlib'
+    exclude group: 'javax.xml.bind',   module: 'jaxb-api'
+    exclude group: 'pull-parser',      module: 'pull-parser'
+    exclude group: 'xpp3',             module: 'xpp3'
+  }
   implementation 'jaxen:jaxen:1.1.6' // only transitive through dom4j:dom4j:1.6.1, which has an *optional* dependency on jaxen:jaxen.
   api 'org.apache.commons:commons-lang3:3.10'
   api 'org.apache.commons:commons-text:1.8'
@@ -83,7 +93,6 @@ dependencies {
   guiImplementation sourceSets.main.runtimeClasspath
   guiImplementation 'org.apache.commons:commons-lang3:3.10'
   guiImplementation 'org.apache.commons:commons-text:1.8'
-  guiImplementation 'org.dom4j:dom4j:2.1.3'
   guiCompileOnly 'com.apple:AppleJavaExtensions:1.4'
   guiCompileOnly project(':spotbugs-annotations')
   guiTestImplementation sourceSets.gui.runtimeClasspath

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -63,7 +63,7 @@ dependencies {
   api 'org.ow2.asm:asm-util:8.0.1'
   api 'org.apache.bcel:bcel:6.4.1'
   api 'net.jcip:jcip-annotations:1.0'
-  api 'org.dom4j:dom4j:2.1.1'
+  api 'org.dom4j:dom4j:2.1.3'
   implementation 'jaxen:jaxen:1.1.6' // only transitive through dom4j:dom4j:1.6.1, which has an *optional* dependency on jaxen:jaxen.
   api 'org.apache.commons:commons-lang3:3.10'
   api 'org.apache.commons:commons-text:1.8'
@@ -83,7 +83,7 @@ dependencies {
   guiImplementation sourceSets.main.runtimeClasspath
   guiImplementation 'org.apache.commons:commons-lang3:3.10'
   guiImplementation 'org.apache.commons:commons-text:1.8'
-  guiImplementation 'org.dom4j:dom4j:2.1.1'
+  guiImplementation 'org.dom4j:dom4j:2.1.3'
   guiCompileOnly 'com.apple:AppleJavaExtensions:1.4'
   guiCompileOnly project(':spotbugs-annotations')
   guiTestImplementation sourceSets.gui.runtimeClasspath

--- a/spotbugs/etc/MANIFEST-findbugs.MF
+++ b/spotbugs/etc/MANIFEST-findbugs.MF
@@ -1,3 +1,3 @@
 Manifest-Version: 1.0
 Main-Class: edu.umd.cs.findbugs.LaunchAppropriateUI
-Class-Path: bcel.jar dom4j-2.1.1.jar jaxen-1.1.6.jar asm-8.0.1.jar asm-analysis-8.0.1.jar asm-commons-8.0.1.jar asm-tree-8.0.1.jar asm-util-8.0.1.jar asm-xml-8.0.1.jar jsr305.jar commons-lang3-3.10.jar commons-text-1.8.jar
+Class-Path: bcel.jar dom4j-2.1.3.jar jaxen-1.1.6.jar asm-8.0.1.jar asm-analysis-8.0.1.jar asm-commons-8.0.1.jar asm-tree-8.0.1.jar asm-util-8.0.1.jar asm-xml-8.0.1.jar jsr305.jar commons-lang3-3.10.jar commons-text-1.8.jar

--- a/spotbugs/etc/MANIFEST-findbugsGUI.MF
+++ b/spotbugs/etc/MANIFEST-findbugsGUI.MF
@@ -1,3 +1,3 @@
 Manifest-Version: 1.0
 Main-Class: edu.umd.cs.findbugs.LaunchAppropriateUI
-Class-Path: bcel.jar dom4j-2.1.1.jar jaxen-1.1.6.jar asm-8.0.1.jar asm-analysis-8.0.1.jar asm-commons-8.0.1.jar asm-tree-8.0.1.jar asm-util-8.0.1.jar asm-xml-8.0.1.jar jsr305.jar commons-lang3-3.10.jar commons-text-1.8.jar plastic.jar
+Class-Path: bcel.jar dom4j-2.1.3.jar jaxen-1.1.6.jar asm-8.0.1.jar asm-analysis-8.0.1.jar asm-commons-8.0.1.jar asm-tree-8.0.1.jar asm-util-8.0.1.jar asm-xml-8.0.1.jar jsr305.jar commons-lang3-3.10.jar commons-text-1.8.jar plastic.jar

--- a/spotbugs/src/sampleXml/analysisResultsWithFilterAndUserAnnotations.xml
+++ b/spotbugs/src/sampleXml/analysisResultsWithFilterAndUserAnnotations.xml
@@ -7,7 +7,7 @@
     <AuxClasspathEntry>/Users/pugh/Documents/fb-trunk/findbugs/lib/findbugs.jar</AuxClasspathEntry>
     <AuxClasspathEntry>/Users/pugh/Documents/fb-trunk/findbugs/lib/jdepend-2.9.jar</AuxClasspathEntry>
     <AuxClasspathEntry>/Users/pugh/Documents/fb-trunk/findbugs/lib/bcel.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/Users/pugh/Documents/fb-trunk/findbugs/lib/dom4j-2.1.1.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/pugh/Documents/fb-trunk/findbugs/lib/dom4j-2.1.3.jar</AuxClasspathEntry>
     <AuxClasspathEntry>/Users/pugh/Documents/fb-trunk/findbugs/lib/AppleJavaExtensions.jar</AuxClasspathEntry>
     <AuxClasspathEntry>/Users/pugh/Documents/fb-trunk/findbugs/lib/junit.jar</AuxClasspathEntry>
     <AuxClasspathEntry>/Users/pugh/Documents/fb-trunk/findbugs/lib/asm-7.3.1.jar</AuxClasspathEntry>


### PR DESCRIPTION
This PR close #1122 by upgrading dom4j from 2.1.1 to 2.1.3.
To avoid a known bug https://github.com/dom4j/dom4j/issues/85 added some hack into `spotbugs/build.gradle` to exclude all optional dependencies. Refer https://github.com/spotbugs/spotbugs/issues/1122#issuecomment-627293820 to find the actual dependencies in this branch.