### PR TITLE
Release SpotBugs 4.0.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,7 @@ jobs:
         # https://github.com/actions/upload-release-asset/issues/28#issuecomment-617208601
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: startsWith(github.ref, 'refs/tags/')
         run: |
           set -x
           curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased - 2020-??-??
+
 ## 4.0.4 - 2020-06-09
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased - 2020-??-??
+## 4.0.4 - 2020-06-09
 ### Security
 
 * Update dom4j to 2.1.3 to fix security vulnerability. ([#1122](https://github.com/spotbugs/spotbugs/issues/1122))

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ apply plugin: "org.sonarqube"
 apply plugin: "com.diffplug.gradle.spotless"
 apply plugin: "org.gradle.crypto.checksum"
 
-version = '4.0.4'
+version = '4.0.5-SNAPSHOT'
 
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/jacoco.gradle"

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ apply plugin: "org.sonarqube"
 apply plugin: "com.diffplug.gradle.spotless"
 apply plugin: "org.gradle.crypto.checksum"
 
-version = '4.0.4-SNAPSHOT'
+version = '4.0.4'
 
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/jacoco.gradle"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,9 +17,9 @@ import os
 
 html_context = {
   'version' : '4.0',
-  'full_version' : '4.0.3',
+  'full_version' : '4.0.4',
   'maven_plugin_version' : '4.0.0',
-  'gradle_plugin_version' : '4.0.8',
+  'gradle_plugin_version' : '4.3.0',
   'archetype_version' : '0.2.3'
 }
 


### PR DESCRIPTION
This release contains a security fix. #1122 

[//]: # (rtdbot-start)

URL of RTD documents:
en: https://spotbugs.readthedocs.io/en/release-4.0.4/
ja: https://spotbugs.readthedocs.io/ja/release-4.0.4/

[//]: # (rtdbot-end)
