### PR TITLE
Remove "refs/tags/" from the name of tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,10 @@ jobs:
           personal_token: ${{ secrets.PERSONAL_TOKEN_FOR_PAGES }}
           publish_branch: gh-pages
           publish_dir: ./eclipsePlugin/build/site/eclipse
+      - name: Get the version
+        if: startsWith(github.ref, 'refs/tags/')
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
       - name: Create Release
         # attach zip, tgz and eclipse plugin to the GitHub Release
         # https://github.com/github/hub#github-actions
@@ -76,4 +80,4 @@ jobs:
           for asset in ./spotbugs/build/distributions/*; do
             assets+=("-a" "$asset")
           done
-          bin/hub release create "${assets[@]}" -F build/release.md "${{ github.ref }}"
+          bin/hub release create "${assets[@]}" -F build/release.md "${{ steps.get_version.outputs.VERSION }}"


### PR DESCRIPTION
#1132 worked well, and now the release page can be generated automatically.
e.g. https://github.com/spotbugs/spotbugs/releases/tag/4.0.4

But currently, it uses `refs/tags/$VERSION` as a tag name, so I need to rename the tag of the release page manually.
This change will remove this manual operation for the next release.