### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -8,8 +8,8 @@ When you find problems such as false-positives or false-negatives, consider to a
 Just three steps to follow:
 
 1. Create a [minimum and complete](http://stackoverflow.com/help/mcve) .java file under `spotbugsTestCases/src/java` directory.
-2. Create a unit test case under `spotbugs/src/test/java` directory, Refer [pull request #69](https://github.com/spotbugs/spotbugs/pull/69/files) as example.
-3. Confirm that `./gradlew clean spotbugs:build` is failed by your new unit test case.
+2. Create a unit test case under `spotbugs-tests/src/test/java` directory, Refer to [this commit](https://github.com/spotbugs/spotbugs/commit/c05c0f029c7ae4874791fddbd6e954c5908b80ff) as example.
+3. Confirm that `./gradlew clean build` is failed by your new unit test case.
 
 ## Before you propose new rules
 


### PR DESCRIPTION
I found that the provided pointers to the CONTRIBUTING guide are very old in 2 ways.
1) The welcome bot sends you to an ancient version that is no longer accurate.
    https://github.com/spotbugs/spotbugs/blob/release-3.1/.github/CONTRIBUTING.md
I would expect this to be a better one
   https://github.com/spotbugs/spotbugs/blob/master/.github/CONTRIBUTING.md
2) The content shows things that are no longer correct as the tree of this project has apparently changed over the years.

This pull request only contains what I would expect to be the correct instructions.
I'm NOT SURE these are correct, I just think they are better.

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [ ] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
