### PR TITLE
Update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased - 2020-??-??
+### Changed
+
+* Bump up Apache Commons BCEL to the version 6.5.0
 
 ## 4.0.4 - 2020-06-09
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased - 2020-??-??
+### Fixed
+
+* dependency conflict around apache-commons-lang3 ([#1135](https://github.com/spotbugs/spotbugs/issues/1135))
+
 ### Changed
 
 * Bump up Apache Commons BCEL to the version 6.5.0

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -75,8 +75,16 @@ dependencies {
     exclude group: 'xpp3',             module: 'xpp3'
   }
   implementation 'jaxen:jaxen:1.1.6' // only transitive through dom4j:dom4j:1.6.1, which has an *optional* dependency on jaxen:jaxen.
-  api 'org.apache.commons:commons-lang3:3.10'
-  api 'org.apache.commons:commons-text:1.8'
+  api 'org.apache.commons:commons-lang3'
+  api 'org.apache.commons:commons-text'
+  constraints {
+    implementation('org.apache.commons:commons-text:1.8') {
+      because 'this is the latest version'
+    }
+    implementation('org.apache.commons:commons-lang3:3.10') {
+      because 'version 3.9 pulled from commons-text is too old, and commons-text has no later release'
+    }
+  }
   api 'org.slf4j:slf4j-api:1.8.0-beta4'
   implementation 'net.sf.saxon:Saxon-HE:9.9.1-2'
   logBinding 'org.apache.logging.log4j:log4j-slf4j18-impl:2.13.1'
@@ -91,12 +99,9 @@ dependencies {
   testImplementation sourceSets.gui.output
 
   guiImplementation sourceSets.main.runtimeClasspath
-  guiImplementation 'org.apache.commons:commons-lang3:3.10'
-  guiImplementation 'org.apache.commons:commons-text:1.8'
   guiCompileOnly 'com.apple:AppleJavaExtensions:1.4'
   guiCompileOnly project(':spotbugs-annotations')
   guiTestImplementation sourceSets.gui.runtimeClasspath
-  guiTestImplementation 'junit:junit:4.12'
   guiTestCompileOnly project(':spotbugs-annotations')
 }
 

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -102,6 +102,7 @@ dependencies {
   guiCompileOnly 'com.apple:AppleJavaExtensions:1.4'
   guiCompileOnly project(':spotbugs-annotations')
   guiTestImplementation sourceSets.gui.runtimeClasspath
+  guiTestImplementation 'junit:junit:4.12'
   guiTestCompileOnly project(':spotbugs-annotations')
 }
 

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -78,10 +78,10 @@ dependencies {
   api 'org.apache.commons:commons-lang3'
   api 'org.apache.commons:commons-text'
   constraints {
-    implementation('org.apache.commons:commons-text:1.8') {
+    api ('org.apache.commons:commons-text:1.8') {
       because 'this is the latest version'
     }
-    implementation('org.apache.commons:commons-lang3:3.10') {
+    api ('org.apache.commons:commons-lang3:3.10') {
       because 'version 3.9 pulled from commons-text is too old, and commons-text has no later release'
     }
   }

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -61,7 +61,7 @@ dependencies {
   api 'org.ow2.asm:asm-commons:8.0.1'
   api 'org.ow2.asm:asm-tree:8.0.1'
   api 'org.ow2.asm:asm-util:8.0.1'
-  api 'org.apache.bcel:bcel:6.4.1'
+  api 'org.apache.bcel:bcel:6.5.0'
   api 'net.jcip:jcip-annotations:1.0'
   api('org.dom4j:dom4j:2.1.3') {
     // exclude transitive dependencies to keep compatible with dom4j 2.1.1


### PR DESCRIPTION
This PR fixes #1135, and bump up BCEL to the latest 6.5.0. Here is result of `./gradlew dependencies`:

```
compileClasspath - Compile classpath for source set 'main'.
+--- org.ow2.asm:asm:8.0.1
+--- org.ow2.asm:asm-analysis:8.0.1
|    \--- org.ow2.asm:asm-tree:8.0.1
|         \--- org.ow2.asm:asm:8.0.1
+--- org.ow2.asm:asm-commons:8.0.1
|    +--- org.ow2.asm:asm:8.0.1
|    +--- org.ow2.asm:asm-tree:8.0.1 (*)
|    \--- org.ow2.asm:asm-analysis:8.0.1 (*)
+--- org.ow2.asm:asm-tree:8.0.1 (*)
+--- org.ow2.asm:asm-util:8.0.1
|    +--- org.ow2.asm:asm:8.0.1
|    +--- org.ow2.asm:asm-tree:8.0.1 (*)
|    \--- org.ow2.asm:asm-analysis:8.0.1 (*)
+--- org.apache.bcel:bcel:6.5.0
+--- net.jcip:jcip-annotations:1.0
+--- org.dom4j:dom4j:2.1.3
+--- org.apache.commons:commons-lang3 -> 3.10
+--- org.apache.commons:commons-text -> 1.8
|    \--- org.apache.commons:commons-lang3:3.9 -> 3.10
+--- org.slf4j:slf4j-api:1.8.0-beta4
+--- project :spotbugs-annotations
|    \--- com.google.code.findbugs:jsr305:3.0.2
+--- jaxen:jaxen:1.1.6
+--- net.sf.saxon:Saxon-HE:9.9.1-2
|    \--- com.ibm.icu:icu4j:63.1
+--- org.apache.commons:commons-text:1.8 (c)
\--- org.apache.commons:commons-lang3:3.10 (c)
```