### PR TITLE
plain.xsl declares it is a 2.0 stylesheet, but it appears to have iss…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 ### Fixed
 
 * dependency conflict around apache-commons-lang3 ([#1135](https://github.com/spotbugs/spotbugs/issues/1135))
+* plain.xsl declares it is a 2.0 stylesheet, but it appears to have issues with a 2.0 processor
 
 ### Changed
 

--- a/spotbugs/src/xsl/plain.xsl
+++ b/spotbugs/src/xsl/plain.xsl
@@ -25,7 +25,7 @@
 <xsl:output
 	method="xml"
 	omit-xml-declaration="yes"
-	standalone="yes"
+	standalone="omit"
          doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"
          doctype-public="-//W3C//DTD XHTML 1.0 Transitional//EN"
 	indent="yes"


### PR DESCRIPTION
…ues with a 2.0 processor

The same problem with default.xsl was solved here: https://github.com/spotbugs/spotbugs/pull/1000

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
