### PR TITLE
Ensure the Eclipse plugin contains spotbugs.jar

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,14 +26,14 @@ jobs:
         run: |
           wget -nv 'https://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops4/R-4.6.3-201703010400/eclipse-SDK-4.6.3-linux-gtk-x86_64.tar.gz&r=1' -O eclipse-SDK-4.6.3-linux-gtk-x86_64.tar.gz
           tar xzvf eclipse-SDK-4.6.3-linux-gtk-x86_64.tar.gz eclipse
-          echo "eclipseRoot.dir=$(pwd)/eclipse" > eclipsePlugin/local.properties
+          echo "eclipseRoot.dir=$(pwd)/eclipse" | tee eclipsePlugin/local.properties
       - name: Build
         # https://community.sonarsource.com/t/sonarcloud-now-not-updating-github-pr-and-checks/6595/17
         run: |
           echo "keystorepass=${KEYSTORE_PASS}" >> gradle.properties
           git fetch --no-tags https://$GITHUB_TOKEN@github.com/spotbugs/spotbugs.git +refs/heads/master:refs/remotes/origin/master
           gpg --quiet --batch --yes --decrypt --passphrase="$GPG_SECRET_PASSPHRASE" --output spotbugs.jks .github/workflows/spotbugs.jks.gpg
-          ./gradlew spotlessCheck build smoketest sonarqube --no-daemon --parallel -Dsonar.login=$SONAR_LOGIN
+          ./gradlew spotlessCheck build smoketest sonarqube --no-daemon -Dsonar.login=$SONAR_LOGIN
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_SECRET_PASSPHRASE: ${{ secrets.GPG_SECRET_PASSPHRASE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           echo ossrhUsername=eller86 >> gradle.properties
           echo "ossrhPassword=${SONATYPE_PASSWORD}" >> gradle.properties
           echo "keystorepass=${KEYSTORE_PASS}" >> gradle.properties
-          ./gradlew assemble publish createReleaseBody --no-daemon --parallel
+          ./gradlew assemble publish createReleaseBody --no-daemon
         env:
           GPG_SECRET_PASSPHRASE: ${{ secrets.GPG_SECRET_PASSPHRASE }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 ### Fixed
 
 * dependency conflict around apache-commons-lang3 ([#1135](https://github.com/spotbugs/spotbugs/issues/1135))
+* eclipse plugin does not contain `lib/spotbugs.jar`  ([#1158](https://github.com/spotbugs/spotbugs/issues/1158))
 
 ### Changed
 

--- a/eclipsePlugin/build.gradle
+++ b/eclipsePlugin/build.gradle
@@ -234,10 +234,24 @@ task distZip(type:Zip, dependsOn:jar) {
   archiveName = "${eclipsePluginId}_${project.version}.zip"
 }
 
+task testPluginJar {
+  doLast {
+    def spotbugsJar = zipTree("$buildDir/site/eclipse/plugins/${eclipsePluginId}_${project.version}.jar")
+            .matching { include 'lib/spotbugs.jar' }
+            .singleFile
+    if (!spotbugsJar.exists()) {
+      throw GradleException('Eclipse plugin does not contain spotbugs.jar');
+    } else {
+      println 'Eclipse plugin contains spotbugs.jar'
+    }
+  }
+}
+
 task pluginJar(type:Zip, dependsOn:jar) { // use Zip task, we already provide a manifest
   with distSpec
   archiveName = "${eclipsePluginId}_${project.version}.jar"
   destinationDir = file("${buildDir}/site/eclipse/plugins/")
+  finalizedBy testPluginJar
 }
 
 task pluginCandidateJar(type:Copy, dependsOn:pluginJar) {


### PR DESCRIPTION
The current build script around Eclipse does not handle task dependencies in a proper way.
To apply the permanent fix, we probably need to refactor the build script, then firstly merge this PR as a hotfix.

close #1158