### PR TITLE
Use GitHub Secrets only when they are accessible

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,19 +27,17 @@ jobs:
           wget -nv 'https://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops4/R-4.6.3-201703010400/eclipse-SDK-4.6.3-linux-gtk-x86_64.tar.gz&r=1' -O eclipse-SDK-4.6.3-linux-gtk-x86_64.tar.gz
           tar xzvf eclipse-SDK-4.6.3-linux-gtk-x86_64.tar.gz eclipse
           echo "eclipseRoot.dir=$(pwd)/eclipse" > eclipsePlugin/local.properties
-      - name: Extract GitHub Secrets to local files
-        run: |
-          echo "keystorepass=${KEYSTORE_PASS}" >> gradle.properties
-          gpg --quiet --batch --yes --decrypt --passphrase="$GPG_SECRET_PASSPHRASE" --output spotbugs.jks .github/workflows/spotbugs.jks.gpg
-        env:
-          GPG_SECRET_PASSPHRASE: ${{ secrets.GPG_SECRET_PASSPHRASE }}
-          KEYSTORE_PASS: ${{ secrets.KEYSTORE_PASS }}
-        if: ${{ GPG_SECRET_PASSPHRASE != '' }}
       - name: Build
         # https://community.sonarsource.com/t/sonarcloud-now-not-updating-github-pr-and-checks/6595/17
         run: |
+          echo "keystorepass=${KEYSTORE_PASS}" >> gradle.properties
+          if ["$GPG_SECRET_PASSPHRASE" != ""]; then
+            gpg --quiet --batch --yes --decrypt --passphrase="$GPG_SECRET_PASSPHRASE" --output spotbugs.jks .github/workflows/spotbugs.jks.gpg
+          fi
           git fetch --no-tags https://$GITHUB_TOKEN@github.com/spotbugs/spotbugs.git +refs/heads/master:refs/remotes/origin/master
           ./gradlew spotlessCheck build smoketest sonarqube --no-daemon --parallel -Dsonar.login=$SONAR_LOGIN
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GPG_SECRET_PASSPHRASE: ${{ secrets.GPG_SECRET_PASSPHRASE }}
+          KEYSTORE_PASS: ${{ secrets.KEYSTORE_PASS }}
           SONAR_LOGIN: ${{ secrets.SONAR_LOGIN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,13 +28,13 @@ jobs:
           tar xzvf eclipse-SDK-4.6.3-linux-gtk-x86_64.tar.gz eclipse
           echo "eclipseRoot.dir=$(pwd)/eclipse" > eclipsePlugin/local.properties
       - name: Extract GitHub Secrets to local files
-        if: ${{ GPG_SECRET_PASSPHRASE != '' }}
         run: |
           echo "keystorepass=${KEYSTORE_PASS}" >> gradle.properties
           gpg --quiet --batch --yes --decrypt --passphrase="$GPG_SECRET_PASSPHRASE" --output spotbugs.jks .github/workflows/spotbugs.jks.gpg
         env:
           GPG_SECRET_PASSPHRASE: ${{ secrets.GPG_SECRET_PASSPHRASE }}
           KEYSTORE_PASS: ${{ secrets.KEYSTORE_PASS }}
+        if: ${{ GPG_SECRET_PASSPHRASE != '' }}
       - name: Build
         # https://community.sonarsource.com/t/sonarcloud-now-not-updating-github-pr-and-checks/6595/17
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,8 +32,8 @@ jobs:
         run: |
           echo "keystorepass=${KEYSTORE_PASS}" >> gradle.properties
           git fetch --no-tags https://$GITHUB_TOKEN@github.com/spotbugs/spotbugs.git +refs/heads/master:refs/remotes/origin/master
-          if ["$GPG_SECRET_PASSPHRASE" != ""]; then
-            gpg --quiet --batch --yes --decrypt --passphrase="$GPG_SECRET_PASSPHRASE" --output spotbugs.jks .github/workflows/spotbugs.jks.gpg
+          if [ "$GPG_SECRET_PASSPHRASE" != "" ]; then
+            gpg --quiet --batch --yes --decrypt --passphrase="$GPG_SECRET_PASSPHRASE" --output spotbugs.jks .github/workflows/spotbugs.jks.gpg;
           fi
           ./gradlew spotlessCheck build smoketest sonarqube --no-daemon --parallel -Dsonar.login=$SONAR_LOGIN
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
           tar xzvf eclipse-SDK-4.6.3-linux-gtk-x86_64.tar.gz eclipse
           echo "eclipseRoot.dir=$(pwd)/eclipse" > eclipsePlugin/local.properties
       - name: Extract GitHub Secrets to local files
-        if: ${{ secrets.GPG_SECRET_PASSPHRASE != '' }}
+        if: ${{ GPG_SECRET_PASSPHRASE != '' }}
         run: |
           echo "keystorepass=${KEYSTORE_PASS}" >> gradle.properties
           gpg --quiet --batch --yes --decrypt --passphrase="$GPG_SECRET_PASSPHRASE" --output spotbugs.jks .github/workflows/spotbugs.jks.gpg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,10 +31,10 @@ jobs:
         # https://community.sonarsource.com/t/sonarcloud-now-not-updating-github-pr-and-checks/6595/17
         run: |
           echo "keystorepass=${KEYSTORE_PASS}" >> gradle.properties
+          git fetch --no-tags https://$GITHUB_TOKEN@github.com/spotbugs/spotbugs.git +refs/heads/master:refs/remotes/origin/master
           if ["$GPG_SECRET_PASSPHRASE" != ""]; then
             gpg --quiet --batch --yes --decrypt --passphrase="$GPG_SECRET_PASSPHRASE" --output spotbugs.jks .github/workflows/spotbugs.jks.gpg
           fi
-          git fetch --no-tags https://$GITHUB_TOKEN@github.com/spotbugs/spotbugs.git +refs/heads/master:refs/remotes/origin/master
           ./gradlew spotlessCheck build smoketest sonarqube --no-daemon --parallel -Dsonar.login=$SONAR_LOGIN
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,15 +27,19 @@ jobs:
           wget -nv 'https://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops4/R-4.6.3-201703010400/eclipse-SDK-4.6.3-linux-gtk-x86_64.tar.gz&r=1' -O eclipse-SDK-4.6.3-linux-gtk-x86_64.tar.gz
           tar xzvf eclipse-SDK-4.6.3-linux-gtk-x86_64.tar.gz eclipse
           echo "eclipseRoot.dir=$(pwd)/eclipse" > eclipsePlugin/local.properties
+      - name: Extract GitHub Secrets to local files
+        if: ${{ secrets.GPG_SECRET_PASSPHRASE != '' }}
+        run: |
+          echo "keystorepass=${KEYSTORE_PASS}" >> gradle.properties
+          gpg --quiet --batch --yes --decrypt --passphrase="$GPG_SECRET_PASSPHRASE" --output spotbugs.jks .github/workflows/spotbugs.jks.gpg
+        env:
+          GPG_SECRET_PASSPHRASE: ${{ secrets.GPG_SECRET_PASSPHRASE }}
+          KEYSTORE_PASS: ${{ secrets.KEYSTORE_PASS }}
       - name: Build
         # https://community.sonarsource.com/t/sonarcloud-now-not-updating-github-pr-and-checks/6595/17
         run: |
-          echo "keystorepass=${KEYSTORE_PASS}" >> gradle.properties
           git fetch --no-tags https://$GITHUB_TOKEN@github.com/spotbugs/spotbugs.git +refs/heads/master:refs/remotes/origin/master
-          gpg --quiet --batch --yes --decrypt --passphrase="$GPG_SECRET_PASSPHRASE" --output spotbugs.jks .github/workflows/spotbugs.jks.gpg
           ./gradlew spotlessCheck build smoketest sonarqube --no-daemon --parallel -Dsonar.login=$SONAR_LOGIN
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GPG_SECRET_PASSPHRASE: ${{ secrets.GPG_SECRET_PASSPHRASE }}
-          KEYSTORE_PASS: ${{ secrets.KEYSTORE_PASS }}
           SONAR_LOGIN: ${{ secrets.SONAR_LOGIN }}


### PR DESCRIPTION
Invoke `gpg` command only when the GitHub Secrets are accessible.
Note that [the GitHub Secrets are not accessible for PR from forked repo](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets#using-encrypted-secrets-in-a-workflow).

close #1163