### PR TITLE
Release 4.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased - 2020-??-??
+
 ## 4.0.5 - 2020-06-20
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased - 2020-??-??
+## 4.0.5 - 2020-06-20
 ### Fixed
 
 * dependency conflict around apache-commons-lang3 ([#1135](https://github.com/spotbugs/spotbugs/issues/1135))

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ apply plugin: "org.sonarqube"
 apply plugin: "com.diffplug.gradle.spotless"
 apply plugin: "org.gradle.crypto.checksum"
 
-version = '4.0.5-SNAPSHOT'
+version = '4.0.5'
 
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/jacoco.gradle"

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ apply plugin: "org.sonarqube"
 apply plugin: "com.diffplug.gradle.spotless"
 apply plugin: "org.gradle.crypto.checksum"
 
-version = '4.0.5'
+version = '4.0.6-SNAPSHOT'
 
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/jacoco.gradle"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,9 +17,9 @@ import os
 
 html_context = {
   'version' : '4.0',
-  'full_version' : '4.0.4',
-  'maven_plugin_version' : '4.0.0',
-  'gradle_plugin_version' : '4.3.0',
+  'full_version' : '4.0.5',
+  'maven_plugin_version' : '4.0.4',
+  'gradle_plugin_version' : '4.4.1',
   'archetype_version' : '0.2.3'
 }
 


### PR DESCRIPTION
This release is mainly to fix the eclipse update site #1158.

[//]: # (rtdbot-start)

URL of RTD documents:
en: https://spotbugs.readthedocs.io/en/release-4.0.5/
ja: https://spotbugs.readthedocs.io/ja/release-4.0.5/

[//]: # (rtdbot-end)
