### PR TITLE
Bump up org.sonarqube plugin to 3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,32 +1,8 @@
-buildscript {
-  repositories {
-    maven {
-      url "https://plugins.gradle.org/m2/"
-    }
-  }
-  dependencies {
-    classpath "com.diffplug.spotless:spotless-plugin-gradle:3.27.1"
-
-    classpath "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin"
-    constraints {
-      classpath ("org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.8") {
-        because 'to keep using the latest version'
-      }
-      classpath ('org.sonarsource.scanner.api:sonar-scanner-api:2.15.0.2182') {
-        because 'version 2.14 has a connection leak bug (SC-1431)'
-      }
-      classpath ('org.sonarsource.sonarqube:sonar-scanner-engine:8.3.1.34397') {
-        because 'make sure the DefaultScannerWsClient in the CLASSPATH is updated'
-      }
-    }
-
-    classpath "gradle.plugin.org.gradle.crypto:checksum:1.2.0"
-  }
+plugins {
+  id "org.sonarqube" version "3.0"
+  id "com.diffplug.gradle.spotless" version "4.4.0"
+  id "org.gradle.crypto.checksum" version "1.2.0"
 }
-
-apply plugin: "org.sonarqube"
-apply plugin: "com.diffplug.gradle.spotless"
-apply plugin: "org.gradle.crypto.checksum"
 
 version = '4.0.5-SNAPSHOT'
 


### PR DESCRIPTION
This version uses the latest sonarqube-scanner-api that contains the following resource leak:
https://github.com/SonarSource/sonar-scanner-api/commit/c0c757f2ae7f700d6eb586dbb6a86ac3f4aa4999

So we do not need to use `buildscript {}` to bump up the transitive dependency of `org.soanrqube` plugin.
refs #1133