### PR TITLE
feat: integrate SARIF bug reporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased - 2020-??-??
+### Added
+* Support for the SARIF 2.1.0 report ([discuss#95](https://github.com/spotbugs/discuss/issues/95))
+
 ### Fixed
 * Fixed not working detector 'CbeckMustOverrideSuperAnnotation' and renamed to 'OverridingMethodsMustInvokeSuperDetector'
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
   id "com.github.spotbugs" version "4.4.4"
 }
 
-version = '4.0.7-SNAPSHOT'
+version = '4.1.0-SNAPSHOT'
 
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/jacoco.gradle"

--- a/docs/locale/ja/LC_MESSAGES/running.po
+++ b/docs/locale/ja/LC_MESSAGES/running.po
@@ -7,20 +7,20 @@ msgid ""
 msgstr ""
 "Project-Id-Version: spotbugs 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-11-05 12:44+0000\n"
+"POT-Creation-Date: 2020-07-02 22:46+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.7.0\n"
+"Generated-By: Babel 2.8.0\n"
 
-#: ../../running.rst:2
+#: /documents/docs/running.rst:2
 msgid "Running SpotBugs"
 msgstr "SpotBugs の実行"
 
-#: ../../running.rst:4
+#: /documents/docs/running.rst:4
 msgid ""
 "SpotBugs has two user interfaces: a graphical user interface (GUI) and a "
 "command line user interface. This chapter describes how to run each of "
@@ -29,11 +29,11 @@ msgstr ""
 "SpotBugs には，グラフィカルユーザインターフェイス (GUI) "
 "とコマンドラインユーザインターフェイスの2つのユーザインターフェイスがあります。この章では，それぞれのユーザインタフェースを実行する方法について説明します。"
 
-#: ../../running.rst:8
+#: /documents/docs/running.rst:8
 msgid "Quick Start"
 msgstr "クイックスタート"
 
-#: ../../running.rst:10
+#: /documents/docs/running.rst:10
 msgid ""
 "If you are running SpotBugs on a Windows system, double-click on the file"
 " ``%SPOTBUGS_HOME%\\lib\\spotbugs.jar`` to start the SpotBugs GUI."
@@ -41,7 +41,7 @@ msgstr ""
 "Windows で SpotBugs を実行するときは，``%SPOTBUGS_HOME%\\lib\\spotbugs.jar`` "
 "ファイルをダブルクリックして SpotBugs GUI を起動します。"
 
-#: ../../running.rst:12
+#: /documents/docs/running.rst:12
 msgid ""
 "On a Unix, Linux, or macOS system, run the "
 "``$SPOTBUGS_HOME/bin/spotbugs`` script, or run the command ``java -jar "
@@ -50,15 +50,15 @@ msgstr ""
 "Unix，Linux，macOS では，  ``$SPOTBUGS_HOME/bin/spotbugs`` スクリプト，または ``java "
 "-jar $SPOTBUGS_HOME/lib/spotbugs.jar`` コマンドで SpotBugs GUI を実行します。"
 
-#: ../../running.rst:14
+#: /documents/docs/running.rst:14
 msgid "Refer to :doc:`gui` for information on how to use the GUI."
 msgstr "GUI の使い方は :doc:`gui` を参照してください。"
 
-#: ../../running.rst:17
+#: /documents/docs/running.rst:17
 msgid "Executing SpotBugs"
 msgstr "SpotBugs の実行"
 
-#: ../../running.rst:19
+#: /documents/docs/running.rst:19
 msgid ""
 "This section describes how to invoke the SpotBugs program. There are two "
 "ways to invoke SpotBugs: directly, or using a wrapper script."
@@ -66,11 +66,11 @@ msgstr ""
 "この節では，SpotBugs プログラムを起動する方法について説明します。SpotBugs "
 "を起動するためには，直接，またはラッパースクリプトを使用する2つの方法があります。"
 
-#: ../../running.rst:23
+#: /documents/docs/running.rst:23
 msgid "Direct invocation of SpotBugs"
 msgstr "SpotBugs の直接起動"
 
-#: ../../running.rst:25
+#: /documents/docs/running.rst:25
 msgid ""
 "The preferred method of running SpotBugs is to directly execute "
 "``$SPOTBUGS_HOME/lib/spotbugs.jar`` using the -jar command line switch of"
@@ -81,73 +81,73 @@ msgstr ""
 "``$SPOTBUGS_HOME/lib/spotbugs.jar`` を直接実行する方法を推奨します。(バージョン 1.3.5 以前の "
 "SpotBugs では，SpotBugs を起動するためのラッパースクリプトが必要でした。)"
 
-#: ../../running.rst:28
+#: /documents/docs/running.rst:28
 msgid "The general syntax of invoking SpotBugs directly is the following:"
 msgstr "SpotBugs を直接起動する一般的な構文は次のようになります。"
 
-#: ../../running.rst:35
+#: /documents/docs/running.rst:35
 msgid "Choosing the User Interface"
 msgstr "ユーザインタフェースの選択"
 
-#: ../../running.rst:37
+#: /documents/docs/running.rst:37
 msgid ""
 "The first command line option chooses the SpotBugs user interface to "
 "execute. Possible values are:"
 msgstr "最初のコマンドラインオプションは，実行する SpotBugs ユーザインタフェースの選択です。指定可能な値は次のとおりです。"
 
-#: ../../running.rst:40
+#: /documents/docs/running.rst:40
 msgid "-gui:"
 msgstr ""
 
-#: ../../running.rst:40
+#: /documents/docs/running.rst:40
 msgid "runs the graphical user interface (GUI)"
 msgstr "グラフィカルユーザインタフェース (GUI) の実行"
 
-#: ../../running.rst:43
+#: /documents/docs/running.rst:43
 msgid "-textui:"
 msgstr ""
 
-#: ../../running.rst:43
+#: /documents/docs/running.rst:43
 msgid "runs the command line user interface"
 msgstr "コマンドラインユーザインタフェースの実行"
 
-#: ../../running.rst:46
+#: /documents/docs/running.rst:46
 msgid "-version:"
 msgstr ""
 
-#: ../../running.rst:46
+#: /documents/docs/running.rst:46
 msgid "displays the SpotBugs version number"
 msgstr "SpotBugs のバージョン番号の表示"
 
-#: ../../running.rst:49
+#: /documents/docs/running.rst:49
 msgid "-help:"
 msgstr ""
 
-#: ../../running.rst:49
+#: /documents/docs/running.rst:49
 msgid "displays help information for the SpotBugs command line user interface"
 msgstr "SpotBugs コマンドラインユーザインタフェースに関するヘルプ情報の表示"
 
-#: ../../running.rst:52
+#: /documents/docs/running.rst:52
 msgid "-gui1:"
 msgstr ""
 
-#: ../../running.rst:52
+#: /documents/docs/running.rst:52
 msgid "executes the original (obsolete) SpotBugs graphical user interface"
 msgstr "オリジナル SpotBugs グラフィカルユーザインタフェース (廃止されている) の実行"
 
-#: ../../running.rst:55
+#: /documents/docs/running.rst:55
 msgid "Java Virtual Machine (JVM) arguments"
 msgstr "Java 仮想マシン (JVM) の引数"
 
-#: ../../running.rst:57
+#: /documents/docs/running.rst:57
 msgid "Several Java Virtual Machine arguments are useful when invoking SpotBugs."
 msgstr "Java 仮想マシンのいくつかの引数は，SpotBugs を起動するときに役立ちます。"
 
-#: ../../running.rst:62
+#: /documents/docs/running.rst:62
 msgid "-XmxNNm:"
 msgstr ""
 
-#: ../../running.rst:60
+#: /documents/docs/running.rst:60
 msgid ""
 "Set the maximum Java heap size to NN megabytes. SpotBugs generally "
 "requires a large amount of memory. For a very large project, using 1500 "
@@ -156,11 +156,11 @@ msgstr ""
 "Java ヒープサイズの最大値を NN メガバイトに設定します。SpotBugs "
 "は，通常大量のメモリを必要とします。巨大なプロジェクトでは，1500メガバイトを使用することは珍しいことではありません。"
 
-#: ../../running.rst:66
+#: /documents/docs/running.rst:66
 msgid "-Dname=value:"
 msgstr ""
 
-#: ../../running.rst:65
+#: /documents/docs/running.rst:65
 msgid ""
 "Set a Java system property. For example, you might use the argument "
 "``-Duser.language=ja`` to display GUI messages in Japanese."
@@ -168,25 +168,25 @@ msgstr ""
 "Java システムプロパティを設定します。たとえば，GUI メッセージを日本語で表示したいときは ``-Duser.language=ja`` "
 "引数を使用します。"
 
-#: ../../running.rst:69
+#: /documents/docs/running.rst:69
 msgid "Invocation of SpotBugs using a wrapper script"
 msgstr "ラッパースクリプトを使用した SpotBugs の起動"
 
-#: ../../running.rst:71
+#: /documents/docs/running.rst:71
 msgid "Another way to run SpotBugs is to use a wrapper script."
 msgstr "SpotBugs を実行するもう一つの方法は，ラッパースクリプトを使うことです。"
 
-#: ../../running.rst:73
+#: /documents/docs/running.rst:73
 msgid ""
 "On Unix-like systems, use the following command to invoke the wrapper "
 "script:"
 msgstr "Unix 系システムでは，次のコマンドを使用してラッパースクリプトを起動します。"
 
-#: ../../running.rst:79
+#: /documents/docs/running.rst:79
 msgid "On Windows systems, the command to invoke the wrapper script is"
 msgstr "Windows では，次のコマンドを使用してラッパースクリプトを起動します。"
 
-#: ../../running.rst:85
+#: /documents/docs/running.rst:85
 msgid ""
 "On both Unix-like and Windows systems, you can simply add the "
 "``$SPOTBUGS_HOME/bin`` directory to your ``PATH`` environment variable "
@@ -195,11 +195,11 @@ msgstr ""
 "Unix 系システムと Windows のどちらでも，``$SPOTBUGS_HOME/bin`` ディレクトリを環境変数 ``PATH`` "
 "に追加するだけで，``spotbugs`` コマンドを使用して SpotBugs を起動できます。"
 
-#: ../../running.rst:88
+#: /documents/docs/running.rst:88
 msgid "Wrapper script command line options"
 msgstr "ラッパースクリプトのコマンドラインオプション"
 
-#: ../../running.rst:90
+#: /documents/docs/running.rst:90
 msgid ""
 "The SpotBugs wrapper scripts support the following command-line options. "
 "Note that these command line options are not handled by the SpotBugs "
@@ -209,31 +209,31 @@ msgstr ""
 "ラッパースクリプトは，次のようなコマンドラインオプションをサポートしています。留意すべきは，これらのコマンドラインオプションは，SpotBugs "
 "プログラム自体では処理されません。それらはラッパースクリプトによって処理されます。"
 
-#: ../../running.rst:98
+#: /documents/docs/running.rst:98
 msgid "-jvmArgs *args*:"
 msgstr ""
 
-#: ../../running.rst:94
+#: /documents/docs/running.rst:94
 msgid ""
 "Specifies arguments to pass to the JVM. For example, you might want to "
 "set a JVM property:"
 msgstr "JVM に渡す引数を指定します。たとえは，JVM プロパティを設定したいとします。"
 
-#: ../../running.rst:101
+#: /documents/docs/running.rst:101
 msgid "-javahome *directory*:"
 msgstr ""
 
-#: ../../running.rst:101
+#: /documents/docs/running.rst:101
 msgid ""
 "Specifies the directory containing the JRE (Java Runtime Environment) to "
 "use to execute FindBugs."
 msgstr "SpotBugs の実行に使用する JRE(Javaランタイム環境) があるディレクトリを指定します。"
 
-#: ../../running.rst:105
+#: /documents/docs/running.rst:105
 msgid "-maxHeap *size*:"
 msgstr ""
 
-#: ../../running.rst:104
+#: /documents/docs/running.rst:104
 msgid ""
 "Specifies the maximum Java heap size in megabytes. The default is 256. "
 "More memory may be required to analyze very large programs or libraries."
@@ -241,21 +241,21 @@ msgstr ""
 "Java "
 "ヒープサイズの最大値をメガバイトで指定します。デフォルトは256です。巨大なプログラムやライブラリを解析するためには，より多くのメモリが必要になることがあります。"
 
-#: ../../running.rst:109
+#: /documents/docs/running.rst:109
 msgid "-debug:"
 msgstr ""
 
-#: ../../running.rst:108
+#: /documents/docs/running.rst:108
 msgid ""
 "Prints a trace of detectors run and classes analyzed to standard output. "
 "Useful for troubleshooting unexpected analysis failures."
 msgstr "ディテクタの実行トレースと解析したクラスを標準出力に出力します。予期しない解析エラーのトラブルシューティングに役立ちます。"
 
-#: ../../running.rst:116
+#: /documents/docs/running.rst:116
 msgid "-property *name=value*:"
 msgstr ""
 
-#: ../../running.rst:112
+#: /documents/docs/running.rst:112
 msgid ""
 "This option sets a system property. SpotBugs uses system properties to "
 "configure analysis options. See :doc:`analysisprops`. You can use this "
@@ -267,11 +267,11 @@ msgstr ""
 "を参照してください。複数のプロパティを設定したいときは，このオプションを複数回使用します。注:ほとんどの Windows "
 "のバージョンでは，name=value 文字列を引用符で囲む必要があります。"
 
-#: ../../running.rst:119
+#: /documents/docs/running.rst:119
 msgid "Command-line Options"
 msgstr "コマンドラインオプション"
 
-#: ../../running.rst:121
+#: /documents/docs/running.rst:121
 msgid ""
 "This section describes the command line options supported by SpotBugs. "
 "These command line options may be used when invoking SpotBugs directly, "
@@ -280,19 +280,19 @@ msgstr ""
 "この節では，SpotBugs でサポートされているコマンドラインオプションについて説明します。これらのコマンドラインオプションは，SpotBugs"
 " を直接起動するとき，またはラッパースクリプトを使用するときに使えます。"
 
-#: ../../running.rst:125
+#: /documents/docs/running.rst:125
 msgid "Common command-line options"
 msgstr "共通のコマンドラインオプション"
 
-#: ../../running.rst:127
+#: /documents/docs/running.rst:127
 msgid "These options may be used with both the GUI and command-line interfaces."
 msgstr "これらのオプションは，GUI とコマンドラインユーザインタフェースの両方で使えます。"
 
-#: ../../running.rst:135
+#: /documents/docs/running.rst:135
 msgid "-effort[:min|less|default|more|max]:"
 msgstr ""
 
-#: ../../running.rst:130
+#: /documents/docs/running.rst:130
 msgid ""
 "Set analysis effort level. The -effort:min disables several analyses that"
 " increase precision but also increase memory consumption. You may want to"
@@ -308,15 +308,14 @@ msgid ""
 " to complete. See :doc:`effort`."
 msgstr ""
 "解析力を設定します。-effort:min は精度を向上させるがメモリ消費量も増やす解析を無効にします。SpotBugs "
-"を実行するためのメモリが不足したり，解析が完了するまでに異常に長い時間がかかるときは，"
-"このオプションを試してみると良いでしょう。詳細は :doc:`effort` を参照してください。"
+"を実行するためのメモリが不足したり，解析が完了するまでに異常に長い時間がかかるときは，このオプションを試してみると良いでしょう。詳細は "
+":doc:`effort` を参照してください。"
 
-
-#: ../../running.rst:139
+#: /documents/docs/running.rst:139
 msgid "-project *project*:"
 msgstr ""
 
-#: ../../running.rst:138
+#: /documents/docs/running.rst:138
 msgid ""
 "Specify a project to be analyzed. The project file you specify should be "
 "one that was created using the GUI interface. It will typically end in "
@@ -325,93 +324,93 @@ msgstr ""
 "解析するプロジェクトを指定します。指定するプロジェクトファイルは，GUI インタフェースを使用して作成したものでなければなりません。拡張子は，通常"
 " .fb または .fbp です。"
 
-#: ../../running.rst:142
+#: /documents/docs/running.rst:142
 msgid "-pluginList <jar1[;jar2...]>:"
 msgstr ""
 
-#: ../../running.rst:142
+#: /documents/docs/running.rst:142
 msgid "Specify list of plugin Jar files to load."
 msgstr ""
 
-#: ../../running.rst:145
+#: /documents/docs/running.rst:145
 msgid "-home <home directory>:"
 msgstr ""
 
-#: ../../running.rst:145
+#: /documents/docs/running.rst:145
 msgid "Specify SpotBugs home directory."
 msgstr ""
 
-#: ../../running.rst:148
+#: /documents/docs/running.rst:148
 msgid "-adjustExperimental:"
 msgstr ""
 
-#: ../../running.rst:148
+#: /documents/docs/running.rst:148
 msgid "Lower priority of experimental Bug Patterns."
 msgstr ""
 
-#: ../../running.rst:151
+#: /documents/docs/running.rst:151
 msgid "-workHard:"
 msgstr ""
 
-#: ../../running.rst:151
+#: /documents/docs/running.rst:151
 msgid "Ensure analysis effort is at least 'default'."
 msgstr ""
 
-#: ../../running.rst:154
+#: /documents/docs/running.rst:154
 msgid "-conserveSpace:"
 msgstr ""
 
-#: ../../running.rst:154
+#: /documents/docs/running.rst:154
 msgid "Same as -effort:min (for backward compatibility)."
 msgstr ""
 
-#: ../../running.rst:157
+#: /documents/docs/running.rst:157
 msgid "GUI Options"
 msgstr "GUI オプション"
 
-#: ../../running.rst:159
+#: /documents/docs/running.rst:159
 msgid "These options are only accepted by the Graphical User Interface."
 msgstr "これらのオプションは，グラフィカルユーザインタフェースだけで受け入れられます。"
 
-#: ../../running.rst:162
+#: /documents/docs/running.rst:162
 msgid "-look:plastic|gtk|native:"
 msgstr ""
 
-#: ../../running.rst:162
+#: /documents/docs/running.rst:162
 msgid "Set Swing look and feel."
 msgstr "Swing のルック & フィールを設定します。"
 
-#: ../../running.rst:165
+#: /documents/docs/running.rst:165
 msgid "Text UI Options"
 msgstr "テキスト UI オプション"
 
-#: ../../running.rst:167
+#: /documents/docs/running.rst:167
 msgid "These options are only accepted by the Text User Interface."
 msgstr "これらのオプションは，テキストユーザインタフェースだけで受け入れられます。"
 
-#: ../../running.rst:170
+#: /documents/docs/running.rst:170
 msgid "-sortByClass:"
 msgstr ""
 
-#: ../../running.rst:170
+#: /documents/docs/running.rst:170
 msgid "Sort reported bug instances by class name."
 msgstr "報告されたバグインスタンスをクラス名でソートします。"
 
-#: ../../running.rst:174
+#: /documents/docs/running.rst:174
 msgid "-include *filterFile.xml*:"
 msgstr ""
 
-#: ../../running.rst:173
+#: /documents/docs/running.rst:173
 msgid ""
 "Only report bug instances that match the filter specified by "
 "filterFile.xml. See :doc:`filter`."
 msgstr "filterFile.xml で指定したフィルタと一致するバグインスタンスだけを報告します。:doc:`filter` を参照してください。"
 
-#: ../../running.rst:178
+#: /documents/docs/running.rst:178
 msgid "-exclude *filterFile.xml*:"
 msgstr ""
 
-#: ../../running.rst:177
+#: /documents/docs/running.rst:177
 msgid ""
 "Report all bug instances except those matching the filter specified by "
 "filterFile.xml. See :doc:`filter`."
@@ -419,11 +418,11 @@ msgstr ""
 "filterFile.xml で指定したフィルタと一致するもの以外のすべてのバグインスタンスを報告します。:doc:`filter` "
 "を参照してください。"
 
-#: ../../running.rst:185
+#: /documents/docs/running.rst:185
 msgid "-onlyAnalyze *com.foobar.MyClass,com.foobar.mypkg.**:"
 msgstr ""
 
-#: ../../running.rst:181
+#: /documents/docs/running.rst:181
 msgid ""
 "Restrict analysis to find bugs to given comma-separated list of classes "
 "and packages. Unlike filtering, this option avoids running analysis on "
@@ -441,45 +440,45 @@ msgstr ""
 "Java import 文と同じ方法で指定する必要があります (つまり，パッケージの完全な名前に .* を追加します)。 .* を .- "
 "に換えるとすべてのサブパッケージも解析できます。"
 
-#: ../../running.rst:188
+#: /documents/docs/running.rst:188
 msgid "-low:"
 msgstr ""
 
-#: ../../running.rst:188
+#: /documents/docs/running.rst:188
 msgid "Report all bugs."
 msgstr "すべてのバグを報告します。"
 
-#: ../../running.rst:191
+#: /documents/docs/running.rst:191
 msgid "-medium:"
 msgstr ""
 
-#: ../../running.rst:191
+#: /documents/docs/running.rst:191
 msgid "Report medium and high priority bugs. This is the default setting."
 msgstr "優先度が中・高のバグを報告します。デフォルトの設定です。"
 
-#: ../../running.rst:194
+#: /documents/docs/running.rst:194
 msgid "-high:"
 msgstr ""
 
-#: ../../running.rst:194
+#: /documents/docs/running.rst:194
 msgid "Report only high priority bugs."
 msgstr "優先度が高のバグを報告します。"
 
-#: ../../running.rst:198
+#: /documents/docs/running.rst:198
 msgid "-relaxed:"
 msgstr ""
 
-#: ../../running.rst:197
+#: /documents/docs/running.rst:197
 msgid ""
 "Relaxed reporting mode. For many detectors, this option suppresses the "
 "heuristics used to avoid reporting false positives."
 msgstr "ざっくりとした報告をするモードです。多くのディテクタにおいて，このオプションは誤検出を回避するために使用されるヒューリスティックを抑制します。"
 
-#: ../../running.rst:204
+#: /documents/docs/running.rst:204
 msgid "-xml:"
 msgstr ""
 
-#: ../../running.rst:201
+#: /documents/docs/running.rst:201
 msgid ""
 "Produce the bug reports as XML. The XML data produced may be viewed in "
 "the GUI at a later time. You may also specify this option as "
@@ -492,11 +491,11 @@ msgstr ""
 "``-xml:withMessages`` として指定することもできます。このオプションを使用すると出力された XML "
 "ファイルには人間が読める警告を説明するメッセージが含まれるようになります。この方法で生成された XML ファイルは簡単にレポートに変換できます。"
 
-#: ../../running.rst:213
+#: /documents/docs/running.rst:213
 msgid "-html:"
 msgstr ""
 
-#: ../../running.rst:207
+#: /documents/docs/running.rst:207
 msgid ""
 "Generate HTML output. By default, SpotBugs will use the default.xsl XSLT "
 "stylesheet to generate the HTML: you can find this file in spotbugs.jar, "
@@ -519,7 +518,7 @@ msgstr ""
 "hist.xsl`` は，``fancy.xsl`` スタイルシートが進化したものです。バグのリストを動的にフィルタリングするために DOM と "
 "Javascript をフル活用します。"
 
-#: ../../running.rst:213
+#: /documents/docs/running.rst:213
 msgid ""
 "If you want to specify your own XSLT stylesheet to perform the "
 "transformation to HTML, specify the option as ``-html:myStylesheet.xsl``,"
@@ -529,43 +528,54 @@ msgstr ""
 "独自の XSLT スタイルシートを指定して HTML への変換を実行したいときは，``-html:myStylesheet.xsl`` "
 "としてオプションを指定します。ここで ``myStylesheet.xsl`` は使用するスタイルシートのファイル名です。"
 
-#: ../../running.rst:216
+#: /documents/docs/running.rst:216
+msgid "-sarif:"
+msgstr ""
+
+#: /documents/docs/running.rst:216
+msgid ""
+"Produce the bug reports in `SARIF 2.1.0 <https://docs.oasis-"
+"open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html>`_."
+msgstr ""
+"バグレポートを `SARIF 2.1.0 <https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html>`_ 形式として出力します。"
+
+#: /documents/docs/running.rst:219
 msgid "-emacs:"
 msgstr ""
 
-#: ../../running.rst:216
+#: /documents/docs/running.rst:219
 msgid "Produce the bug reports in Emacs format."
 msgstr "バグレポートを Emacs 形式として生成します。"
 
-#: ../../running.rst:219
+#: /documents/docs/running.rst:222
 msgid "-xdocs:"
 msgstr ""
 
-#: ../../running.rst:219
+#: /documents/docs/running.rst:222
 msgid "Produce the bug reports in xdoc XML format for use with Apache Maven."
 msgstr "Apache Maven で使用するための xdoc XML 形式のバグレポートを生成します。"
 
-#: ../../running.rst:222
+#: /documents/docs/running.rst:225
 msgid "-output *filename*:"
 msgstr ""
 
-#: ../../running.rst:222
+#: /documents/docs/running.rst:225
 msgid "Produce the output in the specified file."
 msgstr "指定されたファイルに出力を生成します。"
 
-#: ../../running.rst:225
+#: /documents/docs/running.rst:228
 msgid "-outputFile *filename*:"
 msgstr ""
 
-#: ../../running.rst:225
+#: /documents/docs/running.rst:228
 msgid "This argument is deprecated. Use ``-output`` instead."
 msgstr "この引数は推奨されません。代わりに ``-output`` を使用してください。"
 
-#: ../../running.rst:229
+#: /documents/docs/running.rst:232
 msgid "-nested[:true|false]:"
 msgstr ""
 
-#: ../../running.rst:228
+#: /documents/docs/running.rst:231
 msgid ""
 "This option enables or disables scanning of nested jar and zip files "
 "found in the list of files and directories to be analyzed. By default, "
@@ -576,11 +586,11 @@ msgstr ""
 "ファイルのスキャンを有効また無効にします。デフォルトでは，ネストされた jar/zip "
 "ファイルのスキャンが有効になっています。無効にしたいときは，コマンドライン引数に ``-nested:false`` を追加します。"
 
-#: ../../running.rst:233
+#: /documents/docs/running.rst:236
 msgid "-auxclasspath *classpath*:"
 msgstr ""
 
-#: ../../running.rst:232
+#: /documents/docs/running.rst:235
 msgid ""
 "Set the auxiliary classpath for analysis. This classpath should include "
 "all jar files and directories containing classes that are part of the "
@@ -589,41 +599,41 @@ msgstr ""
 "解析のための補助クラスパスを設定します。補助クラスパスには解析するプログラムで使用するクラスを含むディレクトリと jar "
 "ファイルをすべて指定します。バグの解析対象にはなりません。"
 
-#: ../../running.rst:236
+#: /documents/docs/running.rst:239
 msgid "-auxclasspathFromInput:"
 msgstr ""
 
-#: ../../running.rst:236
+#: /documents/docs/running.rst:239
 msgid ""
 "Read the auxiliary classpath for analysis from standard input, each line "
 "adds new entry to the auxiliary classpath for analysis."
 msgstr "標準入力から解析のための補助クラスパスを読み，それぞれの行を解析のための補助クラスパスに新規登録します。"
 
-#: ../../running.rst:239
+#: /documents/docs/running.rst:242
 msgid "-auxclasspathFromFile *filepath*:"
 msgstr ""
 
-#: ../../running.rst:239
+#: /documents/docs/running.rst:242
 msgid ""
 "Read the auxiliary classpath for analysis from file, each line adds new "
 "entry to the auxiliary classpath for analysis."
 msgstr "ファイルから解析のための補助クラスパスを読み，それぞれの行を解析のための補助クラスパスに新規登録します。"
 
-#: ../../running.rst:242
+#: /documents/docs/running.rst:245
 msgid "-analyzeFromFile *filepath*:"
 msgstr ""
 
-#: ../../running.rst:242
+#: /documents/docs/running.rst:245
 msgid ""
 "Read the files to analyze from file, each line adds new entry to the "
 "classpath for analysis."
 msgstr "ファイルから解析するファイルを読み，それぞれの行を解析のためのクラスパスに新規登録します。"
 
-#: ../../running.rst:247
+#: /documents/docs/running.rst:250
 msgid "-userPrefs *edu.umd.cs.findbugs.core.prefs*:"
 msgstr ""
 
-#: ../../running.rst:245
+#: /documents/docs/running.rst:248
 msgid ""
 "Set the path of the user preferences file to use, which might override "
 "some of the options above. Specifying userPrefs as first argument would "
@@ -636,244 +646,245 @@ msgstr ""
 "を指定すると，後続のオプションで上書きすることになります。最後の引数として指定すると以前のオプションを上書きすることになります。このオプションの背後にある根拠は，コマンドライン実行で"
 " SpotBugs Eclipse プロジェクトの設定を再利用するためです。"
 
-#: ../../running.rst:250
+#: /documents/docs/running.rst:253
 msgid "-showPlugins:"
 msgstr ""
 
-#: ../../running.rst:250
+#: /documents/docs/running.rst:253
 msgid "Show list of available detector plugins."
 msgstr ""
 
-#: ../../running.rst:253
+#: /documents/docs/running.rst:256
 msgid "Output options"
 msgstr ""
 
-#: ../../running.rst:255
+#: /documents/docs/running.rst:258
 msgid "-timestampNow:"
 msgstr ""
 
-#: ../../running.rst:255
+#: /documents/docs/running.rst:258
 msgid "Set timestamp of results to be current time."
 msgstr ""
 
-#: ../../running.rst:258
+#: /documents/docs/running.rst:261
 msgid "-quiet:"
 msgstr ""
 
-#: ../../running.rst:258
+#: /documents/docs/running.rst:261
 msgid "Suppress error messages."
 msgstr ""
 
-#: ../../running.rst:261
+#: /documents/docs/running.rst:264
 msgid "-longBugCodes:"
 msgstr ""
 
-#: ../../running.rst:261
+#: /documents/docs/running.rst:264
 msgid "Report long bug codes."
 msgstr "すべてのバグを報告します。"
 
-#: ../../running.rst:264
+#: /documents/docs/running.rst:267
 msgid "-progress:"
 msgstr ""
 
-#: ../../running.rst:264
+#: /documents/docs/running.rst:267
 msgid "Display progress in terminal window."
 msgstr ""
 
-#: ../../running.rst:267
+#: /documents/docs/running.rst:270
 msgid "-release <release name>:"
 msgstr ""
 
-#: ../../running.rst:267
+#: /documents/docs/running.rst:270
 msgid "Set the release name of the analyzed application."
 msgstr ""
 
-#: ../../running.rst:270
+#: /documents/docs/running.rst:273
 msgid "-maxRank <rank>:"
 msgstr ""
 
-#: ../../running.rst:270
+#: /documents/docs/running.rst:273
 msgid "Only report issues with a bug rank at least as scary as that provided."
 msgstr ""
 
-#: ../../running.rst:273
+#: /documents/docs/running.rst:276
 msgid "-dontCombineWarnings:"
 msgstr ""
 
-#: ../../running.rst:273
+#: /documents/docs/running.rst:276
 msgid "Don't combine warnings that differ only in line number."
 msgstr ""
 
-#: ../../running.rst:276
+#: /documents/docs/running.rst:279
 msgid "-train[:outputDir]:"
 msgstr ""
 
-#: ../../running.rst:276
+#: /documents/docs/running.rst:279
 msgid "Save training data (experimental); output dir defaults to '.'."
 msgstr ""
 
-#: ../../running.rst:279
+#: /documents/docs/running.rst:282
 msgid "-useTraining[:inputDir]:"
 msgstr ""
 
-#: ../../running.rst:279
+#: /documents/docs/running.rst:282
 msgid "Use training data (experimental); input dir defaults to '.'."
 msgstr ""
 
-#: ../../running.rst:282
+#: /documents/docs/running.rst:285
 msgid "-redoAnalysis <filename>:"
 msgstr ""
 
-#: ../../running.rst:282
+#: /documents/docs/running.rst:285
 msgid "Redo analysis using configureation from previous analysis."
 msgstr ""
 
-#: ../../running.rst:285
+#: /documents/docs/running.rst:288
 msgid "-sourceInfo <filename>:"
 msgstr ""
 
-#: ../../running.rst:285
+#: /documents/docs/running.rst:288
 msgid "Specify source info file (line numbers for fields/classes)."
 msgstr ""
 
-#: ../../running.rst:288
+#: /documents/docs/running.rst:291
 msgid "-projectName <project name>:"
 msgstr ""
 
-#: ../../running.rst:288
+#: /documents/docs/running.rst:291
 msgid "Descriptive name of project."
 msgstr ""
 
-#: ../../running.rst:291
+#: /documents/docs/running.rst:294
 msgid "-reanalyze <filename>:"
 msgstr ""
 
-#: ../../running.rst:291
+#: /documents/docs/running.rst:294
 msgid "Redo analysis in provided file."
 msgstr ""
 
-#: ../../running.rst:294
+#: /documents/docs/running.rst:297
 msgid "Output filtering options"
 msgstr ""
 
-#: ../../running.rst:296
+#: /documents/docs/running.rst:299
 msgid "-bugCategories <cat1[,cat2...]>:"
 msgstr ""
 
-#: ../../running.rst:296
+#: /documents/docs/running.rst:299
 msgid "Only report bugs in given categories."
 msgstr ""
 
-#: ../../running.rst:299
+#: /documents/docs/running.rst:302
 msgid "-excludeBugs <baseline bugs>:"
 msgstr ""
 
-#: ../../running.rst:299
+#: /documents/docs/running.rst:302
 msgid "Exclude bugs that are also reported in the baseline xml output."
 msgstr ""
 
-#: ../../running.rst:302
+#: /documents/docs/running.rst:305
 msgid "-applySuppression:"
 msgstr ""
 
-#: ../../running.rst:302
+#: /documents/docs/running.rst:305
 msgid "Exclude any bugs that match suppression filter loaded from fbp file."
 msgstr "fbpファイルによって指定された抑制フィルタにマッチするバグを出力から除きます。"
 
-#: ../../running.rst:305
+#: /documents/docs/running.rst:308
 msgid "Detector (visitor) configuration options"
 msgstr "Detector（Visitor）設定用オプション"
 
-#: ../../running.rst:307
+#: /documents/docs/running.rst:310
 msgid "-visitors <v1[,v2...]>:"
 msgstr ""
 
-#: ../../running.rst:307
+#: /documents/docs/running.rst:310
 msgid "Run only named visitors."
 msgstr "指定されたVisitorのみを実行します。"
 
-#: ../../running.rst:310
+#: /documents/docs/running.rst:313
 msgid "-omitVisitors <v1[,v2...]>:"
 msgstr ""
 
-#: ../../running.rst:310
+#: /documents/docs/running.rst:313
 msgid "Omit named visitors."
 msgstr "指定されたVisitorを実行しません。"
 
-#: ../../running.rst:313
+#: /documents/docs/running.rst:316
 msgid "-chooseVisitors <+v1,-v2,...>:"
 msgstr ""
 
-#: ../../running.rst:313
+#: /documents/docs/running.rst:316
 msgid "Selectively enable/disable detectors."
 msgstr "指定されたDetectorを有効化したり無効化したりします。"
 
-#: ../../running.rst:316
+#: /documents/docs/running.rst:319
 msgid "-choosePlugins <+p1,-p2,...>:"
 msgstr ""
 
-#: ../../running.rst:316
+#: /documents/docs/running.rst:319
 msgid "Selectively enable/disable plugins."
 msgstr "指定されたプラグインを有効化したり無効化したりします。"
 
-#: ../../running.rst:319
+#: /documents/docs/running.rst:322
 msgid "-adjustPriority <v1=(raise|lower)[,...]>:"
 msgstr ""
 
-#: ../../running.rst:319
+#: /documents/docs/running.rst:322
 msgid "Raise/lower priority of warnings for given visitor(s)"
 msgstr "指定した警告の優先度を変更します。"
 
-#: ../../running.rst:322
+#: /documents/docs/running.rst:325
 msgid "Project configuration options"
 msgstr "プロジェクト設定用オプション"
 
-#: ../../running.rst:324
+#: /documents/docs/running.rst:327
 msgid "-sourcepath <source path>:"
 msgstr ""
 
-#: ../../running.rst:324
+#: /documents/docs/running.rst:327
 msgid "Set source path for analyzed classes."
 msgstr "解析対象クラスのソースコードが保管されているパスを指定します。"
 
-#: ../../running.rst:327
+#: /documents/docs/running.rst:330
 msgid "-exitcode:"
 msgstr ""
 
-#: ../../running.rst:327
+#: /documents/docs/running.rst:330
 msgid "Set exit code of process."
 msgstr "プロセスのステータスコードを設定します。"
 
-#: ../../running.rst:330
+#: /documents/docs/running.rst:333
 msgid "-noClassOk:"
 msgstr ""
 
-#: ../../running.rst:330
+#: /documents/docs/running.rst:333
 msgid "Output empty warning file if no classes are specified."
 msgstr "対象クラスが指定されなかった場合にからの警告ファイルを出力します。"
 
-#: ../../running.rst:333
+#: /documents/docs/running.rst:336
 msgid "-xargs:"
 msgstr ""
 
-#: ../../running.rst:333
+#: /documents/docs/running.rst:336
 msgid ""
 "Get list of classfiles/jarfiles from standard input rather than command "
 "line."
 msgstr "クラスファイルやjarファイルの一覧を、コマンドラインオプションではなく標準入力から読み込みます。"
 
-#: ../../running.rst:336
+#: /documents/docs/running.rst:339
 msgid "-bugReporters <name,name2,-name3>:"
 msgstr ""
 
-#: ../../running.rst:336
+#: /documents/docs/running.rst:339
 msgid "Bug reporter decorators to explicitly enable/disable."
 msgstr "バグレポーターを明示的に有効化したり無効化したりできます。"
 
-#: ../../running.rst:338
+#: /documents/docs/running.rst:341
 msgid "-printConfiguration:"
 msgstr ""
 
-#: ../../running.rst:339
+#: /documents/docs/running.rst:342
 msgid "Print configuration and exit, without running analysis."
 msgstr "設定を出力した後に、解析を実行せずに終了します。"
+

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -212,6 +212,9 @@ These options are only accepted by the Text User Interface.
 
   If you want to specify your own XSLT stylesheet to perform the transformation to HTML, specify the option as ``-html:myStylesheet.xsl``, where ``myStylesheet.xsl`` is the filename of the stylesheet you want to use.
 
+-sarif:
+  Produce the bug reports in `SARIF 2.1.0 <https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html>`_.
+
 -emacs:
   Produce the bug reports in Emacs format.
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/FindBugsMessageFormat.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/FindBugsMessageFormat.java
@@ -68,6 +68,9 @@ public class FindBugsMessageFormat {
      * @return the formatted message
      */
     public String format(BugAnnotation[] args, ClassAnnotation primaryClass, boolean abridgedMessages) {
+        // note for maintainer:
+        // This code is copied to edu.umd.cs.findbugs.sarif.MessageFormat.
+        // When you change code in this method, please reflect it even to that class.
         String pat = pattern;
         StringBuilder result = new StringBuilder();
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/TextUICommandLine.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/TextUICommandLine.java
@@ -41,6 +41,7 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.annotation.WillCloseWhenClosed;
 
+import edu.umd.cs.findbugs.sarif.SarifBugReporter;
 import org.dom4j.DocumentException;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -84,6 +85,8 @@ public class TextUICommandLine extends FindBugsCommandLine {
     private static final int HTML_REPORTER = 4;
 
     private static final int XDOCS_REPORTER = 5;
+
+    private static final int SARIF_REPORTER = 6;
 
     private int bugReporterType = PRINTING_REPORTER;
 
@@ -339,6 +342,8 @@ public class TextUICommandLine extends FindBugsCommandLine {
             }
         } else if ("-xdocs".equals(option)) {
             bugReporterType = XDOCS_REPORTER;
+        } else if ("-sarif".equals(option)) {
+            bugReporterType = SARIF_REPORTER;
         } else if ("-applySuppression".equals(option)) {
             applySuppression = true;
         } else if ("-quiet".equals(option)) {
@@ -640,6 +645,9 @@ public class TextUICommandLine extends FindBugsCommandLine {
             break;
         case XDOCS_REPORTER:
             textuiBugReporter = new XDocsBugReporter(project);
+            break;
+        case SARIF_REPORTER:
+            textuiBugReporter = new SarifBugReporter(project);
             break;
         default:
             throw new IllegalStateException();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/TextUICommandLine.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/TextUICommandLine.java
@@ -177,6 +177,7 @@ public class TextUICommandLine extends FindBugsCommandLine {
         addSwitch("-sortByClass", "sort warnings by class");
         addSwitchWithOptionalExtraPart("-xml", "withMessages", "XML output (optionally with messages)");
         addSwitch("-xdocs", "xdoc XML output to use with Apache Maven");
+        addSwitch("-sarif", "SARIF 2.1.0 output");
         addSwitchWithOptionalExtraPart("-html", "stylesheet", "Generate HTML output (default stylesheet is default.xsl)");
         addSwitch("-emacs", "Use emacs reporting format");
         addSwitch("-relaxed", "Relaxed reporting mode (more false positives!)");

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/SourceFinder.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/SourceFinder.java
@@ -628,8 +628,6 @@ public class SourceFinder implements AutoCloseable {
     public Optional<String> getBase(String fileName) {
         return repositoryList.stream()
                 .filter(SourceRepository::isPlatformDependent)
-                .filter(repo -> {
-                    return repo.contains(fileName);
-                }).map(repo -> repo.getDataSource("").getFullFileName()).findFirst();
+                .filter(repo -> repo.contains(fileName)).map(repo -> repo.getDataSource("").getFullFileName()).findFirst();
     }
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/SourceFinder.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/SourceFinder.java
@@ -621,11 +621,15 @@ public class SourceFinder implements AutoCloseable {
     }
 
     public Optional<String> getBase(SourceLineAnnotation sourceLineAnnotation) {
+        String relativePath = getPlatformName(sourceLineAnnotation);
+        return getBase(relativePath);
+    }
+
+    public Optional<String> getBase(String fileName) {
         return repositoryList.stream()
                 .filter(SourceRepository::isPlatformDependent)
                 .filter(repo -> {
-                    String relativePath = getPlatformName(sourceLineAnnotation);
-                    return repo.contains(relativePath);
+                    return repo.contains(fileName);
                 }).map(repo -> repo.getDataSource("").getFullFileName()).findFirst();
     }
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/BugCollectionAnalyser.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/BugCollectionAnalyser.java
@@ -49,7 +49,7 @@ class BugCollectionAnalyser {
     @NonNull
     JSONObject getOriginalUriBaseIds() {
         JSONObject result = new JSONObject();
-        baseToId.forEach((uri, uriBaseId) -> result.put(uriBaseId, new JSONObject().put("uri", uri)));
+        baseToId.forEach((uri, uriBaseId) -> result.put(uriBaseId, new JSONObject().put("uri", "file://" + uri)));
         return result;
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/BugCollectionAnalyser.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/BugCollectionAnalyser.java
@@ -32,7 +32,7 @@ class BugCollectionAnalyser {
         SourceFinder sourceFinder = bugCollection.getProject().getSourceFinder();
         bugCollection.forEach(bug -> {
             String type = bug.getType();
-            int index = typeToIndex.computeIfAbsent(type, (t) -> processRule(bug.getBugPattern()));
+            int index = typeToIndex.computeIfAbsent(type, t -> processRule(bug.getBugPattern()));
 
             processResult(index, bug, sourceFinder);
         });
@@ -49,9 +49,7 @@ class BugCollectionAnalyser {
     @NonNull
     JSONObject getOriginalUriBaseIds() {
         JSONObject result = new JSONObject();
-        baseToId.forEach((uri, uriBaseId) -> {
-            result.put(uriBaseId, new JSONObject().put("uri", uri));
-        });
+        baseToId.forEach((uri, uriBaseId) -> result.put(uriBaseId, new JSONObject().put("uri", uri)));
         return result;
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/BugCollectionAnalyser.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/BugCollectionAnalyser.java
@@ -9,10 +9,7 @@ import edu.umd.cs.findbugs.ba.SourceFinder;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 class BugCollectionAnalyser {
@@ -85,5 +82,9 @@ class BugCollectionAnalyser {
         indexToPlaceholders.add(placeholders);
 
         return ruleIndex;
+    }
+
+    Map<String, String> getBaseToId() {
+        return baseToId;
     }
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/BugCollectionAnalyser.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/BugCollectionAnalyser.java
@@ -3,6 +3,7 @@ package edu.umd.cs.findbugs.sarif;
 import edu.umd.cs.findbugs.BugCollection;
 import edu.umd.cs.findbugs.BugInstance;
 import edu.umd.cs.findbugs.BugPattern;
+import edu.umd.cs.findbugs.BugRanker;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.ba.SourceFinder;
 import org.json.JSONArray;
@@ -63,7 +64,8 @@ class BugCollectionAnalyser {
                 .collect(Collectors.toList());
         List<Location> locations = new ArrayList<>();
         Location.fromBugInstance(bug, sourceFinder, baseToId).ifPresent(locations::add);
-        Result result = new Result(bug.getType(), index, new Message(arguments), locations);
+        int bugRank = BugRanker.findRank(bug);
+        Result result = new Result(bug.getType(), index, new Message(arguments), locations, Level.fromBugRank(bugRank));
         results.add(result);
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Extension.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Extension.java
@@ -33,8 +33,14 @@ class Extension {
     }
 
     JSONObject toJSONObject() {
-        return new JSONObject().put("version", version).put("name", name).putOpt("shortDescription", shortDescription)
-                .putOpt("fullDescription", fullDescription).putOpt("informationUri", informationUri)
+        // TODO put 'fullDescription' with both of text and markdown representations
+        JSONObject desc = null;
+        if (shortDescription != null) {
+            desc = new JSONObject().put("text", shortDescription);
+        }
+        return new JSONObject().put("version", version).put("name", name)
+                .putOpt("shortDescription", desc)
+                .putOpt("informationUri", informationUri)
                 .putOpt("organization", organization);
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Level.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Level.java
@@ -1,6 +1,7 @@
 package edu.umd.cs.findbugs.sarif;
 
-import edu.umd.cs.findbugs.Priorities;
+import edu.umd.cs.findbugs.BugRankCategory;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import org.json.JSONString;
 
 /**
@@ -31,18 +32,20 @@ enum Level implements JSONString {
         return String.format("\"%s\"", name().toLowerCase());
     }
 
-    static Level fromPriority(int priority) {
-        switch (priority) {
-        case Priorities.HIGH_PRIORITY:
+    @NonNull
+    static Level fromBugRank(int bugRank) {
+        BugRankCategory category = BugRankCategory.getRank(bugRank);
+        switch (category) {
+        case SCARIEST:
+        case SCARY:
             return ERROR;
-        case Priorities.NORMAL_PRIORITY:
-        case Priorities.LOW_PRIORITY:
+        case TROUBLING:
             return WARNING;
-        case Priorities.EXP_PRIORITY:
-        case Priorities.IGNORE_PRIORITY:
+        case OF_CONCERN:
             return NOTE;
         default:
-            throw new IllegalArgumentException(String.format("Unknown property %d is given", priority));
+            throw new IllegalArgumentException("Illegal bugRank given: " + bugRank);
         }
     }
+
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Location.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Location.java
@@ -207,6 +207,12 @@ class Location {
         }
 
         @NonNull
+        static LogicalLocation fromStackTraceElement(@NonNull StackTraceElement element) {
+            String decoratedName = String.format("%s.%s", element.getClassName(), element.getMethodName());
+            return new LogicalLocation(element.getMethodName(), decoratedName, "function");
+        }
+
+        @NonNull
         static Optional<LogicalLocation> fromBugInstance(@NonNull BugInstance bugInstance) {
             Objects.requireNonNull(bugInstance);
             ClassAnnotation primaryClass = bugInstance.getPrimaryClass();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Location.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Location.java
@@ -200,7 +200,8 @@ class Location {
         @Nullable
         final Map<String, String> properties = new HashMap<>();
 
-        LogicalLocation(@NonNull String name, @Nullable String decoratedName, @NonNull String kind, @Nullable String fullyQualifiedName, @Nullable Map<String, String> properties) {
+        LogicalLocation(@NonNull String name, @Nullable String decoratedName, @NonNull String kind, @Nullable String fullyQualifiedName,
+                @Nullable Map<String, String> properties) {
             this.name = Objects.requireNonNull(name);
             this.decoratedName = decoratedName;
             this.kind = Objects.requireNonNull(kind);
@@ -212,7 +213,8 @@ class Location {
 
         JSONObject toJSONObject() {
             JSONObject propertiesBag = new JSONObject(properties);
-            return new JSONObject().put("name", name).putOpt("decoratedName", decoratedName).put("kind", kind).putOpt("fullyQualifiedName", fullyQualifiedName).putOpt("properties", propertiesBag.isEmpty() ? null : propertiesBag);
+            return new JSONObject().put("name", name).putOpt("decoratedName", decoratedName).put("kind", kind).putOpt("fullyQualifiedName",
+                    fullyQualifiedName).putOpt("properties", propertiesBag.isEmpty() ? null : propertiesBag);
         }
 
         @NonNull

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/MessageFormat.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/MessageFormat.java
@@ -1,0 +1,69 @@
+package edu.umd.cs.findbugs.sarif;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import java.util.Objects;
+import java.util.function.BiFunction;
+
+/**
+ * Class to parse longDescription to generate formatted test for SARIF.
+ * All the logic is copied from {@code FindBugsMessageFormat}.
+ * @see edu.umd.cs.findbugs.FindBugsMessageFormat
+ */
+class MessageFormat {
+    private final String pattern;
+
+    MessageFormat(@NonNull String pattern) {
+        this.pattern = Objects.requireNonNull(pattern);
+    }
+
+    String format(@NonNull BiFunction<Integer, String, String> handler) {
+        Objects.requireNonNull(handler);
+        String pat = pattern;
+        StringBuilder result = new StringBuilder();
+
+        while (pat.length() > 0) {
+            int subst = pat.indexOf('{');
+            if (subst < 0) {
+                result.append(pat);
+                break;
+            }
+
+            result.append(pat.substring(0, subst));
+            pat = pat.substring(subst + 1);
+
+            int end = pat.indexOf('}');
+            if (end < 0) {
+                throw new IllegalStateException("unmatched { in " + pat);
+            }
+
+            String substPat = pat.substring(0, end);
+
+            int dot = substPat.indexOf('.');
+            String key = "";
+            if (dot >= 0) {
+                key = substPat.substring(dot + 1);
+                substPat = substPat.substring(0, dot);
+            }
+
+            int fieldNum;
+            try {
+                fieldNum = Integer.parseInt(substPat);
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException("Bad integer value " + substPat + " in " + pattern);
+            }
+
+            if (fieldNum < 0) {
+                throw new IllegalArgumentException("The given fieldNum was negative: " + fieldNum);
+            }
+            try {
+                result.append(handler.apply(fieldNum, key));
+            } catch (IllegalArgumentException iae) {
+                throw new IllegalArgumentException("Problem processing " + pattern + " format " + substPat, iae);
+            }
+            pat = pat.substring(end + 1);
+        }
+
+        return result.toString();
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Notification.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Notification.java
@@ -3,8 +3,10 @@ package edu.umd.cs.findbugs.sarif;
 import edu.umd.cs.findbugs.AbstractBugReporter;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import edu.umd.cs.findbugs.ba.SourceFinder;
 import org.json.JSONObject;
 
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -37,13 +39,14 @@ class Notification {
         return result;
     }
 
-    static Notification fromError(@NonNull AbstractBugReporter.Error error) {
+    static Notification fromError(@NonNull AbstractBugReporter.Error error, @NonNull SourceFinder sourceFinder,
+            @NonNull Map<String, String> baseToId) {
         String id = String.format("spotbugs-error-%d", error.getSequence());
         Throwable cause = error.getCause();
         if (cause == null) {
             return new Notification(id, error.getMessage(), Level.ERROR, null);
         } else {
-            return new Notification(id, error.getMessage(), Level.ERROR, SarifException.fromThrowable(cause));
+            return new Notification(id, error.getMessage(), Level.ERROR, SarifException.fromThrowable(cause, sourceFinder, baseToId));
         }
     }
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Placeholder.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Placeholder.java
@@ -1,0 +1,32 @@
+package edu.umd.cs.findbugs.sarif;
+
+import edu.umd.cs.findbugs.BugAnnotation;
+import edu.umd.cs.findbugs.ClassAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+import java.util.List;
+
+class Placeholder {
+    /**
+     * Index of the target {@link edu.umd.cs.findbugs.BugAnnotation} to embed.
+     */
+    final int index;
+
+    /**
+     * Key to formatting {@link edu.umd.cs.findbugs.BugAnnotation}.
+     * @see edu.umd.cs.findbugs.BugAnnotation#format(String, ClassAnnotation)
+     */
+    @NonNull
+    final String key;
+
+    Placeholder(int index, @Nullable String key) {
+        this.index = index;
+        this.key = key == null ? "default" : key;
+    }
+
+    @NonNull
+    String toArgument(List<? extends BugAnnotation> bugAnnotations, @Nullable ClassAnnotation primaryClass) {
+        return bugAnnotations.get(index).format(key, primaryClass);
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Placeholder.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Placeholder.java
@@ -6,6 +6,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
 import java.util.List;
+import java.util.Objects;
 
 class Placeholder {
     /**
@@ -20,9 +21,9 @@ class Placeholder {
     @NonNull
     final String key;
 
-    Placeholder(int index, @Nullable String key) {
+    Placeholder(int index, @NonNull String key) {
         this.index = index;
-        this.key = key == null ? "default" : key;
+        this.key = Objects.requireNonNull(key);
     }
 
     @NonNull

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Result.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Result.java
@@ -16,16 +16,20 @@ final class Result {
     final int ruleIndex;
     final Message message;
     final List<Location> locations;
+    @NonNull
+    final Level level;
 
-    Result(@NonNull String ruleId, int ruleIndex, Message message, List<Location> locations) {
+    Result(@NonNull String ruleId, int ruleIndex, Message message, List<Location> locations, @NonNull Level level) {
         this.ruleId = Objects.requireNonNull(ruleId);
         this.ruleIndex = ruleIndex;
         this.message = Objects.requireNonNull(message);
         this.locations = Collections.unmodifiableList(Objects.requireNonNull(locations));
+        this.level = Objects.requireNonNull(level);
     }
 
     JSONObject toJSONObject() {
-        JSONObject result = new JSONObject().put("ruleId", ruleId).put("ruleIndex", ruleIndex).put("message", message.toJSONObject());
+        JSONObject result = new JSONObject().put("ruleId", ruleId).put("ruleIndex", ruleIndex).put("message", message.toJSONObject()).put("level",
+                level);
         locations.stream().map(Location::toJSONObject).forEach(location -> result.append("locations", location));
         return result;
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Rule.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Rule.java
@@ -54,7 +54,7 @@ final class Rule {
     }
 
     @NonNull
-    static Rule fromBugPattern(BugPattern bugPattern) {
+    static Rule fromBugPattern(BugPattern bugPattern, String formatedMessage) {
         URI helpUri = bugPattern.getUri().orElse(null);
 
         String category = bugPattern.getCategory();
@@ -65,7 +65,7 @@ final class Rule {
             tags = Collections.singletonList(category);
         }
 
-        return new Rule(bugPattern.getType(), bugPattern.getShortDescription(), bugPattern.getDetailText(), bugPattern.getLongDescription(), helpUri,
+        return new Rule(bugPattern.getType(), bugPattern.getShortDescription(), bugPattern.getDetailText(), formatedMessage, helpUri,
                 tags);
     }
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Rule.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Rule.java
@@ -56,7 +56,7 @@ final class Rule {
     }
 
     @NonNull
-    static Rule fromBugPattern(BugPattern bugPattern, String formatedMessage) {
+    static Rule fromBugPattern(BugPattern bugPattern, String formattedMessage) {
         URI helpUri = bugPattern.getUri().orElse(null);
 
         String category = bugPattern.getCategory();
@@ -67,7 +67,7 @@ final class Rule {
             tags = Collections.singletonList(category);
         }
 
-        return new Rule(bugPattern.getType(), bugPattern.getShortDescription(), bugPattern.getDetailText(), formatedMessage, helpUri,
+        return new Rule(bugPattern.getType(), bugPattern.getShortDescription(), bugPattern.getDetailText(), formattedMessage, helpUri,
                 tags);
     }
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Rule.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Rule.java
@@ -42,10 +42,12 @@ final class Rule {
 
     JSONObject toJSONObject() {
         JSONObject messageStrings = new JSONObject().put("default", new JSONObject().put("text", defaultText));
-        JSONObject result = new JSONObject().put("id", id).put("shortDescription", new JSONObject().put("text", shortDescription)).put(
-                "fullDescription", new JSONObject().put("markdown", fullDescription)).put(
-                        "messageStrings",
-                        messageStrings).putOpt("helpUri", helpUri);
+        // TODO put 'fullDescription' with both of text and markdown representations
+        JSONObject result = new JSONObject()
+                .put("id", id)
+                .put("shortDescription", new JSONObject().put("text", shortDescription))
+                .put("messageStrings", messageStrings)
+                .putOpt("helpUri", helpUri);
         if (!tags.isEmpty()) {
             JSONObject propertyBag = new JSONObject().put("tags", new JSONArray(tags));
             result.put("properties", propertyBag);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/SarifBugReporter.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/SarifBugReporter.java
@@ -44,9 +44,9 @@ public class SarifBugReporter extends BugCollectionBugReporter {
         jsonWriter.key("tool").object();
         processExtensions(jsonWriter);
         jsonWriter.key("driver").object();
-        jsonWriter.key("name").value(Version.getApplicationName());
+        jsonWriter.key("name").value("SpotBugs");
         // Eclipse plugin does not follow the semantic-versioning, so use "version" instead of "semanticVersion".
-        jsonWriter.key("version").value(Version.getApplicationVersion());
+        jsonWriter.key("version").value(Version.VERSION_STRING);
         // SpotBugs refers JVM config to decide which language we use.
         jsonWriter.key("language").value(Locale.getDefault().getLanguage());
         jsonWriter.key("rules").value(rules);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/SarifBugReporter.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/SarifBugReporter.java
@@ -9,6 +9,7 @@ import org.json.JSONArray;
 import org.json.JSONWriter;
 
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 
 public class SarifBugReporter extends BugCollectionBugReporter {
@@ -34,13 +35,13 @@ public class SarifBugReporter extends BugCollectionBugReporter {
     private void processRuns(@NonNull JSONWriter jsonWriter) {
         jsonWriter.key("runs").array().object();
         BugCollectionAnalyser analyser = new BugCollectionAnalyser(getBugCollection());
-        jsonWriter.key("originalUriBaseIds").value(analyser.getOriginalUriBaseIds());
-        processTool(jsonWriter, analyser.getRules());
+        processTool(jsonWriter, analyser.getRules(), analyser.getBaseToId());
         jsonWriter.key("results").value(analyser.getResults());
+        jsonWriter.key("originalUriBaseIds").value(analyser.getOriginalUriBaseIds());
         jsonWriter.endObject().endArray();
     }
 
-    private void processTool(@NonNull JSONWriter jsonWriter, @NonNull JSONArray rules) {
+    private void processTool(@NonNull JSONWriter jsonWriter, @NonNull JSONArray rules, @NonNull Map<String, String> baseToId) {
         jsonWriter.key("tool").object();
         processExtensions(jsonWriter);
         jsonWriter.key("driver").object();
@@ -50,7 +51,7 @@ public class SarifBugReporter extends BugCollectionBugReporter {
         // SpotBugs refers JVM config to decide which language we use.
         jsonWriter.key("language").value(Locale.getDefault().getLanguage());
         jsonWriter.key("rules").value(rules);
-        processNotifications(jsonWriter);
+        processNotifications(jsonWriter, baseToId);
         jsonWriter.endObject().endObject();
     }
 
@@ -60,7 +61,7 @@ public class SarifBugReporter extends BugCollectionBugReporter {
         jsonWriter.endArray();
     }
 
-    private void processNotifications(JSONWriter jsonWriter) {
+    private void processNotifications(JSONWriter jsonWriter, @NonNull Map<String, String> baseToId) {
         jsonWriter.key("notifications").array();
         Set<String> missingClasses = getMissingClasses();
         if (missingClasses != null && !missingClasses.isEmpty()) {
@@ -68,7 +69,8 @@ public class SarifBugReporter extends BugCollectionBugReporter {
             Notification notification = new Notification("spotbugs-missing-classes", message, Level.ERROR, null);
             jsonWriter.value(notification.toJSONObject());
         }
-        getQueuedErrors().stream().map(Notification::fromError).map(Notification::toJSONObject).forEach(jsonWriter::value);
+        getQueuedErrors().stream().map(t -> Notification.fromError(t, getProject().getSourceFinder(), baseToId)).map(Notification::toJSONObject)
+                .forEach(jsonWriter::value);
         jsonWriter.endArray();
     }
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/SarifException.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/SarifException.java
@@ -48,8 +48,10 @@ class SarifException {
     }
 
     JSONObject toJSONObject() {
-        JSONObject result = new JSONObject().put("exception", new JSONObject().put("kind", kind).put("message", new JSONObject().put("text",
-                message))).put("stack", stack.toJSONObject());
+        JSONObject result = new JSONObject()
+                .put("kind", kind)
+                .put("message", new JSONObject().put("text", message))
+                .put("stack", stack.toJSONObject());
         innerExceptions.forEach(innerException -> result.append("innerExceptions", innerException.toJSONObject()));
         return result;
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/SarifException.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/SarifException.java
@@ -41,9 +41,10 @@ class SarifException {
         List<Throwable> innerThrowables = new ArrayList<>();
         innerThrowables.add(throwable.getCause());
         innerThrowables.addAll(Arrays.asList(throwable.getSuppressed()));
-        List<SarifException> innerExceptions = innerThrowables.stream().filter(Objects::nonNull).map(t -> fromThrowable(t, sourceFinder, baseToId))
-                .collect(Collectors
-                        .toList());
+        List<SarifException> innerExceptions = innerThrowables.stream()
+                .filter(Objects::nonNull)
+                .map(t -> fromThrowable(t, sourceFinder, baseToId))
+                .collect(Collectors.toList());
         return new SarifException(throwable.getClass().getName(), message, Stack.fromThrowable(throwable, sourceFinder, baseToId), innerExceptions);
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Stack.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Stack.java
@@ -43,19 +43,23 @@ class Stack {
      * @see <a href="https://docs.oasis-open.org/sarif/sarif/v2.1.0/cs01/sarif-v2.1.0-cs01.html#_Toc16012758">3.45 stackFrame object</a>
      */
     static class StackFrame {
-        final String message;
-        // TODO how to build Location object?
+        @NonNull
+        final Location location;
 
-        StackFrame(@NonNull String message) {
-            this.message = Objects.requireNonNull(message);
+        StackFrame(@NonNull Location location) {
+            this.location = Objects.requireNonNull(location);
         }
 
         static StackFrame fromStackTraceElement(@NonNull StackTraceElement element) {
-            return new StackFrame(Objects.requireNonNull(element).toString());
+            Location.LogicalLocation logicalLocation = Location.LogicalLocation.fromStackTraceElement(element);
+            // StackTraceElement#getFileName() provides just a filename, which has no directory info.
+            // So we cannot construct physical location object.
+            Location location = new Location(null, Collections.singletonList(logicalLocation));
+            return new StackFrame(location);
         }
 
         JSONObject toJSONObject() {
-            return new JSONObject().put("location", new JSONObject().put("message", message));
+            return new JSONObject().put("location", location.toJSONObject());
         }
     }
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Stack.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Stack.java
@@ -1,11 +1,13 @@
 package edu.umd.cs.findbugs.sarif;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.ba.SourceFinder;
 import org.json.JSONObject;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
@@ -22,9 +24,10 @@ class Stack {
         this.frames = Collections.unmodifiableList(Objects.requireNonNull(frames));
     }
 
-    static Stack fromThrowable(Throwable throwable) {
-        List<StackFrame> frames = Arrays.stream(Objects.requireNonNull(throwable).getStackTrace()).map(StackFrame::fromStackTraceElement).collect(
-                Collectors.toList());
+    static Stack fromThrowable(Throwable throwable, @NonNull SourceFinder sourceFinder, @NonNull Map<String, String> baseToId) {
+        List<StackFrame> frames = Arrays.stream(Objects.requireNonNull(throwable).getStackTrace()).map(element -> StackFrame.fromStackTraceElement(
+                element, sourceFinder, baseToId)).collect(
+                        Collectors.toList());
         String message = throwable.getMessage();
         if (message == null) {
             message = "no message given";
@@ -50,11 +53,9 @@ class Stack {
             this.location = Objects.requireNonNull(location);
         }
 
-        static StackFrame fromStackTraceElement(@NonNull StackTraceElement element) {
-            Location.LogicalLocation logicalLocation = Location.LogicalLocation.fromStackTraceElement(element);
-            // StackTraceElement#getFileName() provides just a filename, which has no directory info.
-            // So we cannot construct physical location object.
-            Location location = new Location(null, Collections.singletonList(logicalLocation));
+        static StackFrame fromStackTraceElement(@NonNull StackTraceElement element, @NonNull SourceFinder sourceFinder,
+                @NonNull Map<String, String> baseToId) {
+            Location location = Location.fromStackTraceElement(element, sourceFinder, baseToId);
             return new StackFrame(location);
         }
 

--- a/spotbugs/src/test/java/edu/umd/cs/findbugs/sarif/LevelTest.java
+++ b/spotbugs/src/test/java/edu/umd/cs/findbugs/sarif/LevelTest.java
@@ -1,6 +1,5 @@
 package edu.umd.cs.findbugs.sarif;
 
-import edu.umd.cs.findbugs.Priorities;
 import org.json.JSONObject;
 import org.junit.Test;
 
@@ -15,7 +14,22 @@ public class LevelTest {
     }
 
     @Test
-    public void testMapLowestPriorityToNote() {
-        assertThat(Level.fromPriority(Priorities.IGNORE_PRIORITY), is(Level.NOTE));
+    public void testMapHighestRankToError() {
+        assertThat(Level.fromBugRank(1), is(Level.ERROR));
+    }
+
+    @Test
+    public void testMapHighRankToError() {
+        assertThat(Level.fromBugRank(9), is(Level.ERROR));
+    }
+
+    @Test
+    public void testMapLowRankToWarning() {
+        assertThat(Level.fromBugRank(14), is(Level.WARNING));
+    }
+
+    @Test
+    public void testMapLowestRankToNote() {
+        assertThat(Level.fromBugRank(20), is(Level.NOTE));
     }
 }

--- a/spotbugs/src/test/java/edu/umd/cs/findbugs/sarif/PlaceholderTest.java
+++ b/spotbugs/src/test/java/edu/umd/cs/findbugs/sarif/PlaceholderTest.java
@@ -1,0 +1,88 @@
+package edu.umd.cs.findbugs.sarif;
+
+import edu.umd.cs.findbugs.BugInstance;
+import edu.umd.cs.findbugs.BugPattern;
+import edu.umd.cs.findbugs.DetectorFactoryCollection;
+import edu.umd.cs.findbugs.FindBugs2;
+import edu.umd.cs.findbugs.Priorities;
+import edu.umd.cs.findbugs.Project;
+import edu.umd.cs.findbugs.ba.AnalysisContext;
+import edu.umd.cs.findbugs.classfile.Global;
+import edu.umd.cs.findbugs.classfile.IAnalysisCache;
+import edu.umd.cs.findbugs.classfile.impl.ClassFactory;
+import edu.umd.cs.findbugs.classfile.impl.ClassPathImpl;
+import edu.umd.cs.findbugs.internalAnnotations.DottedClassName;
+import org.apache.bcel.Repository;
+import org.apache.bcel.classfile.JavaClass;
+import org.apache.bcel.classfile.Method;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Arrays;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class PlaceholderTest {
+    private SarifBugReporter reporter;
+    private StringWriter writer;
+
+    @Before
+    public void setup() {
+        Project project = new Project();
+        reporter = new SarifBugReporter(project);
+        writer = new StringWriter();
+        reporter.setWriter(new PrintWriter(writer));
+        reporter.setPriorityThreshold(Priorities.IGNORE_PRIORITY);
+        DetectorFactoryCollection.resetInstance(new DetectorFactoryCollection());
+        IAnalysisCache analysisCache = ClassFactory.instance().createAnalysisCache(new ClassPathImpl(), reporter);
+        Global.setAnalysisCacheForCurrentThread(analysisCache);
+        FindBugs2.registerBuiltInAnalysisEngines(analysisCache);
+        AnalysisContext analysisContext = new AnalysisContext(project) {
+            public boolean isApplicationClass(@DottedClassName String className) {
+                // treat all classes as application class, to report bugs in it
+                return true;
+            }
+        };
+        AnalysisContext.setCurrentAnalysisContext(analysisContext);
+    }
+
+    @After
+    public void teardown() {
+        AnalysisContext.removeCurrentAnalysisContext();
+        Global.removeAnalysisCacheForCurrentThread();
+    }
+
+    @Test
+    public void testFormatWithKey() throws ClassNotFoundException {
+        BugPattern bugPattern = new BugPattern("BUG_TYPE", "abbrev", "category", false, "describing about this bug type...",
+                "describing about this bug type with value {0.givenClass} and {1.name}", "detailText", null, 0);
+        DetectorFactoryCollection.instance().registerBugPattern(bugPattern);
+
+        JavaClass clazz = Repository.lookupClass(PlaceholderTest.class);
+        Method method = Arrays.stream(clazz.getMethods()).filter(m -> m.getName().equals("testFormatWithKey")).findFirst().get();
+        reporter.reportBug(new BugInstance(bugPattern.getType(), bugPattern.getPriorityAdjustment()).addClassAndMethod(clazz, method));
+        reporter.finish();
+
+        String json = writer.toString();
+        JSONObject jsonObject = new JSONObject(json);
+        JSONObject run = jsonObject.getJSONArray("runs").getJSONObject(0);
+        JSONArray rules = run.getJSONObject("tool").getJSONObject("driver").getJSONArray("rules");
+        String defaultText = rules.getJSONObject(0).getJSONObject("messageStrings").getJSONObject("default").getString("text");
+        assertThat("key in placeholders are removed",
+                defaultText, is("describing about this bug type with value {0} and {1}"));
+
+        JSONArray results = run.getJSONArray("results");
+        JSONObject message = results.getJSONObject(0).getJSONObject("message");
+        JSONArray arguments = message.getJSONArray("arguments");
+        assertThat("BugAnnotation has been formatted by the key in placeholder",
+                arguments.getString(0), is("PlaceholderTest"));
+        assertThat("BugAnnotation has been formatted by the key in placeholder",
+                arguments.getString(1), is("testFormatWithKey"));
+    }
+}

--- a/spotbugs/src/test/java/edu/umd/cs/findbugs/sarif/SarifBugReporterTest.java
+++ b/spotbugs/src/test/java/edu/umd/cs/findbugs/sarif/SarifBugReporterTest.java
@@ -194,11 +194,11 @@ public class SarifBugReporterTest {
 
     @Test
     public void testExceptionNotification() {
+        reporter.getProject().getSourceFinder().setSourceBaseList(Collections.singletonList(new File("src/test/java").getAbsolutePath()));
         reporter.logError("Unexpected Error", new Exception("Unexpected Problem"));
         reporter.finish();
 
         String json = writer.toString();
-        System.err.println(json);
         JSONObject jsonObject = new JSONObject(json);
         JSONObject run = jsonObject.getJSONArray("runs").getJSONObject(0);
         JSONObject tool = run.getJSONObject("tool");
@@ -210,6 +210,10 @@ public class SarifBugReporterTest {
         assertThat(notification.getJSONObject("descriptor").getString("id"), is("spotbugs-error-0"));
         assertThat(notification.getJSONObject("message").getString("text"), is("Unexpected Error"));
         assertTrue(notification.has("exception"));
+        JSONArray frames = notification.getJSONObject("exception").getJSONObject("stack").getJSONArray("frames");
+        JSONObject physicalLocation = frames.getJSONObject(0).getJSONObject("location").getJSONObject("physicalLocation");
+        String uri = physicalLocation.getJSONObject("artifactLocation").getString("uri");
+        assertThat(uri, is("edu/umd/cs/findbugs/sarif/SarifBugReporterTest.java"));
     }
 
     @Test

--- a/spotbugs/src/test/java/edu/umd/cs/findbugs/sarif/SarifBugReporterTest.java
+++ b/spotbugs/src/test/java/edu/umd/cs/findbugs/sarif/SarifBugReporterTest.java
@@ -303,7 +303,7 @@ public class SarifBugReporterTest {
 
         JSONObject originalUriBaseIds = run.getJSONObject("originalUriBaseIds");
         String uriBaseId = takeFirstKey(originalUriBaseIds).get();
-        assertThat(new File(originalUriBaseIds.getJSONObject(uriBaseId).getString("uri")), is(tmpDir.toFile()));
+        assertThat(originalUriBaseIds.getJSONObject(uriBaseId).getString("uri"), is(tmpDir.toUri().toString()));
 
         JSONArray results = run.getJSONArray("results");
         assertThat(results.length(), is(1));
@@ -318,9 +318,5 @@ public class SarifBugReporterTest {
 
     Optional<String> takeFirstKey(JSONObject object) {
         return object.keySet().stream().findFirst();
-    }
-
-    Optional<Object> takeFirstValue(JSONObject object) {
-        return object.keySet().stream().map(object::get).findFirst();
     }
 }

--- a/spotbugs/src/test/java/edu/umd/cs/findbugs/sarif/SarifBugReporterTest.java
+++ b/spotbugs/src/test/java/edu/umd/cs/findbugs/sarif/SarifBugReporterTest.java
@@ -94,10 +94,8 @@ public class SarifBugReporterTest {
      */
     @Test
     public void testDriver() {
-        final String EXPECTED_NAME = "SpotBugs JUnit Test";
-        final String EXPECTED_VERSION = "1.2.3";
+        final String EXPECTED_VERSION = Version.VERSION_STRING;
         final String EXPECTED_LANGUAGE = "ja";
-        Version.registerApplication(EXPECTED_NAME, EXPECTED_VERSION);
 
         Locale defaultLocale = Locale.getDefault();
         try {
@@ -113,7 +111,7 @@ public class SarifBugReporterTest {
         JSONObject tool = run.getJSONObject("tool");
         JSONObject driver = tool.getJSONObject("driver");
 
-        assertThat(driver.get("name"), is(EXPECTED_NAME));
+        assertThat(driver.get("name"), is("SpotBugs"));
         assertThat(driver.get("version"), is(EXPECTED_VERSION));
         assertThat(driver.get("language"), is(EXPECTED_LANGUAGE));
     }


### PR DESCRIPTION
In this PR, we'll fix following known problems in SARIF reporter developed in #1184, and integrate it to SpotBugs.
refs https://github.com/spotbugs/discuss/issues/95

- [x] `version` is empty, even though SpotBugs should read it from `META-INF/MANIFEST.MF`.
- [x] `messageString` contains placeholders like `{2.givenClass}` that cannot be handled by SARIF client.
- [x] Need to find how to add location data to `frames` in `exception`.
- [x] Add `level` property to Result object
- [x] Pass [SARIF validator](https://sarifweb.azurewebsites.net/Validation)

[spotbugs.sarif.txt](https://github.com/spotbugs/spotbugs/files/4908477/spotbugs.sarif.txt) is the SARIF file generated by the SpotBugs in this branch, here is the command line that I run in the unzipped spotbugs distribution directory:

>  $JAVA_HOME/bin/java -jar lib/spotbugs.jar -textui -sarif -sourcepath /Users/kengo/GitHub/spotbugs/spotbugs/src/main/java -sourcepath /Users/kengo/GitHub/spotbugs/spotbugs/src/gui/main -output ~/Desktop/spotbugs.sarif lib/spotbugs.jar 

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code


[//]: # (rtdbot-start)

URL of RTD documents:
en: https://spotbugs.readthedocs.io/en/more-sarif-report/
ja: https://spotbugs.readthedocs.io/ja/more-sarif-report/

[//]: # (rtdbot-end)
