### PR TITLE
docs: remove colgroup element that is not supported by Java 8

### DIFF
--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/package-info.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/package-info.java
@@ -2,11 +2,6 @@
  * The package providing a {@code BugReporter} implementation which produces report in SARIF format.
  *
  * <table class="plain" style="width:100%">
- *   <colgroup>
- *     <col style="width:30%">
- *     <col style="width:30%">
- *     <col style="width:40%">
- *   </colgroup>
  *   <caption>Mapping from SARIF concepts to SpotBugs concepts</caption>
  *   <thead>
  *     <tr><th>SARIF</th><th>SpotBugs</th><th>Note</th></tr>


### PR DESCRIPTION
These elements broke javadoc build when we set Java 8 in JAVA_HOME.
refs https://github.com/spotbugs/spotbugs/runs/836887902#step:6:201
