### PR TITLE
Simplify the build script 

### DIFF
--- a/eclipsePlugin-test/build.gradle
+++ b/eclipsePlugin-test/build.gradle
@@ -39,9 +39,8 @@ javadoc {
   }
 }
 
-task sourcesJar(type: Jar) {
-  classifier = 'sources'
-  from sourceSets.main.allSource
+java {
+  withSourcesJar()
 }
 
 artifacts {

--- a/eclipsePlugin/build.gradle
+++ b/eclipsePlugin/build.gradle
@@ -231,7 +231,7 @@ def distSpec = copySpec {
 task distZip(type:Zip, dependsOn:jar) {
   with distSpec
   into "${eclipsePluginId}_${project.version}"
-  archiveName = "${eclipsePluginId}_${project.version}.zip"
+  archiveFileName.set "${eclipsePluginId}_${project.version}.zip"
 }
 
 task testPluginJar {
@@ -249,8 +249,8 @@ task testPluginJar {
 
 task pluginJar(type:Zip, dependsOn:jar) { // use Zip task, we already provide a manifest
   with distSpec
-  archiveName = "${eclipsePluginId}_${project.version}.jar"
-  destinationDir = file("${buildDir}/site/eclipse/plugins/")
+  archiveFileName.set "${eclipsePluginId}_${project.version}.jar"
+  destinationDirectory.set file("${buildDir}/site/eclipse/plugins/")
   finalizedBy testPluginJar
 }
 
@@ -277,7 +277,7 @@ def siteFilterTokens = [
 ]
 
 task featureJar(type:Zip) {
-  archiveName = "${eclipsePluginId}_${project.version}.jar"
+  archiveFileName.set "${eclipsePluginId}_${project.version}.jar"
   entryCompression = ZipEntryCompression.STORED // no compression, this is a jar with no manifest
   from('plugin_feature.xml') {
     filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
@@ -287,11 +287,11 @@ task featureJar(type:Zip) {
     filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
     rename { 'p2.inf' }
   }
-  destinationDir = file("${buildDir}/site/eclipse/features/")
+  destinationDirectory.set file("${buildDir}/site/eclipse/features/")
 }
 
 task featureCandidateJar(type:Zip) {
-  archiveName = "${eclipsePluginId}_${project.version}.jar"
+  archiveFileName.set "${eclipsePluginId}_${project.version}.jar"
   entryCompression = ZipEntryCompression.STORED // no compression, this is a jar with no manifest
   from('plugin_feature-candidate.xml') {
     filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
@@ -301,11 +301,11 @@ task featureCandidateJar(type:Zip) {
     filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
     rename { 'p2.inf' }
   }
-  destinationDir = file("${buildDir}/site/eclipse-candidate/features/")
+  destinationDirectory.set file("${buildDir}/site/eclipse-candidate/features/")
 }
 
 task featureDailyJar(type:Zip) {
-  archiveName = "${eclipsePluginId}_${project.version}.jar"
+  archiveFileName.set "${eclipsePluginId}_${project.version}.jar"
   entryCompression = ZipEntryCompression.STORED // no compression, this is a jar with no manifest
   from('plugin_feature-daily.xml') {
     filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
@@ -315,11 +315,11 @@ task featureDailyJar(type:Zip) {
     filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
     rename { 'p2.inf' }
   }
-  destinationDir = file("${buildDir}/site/eclipse-daily/features/")
+  destinationDirectory.set file("${buildDir}/site/eclipse-daily/features/")
 }
 
 task featureStableLatestJar(type:Zip) {
-  archiveName = "${eclipsePluginId}_${project.version}.jar"
+  archiveFileName.set "${eclipsePluginId}_${project.version}.jar"
   entryCompression = ZipEntryCompression.STORED // no compression, this is a jar with no manifest
   from('plugin_feature-stable_latest.xml') {
     filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
@@ -329,7 +329,7 @@ task featureStableLatestJar(type:Zip) {
     filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
     rename { 'p2.inf' }
   }
-  destinationDir = file("${buildDir}/site/eclipse-stable-latest/features/")
+  destinationDirectory.set file("${buildDir}/site/eclipse-stable-latest/features/")
 }
 
 task siteHtml(type:Copy) {
@@ -518,7 +518,7 @@ task eclipseSite() {
 // create zip file to upload to GitHub release page
 task eclipseSiteZip(type:Zip, dependsOn:eclipseSite) {
   from("${buildDir}/site/eclipse")
-  archiveName = "eclipsePlugin.zip"
+  archiveFileName = "eclipsePlugin.zip"
 }
 
 tasks['assemble'].dependsOn eclipseSite, eclipseSiteZip

--- a/eclipsePlugin/build.gradle
+++ b/eclipsePlugin/build.gradle
@@ -231,7 +231,7 @@ def distSpec = copySpec {
 task distZip(type:Zip, dependsOn:jar) {
   with distSpec
   into "${eclipsePluginId}_${project.version}"
-  archiveFileName.set "${eclipsePluginId}_${project.version}.zip"
+  archiveFileName = "${eclipsePluginId}_${project.version}.zip"
 }
 
 task testPluginJar {
@@ -249,8 +249,8 @@ task testPluginJar {
 
 task pluginJar(type:Zip, dependsOn:jar) { // use Zip task, we already provide a manifest
   with distSpec
-  archiveFileName.set "${eclipsePluginId}_${project.version}.jar"
-  destinationDirectory.set file("${buildDir}/site/eclipse/plugins/")
+  archiveFileName = "${eclipsePluginId}_${project.version}.jar"
+  destinationDirectory = file("${buildDir}/site/eclipse/plugins/")
   finalizedBy testPluginJar
 }
 
@@ -277,7 +277,7 @@ def siteFilterTokens = [
 ]
 
 task featureJar(type:Zip) {
-  archiveFileName.set "${eclipsePluginId}_${project.version}.jar"
+  archiveFileName = "${eclipsePluginId}_${project.version}.jar"
   entryCompression = ZipEntryCompression.STORED // no compression, this is a jar with no manifest
   from('plugin_feature.xml') {
     filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
@@ -287,11 +287,11 @@ task featureJar(type:Zip) {
     filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
     rename { 'p2.inf' }
   }
-  destinationDirectory.set file("${buildDir}/site/eclipse/features/")
+  destinationDirectory = file("${buildDir}/site/eclipse/features/")
 }
 
 task featureCandidateJar(type:Zip) {
-  archiveFileName.set "${eclipsePluginId}_${project.version}.jar"
+  archiveFileName = "${eclipsePluginId}_${project.version}.jar"
   entryCompression = ZipEntryCompression.STORED // no compression, this is a jar with no manifest
   from('plugin_feature-candidate.xml') {
     filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
@@ -301,11 +301,11 @@ task featureCandidateJar(type:Zip) {
     filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
     rename { 'p2.inf' }
   }
-  destinationDirectory.set file("${buildDir}/site/eclipse-candidate/features/")
+  destinationDirectory = file("${buildDir}/site/eclipse-candidate/features/")
 }
 
 task featureDailyJar(type:Zip) {
-  archiveFileName.set "${eclipsePluginId}_${project.version}.jar"
+  archiveFileName = "${eclipsePluginId}_${project.version}.jar"
   entryCompression = ZipEntryCompression.STORED // no compression, this is a jar with no manifest
   from('plugin_feature-daily.xml') {
     filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
@@ -315,11 +315,11 @@ task featureDailyJar(type:Zip) {
     filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
     rename { 'p2.inf' }
   }
-  destinationDirectory.set file("${buildDir}/site/eclipse-daily/features/")
+  destinationDirectory = file("${buildDir}/site/eclipse-daily/features/")
 }
 
 task featureStableLatestJar(type:Zip) {
-  archiveFileName.set "${eclipsePluginId}_${project.version}.jar"
+  archiveFileName = "${eclipsePluginId}_${project.version}.jar"
   entryCompression = ZipEntryCompression.STORED // no compression, this is a jar with no manifest
   from('plugin_feature-stable_latest.xml') {
     filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
@@ -329,7 +329,7 @@ task featureStableLatestJar(type:Zip) {
     filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
     rename { 'p2.inf' }
   }
-  destinationDirectory.set file("${buildDir}/site/eclipse-stable-latest/features/")
+  destinationDirectory = file("${buildDir}/site/eclipse-stable-latest/features/")
 }
 
 task siteHtml(type:Copy) {

--- a/eclipsePlugin/build.gradle
+++ b/eclipsePlugin/build.gradle
@@ -240,7 +240,7 @@ task testPluginJar {
             .matching { include 'lib/spotbugs.jar' }
             .singleFile
     if (!spotbugsJar.exists()) {
-      throw GradleException('Eclipse plugin does not contain spotbugs.jar');
+      throw new GradleException('Eclipse plugin does not contain spotbugs.jar');
     } else {
       println 'Eclipse plugin contains spotbugs.jar'
     }

--- a/spotbugs-annotations/build.gradle
+++ b/spotbugs-annotations/build.gradle
@@ -49,19 +49,12 @@ javadoc {
   }
 }
 
-task javadocJar(type: Jar) {
-  classifier = 'javadoc'
-  from javadoc
-}
-
-task sourcesJar(type: Jar) {
-  classifier = 'sources'
-  from sourceSets.main.allSource
+java {
+  withJavadocJar()
+  withSourcesJar()
 }
 
 publishing.publications.maven {
-  artifact javadocJar
-  artifact sourcesJar
   pom {
     name = 'SpotBugs Annotations'
     description = 'Annotations the SpotBugs tool supports'

--- a/spotbugs-annotations/build.gradle
+++ b/spotbugs-annotations/build.gradle
@@ -23,7 +23,7 @@ tasks.eclipse.dependsOn(updateManifest)
 
 jar {
   // To keep backward compatibility, delete version number from jar name
-  archiveName "${baseName}.${extension}"
+  archiveName "${archiveBaseName}.${archiveExtension}"
   manifest {
     attributes 'Bundle-Name': 'spotbugs-annotations',
                'Bundle-SymbolicName': 'spotbugs-annotations',

--- a/spotbugs-ant/build.gradle
+++ b/spotbugs-ant/build.gradle
@@ -19,19 +19,12 @@ jar {
   archiveName "${baseName}.${extension}"
 }
 
-task javadocJar(type: Jar) {
-  classifier = 'javadoc'
-  from javadoc
-}
-
-task sourcesJar(type: Jar) {
-  classifier = 'sources'
-  from sourceSets.main.allSource
+java {
+  withJavadocJar()
+  withSourcesJar()
 }
 
 publishing.publications.maven {
-  artifact javadocJar
-  artifact sourcesJar
   pom {
     name = 'SpotBugs Ant Task'
     description = 'Ant Task to run SpotBugs'

--- a/spotbugs-ant/build.gradle
+++ b/spotbugs-ant/build.gradle
@@ -16,7 +16,7 @@ javadoc {
 
 jar {
   // To keep backward compatibility, delete version number from jar name
-  archiveName "${baseName}.${extension}"
+  archiveName "${archiveBaseName}.${archiveExtension}"
 }
 
 java {

--- a/spotbugs-tests/build.gradle
+++ b/spotbugs-tests/build.gradle
@@ -24,9 +24,8 @@ test {
   }
 }
 
-task sourcesJar(type: Jar) {
-  classifier = 'sources'
-  from sourceSets.main.allSource
+java {
+  withSourcesJar()
 }
 
 artifacts {

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -241,14 +241,9 @@ javadoc {
   }
 }
 
-task javadocJar(type: Jar, dependsOn: javadoc) {
-  classifier 'javadoc'
-  from javadoc.destinationDir
-}
-
-task sourcesJar(type: Jar, dependsOn: classes) {
-  classifier = 'sources'
-  from sourceSets.main.allSource
+java {
+  withJavadocJar()
+  withSourcesJar()
 }
 
 apply plugin: 'distribution'
@@ -329,8 +324,6 @@ task smokeTest {
 }
 
 publishing.publications.maven {
-  artifact javadocJar
-  artifact sourcesJar
   artifact distTar
   artifact distZip
   pom {

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -180,7 +180,7 @@ tasks.eclipse.dependsOn(updateManifest)
 // Manually define what goes into the default jar, since it's not only main sourceset
 jar {
   // To keep backward compatibility, delete version number from jar name
-  archiveName "${baseName}.${extension}"
+  archiveName "${archiveBaseName}.${archiveExtension}"
 
   from sourceSets.main.output
   from sourceSets.gui.output

--- a/test-harness-core/build.gradle
+++ b/test-harness-core/build.gradle
@@ -6,19 +6,12 @@ dependencies {
   compileOnly project(':spotbugs')
 }
 
-task javadocJar(type: Jar) {
-  classifier = 'javadoc'
-  from javadoc
-}
-
-task sourcesJar(type: Jar) {
-  classifier = 'sources'
-  from sourceSets.main.allSource
+java {
+  withJavadocJar()
+  withSourcesJar()
 }
 
 publishing.publications.maven {
-  artifact javadocJar
-  artifact sourcesJar
   pom {
     name = 'Core of Test Harness for SpotBugs Plugin'
     description = 'Core feature to support unit test for SpotBugs Plugin'

--- a/test-harness-jupiter/build.gradle
+++ b/test-harness-jupiter/build.gradle
@@ -28,19 +28,12 @@ javadoc {
   }
 }
 
-task javadocJar(type: Jar) {
-  classifier = 'javadoc'
-  from javadoc
-}
-
-task sourcesJar(type: Jar) {
-  classifier = 'sources'
-  from sourceSets.main.allSource
+java {
+  withJavadocJar()
+  withSourcesJar()
 }
 
 publishing.publications.maven {
-  artifact javadocJar
-  artifact sourcesJar
   pom {
     name = 'JUnit 5 Test Harness for SpotBugs Plugin'
     description = 'A test harness library for SpotBugs plugin developers to test on JUnit 5'

--- a/test-harness/build.gradle
+++ b/test-harness/build.gradle
@@ -8,19 +8,12 @@ dependencies {
   api project(':test-harness-core')
 }
 
-task javadocJar(type: Jar) {
-  classifier = 'javadoc'
-  from javadoc
-}
-
-task sourcesJar(type: Jar) {
-  classifier = 'sources'
-  from sourceSets.main.allSource
+java {
+  withJavadocJar()
+  withSourcesJar()
 }
 
 publishing.publications.maven {
-  artifact javadocJar
-  artifact sourcesJar
   pom {
     name = 'JUnit 4 Test Harness for SpotBugs Plugin'
     description = 'A test harness library for SpotBugs plugin developers to test on JUnit4'


### PR DESCRIPTION
When I fix #1158 by #1170, I found that current build script contains several problems:

- tasks are not ready to run in parallel
- deprecated properties
- tasks output to local filesystem, but they're not handled as their output

To enable parallel build, we'll fix some of them in this PR.