### PR TITLE
Simplify the build script

### DIFF
--- a/eclipsePlugin-test/build.gradle
+++ b/eclipsePlugin-test/build.gradle
@@ -39,9 +39,8 @@ javadoc {
   }
 }
 
-task sourcesJar(type: Jar) {
-  classifier = 'sources'
-  from sourceSets.main.allSource
+java {
+  withSourcesJar()
 }
 
 artifacts {

--- a/eclipsePlugin/build.gradle
+++ b/eclipsePlugin/build.gradle
@@ -112,10 +112,18 @@ task copyLibsForEclipse(type: Copy) {
 }
 
 task distSrcZip(type:Exec) {
-  commandLine 'git', 'archive', '-o', "${buildDir}/distributions/${eclipsePluginId}_${project.version}-source.zip", 'HEAD'
+  def out = "${buildDir}/distributions/${eclipsePluginId}_${project.version}-source.zip"
+  outputs.file out
+  commandLine 'git', 'archive', '-o', out, 'HEAD'
 }
 
 task updateManifest {
+  inputs.file "$projectDir/META-INF/MANIFEST-TEMPLATE.MF"
+  outputs.file "$projectDir/META-INF/MANIFEST.MF"
+  outputs.file "$projectDir/META-INF/MANIFEST-DIST.MF"
+  inputs.file "$projectDir/build-template.properties"
+  outputs.file "$projectDir/build.properties"
+
   dependsOn ':spotbugs:updateManifest', copyLibsForEclipse
   doLast {
     def manifestSpec = manifest {
@@ -138,7 +146,7 @@ task updateManifest {
     distManifestSpec.writeTo("$projectDir/META-INF/MANIFEST-DIST.MF")
 
     // write build.properties
-    def propsTemplate = file('build-template.properties')
+    def propsTemplate = file("$projectDir/build-template.properties")
     def props = new Properties()
     props.load(propsTemplate.newDataInputStream())
     props.setProperty('bin.includes', props.getProperty('bin.includes') + ',' +
@@ -235,8 +243,10 @@ task distZip(type:Zip, dependsOn:jar) {
 }
 
 task testPluginJar {
+  def jarFile = "$buildDir/site/eclipse/plugins/${eclipsePluginId}_${project.version}.jar"
+  inputs.file jarFile
   doLast {
-    def spotbugsJar = zipTree("$buildDir/site/eclipse/plugins/${eclipsePluginId}_${project.version}.jar")
+    def spotbugsJar = zipTree(jarFile)
             .matching { include 'lib/spotbugs.jar' }
             .singleFile
     if (!spotbugsJar.exists()) {

--- a/eclipsePlugin/build.gradle
+++ b/eclipsePlugin/build.gradle
@@ -193,7 +193,7 @@ jar {
   dependsOn updateManifest
   includeEmptyDirs = false
   from sourceSets.main.output
-  archiveName 'spotbugs-plugin.jar'
+  archiveFileName = 'spotbugs-plugin.jar'
 }
 
 def distSpec = copySpec {
@@ -231,7 +231,7 @@ def distSpec = copySpec {
 task distZip(type:Zip, dependsOn:jar) {
   with distSpec
   into "${eclipsePluginId}_${project.version}"
-  archiveName = "${eclipsePluginId}_${project.version}.zip"
+  archiveFileName = "${eclipsePluginId}_${project.version}.zip"
 }
 
 task testPluginJar {
@@ -249,8 +249,8 @@ task testPluginJar {
 
 task pluginJar(type:Zip, dependsOn:jar) { // use Zip task, we already provide a manifest
   with distSpec
-  archiveName = "${eclipsePluginId}_${project.version}.jar"
-  destinationDir = file("${buildDir}/site/eclipse/plugins/")
+  archiveFileName = "${eclipsePluginId}_${project.version}.jar"
+  destinationDirectory = file("${buildDir}/site/eclipse/plugins/")
   finalizedBy testPluginJar
 }
 
@@ -277,7 +277,7 @@ def siteFilterTokens = [
 ]
 
 task featureJar(type:Zip) {
-  archiveName = "${eclipsePluginId}_${project.version}.jar"
+  archiveFileName = "${eclipsePluginId}_${project.version}.jar"
   entryCompression = ZipEntryCompression.STORED // no compression, this is a jar with no manifest
   from('plugin_feature.xml') {
     filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
@@ -287,11 +287,11 @@ task featureJar(type:Zip) {
     filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
     rename { 'p2.inf' }
   }
-  destinationDir = file("${buildDir}/site/eclipse/features/")
+  destinationDirectory = file("${buildDir}/site/eclipse/features/")
 }
 
 task featureCandidateJar(type:Zip) {
-  archiveName = "${eclipsePluginId}_${project.version}.jar"
+  archiveFileName = "${eclipsePluginId}_${project.version}.jar"
   entryCompression = ZipEntryCompression.STORED // no compression, this is a jar with no manifest
   from('plugin_feature-candidate.xml') {
     filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
@@ -301,11 +301,11 @@ task featureCandidateJar(type:Zip) {
     filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
     rename { 'p2.inf' }
   }
-  destinationDir = file("${buildDir}/site/eclipse-candidate/features/")
+  destinationDirectory = file("${buildDir}/site/eclipse-candidate/features/")
 }
 
 task featureDailyJar(type:Zip) {
-  archiveName = "${eclipsePluginId}_${project.version}.jar"
+  archiveFileName = "${eclipsePluginId}_${project.version}.jar"
   entryCompression = ZipEntryCompression.STORED // no compression, this is a jar with no manifest
   from('plugin_feature-daily.xml') {
     filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
@@ -315,11 +315,11 @@ task featureDailyJar(type:Zip) {
     filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
     rename { 'p2.inf' }
   }
-  destinationDir = file("${buildDir}/site/eclipse-daily/features/")
+  destinationDirectory = file("${buildDir}/site/eclipse-daily/features/")
 }
 
 task featureStableLatestJar(type:Zip) {
-  archiveName = "${eclipsePluginId}_${project.version}.jar"
+  archiveFileName = "${eclipsePluginId}_${project.version}.jar"
   entryCompression = ZipEntryCompression.STORED // no compression, this is a jar with no manifest
   from('plugin_feature-stable_latest.xml') {
     filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
@@ -329,7 +329,7 @@ task featureStableLatestJar(type:Zip) {
     filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
     rename { 'p2.inf' }
   }
-  destinationDir = file("${buildDir}/site/eclipse-stable-latest/features/")
+  destinationDirectory = file("${buildDir}/site/eclipse-stable-latest/features/")
 }
 
 task siteHtml(type:Copy) {
@@ -518,7 +518,7 @@ task eclipseSite() {
 // create zip file to upload to GitHub release page
 task eclipseSiteZip(type:Zip, dependsOn:eclipseSite) {
   from("${buildDir}/site/eclipse")
-  archiveName = "eclipsePlugin.zip"
+  archiveFileName = "eclipsePlugin.zip"
 }
 
 tasks['assemble'].dependsOn eclipseSite, eclipseSiteZip

--- a/eclipsePlugin/build.gradle
+++ b/eclipsePlugin/build.gradle
@@ -240,7 +240,7 @@ task testPluginJar {
             .matching { include 'lib/spotbugs.jar' }
             .singleFile
     if (!spotbugsJar.exists()) {
-      throw GradleException('Eclipse plugin does not contain spotbugs.jar');
+      throw new GradleException('Eclipse plugin does not contain spotbugs.jar');
     } else {
       println 'Eclipse plugin contains spotbugs.jar'
     }

--- a/spotbugs-annotations/build.gradle
+++ b/spotbugs-annotations/build.gradle
@@ -49,19 +49,12 @@ javadoc {
   }
 }
 
-task javadocJar(type: Jar) {
-  classifier = 'javadoc'
-  from javadoc
-}
-
-task sourcesJar(type: Jar) {
-  classifier = 'sources'
-  from sourceSets.main.allSource
+java {
+  withJavadocJar()
+  withSourcesJar()
 }
 
 publishing.publications.maven {
-  artifact javadocJar
-  artifact sourcesJar
   pom {
     name = 'SpotBugs Annotations'
     description = 'Annotations the SpotBugs tool supports'

--- a/spotbugs-annotations/build.gradle
+++ b/spotbugs-annotations/build.gradle
@@ -23,7 +23,7 @@ tasks.eclipse.dependsOn(updateManifest)
 
 jar {
   // To keep backward compatibility, delete version number from jar name
-  archiveName "${baseName}.${extension}"
+  archiveFileName = "${archiveBaseName.get()}.${archiveExtension.get()}"
   manifest {
     attributes 'Bundle-Name': 'spotbugs-annotations',
                'Bundle-SymbolicName': 'spotbugs-annotations',

--- a/spotbugs-ant/build.gradle
+++ b/spotbugs-ant/build.gradle
@@ -16,7 +16,7 @@ javadoc {
 
 jar {
   // To keep backward compatibility, delete version number from jar name
-  archiveName "${baseName}.${extension}"
+  archiveFileName = "${archiveBaseName.get()}.${archiveExtension.get()}"
 }
 
 java {

--- a/spotbugs-ant/build.gradle
+++ b/spotbugs-ant/build.gradle
@@ -19,19 +19,12 @@ jar {
   archiveName "${baseName}.${extension}"
 }
 
-task javadocJar(type: Jar) {
-  classifier = 'javadoc'
-  from javadoc
-}
-
-task sourcesJar(type: Jar) {
-  classifier = 'sources'
-  from sourceSets.main.allSource
+java {
+  withJavadocJar()
+  withSourcesJar()
 }
 
 publishing.publications.maven {
-  artifact javadocJar
-  artifact sourcesJar
   pom {
     name = 'SpotBugs Ant Task'
     description = 'Ant Task to run SpotBugs'

--- a/spotbugs-tests/build.gradle
+++ b/spotbugs-tests/build.gradle
@@ -24,9 +24,8 @@ test {
   }
 }
 
-task sourcesJar(type: Jar) {
-  classifier = 'sources'
-  from sourceSets.main.allSource
+java {
+  withSourcesJar()
 }
 
 artifacts {

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -241,14 +241,9 @@ javadoc {
   }
 }
 
-task javadocJar(type: Jar, dependsOn: javadoc) {
-  classifier 'javadoc'
-  from javadoc.destinationDir
-}
-
-task sourcesJar(type: Jar, dependsOn: classes) {
-  classifier = 'sources'
-  from sourceSets.main.allSource
+java {
+  withJavadocJar()
+  withSourcesJar()
 }
 
 apply plugin: 'distribution'
@@ -329,8 +324,6 @@ task smokeTest {
 }
 
 publishing.publications.maven {
-  artifact javadocJar
-  artifact sourcesJar
   artifact distTar
   artifact distZip
   pom {

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -163,6 +163,8 @@ task copyLibsForEclipse (type: Copy) {
 }
 
 task updateManifest {
+  inputs.file "$projectDir/META-INF/MANIFEST-TEMPLATE.MF"
+  outputs.file "$projectDir/META-INF/MANIFEST.MF"
   dependsOn configurations.runtimeClasspath, copyLibsForEclipse
   doLast {
     def manifestSpec = manifest {
@@ -282,7 +284,9 @@ tasks['assemble'].dependsOn tasks['assembleDist']
 tasks['jar'].dependsOn tasks['updateManifest']
 
 task distSrcZip(type:Exec) {
-  commandLine 'git', 'archive', '-o', "${buildDir}/distributions/spotbugs-${project.version}-source.zip",
+  def out = "${buildDir}/distributions/spotbugs-${project.version}-source.zip"
+  outputs.file out
+  commandLine 'git', 'archive', '-o', out,
     '--prefix', "spotbugs-${project.version}/", 'HEAD'
 }
 distSrcZip.onlyIf {

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -8,6 +8,10 @@ configurations {
   logBinding
 }
 
+ext {
+  asmVersion = '8.0.1'
+}
+
 sourceSets {
   main {
     java {
@@ -56,11 +60,11 @@ sourceSets {
 }
 
 dependencies {
-  api 'org.ow2.asm:asm:8.0.1'
-  api 'org.ow2.asm:asm-analysis:8.0.1'
-  api 'org.ow2.asm:asm-commons:8.0.1'
-  api 'org.ow2.asm:asm-tree:8.0.1'
-  api 'org.ow2.asm:asm-util:8.0.1'
+  api "org.ow2.asm:asm:${asmVersion}"
+  api "org.ow2.asm:asm-analysis:${asmVersion}"
+  api "org.ow2.asm:asm-commons:${asmVersion}"
+  api "org.ow2.asm:asm-tree:${asmVersion}"
+  api "org.ow2.asm:asm-util:${asmVersion}"
   api 'org.apache.bcel:bcel:6.5.0'
   api 'net.jcip:jcip-annotations:1.0'
   api('org.dom4j:dom4j:2.1.3') {

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -5,7 +5,9 @@ apply from: "$rootDir/gradle/javadoc.gradle"
 
 configurations {
   // used only in distribution. It is not listed in pom.xml, so users like maven plugin don't use this dependency.
-  logBinding
+  logBinding {
+    transitive = false
+  }
 }
 
 ext {
@@ -148,7 +150,7 @@ task copyLibsForEclipse (type: Copy) {
     include "*.jar"
     exclude "*xml-apis*.jar"
     exclude "*spotbugs-annotations*.jar"
-    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }
 
 task updateManifest {
@@ -214,7 +216,7 @@ task scripts(type:Copy) {
   }
 
   destinationDir file("$buildDir/bin")
-  duplicatesStrategy DuplicatesStrategy.INCLUDE
+  duplicatesStrategy DuplicatesStrategy.FAIL
 }
 
 // This disables hundreds of javadoc warnings on missing tags etc, see #340
@@ -269,6 +271,8 @@ distributions {
 }
 
 distTar.compression = Compression.GZIP
+distTar.duplicatesStrategy = DuplicatesStrategy.FAIL
+distZip.duplicatesStrategy = DuplicatesStrategy.FAIL
 tasks['assemble'].dependsOn tasks['assembleDist']
 tasks['jar'].dependsOn tasks['updateManifest']
 

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -180,7 +180,7 @@ tasks.eclipse.dependsOn(updateManifest)
 // Manually define what goes into the default jar, since it's not only main sourceset
 jar {
   // To keep backward compatibility, delete version number from jar name
-  archiveName "${baseName}.${extension}"
+  archiveFileName = "${archiveBaseName.get()}.${archiveExtension.get()}"
 
   from sourceSets.main.output
   from sourceSets.gui.output

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -118,8 +118,8 @@ tasks.withType(Jar).all {
 }
 
 eclipse.classpath {
-  plusConfigurations += [ configurations.compileOnly ]
-  plusConfigurations += [ configurations.guiCompileOnly ]
+  plusConfigurations += [ configurations.compileClasspath ]
+  plusConfigurations += [ configurations.guiCompileClasspath ]
   plusConfigurations += [ configurations.testRuntimeClasspath ]
 }
 
@@ -139,27 +139,12 @@ eclipse.classpath.file {
 }
 
 task copyLibsForEclipse (type: Copy) {
-    from configurations.runtimeClasspath.files
+    from configurations.testCompileClasspath.files, configurations.testRuntimeClasspath.files, configurations.guiRuntimeClasspath.files, configurations.logBinding.files
     into ".libs"
     include "*.jar"
     exclude "*xml-apis*.jar"
     exclude "*spotbugs-annotations*.jar"
-
-    from configurations.logBinding.files
-    into ".libs"
-    include "*.jar"
-
-    from configurations.testRuntimeClasspath.files
-    into ".libs"
-    include "*.jar"
-
-    from configurations.compileOnly.files
-    into ".libs"
-    include "*.jar"
-
-    from configurations.guiCompileOnly.files
-    into ".libs"
-    include "*.jar"
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
 }
 
 task updateManifest {

--- a/test-harness-core/build.gradle
+++ b/test-harness-core/build.gradle
@@ -6,19 +6,12 @@ dependencies {
   compileOnly project(':spotbugs')
 }
 
-task javadocJar(type: Jar) {
-  classifier = 'javadoc'
-  from javadoc
-}
-
-task sourcesJar(type: Jar) {
-  classifier = 'sources'
-  from sourceSets.main.allSource
+java {
+  withJavadocJar()
+  withSourcesJar()
 }
 
 publishing.publications.maven {
-  artifact javadocJar
-  artifact sourcesJar
   pom {
     name = 'Core of Test Harness for SpotBugs Plugin'
     description = 'Core feature to support unit test for SpotBugs Plugin'

--- a/test-harness-jupiter/build.gradle
+++ b/test-harness-jupiter/build.gradle
@@ -28,19 +28,12 @@ javadoc {
   }
 }
 
-task javadocJar(type: Jar) {
-  classifier = 'javadoc'
-  from javadoc
-}
-
-task sourcesJar(type: Jar) {
-  classifier = 'sources'
-  from sourceSets.main.allSource
+java {
+  withJavadocJar()
+  withSourcesJar()
 }
 
 publishing.publications.maven {
-  artifact javadocJar
-  artifact sourcesJar
   pom {
     name = 'JUnit 5 Test Harness for SpotBugs Plugin'
     description = 'A test harness library for SpotBugs plugin developers to test on JUnit 5'

--- a/test-harness/build.gradle
+++ b/test-harness/build.gradle
@@ -8,19 +8,12 @@ dependencies {
   api project(':test-harness-core')
 }
 
-task javadocJar(type: Jar) {
-  classifier = 'javadoc'
-  from javadoc
-}
-
-task sourcesJar(type: Jar) {
-  classifier = 'sources'
-  from sourceSets.main.allSource
+java {
+  withJavadocJar()
+  withSourcesJar()
 }
 
 publishing.publications.maven {
-  artifact javadocJar
-  artifact sourcesJar
   pom {
     name = 'JUnit 4 Test Harness for SpotBugs Plugin'
     description = 'A test harness library for SpotBugs plugin developers to test on JUnit4'


### PR DESCRIPTION
When I fix #1158 by #1170, I found that current build script contains several problems:

- tasks are not ready to run in parallel
- deprecated properties
- tasks output to local filesystem, but they're not handled as their output

To enable parallel build, we'll fix some of them in this PR. After we merge this PR, we have only one remaining warning:

> The compileOnly configuration has been deprecated for consumption. This will fail with an error in Gradle 7.0. Please use attributes to consume the apiElements configuration instead. See https://docs.gradle.org/6.5/userguide/java_library_plugin.html#sec:java_library_configurations_graph for more details.

It comes from the buildscript for `eclipsePlugin-junit` and `eclipsePlugin-test`.
Still not sure how to fix it, so I'll put it aside at this moment.