### PR TITLE
Move notifications from tool.driver to invocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,14 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ## Unreleased - 2020-??-??
 ### Added
-* Support for the SARIF 2.1.0 report ([discuss#95](https://github.com/spotbugs/discuss/issues/95))
+* Experimental support for the SARIF 2.1.0 report ([discuss#95](https://github.com/spotbugs/discuss/issues/95))
 
 ### Fixed
 * Fixed not working detector 'CbeckMustOverrideSuperAnnotation' and renamed to 'OverridingMethodsMustInvokeSuperDetector'
+
+### Changed
+* Bump up Saxon-HE to 10.1 ([#1214](https://github.com/spotbugs/spotbugs/pull/1214))
+* Bump up log4j-slf4j18-impl to 2.13.3 ([#1192](https://github.com/spotbugs/spotbugs/pull/1192))
 
 ## 4.0.6 - 2020-06-23
 ### Fixed

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -5,9 +5,7 @@ apply from: "$rootDir/gradle/javadoc.gradle"
 
 configurations {
   // used only in distribution. It is not listed in pom.xml, so users like maven plugin don't use this dependency.
-  logBinding {
-    transitive = false
-  }
+  logBinding
 }
 
 ext {
@@ -93,7 +91,9 @@ dependencies {
   }
   api 'org.slf4j:slf4j-api:1.8.0-beta4'
   implementation 'net.sf.saxon:Saxon-HE:9.9.1-2'
-  logBinding 'org.apache.logging.log4j:log4j-slf4j18-impl:2.13.1'
+  logBinding ('org.apache.logging.log4j:log4j-slf4j18-impl:2.13.1') {
+    exclude group: 'org.slf4j'
+  }
 
   // These annotations are repackaged to spotbugs.jar, to keep backward compatibility for Ant task.
   // If they're not repackaged, Ant task will report 'java.lang.ClassNotFoundException: edu.umd.cs.findbugs.annotations.CleanupObligation'

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ExitCode.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ExitCode.java
@@ -36,17 +36,17 @@ public class ExitCode {
         LOG.info("Calculating exit code...");
         if (errors > 0) {
             exitCode |= ExitCodes.ERROR_FLAG;
-            LOG.debug("Setting 'errors encountered' flag ({0})", ExitCodes.ERROR_FLAG);
+            LOG.debug("Setting 'errors encountered' flag ({})", ExitCodes.ERROR_FLAG);
         }
         if (missingClasses > 0) {
             exitCode |= ExitCodes.MISSING_CLASS_FLAG;
-            LOG.debug("Setting 'missing class' flag ({0})", ExitCodes.MISSING_CLASS_FLAG);
+            LOG.debug("Setting 'missing class' flag ({})", ExitCodes.MISSING_CLASS_FLAG);
         }
         if (bugs > 0) {
             exitCode |= ExitCodes.BUGS_FOUND_FLAG;
-            LOG.debug("Setting 'bugs found' flag ({0})", ExitCodes.BUGS_FOUND_FLAG);
+            LOG.debug("Setting 'bugs found' flag ({})", ExitCodes.BUGS_FOUND_FLAG);
         }
-        LOG.debug("Exit code set to: {0}", exitCode);
+        LOG.debug("Exit code set to: {}", exitCode);
 
         return new ExitCode(exitCode, getSignalName(exitCode));
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ExitCode.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ExitCode.java
@@ -1,0 +1,72 @@
+package edu.umd.cs.findbugs;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+
+public class ExitCode {
+    private static final Logger LOG = LoggerFactory.getLogger(ExitCode.class);
+
+    private final int exitCode;
+    @NonNull
+    private final String signalName;
+
+    private ExitCode(int exitCode, @NonNull String signalName) {
+        this.exitCode = exitCode;
+        this.signalName = Objects.requireNonNull(signalName);
+    }
+
+    public int getExitCode() {
+        return exitCode;
+    }
+
+    @NonNull
+    public String getSignalName() {
+        return signalName;
+    }
+
+    public static ExitCode from(int errors, int missingClasses, int bugs) {
+        int exitCode = 0;
+        LOG.info("Calculating exit code...");
+        if (errors > 0) {
+            exitCode |= ExitCodes.ERROR_FLAG;
+            LOG.debug("Setting 'errors encountered' flag ({0})", ExitCodes.ERROR_FLAG);
+        }
+        if (missingClasses > 0) {
+            exitCode |= ExitCodes.MISSING_CLASS_FLAG;
+            LOG.debug("Setting 'missing class' flag ({0})", ExitCodes.MISSING_CLASS_FLAG);
+        }
+        if (bugs > 0) {
+            exitCode |= ExitCodes.BUGS_FOUND_FLAG;
+            LOG.debug("Setting 'bugs found' flag ({0})", ExitCodes.BUGS_FOUND_FLAG);
+        }
+        LOG.debug("Exit code set to: {0}", exitCode);
+
+        return new ExitCode(exitCode, getSignalName(exitCode));
+    }
+
+    private static String getSignalName(int exitCode) {
+        if (exitCode == 0) {
+            return "SUCCESS";
+        }
+
+        List<String> list = new ArrayList<>();
+        if ((exitCode | ExitCodes.ERROR_FLAG) > 0) {
+            list.add("ERROR");
+        }
+        if ((exitCode | ExitCodes.MISSING_CLASS_FLAG) > 0) {
+            list.add("MISSING CLASS");
+        }
+        if ((exitCode | ExitCodes.BUGS_FOUND_FLAG) > 0) {
+            list.add("BUGS FOUND");
+        }
+
+        return list.isEmpty() ? "UNKNOWN" : list.stream().collect(Collectors.joining(","));
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/FindBugs.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/FindBugs.java
@@ -413,22 +413,7 @@ public abstract class FindBugs {
         }
 
         if (commandLine.setExitCode()) {
-            int exitCode = 0;
-            LOG.info("Calculating exit code...");
-            if (errorCount > 0) {
-                exitCode |= ExitCodes.ERROR_FLAG;
-                LOG.log(FINE, "Setting 'errors encountered' flag ({0})", ExitCodes.ERROR_FLAG);
-            }
-            if (missingClassCount > 0) {
-                exitCode |= ExitCodes.MISSING_CLASS_FLAG;
-                LOG.log(FINE, "Setting 'missing class' flag ({0})", ExitCodes.MISSING_CLASS_FLAG);
-            }
-            if (bugCount > 0) {
-                exitCode |= ExitCodes.BUGS_FOUND_FLAG;
-                LOG.log(FINE, "Setting 'bugs found' flag ({0})", ExitCodes.BUGS_FOUND_FLAG);
-            }
-            LOG.log(FINE, "Exit code set to: {0}", exitCode);
-
+            int exitCode = ExitCode.from(errorCount, missingClassCount, bugCount).getExitCode();
             System.exit(exitCode);
         }
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Invocation.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Invocation.java
@@ -1,0 +1,46 @@
+package edu.umd.cs.findbugs.sarif;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import org.json.JSONObject;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * @see <a href="https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/sarif-v2.1.0-os.html#_Toc34317567">3.20 invocation object</a>
+ */
+class Invocation {
+    private final int exitCode;
+    @NonNull
+    private final String exitSignalName;
+    private final boolean executionSuccessful;
+    @NonNull
+    private final List<Notification> toolExecutionNotifications;
+    @NonNull
+    private final List<Notification> toolConfigurationNotifications;
+
+    Invocation(int exitCode, @NonNull String exitSignalName, boolean executionSuccessful, @NonNull List<Notification> toolExecutionNotifications,
+            @NonNull List<Notification> toolConfigurationNotifications) {
+        this.exitCode = exitCode;
+        this.exitSignalName = Objects.requireNonNull(exitSignalName);
+        this.executionSuccessful = executionSuccessful;
+        this.toolExecutionNotifications = Collections.unmodifiableList(toolExecutionNotifications);
+        this.toolConfigurationNotifications = Collections.unmodifiableList(toolConfigurationNotifications);
+    }
+
+    @NonNull
+    JSONObject toJSONObject() {
+        JSONObject result = new JSONObject()
+                .put("exitCode", exitCode)
+                .put("exitSignalName", exitSignalName)
+                .put("executionSuccessful", executionSuccessful);
+        toolExecutionNotifications.stream()
+                .map(Notification::toJSONObject)
+                .forEach(json -> result.append("toolExecutionNotifications", json));
+        toolConfigurationNotifications.stream()
+                .map(Notification::toJSONObject)
+                .forEach(json -> result.append("toolConfigurationNotifications", json));
+        return result;
+    }
+}

--- a/spotbugs/src/test/java/edu/umd/cs/findbugs/sarif/SarifBugReporterTest.java
+++ b/spotbugs/src/test/java/edu/umd/cs/findbugs/sarif/SarifBugReporterTest.java
@@ -162,12 +162,12 @@ public class SarifBugReporterTest {
         String json = writer.toString();
         JSONObject jsonObject = new JSONObject(json);
         JSONObject run = jsonObject.getJSONArray("runs").getJSONObject(0);
-        JSONObject tool = run.getJSONObject("tool");
-        JSONObject driver = tool.getJSONObject("driver");
-        JSONArray notifications = driver.getJSONArray("notifications");
+        JSONArray toolConfigurationNotifications = run.getJSONArray("invocations")
+                .getJSONObject(0)
+                .getJSONArray("toolConfigurationNotifications");
 
-        assertThat(notifications.length(), is(1));
-        JSONObject notification = notifications.getJSONObject(0);
+        assertThat(toolConfigurationNotifications.length(), is(1));
+        JSONObject notification = toolConfigurationNotifications.getJSONObject(0);
         assertThat(notification.getJSONObject("descriptor").getString("id"), is("spotbugs-missing-classes"));
         assertThat(notification.getJSONObject("message").getString("text"), is(
                 "Classes needed for analysis were missing: [com.github.spotbugs.MissingClass]"));
@@ -181,12 +181,12 @@ public class SarifBugReporterTest {
         String json = writer.toString();
         JSONObject jsonObject = new JSONObject(json);
         JSONObject run = jsonObject.getJSONArray("runs").getJSONObject(0);
-        JSONObject tool = run.getJSONObject("tool");
-        JSONObject driver = tool.getJSONObject("driver");
-        JSONArray notifications = driver.getJSONArray("notifications");
+        JSONArray toolExecutionNotifications = run.getJSONArray("invocations")
+                .getJSONObject(0)
+                .getJSONArray("toolExecutionNotifications");
 
-        assertThat(notifications.length(), is(1));
-        JSONObject notification = notifications.getJSONObject(0);
+        assertThat(toolExecutionNotifications.length(), is(1));
+        JSONObject notification = toolExecutionNotifications.getJSONObject(0);
         assertThat(notification.getJSONObject("descriptor").getString("id"), is("spotbugs-error-0"));
         assertThat(notification.getJSONObject("message").getString("text"), is("Unexpected Error"));
         assertFalse(notification.has("exception"));
@@ -201,12 +201,12 @@ public class SarifBugReporterTest {
         String json = writer.toString();
         JSONObject jsonObject = new JSONObject(json);
         JSONObject run = jsonObject.getJSONArray("runs").getJSONObject(0);
-        JSONObject tool = run.getJSONObject("tool");
-        JSONObject driver = tool.getJSONObject("driver");
-        JSONArray notifications = driver.getJSONArray("notifications");
+        JSONArray toolExecutionNotifications = run.getJSONArray("invocations")
+                .getJSONObject(0)
+                .getJSONArray("toolExecutionNotifications");
 
-        assertThat(notifications.length(), is(1));
-        JSONObject notification = notifications.getJSONObject(0);
+        assertThat(toolExecutionNotifications.length(), is(1));
+        JSONObject notification = toolExecutionNotifications.getJSONObject(0);
         assertThat(notification.getJSONObject("descriptor").getString("id"), is("spotbugs-error-0"));
         assertThat(notification.getJSONObject("message").getString("text"), is("Unexpected Error"));
         assertTrue(notification.has("exception"));
@@ -224,12 +224,12 @@ public class SarifBugReporterTest {
         String json = writer.toString();
         JSONObject jsonObject = new JSONObject(json);
         JSONObject run = jsonObject.getJSONArray("runs").getJSONObject(0);
-        JSONObject tool = run.getJSONObject("tool");
-        JSONObject driver = tool.getJSONObject("driver");
-        JSONArray notifications = driver.getJSONArray("notifications");
+        JSONArray toolExecutionNotifications = run.getJSONArray("invocations")
+                .getJSONObject(0)
+                .getJSONArray("toolExecutionNotifications");
 
-        assertThat(notifications.length(), is(1));
-        JSONObject notification = notifications.getJSONObject(0);
+        assertThat(toolExecutionNotifications.length(), is(1));
+        JSONObject notification = toolExecutionNotifications.getJSONObject(0);
         assertThat(notification.getJSONObject("descriptor").getString("id"), is("spotbugs-error-0"));
         assertThat(notification.getJSONObject("message").getString("text"), is("Unexpected Error"));
         assertTrue(notification.has("exception"));


### PR DESCRIPTION
Based on https://github.com/microsoft/sarif-sdk/issues/1952#issuecomment-657254642 current place is not good to put reported errors during parse, so move it to proper place.

Also fix one build problem: c70db23 solved duplicated slf4j-api problem, but it introduced missing log4j-api problem.
Because [log4j binding depends on not only slf4j-api but also log4j-api](https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-slf4j18-impl/2.13.1).
