### PR TITLE
Use URI for files instead of converting string to URI each time.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 ## Unreleased - 2020-??-??
 ### Fixed
 * [A meaningless exception data from `SAXBugCollectionHandler`](https://lgtm.com/projects/g/spotbugs/spotbugs/rev/a77ab08634687b7791e902636996ab6184462693)
+* Use URI for files instead of converting string to URI each time. Fixes tests on Windows.
 
 ## 4.1.1 - 2020-07-31
 ### Fixed

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/FileSourceFileDataSource.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/FileSourceFileDataSource.java
@@ -24,15 +24,18 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 
 /**
  * Data source for source files which are stored in the filesystem.
  */
 public class FileSourceFileDataSource implements SourceFileDataSource {
     private final String fileName;
+    private final URI uri;
 
     public FileSourceFileDataSource(String fileName) {
         this.fileName = fileName;
+        this.uri = new File(fileName).toURI();
     }
 
     @Override
@@ -43,6 +46,11 @@ public class FileSourceFileDataSource implements SourceFileDataSource {
     @Override
     public String getFullFileName() {
         return fileName;
+    }
+
+    @Override
+    public URI getFullURI() {
+        return uri;
     }
 
     @Override

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/SourceFile.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/SourceFile.java
@@ -23,6 +23,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 
 /**
  * Cached data for a source file. Contains a map of line numbers to byte
@@ -117,6 +118,13 @@ public class SourceFile {
      */
     public String getFullFileName() {
         return dataSource.getFullFileName();
+    }
+
+    /**
+     * Get the full URI of the source file (with directory).
+     */
+    public URI getFullURI() {
+        return dataSource.getFullURI();
     }
 
     /**

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/SourceFileDataSource.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/SourceFileDataSource.java
@@ -21,6 +21,7 @@ package edu.umd.cs.findbugs.ba;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 
 /**
  * A data source which can produce a stream for a source file.
@@ -35,6 +36,11 @@ public interface SourceFileDataSource {
      * Get the full filename of the source file.
      */
     public String getFullFileName();
+
+    /**
+     * Get the full URI of the source file.
+     */
+    public URI getFullURI();
 
     public long getLastModified();
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/SourceFinder.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/SourceFinder.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.HashMap;
@@ -193,10 +194,16 @@ public class SourceFinder implements AutoCloseable {
         @Override
         public SourceFileDataSource getDataSource(final String fileName) {
             return new SourceFileDataSource() {
+                private final URI uri = URI.create(fileName);
 
                 @Override
                 public String getFullFileName() {
                     return fileName;
+                }
+
+                @Override
+                public URI getFullURI() {
+                    return uri;
                 }
 
                 @Override
@@ -620,14 +627,14 @@ public class SourceFinder implements AutoCloseable {
         }
     }
 
-    public Optional<String> getBase(SourceLineAnnotation sourceLineAnnotation) {
+    public Optional<URI> getBase(SourceLineAnnotation sourceLineAnnotation) {
         String relativePath = getPlatformName(sourceLineAnnotation);
         return getBase(relativePath);
     }
 
-    public Optional<String> getBase(String fileName) {
+    public Optional<URI> getBase(String fileName) {
         return repositoryList.stream()
                 .filter(SourceRepository::isPlatformDependent)
-                .filter(repo -> repo.contains(fileName)).map(repo -> repo.getDataSource("").getFullFileName()).findFirst();
+                .filter(repo -> repo.contains(fileName)).map(repo -> repo.getDataSource("").getFullURI()).findFirst();
     }
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/SourceFinder.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/SourceFinder.java
@@ -31,6 +31,9 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
@@ -351,9 +354,11 @@ public class SourceFinder implements AutoCloseable {
      */
     static class ZipSourceRepository implements SourceRepository {
         ZipFile zipFile;
+        FileSystem zipFileSystem;
 
-        public ZipSourceRepository(@WillCloseWhenClosed ZipFile zipFile) {
+        public ZipSourceRepository(@WillCloseWhenClosed ZipFile zipFile) throws IOException {
             this.zipFile = zipFile;
+            this.zipFileSystem = FileSystems.newFileSystem(Paths.get(zipFile.getName()), null);
         }
 
         @Override
@@ -368,11 +373,12 @@ public class SourceFinder implements AutoCloseable {
 
         @Override
         public SourceFileDataSource getDataSource(String fileName) {
-            return new ZipSourceFileDataSource(zipFile, fileName);
+            return new ZipSourceFileDataSource(zipFile, zipFileSystem, fileName);
         }
 
         @Override
         public void close() throws IOException {
+            zipFileSystem.close();
             zipFile.close();
         }
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/ZipSourceFileDataSource.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/ZipSourceFileDataSource.java
@@ -22,6 +22,7 @@ package edu.umd.cs.findbugs.ba;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
@@ -33,11 +34,14 @@ public class ZipSourceFileDataSource implements SourceFileDataSource {
 
     private final String entryName;
 
+    private final URI entryURI;
+
     private final ZipEntry zipEntry;
 
     public ZipSourceFileDataSource(ZipFile zipFile, String entryName) {
         this.zipFile = zipFile;
         this.entryName = entryName;
+        this.entryURI = URI.create(entryName);
         this.zipEntry = zipFile.getEntry(entryName);
     }
 
@@ -52,6 +56,11 @@ public class ZipSourceFileDataSource implements SourceFileDataSource {
     @Override
     public String getFullFileName() {
         return entryName;
+    }
+
+    @Override
+    public URI getFullURI() {
+        return entryURI;
     }
 
     /* (non-Javadoc)

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/ZipSourceFileDataSource.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/ZipSourceFileDataSource.java
@@ -23,6 +23,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.nio.file.FileSystem;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
@@ -38,10 +39,10 @@ public class ZipSourceFileDataSource implements SourceFileDataSource {
 
     private final ZipEntry zipEntry;
 
-    public ZipSourceFileDataSource(ZipFile zipFile, String entryName) {
+    public ZipSourceFileDataSource(ZipFile zipFile, FileSystem zipFileSystem, String entryName) {
         this.zipFile = zipFile;
         this.entryName = entryName;
-        this.entryURI = URI.create(entryName);
+        this.entryURI = zipFileSystem.getPath(entryName).toUri();
         this.zipEntry = zipFile.getEntry(entryName);
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/BugCollectionAnalyser.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/BugCollectionAnalyser.java
@@ -9,6 +9,7 @@ import edu.umd.cs.findbugs.ba.SourceFinder;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
+import java.net.URI;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -26,7 +27,7 @@ class BugCollectionAnalyser {
      * Map baseURI to uriBaseId. e.g. {@code "/user/ubuntu/github/spotbugs/" -> "8736793520"}
      */
     @NonNull
-    private final Map<String, String> baseToId = new HashMap<>();
+    private final Map<URI, String> baseToId = new HashMap<>();
 
     BugCollectionAnalyser(@NonNull BugCollection bugCollection) {
         SourceFinder sourceFinder = bugCollection.getProject().getSourceFinder();
@@ -49,7 +50,7 @@ class BugCollectionAnalyser {
     @NonNull
     JSONObject getOriginalUriBaseIds() {
         JSONObject result = new JSONObject();
-        baseToId.forEach((uri, uriBaseId) -> result.put(uriBaseId, new JSONObject().put("uri", "file://" + uri)));
+        baseToId.forEach((uri, uriBaseId) -> result.put(uriBaseId, new JSONObject().put("uri", uri.toString())));
         return result;
     }
 
@@ -82,7 +83,7 @@ class BugCollectionAnalyser {
         return ruleIndex;
     }
 
-    Map<String, String> getBaseToId() {
+    Map<URI, String> getBaseToId() {
         return baseToId;
     }
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Location.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Location.java
@@ -61,7 +61,7 @@ class Location {
     }
 
     static Optional<Location> fromBugInstance(@NonNull BugInstance bugInstance, @NonNull SourceFinder sourceFinder,
-            @NonNull Map<String, String> baseToId) {
+            @NonNull Map<URI, String> baseToId) {
         Objects.requireNonNull(bugInstance);
         Objects.requireNonNull(sourceFinder);
         Objects.requireNonNull(baseToId);
@@ -72,7 +72,7 @@ class Location {
     }
 
     static Location fromStackTraceElement(@NonNull StackTraceElement element, @NonNull SourceFinder sourceFinder,
-            @NonNull Map<String, String> baseToId) {
+            @NonNull Map<URI, String> baseToId) {
         Objects.requireNonNull(element);
         Objects.requireNonNull(sourceFinder);
         Objects.requireNonNull(baseToId);
@@ -84,7 +84,7 @@ class Location {
 
     @CheckForNull
     private static PhysicalLocation findPhysicalLocation(@NonNull BugInstance bugInstance, @NonNull SourceFinder sourceFinder,
-            Map<String, String> baseToId) {
+            Map<URI, String> baseToId) {
         try {
             SourceLineAnnotation sourceLine = bugInstance.getPrimarySourceLineAnnotation();
             return PhysicalLocation.fromBugAnnotation(sourceLine, sourceFinder, baseToId).orElse(null);
@@ -96,7 +96,7 @@ class Location {
 
     @CheckForNull
     private static Optional<PhysicalLocation> findPhysicalLocation(@NonNull StackTraceElement element, @NonNull SourceFinder sourceFinder,
-            Map<String, String> baseToId) {
+            Map<URI, String> baseToId) {
         Optional<Region> region = Optional.of(element.getLineNumber())
                 .filter(line -> line > 0)
                 .map(line -> new Region(line, line));
@@ -123,7 +123,7 @@ class Location {
         }
 
         static Optional<ArtifactLocation> fromBugAnnotation(@NonNull SourceLineAnnotation bugAnnotation, @NonNull SourceFinder sourceFinder,
-                @NonNull Map<String, String> baseToId) {
+                @NonNull Map<URI, String> baseToId) {
             Objects.requireNonNull(bugAnnotation);
             Objects.requireNonNull(sourceFinder);
             Objects.requireNonNull(baseToId);
@@ -132,14 +132,14 @@ class Location {
                 String uriBaseId = baseToId.computeIfAbsent(base, s -> Integer.toString(s.hashCode()));
                 try {
                     SourceFile sourceFile = sourceFinder.findSourceFile(bugAnnotation);
-                    return new ArtifactLocation(URI.create(base).relativize(URI.create(sourceFile.getFullFileName())), uriBaseId);
+                    return new ArtifactLocation(base.relativize(sourceFile.getFullURI()), uriBaseId);
                 } catch (IOException e) {
                     throw new UncheckedIOException(e);
                 }
             });
         }
 
-        static Optional<ArtifactLocation> fromStackTraceElement(StackTraceElement element, SourceFinder sourceFinder, Map<String, String> baseToId) {
+        static Optional<ArtifactLocation> fromStackTraceElement(StackTraceElement element, SourceFinder sourceFinder, Map<URI, String> baseToId) {
             Objects.requireNonNull(element);
             Objects.requireNonNull(sourceFinder);
             Objects.requireNonNull(baseToId);
@@ -154,7 +154,7 @@ class Location {
                 String relativeFileName = fullFileName.substring(index);
                 return sourceFinder.getBase(relativeFileName).map(base -> {
                     String baseId = baseToId.computeIfAbsent(base, s -> Integer.toString(s.hashCode()));
-                    URI relativeUri = URI.create(base).relativize(URI.create(sourceFile.getFullFileName()));
+                    URI relativeUri = base.relativize(sourceFile.getFullURI());
                     return new ArtifactLocation(relativeUri, baseId);
                 });
             } catch (IOException fileNotFound) {
@@ -219,7 +219,7 @@ class Location {
         }
 
         static Optional<PhysicalLocation> fromBugAnnotation(SourceLineAnnotation bugAnnotation, SourceFinder sourceFinder,
-                Map<String, String> baseToId) {
+                Map<URI, String> baseToId) {
             Optional<ArtifactLocation> artifactLocation = ArtifactLocation.fromBugAnnotation(bugAnnotation, sourceFinder, baseToId);
             Optional<Region> region = Region.fromBugAnnotation(bugAnnotation);
             return artifactLocation.map(location -> new PhysicalLocation(location, region.orElse(null)));

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Notification.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Notification.java
@@ -6,6 +6,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 import edu.umd.cs.findbugs.ba.SourceFinder;
 import org.json.JSONObject;
 
+import java.net.URI;
 import java.util.Map;
 import java.util.Objects;
 
@@ -40,7 +41,7 @@ class Notification {
     }
 
     static Notification fromError(@NonNull AbstractBugReporter.Error error, @NonNull SourceFinder sourceFinder,
-            @NonNull Map<String, String> baseToId) {
+            @NonNull Map<URI, String> baseToId) {
         String id = String.format("spotbugs-error-%d", error.getSequence());
         Throwable cause = error.getCause();
         if (cause == null) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/SarifBugReporter.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/SarifBugReporter.java
@@ -5,6 +5,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import org.json.JSONArray;
 import org.json.JSONWriter;
 
+import java.net.URI;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -38,8 +39,7 @@ public class SarifBugReporter extends BugCollectionBugReporter {
         jsonWriter.endObject().endArray();
     }
 
-
-    private void processInvocations(JSONWriter jsonWriter, @NonNull Map<String, String> baseToId) {
+    private void processInvocations(JSONWriter jsonWriter, @NonNull Map<URI, String> baseToId) {
         List<Notification> configNotifications = new ArrayList<>();
 
         Set<String> missingClasses = getMissingClasses();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/SarifException.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/SarifException.java
@@ -4,6 +4,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.ba.SourceFinder;
 import org.json.JSONObject;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -33,7 +34,7 @@ class SarifException {
     }
 
     @NonNull
-    static SarifException fromThrowable(@NonNull Throwable throwable, @NonNull SourceFinder sourceFinder, @NonNull Map<String, String> baseToId) {
+    static SarifException fromThrowable(@NonNull Throwable throwable, @NonNull SourceFinder sourceFinder, @NonNull Map<URI, String> baseToId) {
         String message = throwable.getMessage();
         if (message == null) {
             message = "no message given";

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Stack.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Stack.java
@@ -4,6 +4,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.ba.SourceFinder;
 import org.json.JSONObject;
 
+import java.net.URI;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -24,7 +25,7 @@ class Stack {
         this.frames = Collections.unmodifiableList(Objects.requireNonNull(frames));
     }
 
-    static Stack fromThrowable(Throwable throwable, @NonNull SourceFinder sourceFinder, @NonNull Map<String, String> baseToId) {
+    static Stack fromThrowable(Throwable throwable, @NonNull SourceFinder sourceFinder, @NonNull Map<URI, String> baseToId) {
         List<StackFrame> frames = Arrays.stream(Objects.requireNonNull(throwable).getStackTrace()).map(element -> StackFrame.fromStackTraceElement(
                 element, sourceFinder, baseToId)).collect(
                         Collectors.toList());
@@ -54,7 +55,7 @@ class Stack {
         }
 
         static StackFrame fromStackTraceElement(@NonNull StackTraceElement element, @NonNull SourceFinder sourceFinder,
-                @NonNull Map<String, String> baseToId) {
+                @NonNull Map<URI, String> baseToId) {
             Location location = Location.fromStackTraceElement(element, sourceFinder, baseToId);
             return new StackFrame(location);
         }

--- a/spotbugs/src/test/java/edu/umd/cs/findbugs/sarif/SarifBugReporterTest.java
+++ b/spotbugs/src/test/java/edu/umd/cs/findbugs/sarif/SarifBugReporterTest.java
@@ -29,6 +29,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
@@ -303,7 +304,7 @@ public class SarifBugReporterTest {
 
         JSONObject originalUriBaseIds = run.getJSONObject("originalUriBaseIds");
         String uriBaseId = takeFirstKey(originalUriBaseIds).get();
-        assertThat(originalUriBaseIds.getJSONObject(uriBaseId).getString("uri"), is(tmpDir.toUri().toString()));
+        assertThat(URI.create(originalUriBaseIds.getJSONObject(uriBaseId).getString("uri")), is(tmpDir.toUri()));
 
         JSONArray results = run.getJSONArray("results");
         assertThat(results.length(), is(1));


### PR DESCRIPTION
Fix java.net.URISyntaxException: Illegal character in opaque part at index 2: C:\... on WIndows
Fixes some test by comparing URIs because File and Path returns URIs
with different String representation https://stackoverflow.com/a/46634310

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
