### PR TITLE
Allow private methods to inherit default annotations from package or class scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 ## Unreleased - 2020-??-??
 ### Fixed
 * [A meaningless exception data from `SAXBugCollectionHandler`](https://lgtm.com/projects/g/spotbugs/spotbugs/rev/a77ab08634687b7791e902636996ab6184462693)
+* Allow private methods to inherit default annotations from package or class scope. ([#374](https://github.com/spotbugs/spotbugs/issues/374))
 
 ## 4.1.1 - 2020-07-31
 ### Fixed
@@ -19,7 +20,6 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ### Fixed
 * Fixed not working detector 'CbeckMustOverrideSuperAnnotation' and renamed to 'OverridingMethodsMustInvokeSuperDetector'
-* Allow private methods to inherit default annotations from package or class scope. ([#374](https://github.com/spotbugs/spotbugs/issues/374))
 
 ### Changed
 * Bump commons-lang3 from 3.10 to 3.11 ([#1231](https://github.com/spotbugs/spotbugs/pull/1231))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ### Fixed
 * Fixed not working detector 'CbeckMustOverrideSuperAnnotation' and renamed to 'OverridingMethodsMustInvokeSuperDetector'
+* Allow private methods to inherit default annotations from package or class scope. ([#374](https://github.com/spotbugs/spotbugs/issues/374))
 
 ## 4.0.6 - 2020-06-23
 ### Fixed

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue374Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue374Test.java
@@ -37,8 +37,7 @@ public class Issue374Test extends AbstractIntegrationTest {
                 "ghIssues/issue374/package-info.class",
                 "ghIssues/issue374/ClassLevel.class",
                 "ghIssues/issue374/MethodLevel.class",
-                "ghIssues/issue374/PackageLevel.class"
-        );
+                "ghIssues/issue374/PackageLevel.class");
         BugInstanceMatcher matcher = new BugInstanceMatcherBuilder()
                 .bugType("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
                 .build();

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue374Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue374Test.java
@@ -1,6 +1,6 @@
 /*
  * Contributions to SpotBugs
- * Copyright (C) 2018, kengo
+ * Copyright (C) 2020, kengo
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue374Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue374Test.java
@@ -1,6 +1,6 @@
 /*
  * Contributions to SpotBugs
- * Copyright (C) 2020, kengo
+ * Copyright (C) 2020, ritchan
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue374Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue374Test.java
@@ -1,0 +1,47 @@
+/*
+ * Contributions to SpotBugs
+ * Copyright (C) 2018, kengo
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
+import org.junit.Test;
+
+import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * @see <a href="https://github.com/spotbugs/spotbugs/issues/374">GitHub issue</a>
+ */
+public class Issue374Test extends AbstractIntegrationTest {
+    @Test
+    public void test() {
+        performAnalysis(
+                "ghIssues/issue374/package-info.class",
+                "ghIssues/issue374/ClassLevel.class",
+                "ghIssues/issue374/MethodLevel.class",
+                "ghIssues/issue374/PackageLevel.class"
+        );
+        BugInstanceMatcher matcher = new BugInstanceMatcherBuilder()
+                .bugType("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
+                .build();
+        assertThat(getBugCollection(), containsExactly(3, matcher));
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/TypeQualifierApplications.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/TypeQualifierApplications.java
@@ -986,11 +986,6 @@ public class TypeQualifierApplications {
             // default annotations
         }
 
-        /** private methods don't inherit from class or package scope */
-        if (xmethod.isPrivate()) {
-            stopAtMethodScope = true;
-        }
-
         boolean stopAtClassScope = false;
 
         if (!xmethod.isPublic() && !xmethod.isProtected() && (xmethod.isStatic() || "<init>".equals(xmethod.getName()))) {

--- a/spotbugsTestCases/src/java/ghIssues/issue374/ClassLevel.java
+++ b/spotbugsTestCases/src/java/ghIssues/issue374/ClassLevel.java
@@ -1,0 +1,19 @@
+package ghIssues.issue374;
+
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
+public class ClassLevel {
+    public String method() {
+        return methodNullable(null);
+    }
+
+    private String methodNullable(@Nullable final String test) {
+        return methodNonNull(test);
+    }
+
+    private String methodNonNull(final String test) {
+        return test;
+    }
+}

--- a/spotbugsTestCases/src/java/ghIssues/issue374/MethodLevel.java
+++ b/spotbugsTestCases/src/java/ghIssues/issue374/MethodLevel.java
@@ -1,0 +1,19 @@
+package ghIssues.issue374;
+
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+public class MethodLevel {
+    public String method() {
+        return methodNullable(null);
+    }
+
+    private String methodNullable(@Nullable final String test) {
+        return methodNonNull(test);
+    }
+
+    @ParametersAreNonnullByDefault
+    private String methodNonNull(final String test) {
+        return test;
+    }
+}

--- a/spotbugsTestCases/src/java/ghIssues/issue374/PackageLevel.java
+++ b/spotbugsTestCases/src/java/ghIssues/issue374/PackageLevel.java
@@ -1,0 +1,17 @@
+package ghIssues.issue374;
+
+import javax.annotation.Nullable;
+
+public class PackageLevel {
+    public String method() {
+        return methodNullable(null);
+    }
+
+    private String methodNullable(@Nullable final String test) {
+        return methodNonNull(test);
+    }
+
+    private String methodNonNull(final String test) {
+        return test;
+    }
+}

--- a/spotbugsTestCases/src/java/ghIssues/issue374/package-info.java
+++ b/spotbugsTestCases/src/java/ghIssues/issue374/package-info.java
@@ -1,0 +1,5 @@
+/*
+ * An example to reproduce problem at https://github.com/spotbugs/spotbugs/issues/374
+ */
+@javax.annotation.ParametersAreNonnullByDefault
+package ghIssues.issue374;


### PR DESCRIPTION
Resolves #374.

Thanks @RitChan for the reproduction test cases attached to the Issue.

From the comment in the code, the original decision to omit private methods seems very much intentional. But since the issue is classified as a bug it seemed safe to just remove that check.

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
