### PR TITLE
Release 4.1.1 as a hotfix for maven users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased - 2020-??-??
+## 4.1.1 - 2020-07-31
 ### Fixed
 * Missing the version of commons-lang3 for Maven ([#1239](https://github.com/spotbugs/spotbugs/issues/1239))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased - 2020-??-??
+
 ## 4.1.1 - 2020-07-31
 ### Fixed
 * Missing the version of commons-lang3 for Maven ([#1239](https://github.com/spotbugs/spotbugs/issues/1239))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased - 2020-??-??
+### Fixed
+* Missing the version of commons-lang3 for Maven ([#1239](https://github.com/spotbugs/spotbugs/issues/1239))
 
 ## 4.1.0 - 2020-07-30
 ### Added

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
   id "com.github.spotbugs" version "4.4.4"
 }
 
-version = '4.1.1-SNAPSHOT'
+version = '4.1.1'
 
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/jacoco.gradle"

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
   id "com.github.spotbugs" version "4.4.4"
 }
 
-version = '4.1.1'
+version = '4.1.2-SNAPSHOT'
 
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/jacoco.gradle"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,7 @@ import os
 
 html_context = {
   'version' : '4.1',
-  'full_version' : '4.1.0',
+  'full_version' : '4.1.1',
   'maven_plugin_version' : '4.0.4',
   'gradle_plugin_version' : '4.4.4',
   'archetype_version' : '0.2.3'

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -79,7 +79,7 @@ dependencies {
     exclude group: 'xpp3',             module: 'xpp3'
   }
   implementation 'jaxen:jaxen:1.1.6' // only transitive through dom4j:dom4j:1.6.1, which has an *optional* dependency on jaxen:jaxen.
-  api 'org.apache.commons:commons-lang3'
+  api 'org.apache.commons:commons-lang3:3.11'
   api 'org.apache.commons:commons-text:1.9'
   api 'org.slf4j:slf4j-api:1.8.0-beta4'
   implementation 'net.sf.saxon:Saxon-HE:10.1'


### PR DESCRIPTION
4.1.0 can work with Gradle (e.g. functional tests in https://github.com/spotbugs/spotbugs-gradle-plugin/pull/316 is working), but for Maven its `pom.xml` is invalid so #1239 was caused. This PR will fix it, and release 4.1.1 as hot fix.

Following file explains how this change affects the generated POM files.

* [before.pom.txt](https://github.com/spotbugs/spotbugs/files/5003580/before.pom.txt)
* [afrer.pom.txt](https://github.com/spotbugs/spotbugs/files/5003582/afrer.pom.txt)


----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code


[//]: # (rtdbot-start)

URL of RTD documents:
en: https://spotbugs.readthedocs.io/en/hotfix-for-maven/
ja: https://spotbugs.readthedocs.io/ja/hotfix-for-maven/

[//]: # (rtdbot-end)
