### PR TITLE
Add note on conditional reporting of violation

### DIFF
--- a/spotbugs/etc/messages.xml
+++ b/spotbugs/etc/messages.xml
@@ -4345,6 +4345,7 @@ has absolutely no effect.
 This may be leftover marking from a previous version of the code in which the class was transient, or
 it may indicate a misunderstanding of how serialization works.
 </p>
+<p><em>This bug is reported only if special option <tt>reportTransientFieldOfNonSerializableClass</tt> is set.</em></p>
 ]]>
     </Details>
   </BugPattern>


### PR DESCRIPTION
Per 618c4ad9db28c8ac7524dbfcb6dbd65b00fb51eb (change is still in place).

However one has to browse The Code to learn why such violation is not reported by default.

I *expected* to see this bug, but it wasn't reported on several first tries of intentionally changing inspected sources. So finally I found commit referenced above (unfortunately it does not provide reasoning for change).

Maybe the need of property is mentioned somewhere else, but I think it could also be disclosed in bug description.