### PR TITLE
Implement  #390

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 * [A meaningless exception data from `SAXBugCollectionHandler`](https://lgtm.com/projects/g/spotbugs/spotbugs/rev/a77ab08634687b7791e902636996ab6184462693)
 * Use URI for files instead of converting string to URI each time. Fixes tests on Windows.
 
+### Added
+* Implement [issue 390](https://github.com/spotbugs/spotbugs/issues/390) as a detector, `DontAssertInstanceofInTests`, which reports bugs of type `JUA_DONT_ASSERT_INSTANCEOF_IN_TESTS`.
+
 ## 4.1.1 - 2020-07-31
 ### Fixed
 * Missing the version of commons-lang3 for Maven ([#1239](https://github.com/spotbugs/spotbugs/issues/1239))

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue390Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue390Test.java
@@ -1,0 +1,21 @@
+package edu.umd.cs.findbugs.ba;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import edu.umd.cs.findbugs.BugInstance;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
+import org.hamcrest.MatcherAssert;
+import org.junit.Test;
+
+import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
+
+public class Issue390Test extends AbstractIntegrationTest {
+
+    @Test
+    public void test() {
+        performAnalysis("ghIssues/Issue390.class");
+        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder().bugType("JUA_DONT_ASSERT_INSTANCEOF_IN_TESTS").build();
+        MatcherAssert.assertThat(getBugCollection(), containsExactly(1, bugTypeMatcher));
+    }
+
+}

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue390Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue390Test.java
@@ -1,9 +1,9 @@
 package edu.umd.cs.findbugs.ba;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.BugInstance;
 import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
 import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
+
 import org.hamcrest.MatcherAssert;
 import org.junit.Test;
 

--- a/spotbugs/etc/findbugs.xml
+++ b/spotbugs/etc/findbugs.xml
@@ -647,7 +647,8 @@
                     reports="DM_DEFAULT_ENCODING"/>
           <Detector class="edu.umd.cs.findbugs.detect.CheckRelaxingNullnessAnnotation" speed="fast"
                     reports="NP_METHOD_RETURN_RELAXING_ANNOTATION,NP_METHOD_PARAMETER_TIGHTENS_ANNOTATION"/>
-
+          <Detector class="edu.umd.cs.findbugs.detect.DontAssertInstanceofInTests" speed="fast"
+                    reports="JUA_DONT_ASSERT_INSTANCEOF_IN_TESTS"/>
             <!-- Bug Categories -->
            <BugCategory category="NOISE" hidden="true"/>
 
@@ -675,6 +676,7 @@
           <BugCode abbrev="FB"/>
           <BugCode abbrev="AT"/>
           <!-- Bug patterns -->
+          <BugPattern abbrev="JUA" type="JUA_DONT_ASSERT_INSTANCEOF_IN_TESTS" category="BAD_PRACTICE" experimental="true" />
           <BugPattern abbrev="CN" type="OVERRIDING_METHODS_MUST_INVOKE_SUPER" category="CORRECTNESS" />
           <BugPattern abbrev="CNT" type="CNT_ROUGH_CONSTANT_VALUE" category="BAD_PRACTICE"/>
 

--- a/spotbugs/etc/messages.xml
+++ b/spotbugs/etc/messages.xml
@@ -1664,8 +1664,7 @@ factory pattern to create these objects.</p>
     <Details>
       <![CDATA[
             <p>Detector for patterns in JUnit tests where the type of an object
-               is checked by asserting the instanceof operator before an object
-               is cast to a certain type. </p>
+               is checked by asserting the instanceof operator.</p>
             <p>
                This should be avoided as the ClassCastException that would result
                from an improper cast may provide more information regarding the
@@ -1695,6 +1694,8 @@ factory pattern to create these objects.</p>
             Asserting the type before casting would instead result in a less informative <code>"false is not true"</code>
             message.</p>
 
+            <p>If JUnit is used with hamcrest, the <a href="https://junit.org/junit4/javadoc/latest/index.html?org/hamcrest/core/IsInstanceOf.html"><code>IsInstanceOf</code></a>
+            class from hamcrest could be used instead.</p>
             ]]>
     </Details>
   </BugPattern>

--- a/spotbugs/etc/messages.xml
+++ b/spotbugs/etc/messages.xml
@@ -1660,11 +1660,45 @@ factory pattern to create these objects.</p>
       ]]>
       </Details>
   </Detector>
+  <Detector class="edu.umd.cs.findbugs.detect.DontAssertInstanceofInTests">
+    <Details>
+      <![CDATA[
+            <p>Detector for patterns in JUnit tests where the type of an object
+               is checked by asserting the instanceof operator before an object
+               is cast to a certain type. </p>
+            <p>
+               This should be avoided as the ClassCastException that would result
+               from an improper cast may provide more information regarding the
+               cause of the error than a "false is not true" message which would
+               result from asserting the result of the instanceof operator.
+            </p>
+			<p>It is a fast detector</p>
+            ]]>
+    </Details>
+  </Detector>
   <!--
   **********************************************************************
   BugPatterns
   **********************************************************************
    -->
+
+  <BugPattern type="JUA_DONT_ASSERT_INSTANCEOF_IN_TESTS">
+    <ShortDescription> Asserting value of instanceof in tests is not recommended. </ShortDescription>
+    <LongDescription> Assertion of type {0} in {2} at {3} may hide useful information about why a cast may have failed.</LongDescription>
+    <Details>
+      <![CDATA[
+            <p>Asserting type checks in tests is not recommended as a class cast exception message could better indicate
+            the cause of an instance of the wrong class being used than an instanceof assertion.</p>
+
+            <p>When debugging tests that fail due to bad casts, it may be more useful to observe the output of the
+            resulting ClassCastException which could provide information about the actual encountered type.
+            Asserting the type before casting would instead result in a less informative <code>"false is not true"</code>
+            message.</p>
+
+            ]]>
+    </Details>
+  </BugPattern>
+
   <BugPattern type="OVERRIDING_METHODS_MUST_INVOKE_SUPER">
     <ShortDescription>Super method is annotated with @OverridingMethodsMustInvokeSuper, but the overriding method isn't calling the super method.</ShortDescription>
     <LongDescription>Super method is annotated with @OverridingMethodsMustInvokeSuper, but {1} isn't calling the super method.</LongDescription>

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DontAssertInstanceofInTests.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DontAssertInstanceofInTests.java
@@ -47,29 +47,29 @@ public class DontAssertInstanceofInTests extends BytecodeScanningDetector {
     public void sawOpcode(int seen) {
 
         switch (seen) {
-            case Const.INSTANCEOF: {
-                // Initialise the bug instance here.
-                currBug = new BugInstance(this, "JUA_DONT_ASSERT_INSTANCEOF_IN_TESTS", NORMAL_PRIORITY);
-                String operand = getDottedClassConstantOperand();
-                currBug.addTypeOfNamedClass(operand); // {0}
+        case Const.INSTANCEOF: {
+            // Initialise the bug instance here.
+            currBug = new BugInstance(this, "JUA_DONT_ASSERT_INSTANCEOF_IN_TESTS", NORMAL_PRIORITY);
+            String operand = getDottedClassConstantOperand();
+            currBug.addTypeOfNamedClass(operand); // {0}
 
-                break;
-            }
-            case Const.INVOKESTATIC: {
-                if (getPrevOpcode(1) == Const.INSTANCEOF) {
-                    String ciOp = getClassConstantOperand();
-                    String ncOp = getNameConstantOperand();
+            break;
+        }
+        case Const.INVOKESTATIC: {
+            if (getPrevOpcode(1) == Const.INSTANCEOF) {
+                String ciOp = getClassConstantOperand();
+                String ncOp = getNameConstantOperand();
 
-                    if ("org/junit/Assert".equals(ciOp) &&
-                            "assertTrue".equals(ncOp)) {
-                        // This condition only triggers if the previous opcode was instanceof,
-                        // so currBug is guaranteed to be a new BugInstance.
-                        currBug.addClassAndMethod(this) // {2}
-                                .addSourceLine(this); // {3}
-                        bugReporter.reportBug(currBug);
-                    }
+                if ("org/junit/Assert".equals(ciOp) &&
+                        "assertTrue".equals(ncOp)) {
+                    // This condition only triggers if the previous opcode was instanceof,
+                    // so currBug is guaranteed to be a new BugInstance.
+                    currBug.addClassAndMethod(this) // {2}
+                            .addSourceLine(this); // {3}
+                    bugReporter.reportBug(currBug);
                 }
             }
+        }
         }
 
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DontAssertInstanceofInTests.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DontAssertInstanceofInTests.java
@@ -1,0 +1,76 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.BugInstance;
+import edu.umd.cs.findbugs.BugReporter;
+import edu.umd.cs.findbugs.BytecodeScanningDetector;
+
+import org.apache.bcel.Const;
+import org.apache.bcel.classfile.AnnotationEntry;
+import org.apache.bcel.classfile.Code;
+import org.apache.bcel.classfile.Method;
+
+/**
+ * A detector that checks for lines in JUnit tests that look like `assertTrue(object instanceof Class)` and discourages them.
+ *
+ * It may be more useful to observe error messages from bad casts, as this may reveal more information regarding the
+ * circumstances of the exception than a "false is not true" assert message.
+ *
+ * This detector reports bugs of the type `JUA_DONT_ASSERT_INSTANCEOF_IN_TESTS`.
+ */
+public class DontAssertInstanceofInTests extends BytecodeScanningDetector {
+    private boolean isTest;
+
+    private BugInstance currBug = null;
+
+    BugReporter bugReporter;
+
+    public DontAssertInstanceofInTests(BugReporter bugReporter) {
+        this.bugReporter = bugReporter;
+    }
+
+    @Override
+    public void visitMethod(Method obj) {
+        isTest = false;
+        for (AnnotationEntry entry : obj.getAnnotationEntries()) {
+            String entryType = entry.getAnnotationType();
+            isTest |= "Lorg/junit/Test;".equals(entryType);
+        }
+    }
+
+    @Override
+    public void visitCode(Code obj) {
+        if (isTest)
+            super.visitCode(obj);
+    }
+
+    @Override
+    public void sawOpcode(int seen) {
+
+        switch (seen) {
+            case Const.INSTANCEOF: {
+                // Initialise the bug instance here.
+                currBug = new BugInstance(this, "JUA_DONT_ASSERT_INSTANCEOF_IN_TESTS", NORMAL_PRIORITY);
+                String operand = getDottedClassConstantOperand();
+                currBug.addTypeOfNamedClass(operand); // {0}
+
+                break;
+            }
+            case Const.INVOKESTATIC: {
+                if (getPrevOpcode(1) == Const.INSTANCEOF) {
+                    String ciOp = getClassConstantOperand();
+                    String ncOp = getNameConstantOperand();
+
+                    if ("org/junit/Assert".equals(ciOp) &&
+                            "assertTrue".equals(ncOp)) {
+                        // This condition only triggers if the previous opcode was instanceof,
+                        // so currBug is guaranteed to be a new BugInstance.
+                        currBug.addClassAndMethod(this) // {2}
+                                .addSourceLine(this); // {3}
+                        bugReporter.reportBug(currBug);
+                    }
+                }
+            }
+        }
+
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DontAssertInstanceofInTests.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DontAssertInstanceofInTests.java
@@ -2,8 +2,8 @@ package edu.umd.cs.findbugs.detect;
 
 import edu.umd.cs.findbugs.BugInstance;
 import edu.umd.cs.findbugs.BugReporter;
-import edu.umd.cs.findbugs.BytecodeScanningDetector;
 
+import edu.umd.cs.findbugs.bcel.OpcodeStackDetector;
 import org.apache.bcel.Const;
 import org.apache.bcel.classfile.AnnotationEntry;
 import org.apache.bcel.classfile.Code;
@@ -17,7 +17,7 @@ import org.apache.bcel.classfile.Method;
  *
  * This detector reports bugs of the type `JUA_DONT_ASSERT_INSTANCEOF_IN_TESTS`.
  */
-public class DontAssertInstanceofInTests extends BytecodeScanningDetector {
+public class DontAssertInstanceofInTests extends OpcodeStackDetector {
     private boolean isTest;
 
     private BugInstance currBug = null;
@@ -33,14 +33,14 @@ public class DontAssertInstanceofInTests extends BytecodeScanningDetector {
         isTest = false;
         for (AnnotationEntry entry : obj.getAnnotationEntries()) {
             String entryType = entry.getAnnotationType();
+            // Visit the method only if it's a JUnit test.
             isTest |= "Lorg/junit/Test;".equals(entryType);
         }
     }
 
     @Override
-    public void visitCode(Code obj) {
-        if (isTest)
-            super.visitCode(obj);
+    public boolean shouldVisitCode(Code obj) {
+        return isTest;
     }
 
     @Override

--- a/spotbugsTestCases/src/java/ghIssues/Issue390.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue390.java
@@ -6,6 +6,12 @@ import static org.junit.Assert.assertTrue;
 
 public class Issue390 {
 
+    // Should not trigger the lint.
+    public void not_test() {
+        Integer intVal = 1;
+        assertTrue(intVal instanceof Integer);
+    }
+
     @Test
     public void test() {
         Integer intVal = 1;

--- a/spotbugsTestCases/src/java/ghIssues/Issue390.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue390.java
@@ -1,0 +1,14 @@
+package ghIssues;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class Issue390 {
+
+    @Test
+    public void test() {
+        Integer intVal = 1;
+        assertTrue(intVal instanceof Integer);
+    }
+}


### PR DESCRIPTION
I've implemented #390 as a detector, `DontAssertInstanceofInTests`. 

This only covers usages of `Assert.assertTrue(obj instanceof Class)` which are present in the body of an `@Test` annotated method.

I would like to add usages such as `assertEquals(true, <instanceof expression>)` but I am not completely sure of the best way to go about it.

- [x] Added an entry into `CHANGELOG.md`
