### PR TITLE
Release 4.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased - 2020-??-??
+
 ## 4.1.2 - 2020-08-18
 ### Fixed
 * [A meaningless exception data from `SAXBugCollectionHandler`](https://lgtm.com/projects/g/spotbugs/spotbugs/rev/a77ab08634687b7791e902636996ab6184462693)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased - 2020-??-??
+## 4.1.2 - 2020-08-18
 ### Fixed
 * [A meaningless exception data from `SAXBugCollectionHandler`](https://lgtm.com/projects/g/spotbugs/spotbugs/rev/a77ab08634687b7791e902636996ab6184462693)
 * Use URI for files instead of converting string to URI each time. Fixes tests on Windows.

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
   id "com.github.spotbugs" version "4.5.0"
 }
 
-version = '4.1.2-SNAPSHOT'
+version = '4.1.2'
 
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/jacoco.gradle"

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
   id "com.github.spotbugs" version "4.5.0"
 }
 
-version = '4.1.2'
+version = '4.1.3-SNAPSHOT'
 
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/jacoco.gradle"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,9 +17,9 @@ import os
 
 html_context = {
   'version' : '4.1',
-  'full_version' : '4.1.1',
+  'full_version' : '4.1.2',
   'maven_plugin_version' : '4.0.4',
-  'gradle_plugin_version' : '4.4.4',
+  'gradle_plugin_version' : '4.5.0',
   'archetype_version' : '0.2.3'
 }
 


### PR DESCRIPTION
Release 4.1.2 which contains three bugfixes and one new detector for the JUnit test.

[//]: # (rtdbot-start)

URL of RTD documents:
en: https://spotbugs.readthedocs.io/en/release-4.1.2/
ja: https://spotbugs.readthedocs.io/ja/release-4.1.2/

[//]: # (rtdbot-end)
