### PR TITLE
Use Java 14 to boost the performance of compilation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,10 +12,10 @@ jobs:
       - uses: actions/checkout@722adc6
         with:
           fetch-depth: 0
-      - name: Set up JDK 11
+      - name: Set up JDK 14
         uses: actions/setup-java@081536e
         with:
-          java-version: '11.0.x'
+          java-version: '14.0.x'
       - uses: actions/cache@cffae95
         with:
           path: ~/.gradle/caches

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@722adc6
-      - name: Set up JDK 11
+      - name: Set up JDK 14
         uses: actions/setup-java@081536e
         with:
-          java-version: '11.0.x'
+          java-version: '14.0.x'
       - uses: actions/cache@cffae95
         with:
           path: ~/.gradle/caches


### PR DESCRIPTION
The performance of javac is improved continuously, then try to apply the latest release to shorten the build time.
This change will not affect the version of .class files in our artifacts, because we have `--release` option to specify the class file version.