### PR TITLE
Remove dependencies on deprecated Gradle feature

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+gradlew linguist-generated=true
+gradlew.bat linguist-generated=true

--- a/eclipsePlugin-junit/build.gradle
+++ b/eclipsePlugin-junit/build.gradle
@@ -1,11 +1,33 @@
 apply from: "$rootDir/gradle/checkstyle.gradle"
 apply from: "$rootDir/gradle/jacoco.gradle"
 
+def localProps = new Properties()
+localProps.load(new FileInputStream("$rootDir/eclipsePlugin/local.properties"))
+
+def eclipseRootDir = new File(localProps.getProperty('eclipseRoot.dir'))
+// Eclipse 4.5+ uses a different directory layout under macOS. Try to detect this first.
+def eclipseExecutable = new File(eclipseRootDir, "Contents/MacOS/eclipse")
+def eclipsePluginsDir = new File(eclipseRootDir, "Contents/Eclipse/plugins")
+if (!eclipseExecutable.exists()) {
+  // Fall back to non-macOS directory layout.
+  eclipsePluginsDir = new File(eclipseRootDir, "plugins")
+}
+
 dependencies {
   implementation project(':eclipsePlugin')
-  testImplementation project(path: ':eclipsePlugin', configuration: 'compileOnly')
   testImplementation 'junit:junit:4.13'
   testImplementation 'org.mockito:mockito-core:3.5.9'
+
+  // List below includes all Eclipse SDK plugins except few causing troubles.
+  // TODO: it should include what is required in the MANIFEST.MF, and nothing else
+  testImplementation fileTree(dir:eclipsePluginsDir, include:'**/*.jar',
+          exclude:[
+                  '**/datanucleus-enhancer*.jar',
+                  'edu.umd.cs.findbugs.**/*.jar',
+                  'org.mockito*.jar',
+                  'com.github.spotbugs.**/*.jar',
+                  '**/*source_*.jar'
+          ])
 }
 
 jacocoTestReport {

--- a/eclipsePlugin-junit/build.gradle
+++ b/eclipsePlugin-junit/build.gradle
@@ -4,7 +4,7 @@ apply from: "$rootDir/gradle/jacoco.gradle"
 def localProps = new Properties()
 localProps.load(new FileInputStream("$rootDir/eclipsePlugin/local.properties"))
 
-def eclipseRootDir = new File(localProps.getProperty('eclipseRoot.dir'))
+def eclipseRootDir = file(localProps.getProperty('eclipseRoot.dir'))
 // Eclipse 4.5+ uses a different directory layout under macOS. Try to detect this first.
 def eclipseExecutable = new File(eclipseRootDir, "Contents/MacOS/eclipse")
 def eclipsePluginsDir = new File(eclipseRootDir, "Contents/Eclipse/plugins")

--- a/eclipsePlugin-test/build.gradle
+++ b/eclipsePlugin-test/build.gradle
@@ -3,7 +3,7 @@ apply from: "$rootDir/gradle/checkstyle.gradle"
 def localProps = new Properties()
 localProps.load(new FileInputStream("$rootDir/eclipsePlugin/local.properties"))
 
-def eclipseRootDir = new File(localProps.getProperty('eclipseRoot.dir'))
+def eclipseRootDir = file(localProps.getProperty('eclipseRoot.dir'))
 // Eclipse 4.5+ uses a different directory layout under macOS. Try to detect this first.
 def eclipseExecutable = new File(eclipseRootDir, "Contents/MacOS/eclipse")
 def eclipsePluginsDir = new File(eclipseRootDir, "Contents/Eclipse/plugins")

--- a/eclipsePlugin-test/build.gradle
+++ b/eclipsePlugin-test/build.gradle
@@ -1,5 +1,17 @@
 apply from: "$rootDir/gradle/checkstyle.gradle"
 
+def localProps = new Properties()
+localProps.load(new FileInputStream("$rootDir/eclipsePlugin/local.properties"))
+
+def eclipseRootDir = new File(localProps.getProperty('eclipseRoot.dir'))
+// Eclipse 4.5+ uses a different directory layout under macOS. Try to detect this first.
+def eclipseExecutable = new File(eclipseRootDir, "Contents/MacOS/eclipse")
+def eclipsePluginsDir = new File(eclipseRootDir, "Contents/Eclipse/plugins")
+if (!eclipseExecutable.exists()) {
+  // Fall back to non-macOS directory layout.
+  eclipsePluginsDir = new File(eclipseRootDir, "plugins")
+}
+
 sourceSets {
   main {
     java {
@@ -17,7 +29,16 @@ dependencies {
   implementation(project(':eclipsePlugin')) {
     transitive = true
   }
-  implementation project(path: ':eclipsePlugin', configuration: 'compileOnly')
+  // List below includes all Eclipse SDK plugins except few causing troubles.
+  // TODO: it should include what is required in the MANIFEST.MF, and nothing else
+  compileOnly fileTree(dir:eclipsePluginsDir, include:'**/*.jar',
+          exclude:[
+                  '**/datanucleus-enhancer*.jar',
+                  'edu.umd.cs.findbugs.**/*.jar',
+                  'org.mockito*.jar',
+                  'com.github.spotbugs.**/*.jar',
+                  '**/*source_*.jar'
+          ])
 
   implementation project(':test-harness')
   implementation 'org.hamcrest:hamcrest-all:1.3'

--- a/eclipsePlugin/build.gradle
+++ b/eclipsePlugin/build.gradle
@@ -46,7 +46,7 @@ def eclipsePluginId = 'com.github.spotbugs.plugin.eclipse'
 def localProps = new Properties()
 localProps.load(new FileInputStream("$projectDir/local.properties"))
 
-def eclipseRootDir = new File(localProps.getProperty('eclipseRoot.dir'))
+def eclipseRootDir = file(localProps.getProperty('eclipseRoot.dir'))
 // Eclipse 4.5+ uses a different directory layout under macOS. Try to detect this first.
 def eclipseExecutable = new File(eclipseRootDir, "Contents/MacOS/eclipse")
 def eclipsePluginsDir = new File(eclipseRootDir, "Contents/Eclipse/plugins")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -82,6 +82,7 @@ esac
 
 CLASSPATH=$APP_HOME/gradle/wrapper/gradle-wrapper.jar
 
+
 # Determine the Java command to use to start the JVM.
 if [ -n "$JAVA_HOME" ] ; then
     if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
@@ -129,6 +130,7 @@ fi
 if [ "$cygwin" = "true" -o "$msys" = "true" ] ; then
     APP_HOME=`cygpath --path --mixed "$APP_HOME"`
     CLASSPATH=`cygpath --path --mixed "$CLASSPATH"`
+    
     JAVACMD=`cygpath --unix "$JAVACMD"`
 
     # We build the pattern for arguments to be converted via cygpath

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -84,6 +84,7 @@ set CMD_LINE_ARGS=%*
 
 set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
 
+
 @rem Execute Gradle
 "%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %CMD_LINE_ARGS%
 


### PR DESCRIPTION
The `compileOnly` configuration is not expected to refer from other projects, so load properties file in `eclipsePlugni-junit` and `eclipsePlugin-test` projects directly.

[This build scan](https://scans.gradle.com/s/7kyeies6rngmm) proves that we have no deprecated feature in the current build.

Also bump up Gradle to the latest version 6.6.1.