### PR TITLE
Resolved XPathException generating html report with plain.xsl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 ### Fixed
 * False positive `RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE` on try-with-resources ([#259](https://github.com/spotbugs/spotbugs/issues/259))
 * Misconfiguration which makes ASM not supporting Java 14 ([#1276](https://github.com/spotbugs/spotbugs/issues/1276))
+* Resolved fatal exception in html report if BugInstance contains multiple Class elements and use the plain.xsl XSLT stylesheet to generate the HTML ([#1025](https://github.com/spotbugs/spotbugs/issues/1025))
 
 ## 4.1.2 - 2020-08-18
 ### Fixed

--- a/spotbugs/src/xsl/plain.xsl
+++ b/spotbugs/src/xsl/plain.xsl
@@ -205,7 +205,7 @@
 				<xsl:apply-templates select="$warningSet">
 					<xsl:sort select="@priority"/>
 					<xsl:sort select="@abbrev"/>
-					<xsl:sort select="Class/@classname"/>
+					<xsl:sort select="Class[1]/@classname"/>
 				</xsl:apply-templates>
 		    </xsl:when>
 		    <xsl:otherwise>


### PR DESCRIPTION
See issue #1025: we had troubles to transorm if BugInstance contained multiple Class elements. This commit  fixes plain.xsl.



----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
