### PR TITLE
Release 4.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased - 2020-??-??
+## 4.1.3 - 2020-09-25
 ### Fixed
 * False positive `RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE` on try-with-resources ([#259](https://github.com/spotbugs/spotbugs/issues/259))
 * Misconfiguration which makes ASM not supporting Java 14 ([#1276](https://github.com/spotbugs/spotbugs/issues/1276))
@@ -25,7 +25,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ## 4.1.0 - 2020-07-30
 ### Added
-* Support custom bug annotation 
+* Support custom bug annotation
 * Experimental support for the SARIF 2.1.0 report ([discuss#95](https://github.com/spotbugs/discuss/issues/95))
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased - 2020-??-??
+
 ## 4.1.3 - 2020-09-25
 ### Fixed
 * False positive `RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE` on try-with-resources ([#259](https://github.com/spotbugs/spotbugs/issues/259))

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
   id "com.github.spotbugs" version "4.5.0"
 }
 
-version = '4.1.3'
+version = '4.1.4-SNAPSHOT'
 
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/jacoco.gradle"

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
   id "com.github.spotbugs" version "4.5.0"
 }
 
-version = '4.1.3-SNAPSHOT'
+version = '4.1.3'
 
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/jacoco.gradle"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,7 @@ import os
 
 html_context = {
   'version' : '4.1',
-  'full_version' : '4.1.2',
+  'full_version' : '4.1.3',
   'maven_plugin_version' : '4.0.4',
   'gradle_plugin_version' : '4.5.0',
   'archetype_version' : '0.2.3'


### PR DESCRIPTION
Release 4.1.3 which contains three bugfixes.



[//]: # (rtdbot-start)

URL of RTD documents:
en: https://spotbugs.readthedocs.io/en/release-4.1.3/
ja: https://spotbugs.readthedocs.io/ja/release-4.1.3/

[//]: # (rtdbot-end)
