### PR TITLE
Fix: jacocoRootReport build failed

### DIFF
--- a/eclipsePlugin-junit/build.gradle
+++ b/eclipsePlugin-junit/build.gradle
@@ -1,5 +1,4 @@
 apply from: "$rootDir/gradle/checkstyle.gradle"
-apply from: "$rootDir/gradle/jacoco.gradle"
 
 dependencies {
   implementation project(':eclipsePlugin')
@@ -8,7 +7,3 @@ dependencies {
   testImplementation 'org.mockito:mockito-core:3.4.4'
 }
 
-jacocoTestReport {
-  additionalSourceDirs.setFrom files(project(':eclipsePlugin').sourceSets.main.java.srcDirs)
-  additionalClassDirs.setFrom files(project(':eclipsePlugin').sourceSets.main.output.classesDirs)
-}

--- a/spotbugs-tests/build.gradle
+++ b/spotbugs-tests/build.gradle
@@ -33,6 +33,7 @@ artifacts {
 }
 
 jacocoTestReport {
+  dependsOn test
   additionalSourceDirs.setFrom files(project(':spotbugs').sourceSets.main.java.srcDirs)
   additionalClassDirs.setFrom files(project(':spotbugs').sourceSets.main.output.classesDirs)
 }


### PR DESCRIPTION
```
./gradlew jacocoRootReport

> Configure project :spotbugs-annotations
The signing key and password are null. This can be ignored if this is a pull request.

> Configure project :spotbugs
The signing key and password are null. This can be ignored if this is a pull request.

> Configure project :spotbugs-ant
The signing key and password are null. This can be ignored if this is a pull request.

> Configure project :test-harness
The signing key and password are null. This can be ignored if this is a pull request.

> Configure project :test-harness-core
The signing key and password are null. This can be ignored if this is a pull request.

> Configure project :test-harness-jupiter
The signing key and password are null. This can be ignored if this is a pull request.

> Task :jacocoRootReport FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':jacocoRootReport'.
> Unable to read execution data file ${spotbugs_home}/eclipsePlugin-junit/build/jacoco/test.exec

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 9s
24 actionable tasks: 4 executed, 20 up-to-date
```

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [ ] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
