### PR TITLE
Fixed issue #1311

### DIFF
--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -6,6 +6,8 @@ apply from: "$rootDir/gradle/javadoc.gradle"
 configurations {
   // used only in distribution. It is not listed in pom.xml, so users like maven plugin don't use this dependency.
   logBinding
+  // used to make sure Eclipse config can see apple library during compilation
+  appleExtensions
 }
 
 ext {
@@ -95,7 +97,6 @@ dependencies {
   testImplementation 'junit:junit:4.13'
   testImplementation 'org.apache.ant:ant:1.10.8'
   testImplementation 'org.apache.logging.log4j:log4j-slf4j18-impl:2.13.1'
-  testImplementation sourceSets.gui.output
 
   guiImplementation sourceSets.main.runtimeClasspath
   guiCompileOnly 'com.apple:AppleJavaExtensions:1.4'
@@ -103,6 +104,9 @@ dependencies {
   guiTestImplementation sourceSets.gui.runtimeClasspath
   guiTestImplementation 'junit:junit:4.13'
   guiTestCompileOnly project(':spotbugs-annotations')
+  
+  // for Eclipse compilation only
+  appleExtensions 'com.apple:AppleJavaExtensions:1.4'
 }
 
 clean {
@@ -120,9 +124,8 @@ tasks.withType(Jar).all {
 }
 
 eclipse.classpath {
-  plusConfigurations += [ configurations.compileClasspath ]
-  plusConfigurations += [ configurations.guiCompileClasspath ]
   plusConfigurations += [ configurations.testRuntimeClasspath ]
+  plusConfigurations += [ configurations.appleExtensions ]
 }
 
 eclipse.classpath.file {
@@ -141,7 +144,7 @@ eclipse.classpath.file {
 }
 
 task copyLibsForEclipse (type: Copy) {
-    from configurations.testCompileClasspath.files, configurations.testRuntimeClasspath.files, configurations.guiRuntimeClasspath.files, configurations.logBinding.files
+    from configurations.testCompileClasspath.files, configurations.testRuntimeClasspath.files, configurations.guiRuntimeClasspath.files, configurations.guiCompileClasspath.files, configurations.logBinding.files
     into ".libs"
     include "*.jar"
     exclude "*xml-apis*.jar"


### PR DESCRIPTION
According to [1], project.configurations.testRuntime is default for
Eclipse (I assume it contains everything). So including compileClasspath
& guiCompileClasspath shouldn't be needed (and avoids that duplicated
classpath entries are generated in the .classpath file).

Removed "testImplementation sourceSets.gui.output" because it caused
generated class files to be added too the project classpath in Eclipse.

Added "appleExtensions" to allow Eclipse compilation see apple jar
without referencing "guiCompileClasspath" that added duplicated entries
to the classpath too.

[1] https://docs.gradle.org/current/dsl/org.gradle.plugins.ide.eclipse.model.EclipseClasspath.html,



----

Make sure these boxes are checked before submitting your PR -- thank you!

- [ ] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
