### PR TITLE
Fix minor typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 ### Changed
 * Bump ASM from 8.0.1 to 9.0 supporting JDK16 (sealed classes)
 
+### Fixed
+* Typos in description, documentation and so on
+
 ## 4.1.3 - 2020-09-25
 ### Fixed
 * False positive `RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE` on try-with-resources ([#259](https://github.com/spotbugs/spotbugs/issues/259))

--- a/docs/ant.rst
+++ b/docs/ant.rst
@@ -111,7 +111,7 @@ quietErrors
 reportLevel
   An optional attribute. It specifies the confidence/priority threshold for reporting issues.
   If set to ``low``, confidence is not used to filter bugs.
-  If set to ``medium`` (the default), low confidence issues are supressed.
+  If set to ``medium`` (the default), low confidence issues are suppressed.
   If set to ``high``, only high confidence bugs are reported.
 
 output

--- a/docs/locale/ja/LC_MESSAGES/running.po
+++ b/docs/locale/ja/LC_MESSAGES/running.po
@@ -735,7 +735,7 @@ msgid "-redoAnalysis <filename>:"
 msgstr ""
 
 #: /documents/docs/running.rst:285
-msgid "Redo analysis using configureation from previous analysis."
+msgid "Redo analysis using configuration from previous analysis."
 msgstr ""
 
 #: /documents/docs/running.rst:288

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -282,7 +282,7 @@ Output options
   Use training data (experimental); input dir defaults to '.'.
 
 -redoAnalysis <filename>:
-  Redo analysis using configureation from previous analysis.
+  Redo analysis using configuration from previous analysis.
 
 -sourceInfo <filename>:
   Specify source info file (line numbers for fields/classes).

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/TextUICommandLine.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/TextUICommandLine.java
@@ -183,7 +183,7 @@ public class TextUICommandLine extends FindBugsCommandLine {
         addSwitch("-relaxed", "Relaxed reporting mode (more false positives!)");
         addSwitchWithOptionalExtraPart("-train", "outputDir", "Save training data (experimental); output dir defaults to '.'");
         addSwitchWithOptionalExtraPart("-useTraining", "inputDir", "Use training data (experimental); input dir defaults to '.'");
-        addOption("-redoAnalysis", "filename", "Redo analysis using configureation from previous analysis");
+        addOption("-redoAnalysis", "filename", "Redo analysis using configuration from previous analysis");
         addOption("-sourceInfo", "filename", "Specify source info file (line numbers for fields/classes)");
         addOption("-projectName", "project name", "Descriptive name of project");
 


### PR DESCRIPTION
Not sure if this actually warants an update to the changelog? But I've added it, similar to: https://github.com/spotbugs/spotbugs/blob/master/CHANGELOG.md#L451-L453

```
### Fixed
* Typos in description, documentation and so on
```

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
