### PR TITLE
fix for issue 1254, support nested private member access from JEP 181

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 * Error dialog on cancelling SpotBugs job in Eclipse ([#1314](https://github.com/spotbugs/spotbugs/issues/1314))
 * IllegalArgumentException in OpcodeStack.constantToInt ([#893](https://github.com/spotbugs/spotbugs/issues/893))
 * Typos in description, documentation and so on
+* spotbugs reports `VR_UNRESOLVABLE_REFERENCE` and `UPM_UNCALLED_PRIVATE_METHOD` when code is compiled with Java 11 ([#1254](https://github.com/spotbugs/spotbugs/issues/1254))
 
 ### Changed
 * Bump jaxen from 1.1.6 to 1.2.0 supporting Java 11 compilation ([#1316](https://github.com/spotbugs/spotbugs/issues/1316))

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue1254Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue1254Test.java
@@ -1,0 +1,45 @@
+package edu.umd.cs.findbugs.ba;
+
+import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import edu.umd.cs.findbugs.BugCollection;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
+
+/**
+ * @see <a href="https://github.com/spotbugs/spotbugs/issues/1254">GitHub issue</a>
+ */
+public class Issue1254Test extends AbstractIntegrationTest {
+
+    private static final String[] CLASS_LIST = { "../java11/module-info.class", "../java11/Issue1254.class",
+        "../java11/Issue1254$Inner.class", "../java11/Issue1254$1.class", };
+
+    /**
+     * Test that accessing private members of a nested class doesn't result in unresolvable reference problems.
+     */
+    @Test
+    public void testUnresolvableReference() {
+        performAnalysis(CLASS_LIST);
+        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder().bugType("VR_UNRESOLVABLE_REFERENCE")
+                .build();
+        assertThat(getBugCollection(), containsExactly(0, bugTypeMatcher));
+    }
+
+    /**
+     * Test that accessing private members of a nested class doesn't result in uncalled method problems.
+     */
+    @Test
+    public void testUncalledPrivateMethod() {
+        performAnalysis(CLASS_LIST);
+        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder().bugType("UPM_UNCALLED_PRIVATE_METHOD")
+                .build();
+        assertThat(getBugCollection(), containsExactly(2, bugTypeMatcher));
+        BugCollection bugCollection = getBugCollection();
+        bugCollection.findBug(null, "UPM_UNCALLED_PRIVATE_METHOD", 25);
+        bugCollection.findBug(null, "UPM_UNCALLED_PRIVATE_METHOD", 36);
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ResolveAllReferences.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ResolveAllReferences.java
@@ -32,6 +32,7 @@ import edu.umd.cs.findbugs.classfile.Global;
 import edu.umd.cs.findbugs.classfile.IAnalysisCache;
 import edu.umd.cs.findbugs.classfile.MissingClassException;
 import edu.umd.cs.findbugs.util.ClassName;
+import edu.umd.cs.findbugs.util.NestedAccessUtil;
 import edu.umd.cs.findbugs.visitclass.PreorderVisitor;
 
 public class ResolveAllReferences extends PreorderVisitor implements Detector {
@@ -83,15 +84,18 @@ public class ResolveAllReferences extends PreorderVisitor implements Detector {
     public void addAllDefinitions(JavaClass obj) {
         String className2 = obj.getClassName();
 
+        // ensure we allow access according to JEP 181, better support for nested member access
+        boolean addPrivateFields = NestedAccessUtil.hasNest(obj);
+
         defined.add(className2);
         for (Method m : obj.getMethods()) {
-            if (!m.isPrivate()) {
+            if (!m.isPrivate() || addPrivateFields) {
                 String name = getMemberName(obj, className2, m.getNameIndex(), m.getSignatureIndex());
                 defined.add(name);
             }
         }
         for (Field f : obj.getFields()) {
-            if (!f.isPrivate()) {
+            if (!f.isPrivate() || addPrivateFields) {
                 String name = getMemberName(obj, className2, f.getNameIndex(), f.getSignatureIndex());
                 defined.add(name);
             }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/NestedAccessUtil.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/NestedAccessUtil.java
@@ -1,0 +1,182 @@
+/*
+ * Contributions to SpotBugs
+ * Copyright (C) 2020, Simeon Andreev
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+package edu.umd.cs.findbugs.util;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.annotation.CheckForNull;
+
+import org.apache.bcel.Const;
+import org.apache.bcel.classfile.Attribute;
+import org.apache.bcel.classfile.ConstantPool;
+import org.apache.bcel.classfile.JavaClass;
+import org.apache.bcel.classfile.NestHost;
+import org.apache.bcel.classfile.NestMembers;
+
+import edu.umd.cs.findbugs.ba.AnalysisContext;
+
+/**
+ * Provides checks to support JEP 181, improved nested member access.
+ *
+ * <p>
+ * In short, JEP 181 defines "nest mates", "nest host" and "nest members" attributes in compiled files. Access rules are
+ * relaxed to allow private member access between nest mates. This removes the need for the compiler to generate
+ * synthetic accessors. Extra attributes are added to the separate .class files to let the compiler know which classes
+ * are nested in which class.
+ * </p>
+ * <b>Summary</b> of terminology for JEP 181 and the added attributes:
+ * <ol>
+ * <li>The "nest host" is the top level class that contains nested classes, i.e. the class that corresponds to the
+ * source file</li>
+ * <li>The "nest members" are the nested classes in the nest host.</li>
+ * <li>The "nest" consists of the nest host and the nest members.</li>
+ * <li>A "nest mate" is a class within the nest, "nest mates" can access each others private members.</li>
+ * <li>The nest host class has an attribute {@code NestMembers} which lists the qualified names of nested classes.</li>
+ * <li>A nested class has an attribute {@code NestHost} which lists the qualified name of the nest host.</li>
+ * </ol>
+ *
+ * @see "https://openjdk.java.net/jeps/181"
+ */
+public class NestedAccessUtil {
+
+    private static final int JAVA_11_CLASS_VERSION = Const.MAJOR_11;
+
+    /**
+     * Checks if the specified class is a nested class or defines nested classes.
+     *
+     * @param javaClass
+     *            The class for which to check.
+     * @return {@code true} if the specified class is a nested class or defines nested class, {@code false} otherwise.
+     */
+    public static boolean hasNest(JavaClass javaClass) {
+        if (supportsNestedAccess(javaClass)) {
+            Attribute[] attributes = javaClass.getAttributes();
+            for (Attribute attribute : attributes) {
+                if (attribute instanceof NestHost) {
+                    return true;
+                } else if (attribute instanceof NestMembers) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Checks whether the specified class supports nested access as per JEP 181.
+     *
+     * @param javaClass
+     *            The class for which to check.
+     * @return {@code true} if the specified class supports nested access as per JEP 181.
+     *
+     * @see NestedAccessUtil
+     */
+    public static boolean supportsNestedAccess(JavaClass javaClass) {
+        return hasJava11OrAboveClassVersion(javaClass);
+    }
+
+    /**
+     * Retrieves the qualified class names of all nest mates of the specified class.
+     *
+     * @param javaClass
+     *            The class for which qualified class names of nest mates are retrieved.
+     * @param analysisContext
+     *            The analysis context, used to look-up a nest host class if required.
+     * @return The qualified class name of all nest mates. If the specified class is not a nested class or does not have
+     *         nested classes, an empty list is returned.
+     * @throws ClassNotFoundException
+     *             If a nest host class was looked-up but could not be found.
+     *
+     * @see NestedAccessUtil
+     */
+    public static List<String> getNestMateClassNames(JavaClass javaClass, AnalysisContext analysisContext)
+            throws ClassNotFoundException {
+        List<String> nestMateClassNames = new ArrayList<>();
+
+        // check if the specified class is a nest member, if so retrieve all nest members from the nest host
+        String nestHostClassName = getHostClassName(javaClass);
+        if (nestHostClassName != null) {
+            JavaClass nestedHostClass = analysisContext.lookupClass(nestHostClassName);
+            String[] nestMemberClassNames = getNestMemberClassNames(nestedHostClass);
+            if (nestMemberClassNames != null) {
+                nestMateClassNames.addAll(Arrays.asList(nestMemberClassNames));
+                nestMateClassNames.add(nestHostClassName);
+            }
+        } else {
+            // check if the specified class is a nest host, if so retrieve the nest members from the specified class.
+            String[] nestMemberClassNames = getNestMemberClassNames(javaClass);
+            if (nestMemberClassNames != null) {
+                nestMateClassNames.addAll(Arrays.asList(nestMemberClassNames));
+                // the nest host class is always in the nest
+                String className = javaClass.getClassName();
+                nestMateClassNames.add(className);
+            }
+        }
+        return nestMateClassNames;
+    }
+
+    private static boolean hasJava11OrAboveClassVersion(JavaClass... javaClasses) {
+        for (JavaClass javaClass : javaClasses) {
+            int javaClassVersion = javaClass.getMajor();
+            if (javaClassVersion < JAVA_11_CLASS_VERSION) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @CheckForNull
+    private static String[] getNestMemberClassNames(JavaClass javaClass) {
+        Attribute[] sourceAttributes = javaClass.getAttributes();
+        for (Attribute sourceAttribute : sourceAttributes) {
+            if (sourceAttribute instanceof NestMembers) {
+                NestMembers nestMembersAttribute = (NestMembers) sourceAttribute;
+                String[] nestMemberClassNames = nestMembersAttribute.getClassNames();
+                return nestMemberClassNames;
+            }
+        }
+        return null;
+    }
+
+    @CheckForNull
+    private static String getHostDottedClassName(JavaClass javaClass) {
+        String hostClassName = getHostClassName(javaClass);
+        if (hostClassName != null) {
+            return ClassName.toDottedClassName(hostClassName);
+        }
+        return null;
+    }
+
+    @CheckForNull
+    private static String getHostClassName(JavaClass javaClass) {
+        Attribute[] attributes = javaClass.getAttributes();
+        for (Attribute attribute : attributes) {
+            if (attribute instanceof NestHost) {
+                NestHost nestHostAttribute = (NestHost) attribute;
+                int targetHostClassIndex = nestHostAttribute.getHostClassIndex();
+                ConstantPool constantPool = nestHostAttribute.getConstantPool();
+                String nestHostClassName = constantPool.getConstantString(targetHostClassIndex, Const.CONSTANT_Class);
+                return nestHostClassName;
+            }
+        }
+        return null;
+    }
+}

--- a/spotbugsTestCases/src/java11/Issue1254.java
+++ b/spotbugsTestCases/src/java11/Issue1254.java
@@ -1,0 +1,40 @@
+/**
+ * Class to check the issue 1254.
+ */
+public class Issue1254 {
+
+	private int outerField = 0;
+
+	private static void println(String string) {
+		System.out.println(string);
+	}
+
+	public void outerMethod() {
+		new Runnable() {
+			@Override
+			public void run() {
+				++outerField;
+				Inner inner = new Inner();
+				++inner.innerField;
+				inner.innerMethod();
+				println("Anonymous class called, outerField=" + outerField);
+			}
+		}.run();
+	}
+
+	private void uncalledOuterMethod() {
+		println("uncalledOuterMethod() should produce a warning during analysis");
+	}
+
+	private static class Inner {
+		private int innerField = 0;
+
+		private void innerMethod() {
+			println("Inner.innerMethod() called, innerField=" + innerField);
+		}
+
+		private void uncalledInnerMethod() {
+			println("uncalledInnerMethod() should produce a warning during analysis");
+		}
+	}
+}


### PR DESCRIPTION
JEP 181 defines relaxed access rules for private members of nested
classes, removing the need for synthetic methods to access private
members of inner/outer classes. Instead, byte code contains e.g. a
method reference constant and the relaxed access rules make the method
call legal.

This changes makes spotbugs aware of JEP 181, so that in case of nested
private access spotbugs does not report unresolvable members/types, or
unused private members.



----

Make sure these boxes are checked before submitting your PR -- thank you!

- [ ] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
