### PR TITLE
Release 4.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased - 2020-??-??
+
 ## 4.1.4 - 2020-10-15
 ### Fixed
 * `IllegalArgumentException` during XML report generation ([#1272](https://github.com/spotbugs/spotbugs/issues/1272))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased - 2020-??-??
+## 4.1.4 - 2020-10-15
 ### Fixed
 * `IllegalArgumentException` during XML report generation ([#1272](https://github.com/spotbugs/spotbugs/issues/1272))
 * Error dialog on cancelling SpotBugs job in Eclipse ([#1314](https://github.com/spotbugs/spotbugs/issues/1314))

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
   id "com.github.spotbugs" version "4.5.1"
 }
 
-version = '4.1.4'
+version = '4.1.5-SNAPSHOT'
 
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/jacoco.gradle"

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
   id "com.github.spotbugs" version "4.5.1"
 }
 
-version = '4.1.4-SNAPSHOT'
+version = '4.1.4'
 
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/jacoco.gradle"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,9 +17,9 @@ import os
 
 html_context = {
   'version' : '4.1',
-  'full_version' : '4.1.3',
-  'maven_plugin_version' : '4.0.4',
-  'gradle_plugin_version' : '4.5.0',
+  'full_version' : '4.1.4',
+  'maven_plugin_version' : '4.1.3',
+  'gradle_plugin_version' : '4.5.1',
   'archetype_version' : '0.2.3'
 }
 


### PR DESCRIPTION
This version bumps up dependencies to support the latest Java ecosystem, and fixes issues like build problems around the Eclipse plugin.


[//]: # (rtdbot-start)

URL of RTD documents:
en: https://spotbugs.readthedocs.io/en/release-4.1.4/
ja: https://spotbugs.readthedocs.io/ja/release-4.1.4/

[//]: # (rtdbot-end)
