### PR TITLE
Bump up actions to the latest version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,14 +9,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@722adc6
+      - uses: actions/checkout@5a4ac90
         with:
           fetch-depth: 0
       - name: Set up JDK 11
-        uses: actions/setup-java@081536e
+        uses: actions/setup-java@d202f5d
         with:
           java-version: '11.0.x'
-      - uses: actions/cache@cffae95
+      - uses: actions/cache@0781355
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@722adc6
+      - uses: actions/checkout@5a4ac90
       - name: Set up JDK 11
-        uses: actions/setup-java@081536e
+        uses: actions/setup-java@d202f5d
         with:
           java-version: '11.0.x'
-      - uses: actions/cache@cffae95
+      - uses: actions/cache@0781355
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}


### PR DESCRIPTION
Same to https://github.com/spotbugs/spotbugs-gradle-plugin/pull/384, this change will fix [broken workflow in `master` branch](https://github.com/spotbugs/spotbugs/runs/1441987065#step:3:7).