### PR TITLE
chore: bump up Guice to v5

### DIFF
--- a/spotbugsTestCases/build.gradle
+++ b/spotbugsTestCases/build.gradle
@@ -6,15 +6,19 @@ sourceSets {
   }
 }
 
+ext {
+  guiceVersion = '5.0.1'
+}
+
 dependencies {
   // TODO : Some of these can be extracted to actual dependencies
   implementation fileTree(dir: 'lib', include: '*.jar')
 
   implementation 'com.google.code.gson:gson:2.8.6'
   implementation 'com.google.guava:guava:30.1-jre'
-  implementation 'com.google.inject:guice:4.2.3'
-  implementation 'com.google.inject.extensions:guice-assistedinject:4.2.3'
-  implementation 'com.google.inject.extensions:guice-servlet:4.2.3'
+  implementation "com.google.inject:guice:${guiceVersion}"
+  implementation "com.google.inject.extensions:guice-assistedinject:${guiceVersion}"
+  implementation "com.google.inject.extensions:guice-servlet:${guiceVersion}"
   implementation 'com.google.truth:truth:1.1.2'
   implementation 'joda-time:joda-time:2.10.10'
   api 'net.jcip:jcip-annotations:1.0'


### PR DESCRIPTION
Bump up Guice's version manually, to avoid confusion in the dependebot side.
Also, define a variable to update the Guice family in batch.

close #1444, close #1445, close #1446