### PR TITLE
Add empty lines into `release.md`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,8 +89,10 @@ createReleaseBody.configure {
   doLast {
     outputFile.delete()
     outputFile << """SpotBugs ${project.version}
+
 ### CHANGELOG
 - https://github.com/spotbugs/spotbugs/blob/${project.version}/CHANGELOG.md
+
 ### CHECKSUM
 | file | checksum (sha256) |
 | ---- | ----------------- |


### PR DESCRIPTION
In [this change](https://github.com/spotbugs/spotbugs/commit/2d1f69b5a6fe05bee0e50714e44f1784c56c3111#diff-49a96e7eea8a94af862798a45174e6ac43eb4f8b4bd40759b5da63ba31ec3ef7L90), I removed necessary empty lines mistakenly,
so GitHub Release wasn't generated properly.

As [document says](https://hub.github.com/hub-release.1.html), we need a blank line to split title and release body:

> The text up to the first blank line in MESSAGE is treated as the release title, and the rest is used as release description in Markdown format.

But we have no blank line so all topics are handled as title.