### PR TITLE
false positive: try-with-resource on JDK11 and later might fail with RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue1338Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue1338Test.java
@@ -1,0 +1,29 @@
+package edu.umd.cs.findbugs.ba;
+
+import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
+
+/**
+ * @see <a href="https://github.com/spotbugs/spotbugs/issues/1338">GitHub issue</a>
+ */
+public class Issue1338Test extends AbstractIntegrationTest {
+
+    private static final String[] CLASS_LIST = { "../java11/module-info.class", "../java11/Issue1338.class", };
+
+    /**
+     * Test that calling a method call when initializing a try-with-resource variable doesn't result in redundant nullcheck of nonnull value.
+     */
+    @Test
+    public void testMethodCallInTryWithResource() {
+        performAnalysis(CLASS_LIST);
+        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder().bugType("RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE")
+                .build();
+        assertThat(getBugCollection(), containsExactly(0, bugTypeMatcher));
+    }
+}

--- a/spotbugsTestCases/src/java11/Issue1338.java
+++ b/spotbugsTestCases/src/java11/Issue1338.java
@@ -1,0 +1,18 @@
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyStore;
+
+/**
+ * Class to check the issue 1338.
+ */
+public class Issue1338 {
+	public static KeyStore loadKeyStore(final Path path) throws Exception {
+		try (InputStream inputStream = Files.newInputStream(path)) {
+			// final KeyStore keyStore = KeyStore.getInstance("JKS");
+			// keyStore.load(inputStream, password.toCharArray());
+			// return keyStore;
+			return KeyStore.getInstance("JKS");
+		}
+	}
+}


### PR DESCRIPTION
#1338 Test that calling a method call when initializing a try-with-reource variable doesn't result in redundant nullcheck of nonnull value.