### PR TITLE
Throw intuitive error when built with Java 10 or older version

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue1254Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue1254Test.java
@@ -1,8 +1,13 @@
 package edu.umd.cs.findbugs.ba;
 
 import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
+import static org.hamcrest.number.OrderingComparison.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeThat;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
@@ -17,6 +22,13 @@ public class Issue1254Test extends AbstractIntegrationTest {
 
     private static final String[] CLASS_LIST = { "../java11/module-info.class", "../java11/Issue1254.class",
         "../java11/Issue1254$Inner.class", "../java11/Issue1254$1.class", };
+
+    @Before
+    public void verifyJavaVersion() {
+        assumeFalse(System.getProperty("java.specification.version").startsWith("1."));
+        int javaVersion = Integer.parseInt(System.getProperty("java.specification.version"));
+        assumeThat(javaVersion, is(greaterThanOrEqualTo(11)));
+    }
 
     /**
      * Test that accessing private members of a nested class doesn't result in unresolvable reference problems.

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue408Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue408Test.java
@@ -3,10 +3,14 @@ package edu.umd.cs.findbugs.ba;
 import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.number.OrderingComparison.greaterThanOrEqualTo;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeThat;
 
 import java.io.IOException;
 
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -22,6 +26,13 @@ import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 public class Issue408Test extends AbstractIntegrationTest {
     @Rule
     public ExpectedException expected = ExpectedException.none();
+
+    @Before
+    public void verifyJavaVersion() {
+        assumeFalse(System.getProperty("java.specification.version").startsWith("1."));
+        int javaVersion = Integer.parseInt(System.getProperty("java.specification.version"));
+        assumeThat(javaVersion, is(greaterThanOrEqualTo(11)));
+    }
 
     @Test
     public void testSingleClass() {

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/IncorrectSelfComparisonInstanceOfPatternMatchingTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/IncorrectSelfComparisonInstanceOfPatternMatchingTest.java
@@ -1,7 +1,9 @@
 package edu.umd.cs.findbugs.detect;
 
 import static org.hamcrest.core.Is.is;
+import static org.hamcrest.number.OrderingComparison.greaterThanOrEqualTo;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeThat;
 
 import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
@@ -26,7 +28,9 @@ public class IncorrectSelfComparisonInstanceOfPatternMatchingTest {
      */
     @Test
     public void testIssue1136() {
-        assumeThat(System.getProperty("java.specification.version"), is("14"));
+        assumeFalse(System.getProperty("java.specification.version").startsWith("1."));
+        int javaVersion = Integer.parseInt(System.getProperty("java.specification.version"));
+        assumeThat(javaVersion, is(greaterThanOrEqualTo(14)));
 
         final BugInstanceMatcher selfComparisonMatcher = new BugInstanceMatcherBuilder()
                 .bugType("SA_LOCAL_SELF_COMPARISON").build();

--- a/spotbugsTestCases/build.gradle
+++ b/spotbugsTestCases/build.gradle
@@ -58,7 +58,7 @@ tasks.named('javadoc', Javadoc).configure {
   }
 }
 
-def jvmVersion = Integer.parseInt(System.getProperty("java.specification.version"))
+def jvmVersion = JavaVersion.current()
 def classesJava8 = tasks.register('classesJava8', JavaCompile) {
   destinationDir = file("$buildDir/classes/java/java8")
   classpath = sourceSets.main.compileClasspath
@@ -80,8 +80,12 @@ def classesJava14 = tasks.register('classesJava14', JavaCompile) {
 
 tasks.named('classes').configure {
   dependsOn classesJava8
-  dependsOn classesJava11
-  if (jvmVersion >= 14) {
+  if (jvmVersion.isCompatibleWith(JavaVersion.VERSION_11)) {
+    dependsOn classesJava11
+  } else {
+    throw new GradleException("Use Java 11 or later to test SpotBugs project")
+  }
+  if (jvmVersion.isCompatibleWith(JavaVersion.VERSION_14)) {
     dependsOn classesJava14
   }
 }

--- a/spotbugsTestCases/build.gradle
+++ b/spotbugsTestCases/build.gradle
@@ -83,10 +83,12 @@ tasks.named('classes').configure {
   if (jvmVersion.isCompatibleWith(JavaVersion.VERSION_11)) {
     dependsOn classesJava11
   } else {
-    throw new GradleException("Use Java 11 or later to test SpotBugs project")
+    println "skip tests for Java 11 features"
   }
   if (jvmVersion.isCompatibleWith(JavaVersion.VERSION_14)) {
     dependsOn classesJava14
+  } else {
+    println "skip tests for Java 14 features"
   }
 }
 


### PR DESCRIPTION
Throw an intuitive error instead of just fail to parse `"1.8"` as integer. We still need to use Java 9 or later to build, to use the [`--release` option](http://mail.openjdk.java.net/pipermail/jdk9-dev/2015-July/002414.html).

close #1462 