### PR TITLE
Add test for proposed rule on CompletableFuture swallowing exceptions

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/ExceptionCompletableFutureTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/ExceptionCompletableFutureTest.java
@@ -1,0 +1,30 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
+import org.junit.Test;
+
+import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsCollectionContaining.hasItem;
+
+public class ExceptionCompletableFutureTest extends AbstractIntegrationTest {
+
+    @Test
+    public void findSwallowedException() {
+        performAnalysis("ExceptionCompletableFuture.class");
+
+        final BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
+                .bugType("DE_COMPLETABLE_FUTURE").build();
+        assertThat(getBugCollection(), containsExactly(1, bugTypeMatcher));
+
+        final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
+                .bugType("DE_COMPLETABLE_FUTURE")
+                .inClass("ExceptionCompletableFuture")
+                .atJspLine(37)
+                .build();
+        assertThat(getBugCollection(), hasItem(bugInstanceMatcher));
+    }
+
+}

--- a/spotbugsTestCases/src/java/ExceptionCompletableFuture.java
+++ b/spotbugsTestCases/src/java/ExceptionCompletableFuture.java
@@ -1,0 +1,40 @@
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class ExceptionCompletableFuture {
+
+    public CompletableFuture<Void> returned() {
+        CompletableFuture<Void> future = CompletableFuture.completedFuture(null);
+        return future;
+    }
+
+    public void awaitedWithJoin() {
+        returned().join();
+    }
+
+    public void awaitedWithGet() throws ExecutionException, InterruptedException {
+        returned().get();
+    }
+
+    public void awaitedWithGetTimeout() throws InterruptedException, ExecutionException, TimeoutException {
+        returned().get(1L, TimeUnit.SECONDS);
+    }
+
+    public void chainedAndHandled() {
+        CompletableFuture<Void> future = returned();
+        future.thenAccept((v) -> {
+
+        }).exceptionally((ex) -> {
+            System.out.println("Found exception");
+            ex.printStackTrace();
+            return null;
+        });
+    }
+
+    public void swallowed() {
+        returned().thenRun(() -> { });
+    }
+
+}


### PR DESCRIPTION
Adds a test to check for the `DE_COMPLETABLE_FUTURE` rule. The test will fail, of course, because such rule doesn't yet exist.

See #950 for the reasoning behind this proposed rule.



----

No changelog entry added because this is only a test case and not an implementation of the proposed rule.
