### PR TITLE
Build with Java 16 and Gradle 7.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,10 +12,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Set up JDK 15
+      - name: Set up JDK 16
         uses: actions/setup-java@v1
         with:
-          java-version: '15.0.x'
+          java-version: '16.0.x'
       - uses: actions/cache@v2
         with:
           path: ~/.gradle/caches

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.jvmargs=-XX:+HeapDumpOnOutOfMemoryError -Xmx1G
+org.gradle.jvmargs=-XX:+HeapDumpOnOutOfMemoryError -Xmx1G --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
 
 # https://issues.sonatype.org/browse/MVNCENTRAL-5548
 systemProp.org.gradle.internal.publish.checksums.insecure=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/spotbugsTestCases/build.gradle
+++ b/spotbugsTestCases/build.gradle
@@ -37,7 +37,7 @@ tasks.withType(JavaCompile).configureEach {
   options.compilerArgs << '-Xlint:none'
   options.encoding = 'UTF-8'
   if (it.name == 'classesJava14') {
-    options.release = 15
+    options.release = 16
   } else if (it.name == 'classesJava11') {
     options.release = 11
   } else if (it.name != 'compileJava') {


### PR DESCRIPTION
To make sure SpotBugs works for Java 16, this PR bumps up the Java version in CI.

1. Java 16 requires Gradle 7.0.  
2. For google-java-format, we also [need to add JVM options](https://github.com/google/google-java-format/releases/tag/v1.10.0) to `gradle.properties`.
