### PR TITLE
Improve function mutableSignature() in MutableStaticFields detector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ### Changed
 * Bump Saxon-HE from 10.3 to 10.5 ([#1513](https://github.com/spotbugs/spotbugs/pull/1513))
+* Function `mutableSignature()` improved and factored out from the `MutableStaticFields` detector
 
 ## 4.2.3 - 2021-04-12
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindReturnRef.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindReturnRef.java
@@ -32,6 +32,7 @@ import edu.umd.cs.findbugs.OpcodeStack;
 import edu.umd.cs.findbugs.ba.AnalysisContext;
 import edu.umd.cs.findbugs.ba.XField;
 import edu.umd.cs.findbugs.bcel.OpcodeStackDetector;
+import edu.umd.cs.findbugs.util.MutableClasses;
 
 public class FindReturnRef extends OpcodeStackDetector {
     boolean check = false;
@@ -109,7 +110,7 @@ public class FindReturnRef extends OpcodeStackDetector {
         }
 
         if (staticMethod && seen == Const.PUTSTATIC && nonPublicFieldOperand()
-                && MutableStaticFields.mutableSignature(getSigConstantOperand())) {
+                && MutableClasses.mutableSignature(getSigConstantOperand())) {
             OpcodeStack.Item top = stack.getStackItem(0);
             if (isPotentialCapture(top)) {
                 bugAccumulator.accumulateBug(
@@ -121,7 +122,7 @@ public class FindReturnRef extends OpcodeStackDetector {
             }
         }
         if (!staticMethod && seen == Const.PUTFIELD && nonPublicFieldOperand()
-                && MutableStaticFields.mutableSignature(getSigConstantOperand())) {
+                && MutableClasses.mutableSignature(getSigConstantOperand())) {
             OpcodeStack.Item top = stack.getStackItem(0);
             OpcodeStack.Item target = stack.getStackItem(1);
             if (isPotentialCapture(top) && target.getRegisterNumber() == 0) {
@@ -167,7 +168,7 @@ public class FindReturnRef extends OpcodeStackDetector {
          * && !sigOnStack.equals("Ljava/lang/String;") &&
          * sigOnStack.indexOf("Exception") == -1 && sigOnStack.indexOf("[") >= 0
          */
-                && nameOnStack.indexOf("EMPTY") == -1 && MutableStaticFields.mutableSignature(sigOnStack)) {
+                && nameOnStack.indexOf("EMPTY") == -1 && MutableClasses.mutableSignature(sigOnStack)) {
             bugAccumulator.accumulateBug(new BugInstance(this, staticMethod ? "MS_EXPOSE_REP" : "EI_EXPOSE_REP", NORMAL_PRIORITY)
                     .addClassAndMethod(this).addField(classNameOnStack, nameOnStack, sigOnStack, fieldIsStatic), this);
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MutableStaticFields.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MutableStaticFields.java
@@ -44,6 +44,7 @@ import edu.umd.cs.findbugs.ba.XMethod;
 import edu.umd.cs.findbugs.classfile.CheckedAnalysisException;
 import edu.umd.cs.findbugs.classfile.ClassDescriptor;
 import edu.umd.cs.findbugs.classfile.Global;
+import edu.umd.cs.findbugs.util.MutableClasses;
 
 public class MutableStaticFields extends BytecodeScanningDetector {
     private static final Set<String> COLLECTION_SUPERCLASSES = new HashSet<>(Arrays.asList("java/util/Collection",
@@ -78,13 +79,6 @@ public class MutableStaticFields extends BytecodeScanningDetector {
             return "";
         }
         return c.substring(0, i);
-    }
-
-    static boolean mutableSignature(String sig) {
-        return sig.equals("Ljava/util/Hashtable;") || sig.equals("Ljava/util/Date;") ||
-                sig.equals("Ljava/sql/Date;") ||
-                sig.equals("Ljava/sql/Timestamp;") ||
-                sig.charAt(0) == '[';
     }
 
     LinkedList<XField> seen = new LinkedList<>();
@@ -181,7 +175,7 @@ public class MutableStaticFields extends BytecodeScanningDetector {
             boolean samePackage = packageName.equals(extractPackage(xField.getFieldDescriptor().getSlashedClassName()));
             boolean initOnly = seen == Const.GETSTATIC || getClassName().equals(getClassConstantOperand()) && inStaticInitializer;
             boolean safeValue = seen == Const.GETSTATIC || emptyArrayOnTOS
-                    || AnalysisContext.currentXFactory().isEmptyArrayField(xField) || !mutableSignature(getSigConstantOperand());
+                    || AnalysisContext.currentXFactory().isEmptyArrayField(xField) || !MutableClasses.mutableSignature(getSigConstantOperand());
 
             if (seen == Const.GETSTATIC) {
                 readAnywhere.add(xField);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/MutableClasses.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/MutableClasses.java
@@ -1,0 +1,81 @@
+package edu.umd.cs.findbugs.util;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.List;
+
+import org.apache.bcel.Repository;
+import org.apache.bcel.classfile.JavaClass;
+import org.apache.bcel.classfile.Method;
+
+import edu.umd.cs.findbugs.ba.AnalysisContext;
+
+public class MutableClasses {
+
+    private static final Set<String> KNOWN_IMMUTABLE_CLASSES = new HashSet<>(Arrays.asList(
+            "java.lang.String", "java.lang.Integer", "java.lang.Byte", "java.lang.Character",
+            "java.lang.Short", "java.lang.Boolean", "java.lang.Long", "java.lang.Double",
+            "java.lang.Float", "java.lang.StackTraceElement", "java.math.BigInteger",
+            "java.math.Decimal", "java.io.File", "java.awt.Font", "java.awt.BasicStroke",
+            "java.awt.Color", "java.awt.GradientPaint", "java.awt.LinearGradientPaint",
+            "java.awt.RadialGradientPaint", "java.Cursor.", "java.util.UUID", "java.util.URL",
+            "java.util.URI", "java.util.Inet4Address", "java.util.InetSocketAddress",
+            "java.security.Permission"));
+
+    private static final List<String> SETTER_LIKE_NAMES = Arrays.asList(
+            "set", "put", "add", "insert", "delete", "remove", "erase", "clear", "push", "pop",
+            "enqueue", "dequeue", "write", "append", "replace");
+
+    public static boolean mutableSignature(String sig) {
+        if (sig.charAt(0) == '[') {
+            return true;
+        }
+
+        if (sig.charAt(0) != 'L') {
+            return false;
+        }
+
+        String dottedClassName = sig.substring(1, sig.length() - 1).replace('/', '.');
+        if (KNOWN_IMMUTABLE_CLASSES.contains(dottedClassName)) {
+            return false;
+        }
+
+        try {
+            JavaClass cls = Repository.lookupClass(dottedClassName);
+            return isMutable(cls);
+        } catch (ClassNotFoundException e) {
+            AnalysisContext.reportMissingClass(e);
+            return false;
+        }
+    }
+
+    private static boolean isMutable(JavaClass cls) {
+        for (Method method : cls.getMethods()) {
+            if (looksLikeASetter(method, cls)) {
+                return true;
+            }
+        }
+        try {
+            JavaClass sup = cls.getSuperClass();
+            if (sup != null) {
+                return isMutable(sup);
+            }
+        } catch (ClassNotFoundException e) {
+            AnalysisContext.reportMissingClass(e);
+        }
+        return false;
+    }
+
+    public static boolean looksLikeASetter(Method method, JavaClass cls) {
+        for (String name : SETTER_LIKE_NAMES) {
+            if (method.getName().startsWith(name)) {
+                String retSig = method.getReturnType().getSignature();
+                // If setter-like methods returns an object of the same type then we suppose that it
+                // is not a setter but creates a new instance instead.
+                return !("L" + cls.getClassName().replace('.', '/') + ";").equals(retSig);
+            }
+        }
+        return false;
+    }
+}

--- a/spotbugs/src/test/java/edu/umd/cs/findbugs/util/MutableClassesTest.java
+++ b/spotbugs/src/test/java/edu/umd/cs/findbugs/util/MutableClassesTest.java
@@ -1,0 +1,63 @@
+package edu.umd.cs.findbugs.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MutableClassesTest {
+    @Test
+    public void TestKnownMutable() {
+        Assert.assertTrue(MutableClasses.mutableSignature("Ljava/util/Date;"));
+    }
+
+    @Test
+    public void TestKnownImmutable() {
+        Assert.assertFalse(MutableClasses.mutableSignature("Ljava/lang/String;"));
+    }
+
+    @Test
+    public void TestArray() {
+        Assert.assertTrue(MutableClasses.mutableSignature("[I"));
+    }
+
+    public static class Mutable {
+        private int n;
+
+        public Mutable(int n) {
+            this.n = n;
+        }
+
+        public void setN(int n) {
+            this.n = n;
+        }
+
+        public int getN() {
+            return n;
+        }
+    }
+
+    @Test
+    public void TestMutable() {
+        Assert.assertTrue(MutableClasses.mutableSignature("Ledu/umd/cs/findbugs/util/MutableClassesTest$Mutable;"));
+    }
+
+    public static class Immutable {
+        private int n;
+
+        public Immutable(int n) {
+            this.n = n;
+        }
+
+        public int getN() {
+            return n;
+        }
+
+        public Immutable setN(int n) {
+            return new Immutable(n);
+        }
+    }
+
+    @Test
+    public void TestImmutable() {
+        Assert.assertFalse(MutableClasses.mutableSignature("Ledu/umd/cs/findbugs/util/MutableClassesTest$Immutable;"));
+    }
+}


### PR DESCRIPTION
The current implementation of `mutableSignature()` is a prototype. This
patch contains an implementation which uses several heuristics to
attempt determining whether a class is mutable. Furthermore we moved
this function to the `util` package.



----

Make sure these boxes are checked before submitting your PR -- thank you!

- [ ] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
