### PR TITLE
Try to build with JDK 17-ea

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,10 +12,15 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Set up JDK 16
-        uses: actions/setup-java@v1
+      - uses: sormuras/download-jdk@v1
         with:
-          java-version: '16.0.x'
+          feature: 17
+      - name: Set up JDK 17-ea
+        uses: actions/setup-java@v2
+        with:
+          java-version: ${{ env.JDK_VERSION }}
+          distribution: jdkfile
+          jdkFile: ${{ env.JDK_FILE }}
       - uses: actions/cache@v2
         with:
           path: ~/.gradle/caches

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,3 +53,8 @@ jobs:
           GPG_SECRET_PASSPHRASE: ${{ secrets.GPG_SECRET_PASSPHRASE }}
           KEYSTORE_PASS: ${{ secrets.KEYSTORE_PASS }}
           SONAR_LOGIN: ${{ secrets.SONAR_LOGIN }}
+      - uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: my-artifact
+          path: spotbugsTestCases/build/classes/java/java14/PatternMatchingForSwitch.class

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,10 +17,16 @@ jobs:
           feature: 17
       - name: Set up JDK 17-ea
         uses: actions/setup-java@v2
+        id: jdk17
         with:
           java-version: ${{ env.JDK_VERSION }}
           distribution: jdkfile
           jdkFile: ${{ env.JDK_FILE }}
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: 11
+          distribution: adopt
       - uses: actions/cache@v2
         with:
           path: ~/.gradle/caches
@@ -35,6 +41,7 @@ jobs:
       - name: Build
         # https://community.sonarsource.com/t/sonarcloud-now-not-updating-github-pr-and-checks/6595/17
         run: |
+          echo "org.gradle.java.installations.paths=${{ steps.jdk17.outputs.path }}" >> gradle.properties
           echo "keystorepass=${KEYSTORE_PASS}" >> gradle.properties
           git fetch --no-tags https://$GITHUB_TOKEN@github.com/spotbugs/spotbugs.git +refs/heads/master:refs/remotes/origin/master
           if [ "$GPG_SECRET_PASSPHRASE" != "" ]; then

--- a/gradle/jacoco.gradle
+++ b/gradle/jacoco.gradle
@@ -1,7 +1,7 @@
 apply plugin: "jacoco"
 
 jacoco {
-  toolVersion = "0.8.6"
+  toolVersion = "0.8.7"
 }
 
 jacocoTestReport {

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -34,3 +34,9 @@ tasks.withType(SpotBugsTask).configureEach {
         }
     }
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-7.2-20210531220051+0000-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-7.2-20210531220051+0000-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/PatternMatchingForSwitchTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/PatternMatchingForSwitchTest.java
@@ -1,0 +1,24 @@
+package edu.umd.cs.findbugs;
+
+import edu.umd.cs.findbugs.test.SpotBugsRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.nio.file.Paths;
+
+import static org.junit.Assert.assertTrue;
+
+
+/**
+ * @see <a href="https://github.com/spotbugs/spotbugs/issues/1561">The related GitHub pull request</a>
+ */
+public class PatternMatchingForSwitchTest {
+    @Rule
+    public SpotBugsRule spotbugs = new SpotBugsRule();
+
+    @Test
+    public void test() {
+        BugCollection bugCollection = spotbugs.performAnalysis(Paths.get("../spotbugsTestCases/build/classes/java14/PatternMatchingForSwitch.class"));
+        assertTrue(bugCollection.getCollection().isEmpty());
+    }
+}

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/PatternMatchingForSwitchTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/PatternMatchingForSwitchTest.java
@@ -18,7 +18,8 @@ public class PatternMatchingForSwitchTest {
 
     @Test
     public void test() {
-        BugCollection bugCollection = spotbugs.performAnalysis(Paths.get("../spotbugsTestCases/build/classes/java/java14/PatternMatchingForSwitch.class"));
+        BugCollection bugCollection = spotbugs.performAnalysis(Paths.get(
+                "../spotbugsTestCases/build/classes/java/java14/PatternMatchingForSwitch.class"));
         assertTrue(bugCollection.getCollection().isEmpty());
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/PatternMatchingForSwitchTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/PatternMatchingForSwitchTest.java
@@ -18,7 +18,7 @@ public class PatternMatchingForSwitchTest {
 
     @Test
     public void test() {
-        BugCollection bugCollection = spotbugs.performAnalysis(Paths.get("../spotbugsTestCases/build/classes/java14/PatternMatchingForSwitch.class"));
+        BugCollection bugCollection = spotbugs.performAnalysis(Paths.get("../spotbugsTestCases/build/classes/java/java14/PatternMatchingForSwitch.class"));
         assertTrue(bugCollection.getCollection().isEmpty());
     }
 }

--- a/spotbugsTestCases/build.gradle
+++ b/spotbugsTestCases/build.gradle
@@ -43,6 +43,9 @@ tasks.withType(JavaCompile).configureEach {
   } else if (it.name != 'compileJava') {
     options.release = 8
   }
+  javaCompiler = javaToolchains.compilerFor {
+    languageVersion = JavaLanguageVersion.of(17)
+  }
 }
 
 // This disables hundreds of javadoc warnings on missing tags etc, see #340
@@ -58,7 +61,6 @@ tasks.named('javadoc', Javadoc).configure {
   }
 }
 
-def jvmVersion = JavaVersion.current()
 def classesJava8 = tasks.register('classesJava8', JavaCompile) {
   destinationDir = file("$buildDir/classes/java/java8")
   classpath = sourceSets.main.compileClasspath
@@ -79,17 +81,7 @@ def classesJava14 = tasks.register('classesJava14', JavaCompile) {
 }
 
 tasks.named('classes').configure {
-  dependsOn classesJava8
-  if (jvmVersion.isCompatibleWith(JavaVersion.VERSION_11)) {
-    dependsOn classesJava11
-  } else {
-    println "skip tests for Java 11 features"
-  }
-  if (jvmVersion.isCompatibleWith(JavaVersion.VERSION_14)) {
-    dependsOn classesJava14
-  } else {
-    println "skip tests for Java 14 features"
-  }
+  dependsOn classesJava8, classesJava11, classesJava14
 }
 
 sonarqube {

--- a/spotbugsTestCases/build.gradle
+++ b/spotbugsTestCases/build.gradle
@@ -37,7 +37,7 @@ tasks.withType(JavaCompile).configureEach {
   options.compilerArgs << '-Xlint:none'
   options.encoding = 'UTF-8'
   if (it.name == 'classesJava14') {
-    options.release = 16
+    options.release = 17
   } else if (it.name == 'classesJava11') {
     options.release = 11
   } else if (it.name != 'compileJava') {

--- a/spotbugsTestCases/src/java14/PatternMatchingForSwitch.java
+++ b/spotbugsTestCases/src/java14/PatternMatchingForSwitch.java
@@ -16,27 +16,21 @@ class Triangle extends Shape {
 public class PatternMatchingForSwitch {
     String formatterPatternSwitch(Object o) {
         return switch (o) {
-            case Integer
-                i -> String.format("int %d", i);
-            case Long
-                l -> String.format("long %d", l);
-            case Double
-                d -> String.format("double %f", d);
-            case String
-                s -> String.format("String %s", s);
-                case null -> "null";
-                default -> o.toString();
+            case Integer i -> String.format("int %d", i);
+            case Long l -> String.format("long %d", l);
+            case Double d -> String.format("double %f", d);
+            case String s -> String.format("String %s", s);
+            case null -> "null";
+            default -> o.toString();
         };
     }
 
     void testTriangle(Shape s) {
         switch (s) {
-            case Triangle
-                t && (t.calculateArea() > 100) ->
+            case Triangle t && (t.calculateArea() > 100) ->
                 System.out.println("Large triangle");
-            case Triangle
-                t ->
-                        System.out.println("Small triangle");
+            case Triangle t ->
+                System.out.println("Small triangle");
             default -> System.out.println("Non-triangle");
         }
     }

--- a/spotbugsTestCases/src/java14/PatternMatchingForSwitch.java
+++ b/spotbugsTestCases/src/java14/PatternMatchingForSwitch.java
@@ -1,0 +1,43 @@
+class Shape {
+}
+
+class Rectangle extends Shape {
+}
+
+class Triangle extends Shape {
+    int calculateArea() {
+        return 0;
+    }
+}
+
+/**
+ * @see <a href="https://openjdk.java.net/jeps/406">JEP 406: Pattern Matching for switch (Preview)</a>
+ */
+public class PatternMatchingForSwitch {
+    String formatterPatternSwitch(Object o) {
+        return switch (o) {
+            case Integer
+                i -> String.format("int %d", i);
+            case Long
+                l -> String.format("long %d", l);
+            case Double
+                d -> String.format("double %f", d);
+            case String
+                s -> String.format("String %s", s);
+                case null -> "null";
+                default -> o.toString();
+        };
+    }
+
+    void testTriangle(Shape s) {
+        switch (s) {
+            case Triangle
+                t && (t.calculateArea() > 100) ->
+                System.out.println("Large triangle");
+            case Triangle
+                t ->
+                        System.out.println("Small triangle");
+            default -> System.out.println("Non-triangle");
+        }
+    }
+}


### PR DESCRIPTION
[17-ea build 24](https://github.com/openjdk/jdk/compare/jdk-17%2B23...jdk-17%2B24) now contains support for the [Pattern Matching for switch (preview)](https://openjdk.java.net/jeps/406), so I want to confirm how SpotBugs reacts on it.

I just worry that it may reproduce a previous problem at JDK 11 b7, #756 in our issues.
Java 11 changed a way to generate bytecode for try-with-resources and it affects SpotBugs, JaCoCo, and other tools. It's better to confirm the behavior by Early Access build before the GA for the coming LTS.

note: Gradle now uses Groovy 3.0.7, that depends on ObjectWeb ASM 9.0 which doesn't support JDK 17.
I guess we need to bump up the Groovy to 3.0.8 with [this change](https://github.com/apache/groovy/commit/d27994ea1f516894423980c958b65c8c02fb9395), but not sure how at this moment.
If the build in GitHub Actions failed, I will contact Gradle community to grasp how.

Update: [posted to Gradle Community Slack](https://gradle-community.slack.com/archives/CAHSN3LDN/p1622511901123100)