### PR TITLE
Refactor and improve `FindReturnRef` to find indirect cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ## Unreleased - 2021-??-??
 
+### Fixed
+- `MS_EXPOSE_REP` and `EI_EXPOSE_REP` are now reported for code returning a reference to a mutable object indirectly (e.g. via a local variable)
+
 ### Changed
 * Bump Saxon-HE from 10.3 to 10.5 ([#1513](https://github.com/spotbugs/spotbugs/pull/1513))
 * Bump gson from 2.8.6 to 2.8.7 ([#1556](https://github.com/spotbugs/spotbugs/pull/1556))

--- a/spotbugsTestCases/src/java/FindReturnRefNegativeTest.java
+++ b/spotbugsTestCases/src/java/FindReturnRefNegativeTest.java
@@ -1,12 +1,12 @@
 import edu.umd.cs.findbugs.annotations.NoWarning;
 
 import java.util.Date;
-import java.util.Hashtable;
+import java.util.HashMap;
 
 public class FindReturnRefNegativeTest {
     private Date date;
     private Date[] dateArray;
-    private Hashtable<Integer, String> ht = new Hashtable<Integer, String>();
+    private HashMap<Integer, String> hm = new HashMap<Integer, String>();
 
     private static Date sDate = new Date();
     private static Date[] sDateArray = new Date[20];
@@ -15,14 +15,14 @@ public class FindReturnRefNegativeTest {
             sDateArray[i] = new Date();
         }
     }
-    private static Hashtable<Integer, String> sht = new Hashtable<Integer, String>();
+    private static HashMap<Integer, String> shm = new HashMap<Integer, String>();
     static {
-        sht.put(1, "123-45-6789");
+        shm.put(1, "123-45-6789");
     }
 
     public Date pubDate;
     public Date[] pubDateArray;
-    public Hashtable<Integer, String> puht = new Hashtable<Integer, String>();
+    public HashMap<Integer, String> puhm = new HashMap<Integer, String>();
 
     public static Date pubSDate;
     public static Date[] pubSDateArray;
@@ -31,9 +31,9 @@ public class FindReturnRefNegativeTest {
             pubSDateArray[i] = new Date();
         }
     }
-    public static Hashtable<Integer, String> pusht = new Hashtable<Integer, String>();
+    public static HashMap<Integer, String> pushm = new HashMap<Integer, String>();
     static {
-        pusht.put(1, "123-45-6789");
+        pushm.put(1, "123-45-6789");
     }
 
     private String string;
@@ -52,8 +52,8 @@ public class FindReturnRefNegativeTest {
         pubDate = new Date();
         dateArray = new Date[20];
         pubDateArray = new Date[20];
-        ht.put(1, "123-45-6789");
-        puht.put(1, "123-45-6789");
+        hm.put(1, "123-45-6789");
+        puhm.put(1, "123-45-6789");
         for (int i = 0; i < dateArray.length; i++) {
             dateArray[i] = new Date();
         }
@@ -93,13 +93,13 @@ public class FindReturnRefNegativeTest {
     }
 
     @NoWarning("EI")
-    public Hashtable<Integer, String> getValues() {
-        return (Hashtable<Integer, String>) ht.clone();
+    public HashMap<Integer, String> getValues() {
+        return (HashMap<Integer, String>) hm.clone();
     }
 
     @NoWarning("MS")
-    public static Hashtable<Integer, String> getSaticValues() {
-        return (Hashtable<Integer, String>) sht.clone();
+    public static HashMap<Integer, String> getStaticValues() {
+        return (HashMap<Integer, String>) shm.clone();
     }
 
     // Returning public case should be OK.
@@ -125,13 +125,13 @@ public class FindReturnRefNegativeTest {
     }
 
     @NoWarning("EI")
-    public Hashtable<Integer, String> getPublicValues() {
-        return puht;
+    public HashMap<Integer, String> getPublicValues() {
+        return puhm;
     }
 
     @NoWarning("MS")
-    public static Hashtable<Integer, String> getPublicStaticValues() {
-        return pusht;
+    public static HashMap<Integer, String> getPublicStaticValues() {
+        return pushm;
     }
 
     // Returning a private immutable should be OK.
@@ -185,13 +185,13 @@ public class FindReturnRefNegativeTest {
     }
 
     @NoWarning("EI2")
-    public void setValues(Hashtable<Integer, String> values) {
-        ht = (Hashtable<Integer, String>) values.clone();
+    public void setValues(HashMap<Integer, String> values) {
+        hm = (HashMap<Integer, String>) values.clone();
     }
 
     @NoWarning("MS")
-    public static void getStaticValues(Hashtable<Integer, String>  values) {
-        sht = (Hashtable<Integer, String>) values.clone();
+    public static void getStaticValues(HashMap<Integer, String>  values) {
+        shm = (HashMap<Integer, String>) values.clone();
     }
 
     // Do not warn for synthetic methods.
@@ -201,7 +201,7 @@ public class FindReturnRefNegativeTest {
         private void accessParent() {
             Date d1 = date;
             Date d2 = dateArray[0];
-            String s = ht.get(1);
+            String s = hm.get(1);
         }
     }
 }

--- a/spotbugsTestCases/src/java/FindReturnRefTest.java
+++ b/spotbugsTestCases/src/java/FindReturnRefTest.java
@@ -2,12 +2,12 @@ import edu.umd.cs.findbugs.annotations.DesireWarning;
 import edu.umd.cs.findbugs.annotations.ExpectWarning;
 
 import java.util.Date;
-import java.util.Hashtable;
+import java.util.HashMap;
 
 public class FindReturnRefTest {
     private Date date;
     private Date[] dateArray;
-    private Hashtable<Integer, String> ht = new Hashtable<Integer, String>();
+    private HashMap<Integer, String> hm = new HashMap<Integer, String>();
 
     private static Date sDate = new Date();
     private static Date[] sDateArray = new Date[20];
@@ -16,15 +16,15 @@ public class FindReturnRefTest {
             sDateArray[i] = new Date();
         }
     }
-    private static Hashtable<Integer, String> sht = new Hashtable<Integer, String>();
+    private static HashMap<Integer, String> shm = new HashMap<Integer, String>();
     static {
-        sht.put(1, "123-45-6789");
+        shm.put(1, "123-45-6789");
     }
 
     public FindReturnRefTest() {
         date = new Date();
         dateArray = new Date[20];
-        ht.put(1, "123-45-6789");
+        hm.put(1, "123-45-6789");
         for (int i = 0; i < dateArray.length; i++) {
             dateArray[i] = new Date();
         }
@@ -42,13 +42,13 @@ public class FindReturnRefTest {
         return sDate;
     }
 
-    @DesireWarning("EI") // Indirect way of returning reference
+    @ExpectWarning("EI") // Indirect way of returning reference
     public Date getDate2() {
         Date d = date;
         return d;
     }
 
-    @DesireWarning("MS") // Indirect way of returning reference
+    @ExpectWarning("MS") // Indirect way of returning reference
     public static Date getStaticDate2() {
         Date d = sDate;
         return d;
@@ -75,13 +75,13 @@ public class FindReturnRefTest {
     }
 
     @ExpectWarning("EI")
-    public Hashtable<Integer, String> getValues() {
-        return ht;
+    public HashMap<Integer, String> getValues() {
+        return hm;
     }
 
     @ExpectWarning("MS")
-    public static Hashtable<Integer, String> getStaticValues() {
-        return sht;
+    public static HashMap<Integer, String> getStaticValues() {
+        return shm;
     }
 
     @ExpectWarning("EI2")
@@ -129,12 +129,12 @@ public class FindReturnRefTest {
     }
 
     @ExpectWarning("EI2")
-    public void setValues(Hashtable<Integer, String> values) {
-        ht = values;
+    public void setValues(HashMap<Integer, String> values) {
+        hm = values;
     }
 
     @ExpectWarning("MS")
-    public static void getStaticValues(Hashtable<Integer, String>  values) {
-        sht = values;
+    public static void getStaticValues(HashMap<Integer, String>  values) {
+        shm = values;
     }
 }


### PR DESCRIPTION
Currently, the detector `FindReturnRef` which is responisble for bugs
`EI_EXPOSE_REP`, `EI_EXPOSE_REP2`, `MS_EXPOSE_REP` and
`EI_EXPOSE_STATIC_REP2` tracks the data on the top of the stack.
However, this is not necessary in the current version of SpotBugs
because the infrastructure already does this job more accurately. This
patch removes the redundant tracking the the top of the stack and
relies on the already existing infrastructure instead. This way the
detector is able to find more true positives where returning of the
private mutable attribute happens indirectly, e.g. by first assigning it
to a local variable and then returning that local.

> Reopened version of #1529 