### PR TITLE
Replace "解析力" with "分析力"

### DIFF
--- a/docs/locale/ja/LC_MESSAGES/ant.po
+++ b/docs/locale/ja/LC_MESSAGES/ant.po
@@ -319,7 +319,7 @@ msgid ""
 "#command-line-options>`: for more information about setting the analysis "
 "level."
 msgstr ""
-"解析力を設定します。指定する値は、``min``、``default``、``max`` のいずれかでなければなりません。解析力の詳細については "
+"分析力を設定します。指定する値は、``min``、``default``、``max`` のいずれかでなければなりません。分析力の詳細については "
 "`コマンドラインオプション <running.html#command-line-options>`__ を参照してください。"
 
 #: ../../ant.rst:141

--- a/docs/locale/ja/LC_MESSAGES/effort.po
+++ b/docs/locale/ja/LC_MESSAGES/effort.po
@@ -17,17 +17,17 @@ msgstr "Project-Id-Version: spotbugs 3.1\n"
 
 #: ../../effort.rst:2
 msgid "Effort"
-msgstr "解析力"
+msgstr "分析力"
 
 #: ../../effort.rst:4
 msgid ""
 "Effort value adjusts internal flags of SpotBugs, to reduce computation "
 "cost by lowering the prediction."
-msgstr "解析力の値は、SpotBugの内部フラグを調整し、予測を下げて計算コストを削減します。"
+msgstr "分析力の値は、SpotBugの内部フラグを調整し、予測を下げて計算コストを削減します。"
 
 #: ../../effort.rst:6
 msgid "The default effort configuration is same with ``more``."
-msgstr "デフォルトの解析力の設定は ``more`` と同じです。"
+msgstr "デフォルトの分析力の設定は ``more`` と同じです。"
 
 #: ../../effort.rst:9
 msgid "Flags in FindBugs.java"
@@ -39,7 +39,7 @@ msgstr "説明"
 
 #: ../../effort.rst:9
 msgid "Effort Level"
-msgstr "解析力"
+msgstr "分析力"
 
 #: ../../effort.rst:11
 msgid "min"

--- a/docs/locale/ja/LC_MESSAGES/running.po
+++ b/docs/locale/ja/LC_MESSAGES/running.po
@@ -307,7 +307,7 @@ msgid ""
 " and find more bugs, but which may require more memory and take more time"
 " to complete. See :doc:`effort`."
 msgstr ""
-"解析力を設定します。-effort:minは精度を向上させるがメモリ消費量も増やす解析を無効にします。SpotBugs "
+"分析力を設定します。-effort:minは精度を向上させるがメモリ消費量も増やす解析を無効にします。SpotBugs "
 "を実行するためのメモリが不足したり、解析が完了するまでに異常に長い時間がかかるときは、このオプションを試してみると良いでしょう。詳細は "
 ":doc:`effort` を参照してください。"
 


### PR DESCRIPTION
According to this [blog post](https://tetsufuru.hatenablog.com/entry/2021/06/03/012341), the Eclipse plugin uses "分析力" as the translation for "effort". However, documentation uses a different word "解析力".

Documentation should use the same word with the Eclipse plugin, to avoid making users confused.

[//]: # (rtdbot-start)

URL of RTD documents:
en: https://spotbugs.readthedocs.io/en/unify-translation/
ja: https://spotbugs.readthedocs.io/ja/unify-translation/

[//]: # (rtdbot-end)
