### PR TITLE
Extend FindReturnRef to warn for exposing buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 * Bump gson from 2.8.6 to 2.8.7 ([#1556](https://github.com/spotbugs/spotbugs/pull/1556))
 * Function `mutableSignature()` improved and factored out from the `MutableStaticFields` detector
 
+### Added
+* New bugs `MS_EXPOSE_BUF`, `EI_EXPOSE_BUF`, `EI_EXPOSE_STATIC_BUF2` and `EI_EXPOSE_BUF2` by the `FindReturnRef` detector to detect cases where buffers or their backing arrays are exposed (see [SEI CERT rule FIO05-J](https://wiki.sei.cmu.edu/confluence/display/java/FIO05-J.+Do+not+expose+buffers+or+their+backing+arrays+methods+to+untrusted+code))
+
 ## 4.2.3 - 2021-04-12
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ## Unreleased - 2021-??-??
 
+### Fixed
+- `MS_EXPOSE_REP` and `EI_EXPOSE_REP` are now reported for code returning a reference to a mutable object indirectly (e.g. via a local variable)
+
 ### Changed
 * Bump Saxon-HE from 10.3 to 10.5 ([#1513](https://github.com/spotbugs/spotbugs/pull/1513))
 * Bump gson from 2.8.6 to 2.8.7 ([#1556](https://github.com/spotbugs/spotbugs/pull/1556))

--- a/spotbugs/etc/findbugs.xml
+++ b/spotbugs/etc/findbugs.xml
@@ -436,7 +436,7 @@
           <Detector class="edu.umd.cs.findbugs.detect.FindNakedNotify" speed="fast"
                     reports="NN_NAKED_NOTIFY"/>
           <Detector class="edu.umd.cs.findbugs.detect.FindReturnRef" speed="fast"
-                    reports="MS_EXPOSE_REP,EI_EXPOSE_REP,EI_EXPOSE_REP2,EI_EXPOSE_STATIC_REP2"/>
+                    reports="MS_EXPOSE_REP,EI_EXPOSE_REP,EI_EXPOSE_REP2,EI_EXPOSE_STATIC_REP2,MS_EXPOSE_BUF,EI_EXPOSE_BUF,EI_EXPOSE_STATIC_BUF2,EI_EXPOSE_BUF2"/>
           <Detector class="edu.umd.cs.findbugs.detect.FindRunInvocations" speed="fast"
                     reports="RU_INVOKE_RUN"/>
           <Detector class="edu.umd.cs.findbugs.detect.SwitchFallthrough" speed="fast"
@@ -864,9 +864,13 @@
           <BugPattern abbrev="IS" type="IS2_INCONSISTENT_SYNC" category="MT_CORRECTNESS"/>
           <BugPattern abbrev="NN" type="NN_NAKED_NOTIFY" category="MT_CORRECTNESS"/>
           <BugPattern abbrev="MS" type="MS_EXPOSE_REP" category="MALICIOUS_CODE"/>
+          <BugPattern abbrev="MS" type="MS_EXPOSE_BUF" category="MALICIOUS_CODE"/>
           <BugPattern abbrev="EI" type="EI_EXPOSE_REP" category="MALICIOUS_CODE" cweid="374"/>
+          <BugPattern abbrev="EI" type="EI_EXPOSE_BUF" category="MALICIOUS_CODE" cweid="374"/>
           <BugPattern abbrev="EI2" type="EI_EXPOSE_REP2" category="MALICIOUS_CODE" cweid="374"/>
           <BugPattern abbrev="MS" type="EI_EXPOSE_STATIC_REP2" category="MALICIOUS_CODE"/>
+          <BugPattern abbrev="EI2" type="EI_EXPOSE_BUF2" category="MALICIOUS_CODE" cweid="374"/>
+          <BugPattern abbrev="MS" type="EI_EXPOSE_STATIC_BUF2" category="MALICIOUS_CODE"/>
           <BugPattern abbrev="Ru" type="RU_INVOKE_RUN" category="MT_CORRECTNESS" cweid="572"/>
           <BugPattern abbrev="SP" type="SP_SPIN_ON_FIELD" category="MT_CORRECTNESS"/>
           <BugPattern abbrev="NS" type="NS_NON_SHORT_CIRCUIT" category="STYLE"/>

--- a/spotbugs/etc/messages.xml
+++ b/spotbugs/etc/messages.xml
@@ -3540,18 +3540,18 @@ Thus, having a mutable instance field generally creates race conditions.
 <![CDATA[
   <p> Returning a reference to a buffer (java.nio.*Buffer) which wraps an array stored in one of the object's fields
   exposes the internal representation of the array elements because the buffer only stores a reference to the array
-  instead of copying its content. Simliarly, returning a shallow-copy of such a buffer (using its duplicate() method
+  instead of copying its content. Simlarly, returning a shallow-copy of such a buffer (using its duplicate() method)
   stored in one of the object's fields also exposes the internal representation of the buffer.&nbsp;
    If instances are accessed by untrusted code, and unchecked changes to
    the array would compromise security or other
    important properties, you will need to do something different.
   Returning a read-only buffer (using its asReadOnly() method) or copying the array to a new buffer (using its put()
-  method) is better approach in many situations.</p>
+  method) is a better approach in many situations.</p>
 ]]>
     </Details>
   </BugPattern>
   <BugPattern type="EI_EXPOSE_BUF2">
-    <ShortDescription>May expose internal representation by creating a buffer which incorporating reference to array</ShortDescription>
+    <ShortDescription>May expose internal representation by creating a buffer which incorporates reference to array</ShortDescription>
     <LongDescription>{1} may expose internal representation by creating a buffer which contains an external array into {2.givenClass}</LongDescription>
     <Details>
 <![CDATA[
@@ -3561,7 +3561,7 @@ Thus, having a mutable instance field generally creates race conditions.
    are accessed by untrusted code, and unchecked changes to
    the array would compromise security or other
    important properties, you will need to do something different.
-  Storing a copy of the array is better approach in many situations.</p>
+  Storing a copy of the array is a better approach in many situations.</p>
 ]]>
     </Details>
   </BugPattern>
@@ -3575,7 +3575,7 @@ Thus, having a mutable instance field generally creates race conditions.
    If unchecked changes to
    the array would compromise security or other
    important properties, you will need to do something different.
-  Storing a copy of the array is better approach in many situations.</p>
+  Storing a copy of the array is a better approach in many situations.</p>
 ]]>
     </Details>
   </BugPattern>

--- a/spotbugs/etc/messages.xml
+++ b/spotbugs/etc/messages.xml
@@ -3520,6 +3520,65 @@ Thus, having a mutable instance field generally creates race conditions.
 ]]>
     </Details>
   </BugPattern>
+  <BugPattern type="MS_EXPOSE_BUF">
+    <ShortDescription>May expose internal representation by returning a buffer sharing non-public data</ShortDescription>
+    <LongDescription>{1} may expose internal representation by returning {2.givenClass}</LongDescription>
+    <Details>
+<![CDATA[
+  <p> A public static method either returns a buffer (java.nio.*Buffer) which wraps an array that is part of the
+  static state of the class by holding a reference only to this same array or it returns a shallow-copy of a buffer
+  that is part of the static stat of the class which shares its reference with the original buffer.
+   Any code that calls this method can freely modify the underlying array.
+   One fix is to return a read-only buffer or a new buffer with a copy of the array.</p>
+]]>
+    </Details>
+  </BugPattern>
+  <BugPattern type="EI_EXPOSE_BUF">
+    <ShortDescription>May expose internal representation by returning a buffer sharing non-public data</ShortDescription>
+    <LongDescription>{1} may expose internal representation by returning {2.givenClass}</LongDescription>
+    <Details>
+<![CDATA[
+  <p> Returning a reference to a buffer (java.nio.*Buffer) which wraps an array stored in one of the object's fields
+  exposes the internal representation of the array elements because the buffer only stores a reference to the array
+  instead of copying its content. Simliarly, returning a shallow-copy of such a buffer (using its duplicate() method
+  stored in one of the object's fields also exposes the internal representation of the buffer.&nbsp;
+   If instances are accessed by untrusted code, and unchecked changes to
+   the array would compromise security or other
+   important properties, you will need to do something different.
+  Returning a read-only buffer (using its asReadOnly() method) or copying the array to a new buffer (using its put()
+  method) is better approach in many situations.</p>
+]]>
+    </Details>
+  </BugPattern>
+  <BugPattern type="EI_EXPOSE_BUF2">
+    <ShortDescription>May expose internal representation by creating a buffer which incorporating reference to array</ShortDescription>
+    <LongDescription>{1} may expose internal representation by creating a buffer which contains an external array into {2.givenClass}</LongDescription>
+    <Details>
+<![CDATA[
+  <p> This code creates a buffer which stores a reference to an external array or the array of an external buffer into
+  the internal representation of the object.&nbsp;
+   If instances
+   are accessed by untrusted code, and unchecked changes to
+   the array would compromise security or other
+   important properties, you will need to do something different.
+  Storing a copy of the array is better approach in many situations.</p>
+]]>
+    </Details>
+  </BugPattern>
+  <BugPattern type="EI_EXPOSE_STATIC_BUF2">
+    <ShortDescription>May expose internal static state by creating a buffer which stores an external array into a static field</ShortDescription>
+    <LongDescription>{1} may expose internal static state by creating a buffer which stores an external array into static field {2}</LongDescription>
+    <Details>
+<![CDATA[
+  <p> This code creates a buffer which stores a reference to an external array or the array of an external buffer into
+  a static field.
+   If unchecked changes to
+   the array would compromise security or other
+   important properties, you will need to do something different.
+  Storing a copy of the array is better approach in many situations.</p>
+]]>
+    </Details>
+  </BugPattern>
   <BugPattern type="RU_INVOKE_RUN">
     <ShortDescription>Invokes run on a thread (did you mean to start it instead?)</ShortDescription>
     <LongDescription>{1} explicitly invokes run on a thread (did you mean to start it instead?)</LongDescription>

--- a/spotbugs/etc/messages.xml
+++ b/spotbugs/etc/messages.xml
@@ -3540,7 +3540,7 @@ Thus, having a mutable instance field generally creates race conditions.
 <![CDATA[
   <p> Returning a reference to a buffer (java.nio.*Buffer) which wraps an array stored in one of the object's fields
   exposes the internal representation of the array elements because the buffer only stores a reference to the array
-  instead of copying its content. Simlarly, returning a shallow-copy of such a buffer (using its duplicate() method)
+  instead of copying its content. Similarly, returning a shallow-copy of such a buffer (using its duplicate() method)
   stored in one of the object's fields also exposes the internal representation of the buffer.&nbsp;
    If instances are accessed by untrusted code, and unchecked changes to
    the array would compromise security or other

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindReturnRef.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindReturnRef.java
@@ -62,10 +62,10 @@ public class FindReturnRef extends OpcodeStackDetector {
 
     private final BugAccumulator bugAccumulator;
 
-    private static final Matcher bufferClassMatcher = Pattern.compile("Ljava/nio/[A-Za-z]+Buffer;").matcher("");
-    private static final Matcher duplicateMethodSignatureMatcher =
+    private static final Matcher BUFFER_CLASS_MATCHER = Pattern.compile("Ljava/nio/[A-Za-z]+Buffer;").matcher("");
+    private static final Matcher DUPLICATE_METHODS_SIGNATURE_MATCHER =
             Pattern.compile("\\(\\)Ljava/nio/[A-Za-z]+Buffer;").matcher("");
-    private static final Matcher wrapMethodSignatureMatcher =
+    private static final Matcher WRAP_METHOD_SIGNATURE_MATCHER =
             Pattern.compile("\\(\\[.\\)Ljava/nio/[A-Za-z]+Buffer;").matcher("");
 
     private enum CaptureKind {
@@ -194,8 +194,8 @@ public class FindReturnRef extends OpcodeStackDetector {
             OpcodeStack.Item item = stack.getStackItem(0);
             XField field = item.getXField();
             if (method == null || !"duplicate".equals(method.getName())
-                    || !duplicateMethodSignatureMatcher.reset(method.getSignature()).matches()
-                    || !bufferClassMatcher.reset(method.getClassDescriptor().getSignature()).matches()) {
+                    || !DUPLICATE_METHODS_SIGNATURE_MATCHER.reset(method.getSignature()).matches()
+                    || !BUFFER_CLASS_MATCHER.reset(method.getClassDescriptor().getSignature()).matches()) {
                 return;
             }
 
@@ -209,8 +209,8 @@ public class FindReturnRef extends OpcodeStackDetector {
         if (seen == Const.INVOKESTATIC) {
             MethodDescriptor method = getMethodDescriptorOperand();
             if (method == null || !"wrap".equals(method.getName())
-                    || !wrapMethodSignatureMatcher.reset(method.getSignature()).matches()
-                    || !bufferClassMatcher.reset(method.getClassDescriptor().getSignature()).matches()) {
+                    || !WRAP_METHOD_SIGNATURE_MATCHER.reset(method.getSignature()).matches()
+                    || !BUFFER_CLASS_MATCHER.reset(method.getClassDescriptor().getSignature()).matches()) {
                 return;
             }
             OpcodeStack.Item arg = stack.getStackItem(0);

--- a/spotbugsTestCases/src/java/FindReturnRefNegativeTest.java
+++ b/spotbugsTestCases/src/java/FindReturnRefNegativeTest.java
@@ -1,12 +1,12 @@
 import edu.umd.cs.findbugs.annotations.NoWarning;
 
 import java.util.Date;
-import java.util.Hashtable;
+import java.util.HashMap;
 
 public class FindReturnRefNegativeTest {
     private Date date;
     private Date[] dateArray;
-    private Hashtable<Integer, String> ht = new Hashtable<Integer, String>();
+    private HashMap<Integer, String> hm = new HashMap<Integer, String>();
 
     private static Date sDate = new Date();
     private static Date[] sDateArray = new Date[20];
@@ -15,14 +15,14 @@ public class FindReturnRefNegativeTest {
             sDateArray[i] = new Date();
         }
     }
-    private static Hashtable<Integer, String> sht = new Hashtable<Integer, String>();
+    private static HashMap<Integer, String> shm = new HashMap<Integer, String>();
     static {
-        sht.put(1, "123-45-6789");
+        shm.put(1, "123-45-6789");
     }
 
     public Date pubDate;
     public Date[] pubDateArray;
-    public Hashtable<Integer, String> puht = new Hashtable<Integer, String>();
+    public HashMap<Integer, String> puhm = new HashMap<Integer, String>();
 
     public static Date pubSDate;
     public static Date[] pubSDateArray;
@@ -31,9 +31,9 @@ public class FindReturnRefNegativeTest {
             pubSDateArray[i] = new Date();
         }
     }
-    public static Hashtable<Integer, String> pusht = new Hashtable<Integer, String>();
+    public static HashMap<Integer, String> pushm = new HashMap<Integer, String>();
     static {
-        pusht.put(1, "123-45-6789");
+        pushm.put(1, "123-45-6789");
     }
 
     private String string;
@@ -52,8 +52,8 @@ public class FindReturnRefNegativeTest {
         pubDate = new Date();
         dateArray = new Date[20];
         pubDateArray = new Date[20];
-        ht.put(1, "123-45-6789");
-        puht.put(1, "123-45-6789");
+        hm.put(1, "123-45-6789");
+        puhm.put(1, "123-45-6789");
         for (int i = 0; i < dateArray.length; i++) {
             dateArray[i] = new Date();
         }
@@ -93,13 +93,13 @@ public class FindReturnRefNegativeTest {
     }
 
     @NoWarning("EI")
-    public Hashtable<Integer, String> getValues() {
-        return (Hashtable<Integer, String>) ht.clone();
+    public HashMap<Integer, String> getValues() {
+        return (HashMap<Integer, String>) hm.clone();
     }
 
     @NoWarning("MS")
-    public static Hashtable<Integer, String> getSaticValues() {
-        return (Hashtable<Integer, String>) sht.clone();
+    public static HashMap<Integer, String> getStaticValues() {
+        return (HashMap<Integer, String>) shm.clone();
     }
 
     // Returning public case should be OK.
@@ -125,13 +125,13 @@ public class FindReturnRefNegativeTest {
     }
 
     @NoWarning("EI")
-    public Hashtable<Integer, String> getPublicValues() {
-        return puht;
+    public HashMap<Integer, String> getPublicValues() {
+        return puhm;
     }
 
     @NoWarning("MS")
-    public static Hashtable<Integer, String> getPublicStaticValues() {
-        return pusht;
+    public static HashMap<Integer, String> getPublicStaticValues() {
+        return pushm;
     }
 
     // Returning a private immutable should be OK.
@@ -185,13 +185,13 @@ public class FindReturnRefNegativeTest {
     }
 
     @NoWarning("EI2")
-    public void setValues(Hashtable<Integer, String> values) {
-        ht = (Hashtable<Integer, String>) values.clone();
+    public void setValues(HashMap<Integer, String> values) {
+        hm = (HashMap<Integer, String>) values.clone();
     }
 
     @NoWarning("MS")
-    public static void getStaticValues(Hashtable<Integer, String>  values) {
-        sht = (Hashtable<Integer, String>) values.clone();
+    public static void getStaticValues(HashMap<Integer, String>  values) {
+        shm = (HashMap<Integer, String>) values.clone();
     }
 
     // Do not warn for synthetic methods.
@@ -201,7 +201,7 @@ public class FindReturnRefNegativeTest {
         private void accessParent() {
             Date d1 = date;
             Date d2 = dateArray[0];
-            String s = ht.get(1);
+            String s = hm.get(1);
         }
     }
 }

--- a/spotbugsTestCases/src/java/FindReturnRefNegativeTest.java
+++ b/spotbugsTestCases/src/java/FindReturnRefNegativeTest.java
@@ -1,5 +1,6 @@
 import edu.umd.cs.findbugs.annotations.NoWarning;
 
+import java.nio.CharBuffer;
 import java.util.Date;
 import java.util.HashMap;
 
@@ -203,5 +204,45 @@ public class FindReturnRefNegativeTest {
             Date d2 = dateArray[0];
             String s = hm.get(1);
         }
+    }
+
+    private CharBuffer charBuf;
+    private char[] charArray;
+
+    private static CharBuffer sCharBuf;
+    private static char[] sCharArray;
+
+    @NoWarning("EI")
+    public CharBuffer getBufferReadOnly() {
+        return charBuf.asReadOnlyBuffer();
+    }
+
+    @NoWarning("MS")
+    public static CharBuffer getStaticBufferReadOnly() {
+        return sCharBuf.asReadOnlyBuffer();
+    }
+
+    @NoWarning("EI")
+    public CharBuffer getBufferCopy() {
+        CharBuffer cb = CharBuffer.allocate(charArray.length);
+        cb.put(charArray);
+        return cb;
+    }
+
+    @NoWarning("MS")
+    public static CharBuffer getStaticBufferCopy() {
+        CharBuffer cb = CharBuffer.allocate(sCharArray.length);
+        cb.put(sCharArray);
+        return cb;
+    }
+
+    @NoWarning("EI")
+    public CharBuffer getBuferWrap() {
+        return CharBuffer.wrap(charArray).asReadOnlyBuffer();        
+    }
+
+    @NoWarning("MS")
+    public static CharBuffer getStaticBuferWrap() {
+        return CharBuffer.wrap(sCharArray).asReadOnlyBuffer();        
     }
 }

--- a/spotbugsTestCases/src/java/FindReturnRefTest.java
+++ b/spotbugsTestCases/src/java/FindReturnRefTest.java
@@ -1,6 +1,7 @@
 import edu.umd.cs.findbugs.annotations.DesireWarning;
 import edu.umd.cs.findbugs.annotations.ExpectWarning;
 
+import java.nio.CharBuffer;
 import java.util.Date;
 import java.util.HashMap;
 
@@ -136,5 +137,71 @@ public class FindReturnRefTest {
     @ExpectWarning("MS")
     public static void getStaticValues(HashMap<Integer, String>  values) {
         shm = values;
+    }
+
+    private CharBuffer charBuf;
+    private char[] charArray;
+
+    private static CharBuffer sCharBuf;
+    private static char[] sCharArray;
+
+    @ExpectWarning("EI")
+    public CharBuffer getBuffer() {
+        return charBuf;
+    }
+
+    @ExpectWarning("MS")
+    public static CharBuffer getStaticBuffer() {
+        return sCharBuf;
+    }
+
+    @ExpectWarning("EI")
+    public CharBuffer getBufferDuplicate() {
+        return charBuf.duplicate();
+    }
+
+    @ExpectWarning("MS")
+    public static CharBuffer getStaticBufferDuplicate() {
+        return sCharBuf.duplicate();
+    }
+
+    @ExpectWarning("EI")
+    public CharBuffer getBuferWrap() {
+        return CharBuffer.wrap(charArray);        
+    }
+
+    @ExpectWarning("MS")
+    public static CharBuffer getStaticBuferWrap() {
+        return CharBuffer.wrap(sCharArray);        
+    }
+
+    @ExpectWarning("EI2")
+    public void setBuffer(CharBuffer cb) {
+        charBuf = cb;
+    }
+
+    @ExpectWarning("MS")
+    public static void setStaticBuffer(CharBuffer cb) {
+        sCharBuf = cb;
+    }
+
+    @ExpectWarning("EI2")
+    public void setBufferDuplicate(CharBuffer cb) {
+        charBuf = cb.duplicate();
+    }
+
+    @ExpectWarning("MS")
+    public static void setStaticBufferDuplicate(CharBuffer cb) {
+        sCharBuf = cb.duplicate();
+    }
+
+    @ExpectWarning("EI2")
+    public void setBufferWrap(char[] cArr) {
+        charBuf = CharBuffer.wrap(cArr);
+    }
+
+    @ExpectWarning("MS")
+    public static void setStaticBufferWrap(char[] cArr) {
+        sCharBuf = CharBuffer.wrap(cArr);
     }
 }

--- a/spotbugsTestCases/src/java/FindReturnRefTest.java
+++ b/spotbugsTestCases/src/java/FindReturnRefTest.java
@@ -2,12 +2,12 @@ import edu.umd.cs.findbugs.annotations.DesireWarning;
 import edu.umd.cs.findbugs.annotations.ExpectWarning;
 
 import java.util.Date;
-import java.util.Hashtable;
+import java.util.HashMap;
 
 public class FindReturnRefTest {
     private Date date;
     private Date[] dateArray;
-    private Hashtable<Integer, String> ht = new Hashtable<Integer, String>();
+    private HashMap<Integer, String> hm = new HashMap<Integer, String>();
 
     private static Date sDate = new Date();
     private static Date[] sDateArray = new Date[20];
@@ -16,15 +16,15 @@ public class FindReturnRefTest {
             sDateArray[i] = new Date();
         }
     }
-    private static Hashtable<Integer, String> sht = new Hashtable<Integer, String>();
+    private static HashMap<Integer, String> shm = new HashMap<Integer, String>();
     static {
-        sht.put(1, "123-45-6789");
+        shm.put(1, "123-45-6789");
     }
 
     public FindReturnRefTest() {
         date = new Date();
         dateArray = new Date[20];
-        ht.put(1, "123-45-6789");
+        hm.put(1, "123-45-6789");
         for (int i = 0; i < dateArray.length; i++) {
             dateArray[i] = new Date();
         }
@@ -42,13 +42,13 @@ public class FindReturnRefTest {
         return sDate;
     }
 
-    @DesireWarning("EI") // Indirect way of returning reference
+    @ExpectWarning("EI") // Indirect way of returning reference
     public Date getDate2() {
         Date d = date;
         return d;
     }
 
-    @DesireWarning("MS") // Indirect way of returning reference
+    @ExpectWarning("MS") // Indirect way of returning reference
     public static Date getStaticDate2() {
         Date d = sDate;
         return d;
@@ -75,13 +75,13 @@ public class FindReturnRefTest {
     }
 
     @ExpectWarning("EI")
-    public Hashtable<Integer, String> getValues() {
-        return ht;
+    public HashMap<Integer, String> getValues() {
+        return hm;
     }
 
     @ExpectWarning("MS")
-    public static Hashtable<Integer, String> getStaticValues() {
-        return sht;
+    public static HashMap<Integer, String> getStaticValues() {
+        return shm;
     }
 
     @ExpectWarning("EI2")
@@ -129,12 +129,12 @@ public class FindReturnRefTest {
     }
 
     @ExpectWarning("EI2")
-    public void setValues(Hashtable<Integer, String> values) {
-        ht = values;
+    public void setValues(HashMap<Integer, String> values) {
+        hm = values;
     }
 
     @ExpectWarning("MS")
-    public static void getStaticValues(Hashtable<Integer, String>  values) {
-        sht = values;
+    public static void getStaticValues(HashMap<Integer, String>  values) {
+        shm = values;
     }
 }


### PR DESCRIPTION
SEI CERT rule FIO05-J requires that buffers or their backing arrays
should not be exposed by methods to untrusted code. This patch
implements the check for such behavior in the already existing detector
FindReturnRef. To make the error easier to understand for the user
we did not reuse the existing messages but instead added new
ones: EI_EXPOSE_BUF, MS_EXPOSE_BUF, EI_EXPOSE_BUF2 and
EI_EXPOSE_STATIC_BUF.

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [X] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
