### PR TITLE
Detector for bad End of Stream Checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ## Unreleased - 2021-??-??
 
+### Added
+* New detector `FindBadEndOfStreamCheck` for new bug type `EOS_BAD_END_OF_STREAM_CHECK`. This bug is reported whenever the return value of java.io.FileInputStream.read() or java.io.FileReader.read() is first converted to byte/int and only thereafter checked against -1. (See [SEI CERT rule FIO08-J](https://wiki.sei.cmu.edu/confluence/display/java/FIO08-J.+Distinguish+between+characters+or+bytes+read+from+a+stream+and+-1))
+
 ## 4.3.0 - 2021-07-01
 
 ### Fixed

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindBadEndOfStreamCheckTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindBadEndOfStreamCheckTest.java
@@ -1,0 +1,60 @@
+package edu.umd.cs.findbugs.detect;
+
+import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
+import static org.hamcrest.Matchers.hasItem;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
+
+public class FindBadEndOfStreamCheckTest extends AbstractIntegrationTest {
+    @Test
+    public void testBadEndOfFileChecks() {
+        performAnalysis("endOfStreamCheck/BadEndOfStreamCheck.class");
+
+        assertNumOfEOSBugs(16);
+
+        assertEOSBug("badFileInputStream1", 12);
+        assertEOSBug("badFileInputStream2", 25);
+        assertEOSBug("badFileInputStream3", 39);
+        assertEOSBug("badFileInputStream4", 55);
+        assertEOSBug("badFileInputStream5", 70);
+        assertEOSBug("badFileInputStream6", 83);
+        assertEOSBug("badFileInputStream7", 97);
+        assertEOSBug("badFileInputStream8", 113);
+        assertEOSBug("badFileReader1", 128);
+        assertEOSBug("badFileReader2", 141);
+        assertEOSBug("badFileReader3", 155);
+        assertEOSBug("badFileReader4", 171);
+        assertEOSBug("badFileReader5", 186);
+        assertEOSBug("badFileReader6", 199);
+        assertEOSBug("badFileReader7", 213);
+        assertEOSBug("badFileReader8", 229);
+    }
+
+    @Test
+    public void testGoodEndOfFileChecks() {
+        performAnalysis("endOfStreamCheck/GoodEndOfStreamCheck.class");
+
+        assertNumOfEOSBugs(0);
+    }
+
+    private void assertNumOfEOSBugs(int num) {
+        final BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
+                .bugType("EOS_BAD_END_OF_STREAM_CHECK").build();
+        assertThat(getBugCollection(), containsExactly(num, bugTypeMatcher));
+    }
+
+    private void assertEOSBug(String method, int line) {
+        final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
+                .bugType("EOS_BAD_END_OF_STREAM_CHECK")
+                .inClass("BadEndOfStreamCheck")
+                .inMethod(method)
+                .atLine(line)
+                .build();
+        assertThat(getBugCollection(), hasItem(bugInstanceMatcher));
+    }
+}

--- a/spotbugs/etc/findbugs.xml
+++ b/spotbugs/etc/findbugs.xml
@@ -649,6 +649,8 @@
                     reports="NP_METHOD_RETURN_RELAXING_ANNOTATION,NP_METHOD_PARAMETER_TIGHTENS_ANNOTATION"/>
           <Detector class="edu.umd.cs.findbugs.detect.DontAssertInstanceofInTests" speed="fast"
                     reports="JUA_DONT_ASSERT_INSTANCEOF_IN_TESTS"/>
+          <Detector class="edu.umd.cs.findbugs.detect.FindBadEndOfStreamCheck" speed="fast"
+                    reports="EOS_BAD_END_OF_STREAM_CHECK"/>
             <!-- Bug Categories -->
            <BugCategory category="NOISE" hidden="true"/>
 
@@ -1251,4 +1253,5 @@
           <BugPattern abbrev="NP" type="NP_METHOD_RETURN_RELAXING_ANNOTATION" category="STYLE" />
           <BugPattern abbrev="NP" type="NP_METHOD_PARAMETER_TIGHTENS_ANNOTATION" category="STYLE" />
           <BugPattern abbrev="NP" type="NP_METHOD_PARAMETER_RELAXING_ANNOTATION" category="STYLE" deprecated="true" />
+          <BugPattern abbrev="EOS" type="EOS_BAD_END_OF_STREAM_CHECK" category="CORRECTNESS" />
 </FindbugsPlugin>

--- a/spotbugs/etc/messages.xml
+++ b/spotbugs/etc/messages.xml
@@ -1675,6 +1675,20 @@ factory pattern to create these objects.</p>
             ]]>
     </Details>
   </Detector>
+  <Detector class="edu.umd.cs.findbugs.detect.FindBadEndOfStreamCheck">
+    <Details>
+      <![CDATA[
+            <p>Detector for patterns where the return value of java.io.FileInputStream.read() or
+               java.io.FileReader.read() is converted before checking against -1.</p>
+            <p>
+               Both methods return an int. If this int is converted to byte (in the case of
+               FileInputStream.read()) then -1 and the byte 0xFF become indistinguishable.
+               If it is converted to char (in the case of FileReader.read()) then -1 becomes
+               0xFFFF which is Character.MAX_VALUE since characters are unsigned in Java.
+            </p>
+      ]]>
+    </Details>
+  </Detector>
   <!--
   **********************************************************************
   BugPatterns
@@ -8461,6 +8475,21 @@ after the call to initLogging, the logger configuration is lost
         </p>]]>
       </Details>
   </BugPattern>
+
+  <BugPattern type="EOS_BAD_END_OF_STREAM_CHECK">
+    <ShortDescription>Data read is converted before comparison to -1</ShortDescription>
+    <LongDescription>The return value of {2} in method {1} is converted to {3} before comparison to {4}.</LongDescription>
+    <Details>
+      <![CDATA[<p>
+      The method java.io.FileInputStream.read() returns an int. If this int is converted to a byte then -1 (which
+      indicates an EOF) and the byte 0xFF become indistinguishable, this comparing the (converted) result to -1
+      causes the read (probably in a loop) to end prematurely if the character 0xFF is met. Similarly, the method
+      java.io.FileReader.read() also returns an int. If it is converted to a char then -1 becomes 0xFFFF which is
+      Character.MAX_VALUE. Comparing the result to -1 is pointless, since characters are unsigned in Java. If the
+      checking for EOF is the condition of a loop then this loop is infinite.
+      </p>]]>
+    </Details>
+  </BugPattern>
   <!--
   **********************************************************************
    BugCodes
@@ -8605,4 +8634,5 @@ after the call to initLogging, the logger configuration is lost
   <BugCode abbrev="FB">SpotBugs did not produce the expected warnings on a method</BugCode>
   <BugCode abbrev="DL">Unintended contention or possible deadlock due to locking on shared objects</BugCode>
   <BugCode abbrev="JUA">Problems in JUnit Assertions</BugCode>
+  <BugCode abbrev="EOS">Bad End of Stream check</BugCode>
 </MessageCollection>

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindBadEndOfStreamCheck.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindBadEndOfStreamCheck.java
@@ -1,0 +1,115 @@
+/*
+ * SpotBugs - Find bugs in Java programs
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+package edu.umd.cs.findbugs.detect;
+
+import org.apache.bcel.Const;
+import org.apache.bcel.classfile.JavaClass;
+
+import edu.umd.cs.findbugs.BugAccumulator;
+import edu.umd.cs.findbugs.BugInstance;
+import edu.umd.cs.findbugs.BugReporter;
+import edu.umd.cs.findbugs.OpcodeStack;
+import edu.umd.cs.findbugs.ba.XMethod;
+import edu.umd.cs.findbugs.bcel.OpcodeStackDetector;
+
+public class FindBadEndOfStreamCheck extends OpcodeStackDetector {
+
+    private final BugAccumulator bugAccumulator;
+    private OpcodeStack.Item itemUnderCast;
+    private OpcodeStack.Item castedItem;
+    private XMethod source;
+
+    public FindBadEndOfStreamCheck(BugReporter bugReporter) {
+        this.bugAccumulator = new BugAccumulator(bugReporter);
+    }
+
+    @Override
+    public void visitAfter(JavaClass obj) {
+        bugAccumulator.reportAccumulatedBugs();
+    }
+
+    @Override
+    public void sawOpcode(int seen) {
+        itemUnderCast = null;
+
+        if (seen == Const.I2B || seen == Const.I2C) {
+            OpcodeStack.Item item = stack.getStackItem(0);
+            XMethod method = item.getReturnValueOf();
+            if (method == null || !isFileRead(method)) {
+                return;
+            }
+            itemUnderCast = item;
+            source = method;
+        }
+
+        if ((seen == Const.IF_ICMPEQ || seen == Const.IF_ICMPNE) && castedItem != null) {
+            OpcodeStack.Item rightItem = stack.getStackItem(0);
+            OpcodeStack.Item leftItem = stack.getStackItem(1);
+            Object value = null;
+            if (leftItem.equals(castedItem)) {
+                value = rightItem.getConstant();
+            } else if (rightItem.equals(castedItem)) {
+                value = leftItem.getConstant();
+            }
+            if (value instanceof Integer && ((Integer) value).intValue() == -1) {
+                bugAccumulator.accumulateBug(new BugInstance(this, "EOS_BAD_END_OF_STREAM_CHECK", NORMAL_PRIORITY)
+                        .addClassAndMethod(this).addCalledMethod(source)
+                        .addString(castedItem.getSignature().equals("B") ? "byte" : "char").addInt(-1), this);
+            }
+        }
+
+        if ((seen == Const.IFGE || seen == Const.IFLT) && castedItem != null) {
+            OpcodeStack.Item item = stack.getStackItem(0);
+            if (item.equals(castedItem)) {
+                bugAccumulator.accumulateBug(new BugInstance(this, "EOS_BAD_END_OF_STREAM_CHECK", NORMAL_PRIORITY)
+                        .addClassAndMethod(this).addCalledMethod(source)
+                        .addString(castedItem.getSignature().equals("B") ? "byte" : "char").addInt(0), this);
+            }
+        }
+
+        if ((seen == Const.IF_ICMPLE || seen == Const.IF_ICMPGT) && castedItem != null) {
+            OpcodeStack.Item rightItem = stack.getStackItem(0);
+            OpcodeStack.Item leftItem = stack.getStackItem(1);
+            Object value = null;
+            if (rightItem.equals(castedItem)) {
+                value = leftItem.getConstant();
+            }
+            if (value instanceof Integer && ((Integer) value).intValue() == 0) {
+                bugAccumulator.accumulateBug(new BugInstance(this, "EOS_BAD_END_OF_STREAM_CHECK", NORMAL_PRIORITY)
+                        .addClassAndMethod(this).addCalledMethod(source)
+                        .addString(castedItem.getSignature().equals("B") ? "byte" : "char").addInt(0), this);
+            }
+        }
+    }
+
+    @Override
+    public void afterOpcode(int seen) {
+        super.afterOpcode(seen);
+
+        if ((seen == Const.I2B || seen == Const.I2C) && itemUnderCast != null) {
+            castedItem = stack.getStackItem(0);
+        }
+    }
+
+    private boolean isFileRead(XMethod method) {
+        String classSig = method.getClassDescriptor().getSignature();
+        return method != null && "read".equals(method.getName())
+                && ("Ljava/io/FileInputStream;".equals(classSig) || "Ljava/io/FileReader;".equals(classSig));
+    }
+}

--- a/spotbugsTestCases/src/java/endOfStreamCheck/BadEndOfStreamCheck.java
+++ b/spotbugsTestCases/src/java/endOfStreamCheck/BadEndOfStreamCheck.java
@@ -1,0 +1,240 @@
+package endOfStreamCheck;
+
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+
+public class BadEndOfStreamCheck {
+    void badFileInputStream1() {
+        try (FileInputStream in = new FileInputStream("test.txt")) {
+            byte data;
+            while ((data = (byte) in.read()) != -1) {
+                System.out.println("Read byte: " + data);
+            }
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    void badFileInputStream2() {
+        try (FileInputStream in = new FileInputStream("test.txt")) {
+            byte data;
+            while (-1 != (data = (byte) in.read())) {
+                System.out.println("Read byte: " + data);
+            }
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    void badFileInputStream3() {
+        try (FileInputStream in = new FileInputStream("test.txt")) {
+            byte data;
+            while (true) {
+                if ((data = (byte) in.read()) == -1) {
+                    break;
+                }
+                System.out.println("Read byte: " + data);
+            }
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    void badFileInputStream4() {
+        try (FileInputStream in = new FileInputStream("test.txt")) {
+            byte data;
+            while (true) {
+                if (-1 == (data = (byte) in.read())) {
+                    break;
+                }
+                System.out.println("Read byte: " + data);
+            }
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    void badFileInputStream5() {
+        try (FileInputStream in = new FileInputStream("test.txt")) {
+            byte data;
+            while ((data = (byte) in.read()) >= 0) {
+                System.out.println("Read byte: " + data);
+            }
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    void badFileInputStream6() {
+        try (FileInputStream in = new FileInputStream("test.txt")) {
+            byte data;
+            while (0 <= (data = (byte) in.read())) {
+                System.out.println("Read byte: " + data);
+            }
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    void badFileInputStream7() {
+        try (FileInputStream in = new FileInputStream("test.txt")) {
+            byte data;
+            while (true) {
+                if ((data = (byte) in.read()) < 0) {
+                    break;
+                }
+                System.out.println("Read byte: " + data);
+            }
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    void badFileInputStream8() {
+        try (FileInputStream in = new FileInputStream("test.txt")) {
+            byte data;
+            while (true) {
+                if (0 > (data = (byte) in.read())) {
+                    break;
+                }
+                System.out.println("Read byte: " + data);
+            }
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    void badFileReader1() {
+        try (FileReader in = new FileReader("test2.txt")) {
+            char data;
+            while ((data = (char) in.read()) != -1) {
+                System.out.println("Read character: " + data);
+            }
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }        
+    }
+
+    void badFileReader2() {
+        try (FileReader in = new FileReader("test2.txt")) {
+            char data;
+            while (-1 != (data = (char) in.read())) {
+                System.out.println("Read character: " + data);
+            }
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }        
+    }
+
+    void badFileReader3() {
+        try (FileReader in = new FileReader("test2.txt")) {
+            char data;
+            while (true) {
+                if ((data = (char) in.read()) == -1) {
+                    break;
+                }
+                System.out.println("Read character: " + data);
+            }
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }        
+    }
+
+    void badFileReader4() {
+        try (FileReader in = new FileReader("test2.txt")) {
+            char data;
+            while (true) {
+                if (-1 == (data = (char) in.read())) {
+                    break;
+                }
+                System.out.println("Read character: " + data);
+            }
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }        
+    }
+
+    void badFileReader5() {
+        try (FileReader in = new FileReader("test2.txt")) {
+            char data;
+            while ((data = (char) in.read()) >= 0) {
+                System.out.println("Read character: " + data);
+            }
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }        
+    }
+
+    void badFileReader6() {
+        try (FileReader in = new FileReader("test2.txt")) {
+            char data;
+            while (0 <= (data = (char) in.read())) {
+                System.out.println("Read character: " + data);
+            }
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }        
+    }
+
+    void badFileReader7() {
+        try (FileReader in = new FileReader("test2.txt")) {
+            char data;
+            while (true) {
+                if ((data = (char) in.read()) < 0) {
+                    break;
+                }
+                System.out.println("Read character: " + data);
+            }
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }        
+    }
+
+    void badFileReader8() {
+        try (FileReader in = new FileReader("test2.txt")) {
+            char data;
+            while (true) {
+                if (0 > (data = (char) in.read())) {
+                    break;
+                }
+                System.out.println("Read character: " + data);
+            }
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }        
+    }
+}

--- a/spotbugsTestCases/src/java/endOfStreamCheck/GoodEndOfStreamCheck.java
+++ b/spotbugsTestCases/src/java/endOfStreamCheck/GoodEndOfStreamCheck.java
@@ -1,0 +1,38 @@
+package endOfStreamCheck;
+
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+
+public class GoodEndOfStreamCheck {
+    void goodFileInputStream() {
+        try (FileInputStream in = new FileInputStream("test.txt")) {
+            int inbuff;
+            byte data;
+            while ((inbuff = in.read()) != -1) {
+                data = (byte) inbuff;
+                System.out.println("Read byte: " + data);
+            }
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    void goodFileReader() {
+        try (FileReader in = new FileReader("test2.txt")) {
+            char data;
+            int inbuff;
+            while ((inbuff = in.read()) != -1) {
+                data = (char) inbuff;
+                System.out.println("Read character: " + data);
+            }
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }        
+    }
+}


### PR DESCRIPTION
java.io.FileInputStream.read() and java.io.FileReader.read() both return an integer.
The value of this integer is -1 if the end of the stream is reached. Since
FileInputStream reads bytes and FileReader reads characters their return value
must be casted to these types. However, if the casting happens before the check
for -1 then -1 becomes indistinguishible from 0xFF in case of FileInputStream and
becomes Character.MAX_VALUE (the highest positive value of a character) in case
of FileReader. SEI CERT rule FIO08-J describes these bugs in detail. This patch adds
a new error message EOS_BAD_END_OF_STREAM_CHECK and a new detector
(FindBadEndOfStreamCheck) which checks for this kind of error.

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [X] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
