### PR TITLE
Mutable array clones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ### Added
 * New bugs `MS_EXPOSE_BUF`, `EI_EXPOSE_BUF`, `EI_EXPOSE_STATIC_BUF2` and `EI_EXPOSE_BUF2` by the `FindReturnRef` detector to detect cases where buffers or their backing arrays are exposed (see [SEI CERT rule FIO05-J](https://wiki.sei.cmu.edu/confluence/display/java/FIO05-J.+Do+not+expose+buffers+or+their+backing+arrays+methods+to+untrusted+code))
+*  `MS_EXPOSE_REP`, `EI_EXPOSE_REP`, `EI_EXPOSE_STATIC_REP2` and `EI_EXPOSE_REP2` now report for shallowly copied arrays (using clone()) of mutable objects
 
 ## 4.2.3 - 2021-04-12
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindReturnRef.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindReturnRef.java
@@ -143,7 +143,7 @@ public class FindReturnRef extends OpcodeStackDetector {
             if (capture != CaptureKind.NONE) {
                 bugAccumulator.accumulateBug(
                         new BugInstance(this, "EI_EXPOSE_STATIC_" + (capture == CaptureKind.BUF ? "BUF2" : "REP2"),
-                                (capture == CaptureKind.REP) ? NORMAL_PRIORITY : LOW_PRIORITY)
+                                capture == CaptureKind.REP ? NORMAL_PRIORITY : LOW_PRIORITY)
                                         .addClassAndMethod(this)
                                         .addReferencedField(this)
                                         .add(LocalVariableAnnotation.getLocalVariableAnnotation(getMethod(),
@@ -329,7 +329,6 @@ public class FindReturnRef extends OpcodeStackDetector {
                 kind = CaptureKind.ARRAY_CLONE;
             }
             top = newTop;
-            System.err.println("This is a clone:" + top);
         }
         if ((getMethod().getAccessFlags() & Const.ACC_VARARGS) == 0) {
             return kind;

--- a/spotbugsTestCases/src/java/FindReturnRefTest.java
+++ b/spotbugsTestCases/src/java/FindReturnRefTest.java
@@ -1,4 +1,3 @@
-import edu.umd.cs.findbugs.annotations.DesireWarning;
 import edu.umd.cs.findbugs.annotations.ExpectWarning;
 
 import java.nio.CharBuffer;
@@ -65,12 +64,12 @@ public class FindReturnRefTest {
         return sDateArray;
     }
 
-    @DesireWarning("EI") // Cloning the array does not perform deep copy
+    @ExpectWarning("EI") // Cloning the array does not perform deep copy
     public Date[] getDateArray2() {
         return dateArray.clone();
     }
 
-    @DesireWarning("MS") // Cloning the array does not perform deep copy
+    @ExpectWarning("MS") // Cloning the array does not perform deep copy
     public static Date[] getStaticDateArray2() {
         return sDateArray.clone();
     }
@@ -119,12 +118,12 @@ public class FindReturnRefTest {
         sDateArray = da;
     }
 
-    @DesireWarning("EI2") // Cloning the array does not perform deep copy
+    @ExpectWarning("EI2") // Cloning the array does not perform deep copy
     public void setDateArray2(Date[] da) {
         dateArray = da.clone();
     }
 
-    @DesireWarning("MS") // Cloning the array does not perform deep copy
+    @ExpectWarning("MS") // Cloning the array does not perform deep copy
     public static void setStaticDateArray2(Date[] da) {
         sDateArray = da.clone();
     }


### PR DESCRIPTION
SEI-CERT rule OBJ05-J warns that cloning a private array before returning may not be sufficient if the elements of the array are of a mutable type. The clone() method of arrays only does a shallow-copy thus exposing the elements of the private array to all other classes. This patch improves the FindReturnRef detector to find such issues. The improved detector also warns for methods taking an array parameter of a mutable type and cloning it to a private array: the elements of the array are not copied, thus the caller can later modify them which results in modification of the elements of the private array as well.
----

Reopened version of #1551