### PR TITLE
Update Gradle and disable an insecure feature flg

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,1 @@
 org.gradle.jvmargs=-XX:+HeapDumpOnOutOfMemoryError -Xmx1G --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
-
-# https://issues.sonatype.org/browse/MVNCENTRAL-5548
-systemProp.org.gradle.internal.publish.checksums.insecure=true
-

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
According to https://issues.sonatype.org/browse/NEXUS-21802 Sonatype Nexus can handle sha256/sha512 checksum from version 2.14.18.
The oss.sonatype.org uses Sonatype Nexus version 2.14.20-02 and contains the fix.