### PR TITLE
Fix for the heuristics that recognizes immutable classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 ### Added
 * New detector `FindBadEndOfStreamCheck` for new bug type `EOS_BAD_END_OF_STREAM_CHECK`. This bug is reported whenever the return value of java.io.FileInputStream.read() or java.io.FileReader.read() is first converted to byte/int and only thereafter checked against -1. (See [SEI CERT rule FIO08-J](https://wiki.sei.cmu.edu/confluence/display/java/FIO08-J.+Distinguish+between+characters+or+bytes+read+from+a+stream+and+-1))
 ### Fixed
-- Class names containing the substring "immutable" (case insensitive) are considered immutable
+- Heuristics to detect mutable classes improved: non-public or static "setters" are no longer considered as setters. Also the return value must be of a primitive type to consider the function as a setter. The list of known immutable classes was also extended.
 
 ## 4.3.0 - 2021-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ### Added
 * New detector `FindBadEndOfStreamCheck` for new bug type `EOS_BAD_END_OF_STREAM_CHECK`. This bug is reported whenever the return value of java.io.FileInputStream.read() or java.io.FileReader.read() is first converted to byte/int and only thereafter checked against -1. (See [SEI CERT rule FIO08-J](https://wiki.sei.cmu.edu/confluence/display/java/FIO08-J.+Distinguish+between+characters+or+bytes+read+from+a+stream+and+-1))
+### Fixed
+- Class names containing the substring "immutable" (case insensitive) are considered immutable
 
 ## 4.3.0 - 2021-07-01
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindReturnRef.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindReturnRef.java
@@ -137,7 +137,8 @@ public class FindReturnRef extends OpcodeStackDetector {
         bufferParamUnderDuplication = null;
 
         if (staticMethod && seen == Const.PUTSTATIC && nonPublicFieldOperand()
-                && MutableClasses.mutableSignature(getSigConstantOperand())) {
+                && (MutableClasses.mutableSignature(getSigConstantOperand())
+                        || isBufferClassSignature(getSigConstantOperand()))) {
             OpcodeStack.Item top = stack.getStackItem(0);
             CaptureKind capture = getPotentialCapture(top);
             if (capture != CaptureKind.NONE) {
@@ -152,7 +153,8 @@ public class FindReturnRef extends OpcodeStackDetector {
             }
         }
         if (!staticMethod && seen == Const.PUTFIELD && nonPublicFieldOperand()
-                && MutableClasses.mutableSignature(getSigConstantOperand())) {
+                && (MutableClasses.mutableSignature(getSigConstantOperand())
+                        || isBufferClassSignature(getSigConstantOperand()))) {
             OpcodeStack.Item top = stack.getStackItem(0);
             OpcodeStack.Item target = stack.getStackItem(1);
             CaptureKind capture = getPotentialCapture(top);
@@ -196,7 +198,8 @@ public class FindReturnRef extends OpcodeStackDetector {
                     field.isPublic() ||
                     AnalysisContext.currentXFactory().isEmptyArrayField(field) ||
                     field.getName().indexOf("EMPTY") != -1 ||
-                    !MutableClasses.mutableSignature(field.getSignature())) {
+                    !(MutableClasses.mutableSignature(field.getSignature()) ||
+                            isBufferClassSignature(field.getSignature()))) {
                 return;
             }
             bugAccumulator.accumulateBug(new BugInstance(this, (staticMethod ? "MS" : "EI") + "_EXPOSE_"
@@ -227,7 +230,7 @@ public class FindReturnRef extends OpcodeStackDetector {
 
             if (seen == Const.INVOKEVIRTUAL && "duplicate".equals(method.getName())
                     && DUPLICATE_METHODS_SIGNATURE_MATCHER.reset(method.getSignature()).matches()
-                    && BUFFER_CLASS_MATCHER.reset(method.getClassDescriptor().getSignature()).matches()) {
+                    && isBufferClassSignature(method.getClassDescriptor().getSignature())) {
                 if (field != null && field.getClassDescriptor().equals(getClassDescriptor()) && !field.isPublic()) {
                     bufferFieldUnderDuplication = field;
                 } else if (item.isInitialParameter()) {
@@ -240,7 +243,7 @@ public class FindReturnRef extends OpcodeStackDetector {
             MethodDescriptor method = getMethodDescriptorOperand();
             if (method == null || !"wrap".equals(method.getName())
                     || !WRAP_METHOD_SIGNATURE_MATCHER.reset(method.getSignature()).matches()
-                    || !BUFFER_CLASS_MATCHER.reset(method.getClassDescriptor().getSignature()).matches()) {
+                    || !isBufferClassSignature(method.getClassDescriptor().getSignature())) {
                 return;
             }
             OpcodeStack.Item arg = stack.getStackItem(0);
@@ -351,5 +354,9 @@ public class FindReturnRef extends OpcodeStackDetector {
             }
         } while (klass != null);
         return false;
+    }
+
+    private boolean isBufferClassSignature(String sig) {
+        return BUFFER_CLASS_MATCHER.reset(sig).matches();
     }
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/MutableClasses.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/MutableClasses.java
@@ -102,7 +102,13 @@ public class MutableClasses {
     }
 
     public static boolean looksLikeASetter(Method method, JavaClass cls) {
+        // Static methods are no setters.
         if (method.isStatic()) {
+            return false;
+        }
+
+        // Non-public setters cannot be used from outside the package so disregard them.
+        if (!method.isPublic()) {
             return false;
         }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/MutableClasses.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/MutableClasses.java
@@ -5,6 +5,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 import java.util.List;
 
 import org.apache.bcel.Repository;
@@ -45,12 +46,15 @@ public class MutableClasses {
             return false;
         }
 
-        if (IMMUTABLE_CLASS_NAME_MATCHER.reset(sig).matches()) {
+        if (IMMUTABLE_CLASS_NAME_MATCHER.reset(sig.substring(sig.lastIndexOf('.') + 1)).matches()) {
             return false;
         }
 
         try {
             JavaClass cls = Repository.lookupClass(dottedClassName);
+            if (Stream.of(cls.getAnnotationEntries()).anyMatch(s -> s.getAnnotationType().endsWith("Immutable"))) {
+                return false;
+            }
             return isMutable(cls);
         } catch (ClassNotFoundException e) {
             AnalysisContext.reportMissingClass(e);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/MutableClasses.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/MutableClasses.java
@@ -45,7 +45,7 @@ public class MutableClasses {
 
     private static final List<String> SETTER_LIKE_NAMES = Arrays.asList(
             "set", "put", "add", "insert", "delete", "remove", "erase", "clear", "push", "pop",
-            "enqueue", "dequeue", "write", "append", "replace");
+            "enqueue", "dequeue", "append", "replace");
 
     public static boolean mutableSignature(String sig) {
         if (sig.charAt(0) == '[') {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/MutableClasses.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/MutableClasses.java
@@ -72,7 +72,8 @@ public class MutableClasses {
 
         try {
             JavaClass cls = Repository.lookupClass(dottedClassName);
-            if (Stream.of(cls.getAnnotationEntries()).anyMatch(s -> s.getAnnotationType().endsWith(".Immutable"))) {
+            if (Stream.of(cls.getAnnotationEntries()).anyMatch(s -> (s.getAnnotationType().endsWith(".Immutable"))
+                    || s.getAnnotationType().equals("jdk.internal.ValueBased"))) {
                 return false;
             }
             return isMutable(cls);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/MutableClasses.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/MutableClasses.java
@@ -3,8 +3,6 @@ package edu.umd.cs.findbugs.util;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import java.util.List;
 
@@ -24,13 +22,26 @@ public class MutableClasses {
             "java.awt.Color", "java.awt.GradientPaint", "java.awt.LinearGradientPaint",
             "java.awt.RadialGradientPaint", "java.Cursor.", "java.util.UUID", "java.util.URL",
             "java.util.URI", "java.util.Inet4Address", "java.util.InetSocketAddress",
-            "java.security.Permission"));
+            "java.security.Permission", "com.google.common.collect.ImmutableBiMap",
+            "com.google.common.collect.ImmutableClassToInstanceMap",
+            "com.google.common.collect.ImmutableCollection",
+            "com.google.common.collect.ImmutableList",
+            "com.google.common.collect.ImmutableListMultimap",
+            "com.google.common.collect.ImmutableMap",
+            "com.google.common.collect.ImmutableMultimap",
+            "com.google.common.collect.ImmutableMultiset",
+            "com.google.common.collect.ImmutableRangeMap",
+            "com.google.common.collect.ImmutableRangeSet",
+            "com.google.common.collect.ImmutableSet",
+            "com.google.common.collect.ImmutableSetMultimap",
+            "com.google.common.collect.ImmutableSortedMap",
+            "com.google.common.collect.ImmutableSortedMultiset",
+            "com.google.common.collect.ImmutableSortedSet",
+            "com.google.common.collect.ImmutableTable"));
 
     private static final List<String> SETTER_LIKE_NAMES = Arrays.asList(
             "set", "put", "add", "insert", "delete", "remove", "erase", "clear", "push", "pop",
             "enqueue", "dequeue", "write", "append", "replace");
-
-    private static final Matcher IMMUTABLE_CLASS_NAME_MATCHER = Pattern.compile(".*immutable.*", Pattern.CASE_INSENSITIVE).matcher("");
 
     public static boolean mutableSignature(String sig) {
         if (sig.charAt(0) == '[') {
@@ -46,13 +57,9 @@ public class MutableClasses {
             return false;
         }
 
-        if (IMMUTABLE_CLASS_NAME_MATCHER.reset(sig.substring(sig.lastIndexOf('.') + 1)).matches()) {
-            return false;
-        }
-
         try {
             JavaClass cls = Repository.lookupClass(dottedClassName);
-            if (Stream.of(cls.getAnnotationEntries()).anyMatch(s -> s.getAnnotationType().endsWith("Immutable"))) {
+            if (Stream.of(cls.getAnnotationEntries()).anyMatch(s -> s.getAnnotationType().endsWith(".Immutable"))) {
                 return false;
             }
             return isMutable(cls);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/MutableClasses.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/MutableClasses.java
@@ -39,6 +39,9 @@ public class MutableClasses {
             "com.google.common.collect.ImmutableSortedSet",
             "com.google.common.collect.ImmutableTable"));
 
+    private static final Set<String> KNOWN_IMMUTABLE_PACKAGES = new HashSet<>(Arrays.asList(
+            "java.time"));
+
     private static final List<String> SETTER_LIKE_NAMES = Arrays.asList(
             "set", "put", "add", "insert", "delete", "remove", "erase", "clear", "push", "pop",
             "enqueue", "dequeue", "write", "append", "replace");
@@ -53,6 +56,16 @@ public class MutableClasses {
         }
 
         String dottedClassName = sig.substring(1, sig.length() - 1).replace('/', '.');
+        int lastDot = dottedClassName.lastIndexOf('.');
+
+        if (lastDot >= 0) {
+            String dottedPackageName = dottedClassName.substring(0, lastDot);
+
+            if (KNOWN_IMMUTABLE_PACKAGES.contains(dottedPackageName)) {
+                return false;
+            }
+        }
+
         if (KNOWN_IMMUTABLE_CLASSES.contains(dottedClassName)) {
             return false;
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/MutableClasses.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/MutableClasses.java
@@ -40,7 +40,7 @@ public class MutableClasses {
             "com.google.common.collect.ImmutableTable"));
 
     private static final Set<String> KNOWN_IMMUTABLE_PACKAGES = new HashSet<>(Arrays.asList(
-            "java.time"));
+            "java.math", "java.time"));
 
     private static final List<String> SETTER_LIKE_NAMES = Arrays.asList(
             "set", "put", "add", "insert", "delete", "remove", "erase", "clear", "push", "pop",
@@ -100,12 +100,15 @@ public class MutableClasses {
     }
 
     public static boolean looksLikeASetter(Method method, JavaClass cls) {
+        // If the method returns an object then we suppose that it
+        // is not a setter but creates a new instance instead.
+        if (method.getReturnType().getSignature().startsWith("L")) {
+            return false;
+        }
+
         for (String name : SETTER_LIKE_NAMES) {
             if (method.getName().startsWith(name)) {
-                String retSig = method.getReturnType().getSignature();
-                // If setter-like methods returns an object of the same type then we suppose that it
-                // is not a setter but creates a new instance instead.
-                return !("L" + cls.getClassName().replace('.', '/') + ";").equals(retSig);
+                return true;
             }
         }
         return false;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/MutableClasses.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/MutableClasses.java
@@ -3,6 +3,8 @@ package edu.umd.cs.findbugs.util;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.List;
 
 import org.apache.bcel.Repository;
@@ -27,6 +29,8 @@ public class MutableClasses {
             "set", "put", "add", "insert", "delete", "remove", "erase", "clear", "push", "pop",
             "enqueue", "dequeue", "write", "append", "replace");
 
+    private static final Matcher IMMUTABLE_CLASS_NAME_MATCHER = Pattern.compile(".*immutable.*", Pattern.CASE_INSENSITIVE).matcher("");
+
     public static boolean mutableSignature(String sig) {
         if (sig.charAt(0) == '[') {
             return true;
@@ -38,6 +42,10 @@ public class MutableClasses {
 
         String dottedClassName = sig.substring(1, sig.length() - 1).replace('/', '.');
         if (KNOWN_IMMUTABLE_CLASSES.contains(dottedClassName)) {
+            return false;
+        }
+
+        if (IMMUTABLE_CLASS_NAME_MATCHER.reset(sig).matches()) {
             return false;
         }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/MutableClasses.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/MutableClasses.java
@@ -7,6 +7,7 @@ import java.util.stream.Stream;
 import java.util.List;
 
 import org.apache.bcel.Repository;
+import org.apache.bcel.classfile.ExceptionTable;
 import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.classfile.Method;
 
@@ -101,10 +102,23 @@ public class MutableClasses {
     }
 
     public static boolean looksLikeASetter(Method method, JavaClass cls) {
+        if (method.isStatic()) {
+            return false;
+        }
+
         // If the method returns an object then we suppose that it
         // is not a setter but creates a new instance instead.
         if (method.getReturnType().getSignature().startsWith("L")) {
             return false;
+        }
+
+        // If the method throws an UnsupportedOperationException
+        // then we must ignore it.
+        ExceptionTable exceptions = method.getExceptionTable();
+        if (exceptions != null) {
+            if (Arrays.asList(exceptions.getExceptionNames()).contains("java.lang.UnsupportedOperationException")) {
+                return false;
+            }
         }
 
         for (String name : SETTER_LIKE_NAMES) {

--- a/spotbugs/src/test/java/edu/umd/cs/findbugs/util/MutableClassesTest.java
+++ b/spotbugs/src/test/java/edu/umd/cs/findbugs/util/MutableClassesTest.java
@@ -36,6 +36,7 @@ public class MutableClassesTest {
     }
 
     @Test
+    @Test
     public void TestNamedImmutable() {
         Assert.assertFalse(MutableClasses.mutableSignature("Lcom/google/common/collect/ImmutableMap;"));
     }

--- a/spotbugs/src/test/java/edu/umd/cs/findbugs/util/MutableClassesTest.java
+++ b/spotbugs/src/test/java/edu/umd/cs/findbugs/util/MutableClassesTest.java
@@ -36,11 +36,6 @@ public class MutableClassesTest {
     }
 
     @Test
-    public void TestNamedImmutable() {
-        Assert.assertFalse(MutableClasses.mutableSignature("Lcom/google/common/collect/ImmutableMap;"));
-    }
-
-    @Test
     public void TestAnnotatedImmutable() {
         Assert.assertFalse(MutableClasses.mutableSignature("Ledu/umd/cs/findbugs/util/Annotated;"));
     }

--- a/spotbugs/src/test/java/edu/umd/cs/findbugs/util/MutableClassesTest.java
+++ b/spotbugs/src/test/java/edu/umd/cs/findbugs/util/MutableClassesTest.java
@@ -36,7 +36,6 @@ public class MutableClassesTest {
     }
 
     @Test
-    @Test
     public void TestNamedImmutable() {
         Assert.assertFalse(MutableClasses.mutableSignature("Lcom/google/common/collect/ImmutableMap;"));
     }

--- a/spotbugs/src/test/java/edu/umd/cs/findbugs/util/MutableClassesTest.java
+++ b/spotbugs/src/test/java/edu/umd/cs/findbugs/util/MutableClassesTest.java
@@ -14,6 +14,10 @@ public class MutableClassesTest {
         Assert.assertFalse(MutableClasses.mutableSignature("Ljava/lang/String;"));
     }
 
+    public void TestNamedImmutable() {
+        Assert.assertFalse(MutableClasses.mutableSignature("Lcom/google/common/collect/ImmutableMap;"));
+    }
+
     @Test
     public void TestArray() {
         Assert.assertTrue(MutableClasses.mutableSignature("[I"));

--- a/spotbugs/src/test/java/edu/umd/cs/findbugs/util/MutableClassesTest.java
+++ b/spotbugs/src/test/java/edu/umd/cs/findbugs/util/MutableClassesTest.java
@@ -72,6 +72,7 @@ public class MutableClassesTest {
     }
 
     public static class Immutable {
+        private static Immutable immutable;
         private int n;
 
         public Immutable(int n) {
@@ -82,8 +83,20 @@ public class MutableClassesTest {
             return n;
         }
 
-        public Immutable setN(int n) {
+        public void setN1(int n) throws UnsupportedOperationException {
+            throw new UnsupportedOperationException();
+        }
+
+        public Immutable setN2(int n) {
             return new Immutable(n);
+        }
+
+        public static Immutable getImmutable() {
+            return immutable;
+        }
+
+        public static void setImmutable(Immutable imm) {
+            immutable = imm;
         }
     }
 

--- a/spotbugs/src/test/java/edu/umd/cs/findbugs/util/MutableClassesTest.java
+++ b/spotbugs/src/test/java/edu/umd/cs/findbugs/util/MutableClassesTest.java
@@ -91,6 +91,10 @@ public class MutableClassesTest {
             return new Immutable(n);
         }
 
+        void setN3(int n)  {
+            this.n = n;
+        }
+
         public static Immutable getImmutable() {
             return immutable;
         }

--- a/spotbugs/src/test/java/edu/umd/cs/findbugs/util/MutableClassesTest.java
+++ b/spotbugs/src/test/java/edu/umd/cs/findbugs/util/MutableClassesTest.java
@@ -31,6 +31,11 @@ public class MutableClassesTest {
     }
 
     @Test
+    public void TestKnownImmutablePackage() {
+        Assert.assertFalse(MutableClasses.mutableSignature("Ljava/time/LocalTime;"));
+    }
+
+    @Test
     public void TestNamedImmutable() {
         Assert.assertFalse(MutableClasses.mutableSignature("Lcom/google/common/collect/ImmutableMap;"));
     }

--- a/spotbugs/src/test/java/edu/umd/cs/findbugs/util/MutableClassesTest.java
+++ b/spotbugs/src/test/java/edu/umd/cs/findbugs/util/MutableClassesTest.java
@@ -1,7 +1,23 @@
 package edu.umd.cs.findbugs.util;
 
+import javax.annotation.concurrent.Immutable;
+
 import org.junit.Assert;
 import org.junit.Test;
+
+@Immutable
+class Annotated {
+    int n;
+
+    Annotated(int n) {
+        this.n = n;
+    }
+
+    // False setter
+    Annotated set(int n) {
+        return new Annotated(n);
+    }
+}
 
 public class MutableClassesTest {
     @Test
@@ -14,8 +30,14 @@ public class MutableClassesTest {
         Assert.assertFalse(MutableClasses.mutableSignature("Ljava/lang/String;"));
     }
 
+    @Test
     public void TestNamedImmutable() {
         Assert.assertFalse(MutableClasses.mutableSignature("Lcom/google/common/collect/ImmutableMap;"));
+    }
+
+    @Test
+    public void TestAnnotatedImmutable() {
+        Assert.assertFalse(MutableClasses.mutableSignature("Ledu/umd/cs/findbugs/util/Annotated;"));
     }
 
     @Test

--- a/spotbugs/src/test/java/edu/umd/cs/findbugs/util/MutableClassesTest.java
+++ b/spotbugs/src/test/java/edu/umd/cs/findbugs/util/MutableClassesTest.java
@@ -91,7 +91,7 @@ public class MutableClassesTest {
             return new Immutable(n);
         }
 
-        void setN3(int n)  {
+        void setN3(int n) {
             this.n = n;
         }
 


### PR DESCRIPTION
Class names containting the substring "immutable" are considered now immutable.
Fixing issue #1601.

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [X] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
