### PR TITLE
Declare character encodings in HTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 ### Fixed
 - Fixed False positives for RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE ([#600](https://github.com/spotbugs/spotbugs/issues/600) and [#1338](https://github.com/spotbugs/spotbugs/issues/1338))
 - Inconsistent bug description on `EQ_COMPARING_CLASS_NAMES` ([#1523](https://github.com/spotbugs/spotbugs/issues/1523))
+- Add a declaration of charset encoding in generated reports ([#1623](https://github.com/spotbugs/spotbugs/pull/1623))
 
 ### Added
 * New detector `FindBadEndOfStreamCheck` for new bug type `EOS_BAD_END_OF_STREAM_CHECK`. This bug is reported whenever the return value of java.io.FileInputStream.read() or java.io.FileReader.read() is first converted to byte/int and only thereafter checked against -1. (See [SEI CERT rule FIO08-J](https://wiki.sei.cmu.edu/confluence/display/java/FIO08-J.+Distinguish+between+characters+or+bytes+read+from+a+stream+and+-1))

--- a/spotbugs/src/xsl/default.xsl
+++ b/spotbugs/src/xsl/default.xsl
@@ -69,6 +69,7 @@
 <xsl:template match="/">
 	<html>
 	<head>
+		<meta charset="UTF-8" />
 		<title>SpotBugs Report</title>
 		<style type="text/css">
 		.tablerow0 {

--- a/spotbugs/src/xsl/plain.xsl
+++ b/spotbugs/src/xsl/plain.xsl
@@ -42,6 +42,7 @@
 <xsl:template match="/">
 	<html>
 	<head>
+		<meta charset="UTF-8" />
 		<title>SpotBugs Report</title>
 		<style type="text/css">
 		.tablerow0 {


### PR DESCRIPTION
# Problem

All of generated SpotBugs report files are UTF-8 encoded.
However, there are no declaration of character encodings. 

Thus, in some browsers (such as Vivaldi), we have garbled reports.

# Solution

In this PR, we add `<meta charset="UTF-8" />` to generated reports. It helps some people to avoid garbling.

cf. https://www.w3.org/International/questions/qa-html-encoding-declarations

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
