### PR TITLE
Attach Eclipse plugin to GitHub Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
         run: |
           set -x
           curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.1
-          assets=()
+          assets=("-a" "./eclipsePlugin/build/distributions/eclipsePlugin.zip")
           for asset in ./spotbugs/build/distributions/*; do
             assets+=("-a" "$asset")
           done


### PR DESCRIPTION
Eclipse plugin file is located not in `spotbugs/build/distributions`, but in `eclipsePlugin/build/distributions`.
Just like [TravisCI build script](https://github.com/spotbugs/spotbugs/blob/4.0.3/.travis.yml#L108), we need to add a zip file to target to upload.

refs #1636
