### PR TITLE
Fix #1477 by removing invalid NO_BACKGROUND style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Fixed False positives for RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE ([#600](https://github.com/spotbugs/spotbugs/issues/600) and [#1338](https://github.com/spotbugs/spotbugs/issues/1338))
 - Inconsistent bug description on `EQ_COMPARING_CLASS_NAMES` ([#1523](https://github.com/spotbugs/spotbugs/issues/1523))
 - Add a declaration of charset encoding in generated reports ([#1623](https://github.com/spotbugs/spotbugs/pull/1623))
+- Fixed regression in Bug Info view for Eclipse 2021-03+ ([#1477](https://github.com/spotbugs/spotbugs/issues/1477))
 
 ### Added
 * New detector `FindBadEndOfStreamCheck` for new bug type `EOS_BAD_END_OF_STREAM_CHECK`. This bug is reported whenever the return value of java.io.FileInputStream.read() or java.io.FileReader.read() is first converted to byte/int and only thereafter checked against -1. (See [SEI CERT rule FIO08-J](https://wiki.sei.cmu.edu/confluence/display/java/FIO08-J.+Distinguish+between+characters+or+bytes+read+from+a+stream+and+-1))

--- a/eclipsePlugin/src/de/tobject/findbugs/view/BugInfoView.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/view/BugInfoView.java
@@ -186,7 +186,7 @@ public class BugInfoView extends AbstractFindbugsView {
         data.grabExcessHorizontalSpace = true;
         data.grabExcessVerticalSpace = true;
         try {
-            browser = new Browser(parent, SWT.NO_BACKGROUND);
+            browser = new Browser(parent, SWT.NONE);
             browser.setLayoutData(data);
             browser.setBackground(parent.getBackground());
             browser.addOpenWindowListener(new OpenWindowListener() {


### PR DESCRIPTION
Fixes #1477 by removing the invalid NO_BACKGROUND style for the Browser instance in the Bug Info view, to avoid inadvertently triggering EDGE browser mode.

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
