### PR TITLE
migrate ReadTheDocs App with GitHub Actions

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,5 +1,3 @@
-rtd:
-  project: spotbugs
 newIssueWelcomeComment: >
   Thanks for opening your first issue here! :smiley:
 

--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -1,0 +1,23 @@
+name: Documentation
+on:
+  pull_request_target:
+    paths:
+      - "docs/**"
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed # necessary to deactivate the version in Read the Docs
+permissions:
+  pull-requests: write
+  checks: write
+jobs:
+  staging:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to the staging site
+        uses: KengoTODA/readthedocs-action@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          rtd-token: ${{ secrets.RTD_TOKEN }}
+          rtd-project: spotbugs


### PR DESCRIPTION
[The ReadTheDocs integration](https://github.com/KengoTODA/readthedocs-action) has been migrated to GitHub Actions, so apply migration to this project. It makes the integration process more open and stable.

[Migration process is documented at official repo](https://github.com/KengoTODA/readthedocs-action/tree/ae18846aeebf7e13e7d5182171c48f8641a8bcd2#migrating-from-v1-to-v2). I've already registered `RTD_TOKEN` secret and uninstalled the legacy GitHub App.