### PR TITLE
Release artifacts automatically right after pushing a tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,10 +29,10 @@ jobs:
       - name: Build
         run: |
           gpg --quiet --batch --yes --decrypt --passphrase="$GPG_SECRET_PASSPHRASE" --output spotbugs.jks .github/workflows/spotbugs.jks.gpg
-          echo ossrhUsername=eller86 >> gradle.properties
-          echo "ossrhPassword=${SONATYPE_PASSWORD}" >> gradle.properties
+          echo sonatypeUsername=eller86 >> gradle.properties
+          echo "sonatypePassword=${SONATYPE_PASSWORD}" >> gradle.properties
           echo "keystorepass=${KEYSTORE_PASS}" >> gradle.properties
-          ./gradlew assemble publish createReleaseBody --no-daemon
+          ./gradlew assemble publishToSonatype closeSonatypeStagingRepository createReleaseBody --no-daemon
         env:
           GPG_SECRET_PASSPHRASE: ${{ secrets.GPG_SECRET_PASSPHRASE }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}

--- a/RELEASE_PROCEDURE.md
+++ b/RELEASE_PROCEDURE.md
@@ -10,9 +10,7 @@ When you release fixed version of SpotBugs, please follow these procedures.
 
 ## Release to Maven Central
 
-When we push tag, the build result on Travis CI will be deployed to [SonaType Nexus](https://oss.sonatype.org/). Check [SonaType official page](http://central.sonatype.org/pages/gradle.html) for detail.
-
-After that, please visit SonaType Nexus and [release staging repository](http://central.sonatype.org/pages/releasing-the-deployment.html). Then we can find artifacts after several hours.
+When we push a tag, the build result on GitHub Actions will be deployed to the [SonaType Nexus](https://oss.sonatype.org/), and published to the Maven Central automatically by [Gradle Nexus Publish Plugin](https://github.com/gradle-nexus/publish-plugin). Then we can find [artifacts in the Maven Central](https://repo1.maven.org/maven2/com/github/spotbugs/) after several hours.
 
 ## Release to Eclipse Update Site
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
   id "com.diffplug.spotless" version "5.14.2"
   id "org.gradle.crypto.checksum" version "1.2.0"
   id "com.github.spotbugs" version "4.7.2"
+  id "io.github.gradle-nexus.publish-plugin" version "1.1.0"
 }
 
 version = '4.4.1-SNAPSHOT'
@@ -107,6 +108,12 @@ createReleaseBody.configure {
       outputFile << "| ${ name } | ${hash[0]} |\n"
     }
   }
+}
+
+nexusPublishing {
+    repositories {
+        sonatype()
+    }
 }
 
 apply from: "$rootDir/gradle/sonar.gradle"

--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -4,15 +4,6 @@ apply plugin: 'signing'
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT") && /* for Eclipse plugin */ !version.contains("-SNAPSHOT.")
 
 publishing {
-  repositories {
-    maven {
-      url isReleaseVersion ? "https://oss.sonatype.org/service/local/staging/deploy/maven2/" : "https://oss.sonatype.org/content/repositories/snapshots/"
-      credentials {
-        username = project.hasProperty('ossrhUsername') ? ossrhUsername : "Unknown user"
-        password = project.hasProperty('ossrhPassword') ? ossrhPassword : "Unknown password"
-      }
-    }
-  }
   publications {
     maven(MavenPublication) {
       from components.java


### PR DESCRIPTION
Introduce [Gradle Nexus Publish Plugin](https://github.com/gradle-nexus/publish-plugin/) to deploy and close artifacts automatically. It will solve trouble like #1648, caused by my carelessness in the release procedure.

I've tested this change by deploying a [SNAPSHOT build to Sonatype Nexus](https://oss.sonatype.org/content/repositories/snapshots/com/github/spotbugs/spotbugs/4.4.1-SNAPSHOT/) by `./gradlew assemble publishToSonatype` in local.