### PR TITLE
#1661: Lower ExitCodes to debug level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 ## Unreleased - 2021-??-??
 ### Changed
 - Bump gson from 2.8.7 to 2.8.8 ([#1658](https://github.com/spotbugs/spotbugs/pull/1658))
+- Lower `ExitCodes` logger to debug level ([#1661](https://github.com/spotbugs/spotbugs/issues/1661))
 
 ### Fixed
 - Fixed immutable classes in java.net.* as being flagged as EI ([#1653](https://github.com/spotbugs/spotbugs/issues/1653)

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ExitCodes.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ExitCodes.java
@@ -46,7 +46,7 @@ public interface ExitCodes {
     public static int from(int errors, int missingClasses, int bugs) {
         Logger logger = LoggerFactory.getLogger(ExitCodes.class);
         int exitCode = 0;
-        logger.info("Calculating exit code...");
+        logger.debug("Calculating exit code...");
         if (errors > 0) {
             exitCode |= ERROR_FLAG;
             logger.debug("Setting 'errors encountered' flag ({})", ERROR_FLAG);


### PR DESCRIPTION
Relates to [#1661](https://github.com/spotbugs/spotbugs/issues/1661)

Lowering to debug level looks consistent. Both log lines have to be at the same level.

```java
logger.debug("Calculating exit code...");
logger.debug("Exit code set to: {}", exitCode);
```

The change is relatively small, not sure that I have to update `CHANGELOG.md` 
@KengoTODA @oehme what do you think?


----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
