### PR TITLE
Exclude static methods from setter-like methods when considering a class as immutable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ### Fixed
 - Fixed immutable classes in java.net.* as being flagged as EI ([#1653](https://github.com/spotbugs/spotbugs/issues/1653)
+- Classes containing only static methods with setter-like names are no longer considered as mutable ([#1601](https://github.com/spotbugs/spotbugs/issues/1601))
 
 ## 4.4.0 - 2021-08-12
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/MutableClasses.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/MutableClasses.java
@@ -68,6 +68,10 @@ public class MutableClasses {
     }
 
     public static boolean looksLikeASetter(Method method, JavaClass cls) {
+        if (method.isStatic()) {
+            return false;
+        }
+
         for (String name : SETTER_LIKE_NAMES) {
             if (method.getName().startsWith(name)) {
                 String retSig = method.getReturnType().getSignature();

--- a/spotbugs/src/test/java/edu/umd/cs/findbugs/util/MutableClassesTest.java
+++ b/spotbugs/src/test/java/edu/umd/cs/findbugs/util/MutableClassesTest.java
@@ -42,6 +42,7 @@ public class MutableClassesTest {
 
     public static class Immutable {
         private int n;
+        private static Immutable immutable;
 
         public Immutable(int n) {
             this.n = n;
@@ -53,6 +54,14 @@ public class MutableClassesTest {
 
         public Immutable setN(int n) {
             return new Immutable(n);
+        }
+
+        public static Immutable getImmutable() {
+            return immutable;
+        }
+
+        public static void setImmutable(Immutable imm) {
+            immutable = imm;
         }
     }
 


### PR DESCRIPTION
Static methods are no setters, even if their name is setter-like.

Partial fix for issue [#1601](https://github.com/spotbugs/spotbugs/issues/1601\)

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [X] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
