### PR TITLE
Disregard methods beginning with `write` when checking for mutability of a class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ### Fixed
 - Fixed immutable classes in java.net.* as being flagged as EI ([#1653](https://github.com/spotbugs/spotbugs/issues/1653)
+- Method names beginning with `write` are no longer considered as setters when checking the mutability of a class ([#1601](https://github.com/spotbugs/spotbugs/issues/1601))
 
 ## 4.4.0 - 2021-08-12
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/MutableClasses.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/MutableClasses.java
@@ -25,7 +25,7 @@ public class MutableClasses {
 
     private static final List<String> SETTER_LIKE_NAMES = Arrays.asList(
             "set", "put", "add", "insert", "delete", "remove", "erase", "clear", "push", "pop",
-            "enqueue", "dequeue", "write", "append", "replace");
+            "enqueue", "dequeue", "append", "replace");
 
     public static boolean mutableSignature(String sig) {
         if (sig.charAt(0) == '[') {

--- a/spotbugs/src/test/java/edu/umd/cs/findbugs/util/MutableClassesTest.java
+++ b/spotbugs/src/test/java/edu/umd/cs/findbugs/util/MutableClassesTest.java
@@ -1,5 +1,8 @@
 package edu.umd.cs.findbugs.util;
 
+import java.io.IOException;
+import java.io.OutputStream;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -53,6 +56,10 @@ public class MutableClassesTest {
 
         public Immutable setN(int n) {
             return new Immutable(n);
+        }
+
+        public void writeToStream(OutputStream os) throws IOException {
+            os.write(n);
         }
     }
 


### PR DESCRIPTION
Methods beginning with `write` are almost always output methods (e.g. to streams) and no setters. Disregard them when deciding about mutability of a class.

Partial fix for issue [#1601](https://github.com/spotbugs/spotbugs/issues/1601\)

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [X] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
