### PR TITLE
Exclude methods returning any object from potential setters when deciding on the mutability of a class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ### Fixed
 - Fixed immutable classes in java.net.* as being flagged as EI ([#1653](https://github.com/spotbugs/spotbugs/issues/1653)
+- Fixed algorithm deciding on the mutability of a class: methods returning any object are excluded from the potential setters ([#1601](https://github.com/spotbugs/spotbugs/issues/1601))
 
 ## 4.4.0 - 2021-08-12
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindReturnRef.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindReturnRef.java
@@ -138,7 +138,7 @@ public class FindReturnRef extends OpcodeStackDetector {
 
         if (staticMethod && seen == Const.PUTSTATIC && nonPublicFieldOperand()
                 && (MutableClasses.mutableSignature(getSigConstantOperand())
-                || isBufferClassSignature(getSigConstantOperand()))) {
+                        || isBufferClassSignature(getSigConstantOperand()))) {
             OpcodeStack.Item top = stack.getStackItem(0);
             CaptureKind capture = getPotentialCapture(top);
             if (capture != CaptureKind.NONE) {
@@ -154,7 +154,7 @@ public class FindReturnRef extends OpcodeStackDetector {
         }
         if (!staticMethod && seen == Const.PUTFIELD && nonPublicFieldOperand()
                 && (MutableClasses.mutableSignature(getSigConstantOperand())
-                || isBufferClassSignature(getSigConstantOperand()))) {
+                        || isBufferClassSignature(getSigConstantOperand()))) {
             OpcodeStack.Item top = stack.getStackItem(0);
             OpcodeStack.Item target = stack.getStackItem(1);
             CaptureKind capture = getPotentialCapture(top);
@@ -199,7 +199,8 @@ public class FindReturnRef extends OpcodeStackDetector {
                     AnalysisContext.currentXFactory().isEmptyArrayField(field) ||
                     field.getName().indexOf("EMPTY") != -1 ||
                     !(MutableClasses.mutableSignature(field.getSignature()) ||
-                    isBufferClassSignature(field.getSignature()))) {                return;
+                            isBufferClassSignature(field.getSignature()))) {
+                return;
             }
             bugAccumulator.accumulateBug(new BugInstance(this, (staticMethod ? "MS" : "EI") + "_EXPOSE_"
                     + (isBuf ? "BUF" : "REP"),

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/MutableClasses.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/MutableClasses.java
@@ -68,12 +68,15 @@ public class MutableClasses {
     }
 
     public static boolean looksLikeASetter(Method method, JavaClass cls) {
+        // If the method returns an object (of either the same or another type) then we suppose
+        // that it is not a setter but creates a new instance instead.
+        if (method.getReturnType().getSignature().startsWith("L")) {
+            return false;
+        }
+
         for (String name : SETTER_LIKE_NAMES) {
             if (method.getName().startsWith(name)) {
-                String retSig = method.getReturnType().getSignature();
-                // If setter-like methods returns an object of the same type then we suppose that it
-                // is not a setter but creates a new instance instead.
-                return !("L" + cls.getClassName().replace('.', '/') + ";").equals(retSig);
+                return true;
             }
         }
         return false;

--- a/spotbugs/src/test/java/edu/umd/cs/findbugs/util/MutableClassesTest.java
+++ b/spotbugs/src/test/java/edu/umd/cs/findbugs/util/MutableClassesTest.java
@@ -54,6 +54,10 @@ public class MutableClassesTest {
         public Immutable setN(int n) {
             return new Immutable(n);
         }
+
+        public Mutable addToMutable(Mutable m) {
+            return new Mutable(m.getN() + n);
+        }
     }
 
     @Test


### PR DESCRIPTION
Methods which returned an instance of the owning class itself are probably no setters because they usually return a new instance instead of modifying the existing one. The algorithm did care for that, but it turned out that in many cases this is not enough. Some immutable classes contain methods with a setter-like name which return an instance of a class which is different from their owning class. This patch changes the behavior of the alrogithm to skip these methods as well.

Partial fix for issue [#1601](https://github.com/spotbugs/spotbugs/issues/1601\)

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [X] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
