### PR TITLE
Consider all classes in `java.time` and `java.math` as immutable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Fixed immutable classes in java.net.* as being flagged as EI ([#1653](https://github.com/spotbugs/spotbugs/issues/1653)
 - Classes containing only static methods with setter-like names are no longer considered as mutable ([#1601](https://github.com/spotbugs/spotbugs/issues/1601))
 - Handle all immutable collections in the Guava library as immutable ([#1601](https://github.com/spotbugs/spotbugs/issues/1601))
+- All classes in packages java.time and java.math are now correctly handled as immutable ([#1601](https://github.com/spotbugs/spotbugs/issues/1601))
 
 ## 4.4.0 - 2021-08-12
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/MutableClasses.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/MutableClasses.java
@@ -38,6 +38,9 @@ public class MutableClasses {
             "com.google.common.collect.ImmutableSortedSet",
             "com.google.common.collect.ImmutableTable"));
 
+    private static final Set<String> KNOWN_IMMUTABLE_PACKAGES = new HashSet<>(Arrays.asList(
+            "java.math", "java.time"));
+
     private static final List<String> SETTER_LIKE_NAMES = Arrays.asList(
             "set", "put", "add", "insert", "delete", "remove", "erase", "clear", "push", "pop",
             "enqueue", "dequeue", "write", "append", "replace");
@@ -52,6 +55,16 @@ public class MutableClasses {
         }
 
         String dottedClassName = sig.substring(1, sig.length() - 1).replace('/', '.');
+        int lastDot = dottedClassName.lastIndexOf('.');
+
+        if (lastDot >= 0) {
+            String dottedPackageName = dottedClassName.substring(0, lastDot);
+
+            if (KNOWN_IMMUTABLE_PACKAGES.contains(dottedPackageName)) {
+                return false;
+            }
+        }
+
         if (KNOWN_IMMUTABLE_CLASSES.contains(dottedClassName)) {
             return false;
         }

--- a/spotbugs/src/test/java/edu/umd/cs/findbugs/util/MutableClassesTest.java
+++ b/spotbugs/src/test/java/edu/umd/cs/findbugs/util/MutableClassesTest.java
@@ -10,6 +10,11 @@ public class MutableClassesTest {
     }
 
     @Test
+    public void TestKnownImmutablePackage() {
+        Assert.assertFalse(MutableClasses.mutableSignature("Ljava/time/LocalTime;"));
+    }
+
+    @Test
     public void TestKnownImmutable() {
         Assert.assertFalse(MutableClasses.mutableSignature("Ljava/lang/String;"));
     }


### PR DESCRIPTION
Some packages, such as `java.time` and `java.math` contain immutable classes only. This patch enables handling these classes correctly.

Partial fix for issue [#1601](https://github.com/spotbugs/spotbugs/issues/1601)

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [X] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
