### PR TITLE
Add the Guava immutable collections to the set of immutable classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 ### Fixed
 - Fixed immutable classes in java.net.* as being flagged as EI ([#1653](https://github.com/spotbugs/spotbugs/issues/1653)
 - Classes containing only static methods with setter-like names are no longer considered as mutable ([#1601](https://github.com/spotbugs/spotbugs/issues/1601))
+- Handle all immutable collections in the Guava library as immutable ([#1601](https://github.com/spotbugs/spotbugs/issues/1601))
 
 ## 4.4.0 - 2021-08-12
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/MutableClasses.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/MutableClasses.java
@@ -21,7 +21,22 @@ public class MutableClasses {
             "java.awt.Color", "java.awt.GradientPaint", "java.awt.LinearGradientPaint",
             "java.awt.RadialGradientPaint", "java.Cursor.", "java.util.UUID", "java.net.URL",
             "java.net.URI", "java.net.Inet4Address", "java.net.Inet6Address", "java.net.InetSocketAddress",
-            "java.security.Permission"));
+            "java.security.Permission", "com.google.common.collect.ImmutableBiMap",
+            "com.google.common.collect.ImmutableClassToInstanceMap",
+            "com.google.common.collect.ImmutableCollection",
+            "com.google.common.collect.ImmutableList",
+            "com.google.common.collect.ImmutableListMultimap",
+            "com.google.common.collect.ImmutableMap",
+            "com.google.common.collect.ImmutableMultimap",
+            "com.google.common.collect.ImmutableMultiset",
+            "com.google.common.collect.ImmutableRangeMap",
+            "com.google.common.collect.ImmutableRangeSet",
+            "com.google.common.collect.ImmutableSet",
+            "com.google.common.collect.ImmutableSetMultimap",
+            "com.google.common.collect.ImmutableSortedMap",
+            "com.google.common.collect.ImmutableSortedMultiset",
+            "com.google.common.collect.ImmutableSortedSet",
+            "com.google.common.collect.ImmutableTable"));
 
     private static final List<String> SETTER_LIKE_NAMES = Arrays.asList(
             "set", "put", "add", "insert", "delete", "remove", "erase", "clear", "push", "pop",


### PR DESCRIPTION
The immutable collections of the Guava library are immutable as their name suggest it. Therefore this patch puts it to the list of known immutable classes.

Partial fix for issue [#1601](https://github.com/spotbugs/spotbugs/issues/1601)

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [X] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
