### PR TITLE
Add a link to spotbugs-intellij-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ SpotBugs can be used standalone and through several integrations, including:
 * [Maven](http://spotbugs.readthedocs.io/en/latest/maven.html)
 * [Gradle](http://spotbugs.readthedocs.io/en/latest/gradle.html)
 * [Eclipse](http://spotbugs.readthedocs.io/en/latest/eclipse.html)
+* [IntelliJ IDEA](https://github.com/JetBrains/spotbugs-intellij-plugin)
 
 # Questions?
 You can contact us using [our general purpose mailing list](https://github.com/spotbugs/discuss/issues?q=).

--- a/docs/links.rst
+++ b/docs/links.rst
@@ -9,6 +9,9 @@ IDE Integration
 `m2e-code-quality <https://github.com/m2e-code-quality/m2e-code-quality/>`_
   An Eclipse plugin which configures the FindBugs/SpotBugs Eclipse plugin to match the FindBugs/SpotBugs Maven plugin.
 
+`spotbugs-intellij-plugin <https://github.com/JetBrains/spotbugs-intellij-plugin>`_
+  The SpotBugs Plugin for IntelliJ IDEA.
+
 SpotBugs Plugins
 ----------------
 

--- a/docs/links.rst
+++ b/docs/links.rst
@@ -27,9 +27,6 @@ SpotBugs Plugins
 Similar/Related Tools
 ---------------------
 
-`FindBugs-IDEA <https://plugins.jetbrains.com/plugin/3847-findbugs-idea>`_
-  The FindBugs plugin for `IntelliJ IDEA <https://www.jetbrains.com/idea/>`_.
-
 `sonar-findbugs <https://github.com/SonarQubeCommunity/sonar-findbugs>`_
   A `SonarQube <https://www.sonarqube.org/>`_ plugin which provides rules based on SpotBugs and its major plugins.
 

--- a/docs/links.rst
+++ b/docs/links.rst
@@ -44,3 +44,6 @@ Similar/Related Tools
 
 `Checker Framework <https://checkerframework.org/>`_
   A pluggable type-checking for Java.
+
+`FindBugs-IDEA <https://plugins.jetbrains.com/plugin/3847-findbugs-idea>`_ (outdated)
+  The FindBugs plugin for `IntelliJ IDEA <https://www.jetbrains.com/idea/>`_.

--- a/docs/locale/ja/LC_MESSAGES/links.po
+++ b/docs/locale/ja/LC_MESSAGES/links.po
@@ -7,14 +7,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: spotbugs 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-05 01:09+0000\n"
+"POT-Creation-Date: 2021-09-12 23:12+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.8.0\n"
+"Generated-By: Babel 2.9.0\n"
 
 #: ../../links.rst:2
 msgid "SpotBugs Links"
@@ -43,50 +43,50 @@ msgid ""
 msgstr ""
 
 #: ../../links.rst:13
-msgid "SpotBugs Plugins"
-msgstr "SpotBugsプラグイン"
+msgid ""
+"`spotbugs-intellij-plugin <https://github.com/JetBrains/spotbugs-"
+"intellij-plugin>`_"
+msgstr ""
 
-#: ../../links.rst:16
-msgid "`fb-contrib <http://fb-contrib.sourceforge.net/>`_"
+#: ../../links.rst:13
+msgid "The SpotBugs Plugin for IntelliJ IDEA."
 msgstr ""
 
 #: ../../links.rst:16
+msgid "SpotBugs Plugins"
+msgstr "SpotBugsプラグイン"
+
+#: ../../links.rst:19
+msgid "`fb-contrib <http://fb-contrib.sourceforge.net/>`_"
+msgstr ""
+
+#: ../../links.rst:19
 msgid ""
 "A FindBugs/SpotBugs plugin for doing static code analysis on java byte "
 "code."
 msgstr "Javaバイトコードの静的コード解析を行うFindBugs/SpotBugsプラグインです。"
 
-#: ../../links.rst:19
+#: ../../links.rst:22
 msgid "`Find Security Bugs <https://find-sec-bugs.github.io/>`_"
 msgstr ""
 
-#: ../../links.rst:19
+#: ../../links.rst:22
 msgid "A FindBugs/SpotBugs plugin for security audits of Java web applications."
 msgstr "Javaウェブアプリケーションのセキュリティ監査用のFindBugs/SpotBugs プラグインです。"
 
-#: ../../links.rst:22
+#: ../../links.rst:25
 msgid "`findbugs-slf4j <https://github.com/KengoTODA/findbugs-slf4j>`_"
 msgstr ""
 
-#: ../../links.rst:22
+#: ../../links.rst:25
 msgid ""
 "A FindBugs/SpotBugs plugin to verify usage of `SLF4J "
 "<https://www.slf4j.org/>`_."
 msgstr "`SLF4J <https://www.slf4j.org/>`_ の使い方を検証するためのFindBugs/SpotBugs プラグインです。"
 
-#: ../../links.rst:25
+#: ../../links.rst:28
 msgid "Similar/Related Tools"
 msgstr "類似/関連ツール"
-
-#: ../../links.rst:28
-msgid "`FindBugs-IDEA <https://plugins.jetbrains.com/plugin/3847-findbugs-idea>`_"
-msgstr ""
-
-#: ../../links.rst:28
-msgid ""
-"The FindBugs plugin for `IntelliJ IDEA "
-"<https://www.jetbrains.com/idea/>`_."
-msgstr "`IntelliJ IDEA <https://www.jetbrains.com/idea/>`_ のためのFindBugs プラグインです。"
 
 #: ../../links.rst:31
 msgid "`sonar-findbugs <https://github.com/SonarQubeCommunity/sonar-findbugs>`_"
@@ -123,11 +123,9 @@ msgstr ""
 #: ../../links.rst:40
 msgid ""
 "New Java bytecode static analyzer tool based on `Procyon Compiler Tools "
-"<https://github.com/mstrobel/procyon>`_ aimed to supersede "
-"the FindBugs."
+"<https://github.com/mstrobel/procyon>`_ aimed to supersede the FindBugs."
 msgstr ""
-"`Procyon Compiler Tools "
-"<https://github.com/mstrobel/procyon>`_ "
+"`Procyon Compiler Tools <https://github.com/mstrobel/procyon>`_ "
 "に基づいた新しいバイトコード静的解析ツールで、FindBugs を置き換えることを目指しています。"
 
 #: ../../links.rst:43
@@ -140,11 +138,23 @@ msgid ""
 "at compile-time."
 msgstr "コンパイル時に一般的なプログラミングミスをキャッチする Java 用静的解析ツールです。"
 
-#: ../../links.rst:45
+#: ../../links.rst:46
 msgid "`Checker Framework <https://checkerframework.org/>`_"
 msgstr ""
 
 #: ../../links.rst:46
 msgid "A pluggable type-checking for Java."
 msgstr "プラグイン可能な Java の型チェックツールです。"
+
+#: ../../links.rst:48
+msgid ""
+"`FindBugs-IDEA <https://plugins.jetbrains.com/plugin/3847-findbugs-"
+"idea>`_ (outdated)"
+msgstr ""
+
+#: ../../links.rst:49
+msgid ""
+"The FindBugs plugin for `IntelliJ IDEA "
+"<https://www.jetbrains.com/idea/>`_."
+msgstr "`IntelliJ IDEA <https://www.jetbrains.com/idea/>`_ のためのFindBugs プラグインです。"
 


### PR DESCRIPTION
@h3xstream If the spotbugs-intellij-plugin is stable, I think it's nice to add links to our document.
How do you think?