### PR TITLE
Add bug code to report in fancy-hist.xsl

### DIFF
--- a/spotbugs/src/xsl/fancy-hist.xsl
+++ b/spotbugs/src/xsl/fancy-hist.xsl
@@ -660,19 +660,16 @@
             }
 
             for (var x=0; x<max; x++) {
-               //if (list=="lbp" && (patterns[x].category!=id1 || patterns[x].code!=id2)) continue;
-               //if (list=="lbp" && classStats[x].totalBugs=="0") continue;
-
                if (list=="lbc") {
                   id3 = patterns[x].id;
-                  label = patterns[x].label;
+                  label = patterns[x].label + " ( " + id3 + " )";
                   containerId = "patterns-"+id1;
                   subContainerId = "cat-" + id1 + "-code-" + id2 + "-pattern-" + id3;
                   p = countBugsPattern(state.release, state.priority, id1, id2, id3);
                }
                if (list=="lbp") {
                   id3 = patterns[x].id;
-                  label = patterns[x].label;
+                  label = patterns[x].label + " ( " + id3 + " )";
                   containerId = "classpatterns-"+id1;
                   subContainerId = "package-" + id1 + "-class-" + id2 + "-pattern-" + id3;
                   p = countBugsClassPattern(state.release, state.priority, id2, id3);


### PR DESCRIPTION
Add Bug code near the description to be able to suppress it easily if needed.

This is something that was present in fancy.xls but it is not in the new version.

Some examples with the change applied:

![image](https://user-images.githubusercontent.com/487098/132341543-12de9f48-7af9-4f4e-99ab-32fb4f727a43.png)
![image](https://user-images.githubusercontent.com/487098/132341585-fe838104-4a06-408d-997e-7137f383defa.png)

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [X] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
