### PR TITLE
New detector `FindDangerousPermissionCombination` for new bug type `DPC_DANGEROUS_PERMISSION_COMBINATION`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ## Unreleased - 2021-??-??
 
+### Added
+* New detector `FindDangerousPermissionCombination` for new bug type `DPC_DANGEROUS_PERMISSION_COMBINATION`. This bug is reported thenever `ReflectPermission` is granted on the target `suppressAccessChecks` or `RuntimePermission` on `createClassLoader`. (See [CEI CERT RULE ENV03-J](https://wiki.sei.cmu.edu/confluence/display/java/ENV03-J.+Do+not+grant+dangerous+combinations+of+permissions))
+
 ## 4.4.1 - 2021-09-07
 ### Changed
 - Bump gson from 2.8.7 to 2.8.8 ([#1658](https://github.com/spotbugs/spotbugs/pull/1658))

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindDangerousPermissionCombinationTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindDangerousPermissionCombinationTest.java
@@ -1,0 +1,61 @@
+package edu.umd.cs.findbugs.detect;
+
+import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.Test;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
+
+public class FindDangerousPermissionCombinationTest extends AbstractIntegrationTest {
+    @Test
+    public void testReflectPermissionSuperAccessChecks() {
+        performAnalysis("dangerousPermissionCombination/ReflectPermissionSuppressAccessChecks.class");
+
+        assertNumOfDPCBugs(1);
+
+        assertDPCBug("ReflectPermissionSuppressAccessChecks", 12);
+    }
+
+    @Test
+    public void testReflectPermissionNewProxyInPackage() {
+        performAnalysis("dangerousPermissionCombination/ReflectPermissionNewProxyInPackage.class");
+
+        assertNumOfDPCBugs(0);
+    }
+
+    @Test
+    public void testRuntimePermissionCreateClassLoader() {
+        performAnalysis("dangerousPermissionCombination/RuntimePermissionCreateClassLoader.class");
+
+        assertNumOfDPCBugs(1);
+
+        assertDPCBug("RuntimePermissionCreateClassLoader", 11);
+    }
+
+    @Test
+    public void testRuntimePermissionGetClassLoader() {
+        performAnalysis("dangerousPermissionCombination/RuntimePermissionGetClassLoader.class");
+
+        assertNumOfDPCBugs(0);
+    }
+
+    private void assertNumOfDPCBugs(int num) {
+        final BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
+                .bugType("DPC_DANGEROUS_PERMISSION_COMBINATION").build();
+        assertThat(getBugCollection(), containsExactly(num, bugTypeMatcher));
+    }
+
+    private void assertDPCBug(String klass, int line) {
+        final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
+                .bugType("DPC_DANGEROUS_PERMISSION_COMBINATION")
+                .inClass(klass)
+                .inMethod("getPermissions")
+                .atLine(line)
+                .build();
+        assertThat(getBugCollection(), hasItem(bugInstanceMatcher));
+    }
+}

--- a/spotbugs/etc/findbugs.xml
+++ b/spotbugs/etc/findbugs.xml
@@ -651,6 +651,8 @@
                     reports="JUA_DONT_ASSERT_INSTANCEOF_IN_TESTS"/>
           <Detector class="edu.umd.cs.findbugs.detect.FindBadEndOfStreamCheck" speed="fast"
                     reports="EOS_BAD_END_OF_STREAM_CHECK"/>
+          <Detector class="edu.umd.cs.findbugs.detect.FindDangerousPermissionCombination" speed="fast"
+                    reports="DPC_DANGEROUS_PERMISSION_COMBINATION"/>
             <!-- Bug Categories -->
            <BugCategory category="NOISE" hidden="true"/>
 
@@ -1254,4 +1256,5 @@
           <BugPattern abbrev="NP" type="NP_METHOD_PARAMETER_TIGHTENS_ANNOTATION" category="STYLE" />
           <BugPattern abbrev="NP" type="NP_METHOD_PARAMETER_RELAXING_ANNOTATION" category="STYLE" deprecated="true" />
           <BugPattern abbrev="EOS" type="EOS_BAD_END_OF_STREAM_CHECK" category="CORRECTNESS" />
+          <BugPattern abbrev="DPC" type="DPC_DANGEROUS_PERMISSION_COMBINATION" category="SECURITY" />
 </FindbugsPlugin>

--- a/spotbugs/etc/messages.xml
+++ b/spotbugs/etc/messages.xml
@@ -1689,6 +1689,18 @@ factory pattern to create these objects.</p>
       ]]>
     </Details>
   </Detector>
+  <Detector class="edu.umd.cs.findbugs.detect.FindDangerousPermissionCombination">
+    <Details>
+      <![CDATA[
+            <p>Detector for patterns where combination of dangerous permissions are granted.</p>
+            <p>
+               Granting ReflectPermission on the target suppressAccessChecks or granting
+               RuntimePermission on the target createClassLoader are both dangerous and thus
+               not recommended.
+            </p>
+      ]]>
+    </Details>
+  </Detector>
   <!--
   **********************************************************************
   BugPatterns
@@ -8490,6 +8502,24 @@ after the call to initLogging, the logger configuration is lost
       </p>]]>
     </Details>
   </BugPattern>
+
+  <BugPattern type="DPC_DANGEROUS_PERMISSION_COMBINATION">
+    <ShortDescription>Dangerous combination of permissions granted</ShortDescription>
+    <LongDescription>Granting permission {2} on the target {3} in method {1} is dangerous.</LongDescription>
+    <Details>
+      <![CDATA[<p>
+      Certain combinations of permissions can produce significant capability increases and should not be granted.
+      Granting ReflectPermission on the target suppressAccessChecks is dangerous in that information (possibly
+      confidential) and methods normally unavailable would be accessible to malicious code. Similarly, the
+      permission java.lang.RuntimePermission applied to target createClassLoader grants code the permission to create
+      a ClassLoader object. This is an extremely dangerous, because malicious applications that can instantiate their
+      own class loaders could then load their own rogue classes into the system. These newly loaded classes could be
+      placed into any protection domain by the class loader, thereby automatically granting the classes the permissions
+      for that domain.
+      <p>See SEI-CERT rule <a href="https://wiki.sei.cmu.edu/confluence/display/java/ENV03-J.+Do+not+grant+dangerous+combinations+of+permissions">ENV03-J. Do not grant dangerous combinations of permissions</p>
+      </p>]]>
+    </Details>
+  </BugPattern>
   <!--
   **********************************************************************
    BugCodes
@@ -8635,4 +8665,5 @@ after the call to initLogging, the logger configuration is lost
   <BugCode abbrev="DL">Unintended contention or possible deadlock due to locking on shared objects</BugCode>
   <BugCode abbrev="JUA">Problems in JUnit Assertions</BugCode>
   <BugCode abbrev="EOS">Bad End of Stream check</BugCode>
+  <BugCode abbrev="DPC">Dangerous Permission Combination</BugCode>
 </MessageCollection>

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindDangerousPermissionCombination.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindDangerousPermissionCombination.java
@@ -1,0 +1,62 @@
+/*
+ * SpotBugs - Find bugs in Java programs
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+package edu.umd.cs.findbugs.detect;
+
+import org.apache.bcel.Const;
+import org.apache.bcel.classfile.JavaClass;
+
+import edu.umd.cs.findbugs.BugAccumulator;
+import edu.umd.cs.findbugs.BugInstance;
+import edu.umd.cs.findbugs.BugReporter;
+import edu.umd.cs.findbugs.bcel.OpcodeStackDetector;
+import edu.umd.cs.findbugs.classfile.ClassDescriptor;
+
+public class FindDangerousPermissionCombination extends OpcodeStackDetector {
+
+    private final BugAccumulator bugAccumulator;
+
+    public FindDangerousPermissionCombination(BugReporter bugReporter) {
+        this.bugAccumulator = new BugAccumulator(bugReporter);
+    }
+
+    @Override
+    public void visitAfter(JavaClass obj) {
+        bugAccumulator.reportAccumulatedBugs();
+    }
+
+    @Override
+    public void sawOpcode(int seen) {
+        if (seen == Const.INVOKESPECIAL && Const.CONSTRUCTOR_NAME.equals(getNameConstantOperand())) {
+            ClassDescriptor cd = getClassDescriptorOperand();
+            if (cd != null && "Ljava/lang/reflect/ReflectPermission;".equals(cd.getSignature())) {
+                String stringParam = (String) stack.getStackItem(0).getConstant();
+                if (stringParam != null && "suppressAccessChecks".equals(stringParam)) {
+                    bugAccumulator.accumulateBug(new BugInstance(this, "DPC_DANGEROUS_PERMISSION_COMBINATION", NORMAL_PRIORITY)
+                            .addClassAndMethod(this).addString("ReflectPermission").addString("suppressAccessChecks"), this);
+                }
+            } else if (cd != null && "Ljava/lang/RuntimePermission;".equals(cd.getSignature())) {
+                String stringParam = (String) stack.getStackItem(0).getConstant();
+                if (stringParam != null && "createClassLoader".equals(stringParam)) {
+                    bugAccumulator.accumulateBug(new BugInstance(this, "DPC_DANGEROUS_PERMISSION_COMBINATION", NORMAL_PRIORITY)
+                            .addClassAndMethod(this).addString("RuntimePermission").addString("createClassLoader"), this);
+                }
+            }
+        }
+    }
+}

--- a/spotbugsTestCases/src/java/dangerousPermissionCombination/ReflectPermissionNewProxyInPackage.java
+++ b/spotbugsTestCases/src/java/dangerousPermissionCombination/ReflectPermissionNewProxyInPackage.java
@@ -1,0 +1,16 @@
+package dangerousPermissionCombination;
+
+import java.lang.reflect.ReflectPermission;
+import java.security.CodeSource;
+import java.security.PermissionCollection;
+import java.security.SecureClassLoader;
+
+public class ReflectPermissionNewProxyInPackage extends SecureClassLoader {
+    @Override
+    protected PermissionCollection getPermissions(CodeSource cs) {
+        PermissionCollection pc = super.getPermissions(cs);
+        pc.add(new ReflectPermission("newProxyInPacakge.*"));   // Permission to create a class loader
+        // Other permissions
+        return pc;
+    }
+}

--- a/spotbugsTestCases/src/java/dangerousPermissionCombination/ReflectPermissionSuppressAccessChecks.java
+++ b/spotbugsTestCases/src/java/dangerousPermissionCombination/ReflectPermissionSuppressAccessChecks.java
@@ -1,0 +1,16 @@
+package dangerousPermissionCombination;
+
+import java.lang.reflect.ReflectPermission;
+import java.security.CodeSource;
+import java.security.PermissionCollection;
+import java.security.SecureClassLoader;
+
+public class ReflectPermissionSuppressAccessChecks extends SecureClassLoader {
+    @Override
+    protected PermissionCollection getPermissions(CodeSource cs) {
+        PermissionCollection pc = super.getPermissions(cs);
+        pc.add(new ReflectPermission("suppressAccessChecks"));   // Permission to create a class loader
+        // Other permissions
+        return pc;
+    }
+}

--- a/spotbugsTestCases/src/java/dangerousPermissionCombination/RuntimePermissionCreateClassLoader.java
+++ b/spotbugsTestCases/src/java/dangerousPermissionCombination/RuntimePermissionCreateClassLoader.java
@@ -1,0 +1,15 @@
+package dangerousPermissionCombination;
+
+import java.security.CodeSource;
+import java.security.PermissionCollection;
+import java.security.SecureClassLoader;
+
+public class RuntimePermissionCreateClassLoader extends SecureClassLoader {
+    @Override
+    protected PermissionCollection getPermissions(CodeSource cs) {
+        PermissionCollection pc = super.getPermissions(cs);
+        pc.add(new RuntimePermission("createClassLoader"));   // Permission to create a class loader
+        // Other permissions
+        return pc;
+    }
+}

--- a/spotbugsTestCases/src/java/dangerousPermissionCombination/RuntimePermissionGetClassLoader.java
+++ b/spotbugsTestCases/src/java/dangerousPermissionCombination/RuntimePermissionGetClassLoader.java
@@ -1,0 +1,15 @@
+package dangerousPermissionCombination;
+
+import java.security.CodeSource;
+import java.security.PermissionCollection;
+import java.security.SecureClassLoader;
+
+public class RuntimePermissionGetClassLoader extends SecureClassLoader {
+    @Override
+    protected PermissionCollection getPermissions(CodeSource cs) {
+        PermissionCollection pc = super.getPermissions(cs);
+        pc.add(new RuntimePermission("getClassLoader"));   // Permission to create a class loader
+        // Other permissions
+        return pc;
+    }
+}


### PR DESCRIPTION
This bug is reported thenever `ReflectPermission` is granted on the target `suppressAccessChecks` or `RuntimePermission` on `createClassLoader`.

See [CEI CERT RULE ENV03-J](https://wiki.sei.cmu.edu/confluence/display/java/ENV03-J.+Do+not+grant+dangerous+combinations+of+permissions\)

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [X] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
