### PR TITLE
Recognize OpenDaylight's Immutable interface contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Wrong description of the `SE_TRANSIENT_FIELD_OF_NONSERIALIZABLE_CLASS` ([#1664](https://github.com/spotbugs/spotbugs/pull/1664))
 - Treat types with `@com.google.errorprone.annotations.Immutable` as immutable ([#1705](https://github.com/spotbugs/spotbugs/pull/1705))
 - Fix annotation check for `jdk.internal.ValueBased` ([#1706](https://github.com/spotbugs/spotbugs/pull/1706))
+- Treat types which implement `org.opendaylight.yangtools.concepts.Immutable` as immutable ([#1697](https://github.com/spotbugs/spotbugs/issues/1697))
 
 ## 4.4.1 - 2021-09-07
 ### Changed

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -98,6 +98,7 @@ dependencies {
   testImplementation 'org.apache.ant:ant:1.10.11'
   testImplementation 'org.apache.logging.log4j:log4j-slf4j18-impl:2.14.0'
   testImplementation 'com.google.errorprone:error_prone_annotations:2.9.0'
+  testImplementation 'org.opendaylight.yangtools:concepts:7.0.7'
 
   guiImplementation sourceSets.main.runtimeClasspath
   guiCompileOnly 'com.apple:AppleJavaExtensions:1.4'

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/MutableClasses.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/MutableClasses.java
@@ -171,6 +171,14 @@ public class MutableClasses {
                 }
             }
 
+            // We are not considering transitive interfaces for now to side-step class loading
+            for (String iface : cls.getInterfaceNames()) {
+                // OpenDaylight's Immutable interface is an explicit contract
+                if (iface.equals("org.opendaylight.yangtools.concepts.Immutable")) {
+                    return true;
+                }
+            }
+
             final ClassAnalysis maybeSuper = getSuperAnalysis();
             return maybeSuper != null && maybeSuper.isImmutableByContract();
         }

--- a/spotbugs/src/test/java/edu/umd/cs/findbugs/util/MutableClassesTest.java
+++ b/spotbugs/src/test/java/edu/umd/cs/findbugs/util/MutableClassesTest.java
@@ -122,4 +122,24 @@ public class MutableClassesTest {
         Assert.assertFalse(MutableClasses.mutableSignature(
                 "Ledu/umd/cs/findbugs/util/MutableClassesTest$ErrorProneImmutableSubclass;"));
     }
+
+    public static class OpenDaylightImmutable implements org.opendaylight.yangtools.concepts.Immutable {
+        public void clear() {
+            // Does not matter
+        }
+    }
+
+    public static class OpenDaylightImmutableSubclass extends OpenDaylightImmutable {
+        public String put(String str) {
+            return "";
+        }
+    }
+
+    @Test
+    public void TestOpenDaylightImmutable() {
+        Assert.assertFalse(MutableClasses.mutableSignature(
+                "Ledu/umd/cs/findbugs/util/MutableClassesTest$OpenDaylightImmutable;"));
+        Assert.assertFalse(MutableClasses.mutableSignature(
+                "Ledu/umd/cs/findbugs/util/MutableClassesTest$OpenDaylightImmutableSubclass;"));
+    }
 }


### PR DESCRIPTION
Aside from recognizing annotations, also treat any class that implements
an interface named Immutable as an immutable class. Fixes #1697.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>



----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
