### PR TITLE
Recognize Serializable's writeReplace()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Agree verb with plural subject in the description of
 `SW_SWING_METHODS_INVOKED_IN_SWING_THREAD` ([#1664](https://github.com/spotbugs/spotbugs/pull/1664))
 - Wrong description of the `SE_TRANSIENT_FIELD_OF_NONSERIALIZABLE_CLASS` ([#1664](https://github.com/spotbugs/spotbugs/pull/1664))
+- Do not consider java.io.Serializable with writeReplace() as mutable type ([#1704](https://github.com/spotbugs/spotbugs/pull/1704))
 
 ## 4.4.1 - 2021-09-07
 ### Changed

--- a/spotbugs/src/test/java/edu/umd/cs/findbugs/util/MutableClassesTest.java
+++ b/spotbugs/src/test/java/edu/umd/cs/findbugs/util/MutableClassesTest.java
@@ -1,5 +1,7 @@
 package edu.umd.cs.findbugs.util;
 
+import java.io.ObjectStreamException;
+import java.io.Serializable;
 import javax.annotation.concurrent.Immutable;
 
 import org.junit.Assert;
@@ -94,5 +96,29 @@ public class MutableClassesTest {
     @Test
     public void TestImmutable() {
         Assert.assertFalse(MutableClasses.mutableSignature("Ledu/umd/cs/findbugs/util/MutableClassesTest$Immutable;"));
+    }
+
+    public static final class MutableWriteReplace {
+        Object writeReplace() throws ObjectStreamException {
+            return null;
+        }
+    }
+
+    @Test
+    public void TestMutableWriteReplace() {
+        Assert.assertTrue(MutableClasses.mutableSignature(
+                "Ledu/umd/cs/findbugs/util/MutableClassesTest$MutableWriteReplace;"));
+    }
+
+    public static final class ImmutableWriteReplace implements Serializable {
+        Object writeReplace() throws ObjectStreamException {
+            return null;
+        }
+    }
+
+    @Test
+    public void TestImmutableWriteReplace() {
+        Assert.assertFalse(MutableClasses.mutableSignature(
+                "Ledu/umd/cs/findbugs/util/MutableClassesTest$ImmutableWriteReplace;"));
     }
 }


### PR DESCRIPTION
java.io.Serializable defines semantics of writeReplace() method, it
should not be confused as a mutable method.

Introduce a helper class to encapsulate analysis logic, as there are a
few other cases which we'll need to cover.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>



----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
