### PR TITLE
Check for binary class name in annotation check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 `SW_SWING_METHODS_INVOKED_IN_SWING_THREAD` ([#1664](https://github.com/spotbugs/spotbugs/pull/1664))
 - Wrong description of the `SE_TRANSIENT_FIELD_OF_NONSERIALIZABLE_CLASS` ([#1664](https://github.com/spotbugs/spotbugs/pull/1664))
 - Treat types with `@com.google.errorprone.annotations.Immutable` as immutable ([#1705](https://github.com/spotbugs/spotbugs/pull/1705))
+- Fix annotation check for `jdk.internal.ValueBased` ([#1706](https://github.com/spotbugs/spotbugs/pull/1706))
 
 ## 4.4.1 - 2021-09-07
 ### Changed

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/MutableClasses.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/MutableClasses.java
@@ -69,8 +69,8 @@ public class MutableClasses {
 
         try {
             JavaClass cls = Repository.lookupClass(dottedClassName);
-            if (Stream.of(cls.getAnnotationEntries()).anyMatch(s -> s.toString().endsWith("/Immutable;")
-                    || s.getAnnotationType().equals("jdk.internal.ValueBased"))) {
+            if (Stream.of(cls.getAnnotationEntries()).map(AnnotationEntry::getAnnotationType)
+                    .anyMatch(type -> type.endsWith("/Immutable;") || type.equals("Ljdk/internal/ValueBased;"))) {
                 return false;
             }
             return ClassAnalysis.load(cls, sig).isMutable();

--- a/spotbugs/src/test/java/edu/umd/cs/findbugs/util/MutableClassesTest.java
+++ b/spotbugs/src/test/java/edu/umd/cs/findbugs/util/MutableClassesTest.java
@@ -96,6 +96,12 @@ public class MutableClassesTest {
         Assert.assertFalse(MutableClasses.mutableSignature("Ledu/umd/cs/findbugs/util/MutableClassesTest$Immutable;"));
     }
 
+    @Test
+    public void TestImmutableValuedBased() {
+        // Annotated with @jdk.internal.ValueBased and has "setValue", which should normally trip detection
+        Assert.assertFalse(MutableClasses.mutableSignature("Ljava/util/KeyValueHolder;"));
+    }
+
     @com.google.errorprone.annotations.Immutable
     public static class ErrorProneImmutable {
         public void write() {


### PR DESCRIPTION
We are referencing Class file entries, hence type names use slashes.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>



----

Make sure these boxes are checked before submitting your PR -- thank you!

- [ ] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
