### PR TITLE
New detector `FindOverridableMethodCall`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Wrong description of the `SE_TRANSIENT_FIELD_OF_NONSERIALIZABLE_CLASS` ([#1664](https://github.com/spotbugs/spotbugs/pull/1664))
 - Treat types with `@com.google.errorprone.annotations.Immutable` as immutable ([#1705](https://github.com/spotbugs/spotbugs/pull/1705))
 
+### Added
+* New detector `FindOverridableMethodCall` to detect invocation of overridable method in constructors (`MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR`) and clone() method (`MC_OVERRIDABLE_METHOD_CALL_IN_CLONE`), according to SEI CERT rules [MET05-J. Ensure that constructors do not call overridable methods](https://wiki.sei.cmu.edu/confluence/display/java/MET05-J.+Ensure+that+constructors+do+not+call+overridable+methods) and [MET06-J. Do not invoke overridable methods in clone()](https://wiki.sei.cmu.edu/confluence/pages/viewpage.action?pageId=88487921).
+
 ## 4.4.1 - 2021-09-07
 ### Changed
 - Bump gson from 2.8.7 to 2.8.8 ([#1658](https://github.com/spotbugs/spotbugs/pull/1658))

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindOverridableMethodCallTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindOverridableMethodCallTest.java
@@ -10,6 +10,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import org.junit.Test;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import edu.umd.cs.findbugs.annotations.Confidence;
 import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
 import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
@@ -30,6 +31,7 @@ public class FindOverridableMethodCallTest extends AbstractIntegrationTest {
                 .bugType("MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR")
                 .inClass("OverridableMethodCall")
                 .inMethod(Const.CONSTRUCTOR_NAME)
+                .withConfidence(Confidence.LOW)
                 .atLine(3)
                 .build();
         assertThat(getBugCollection(), hasItem(bugInstanceMatcher));

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindOverridableMethodCallTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindOverridableMethodCallTest.java
@@ -1,0 +1,45 @@
+package edu.umd.cs.findbugs.detect;
+
+import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
+import static org.hamcrest.Matchers.hasItem;
+
+import org.apache.bcel.Const;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.Test;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
+
+public class FindOverridableMethodCallTest extends AbstractIntegrationTest {
+    @Test
+    public void testOverridableMethodCalls() {
+        performAnalysis("OverridableMethodCall.class");
+
+        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
+                .bugType("MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR").build();
+        assertThat(getBugCollection(), containsExactly(1, bugTypeMatcher));
+
+        bugTypeMatcher = new BugInstanceMatcherBuilder()
+                .bugType("MC_OVERRIDABLE_METHOD_CALL_IN_CLONE").build();
+        assertThat(getBugCollection(), containsExactly(1, bugTypeMatcher));
+
+        BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
+                .bugType("MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR")
+                .inClass("OverridableMethodCall")
+                .inMethod(Const.CONSTRUCTOR_NAME)
+                .atLine(3)
+                .build();
+        assertThat(getBugCollection(), hasItem(bugInstanceMatcher));
+
+        bugInstanceMatcher = new BugInstanceMatcherBuilder()
+                .bugType("MC_OVERRIDABLE_METHOD_CALL_IN_CLONE")
+                .inClass("OverridableMethodCall")
+                .inMethod("clone")
+                .atLine(16)
+                .build();
+        assertThat(getBugCollection(), hasItem(bugInstanceMatcher));
+    }
+}

--- a/spotbugs/etc/findbugs.xml
+++ b/spotbugs/etc/findbugs.xml
@@ -1256,6 +1256,6 @@
           <BugPattern abbrev="NP" type="NP_METHOD_PARAMETER_TIGHTENS_ANNOTATION" category="STYLE" />
           <BugPattern abbrev="NP" type="NP_METHOD_PARAMETER_RELAXING_ANNOTATION" category="STYLE" deprecated="true" />
           <BugPattern abbrev="EOS" type="EOS_BAD_END_OF_STREAM_CHECK" category="CORRECTNESS" />
-          <BugPattern abbrev="MC" type="MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR" category="BAD_PRACTICE" />
-          <BugPattern abbrev="MC" type="MC_OVERRIDABLE_METHOD_CALL_IN_CLONE" category="BAD_PRACTICE" />
+          <BugPattern abbrev="MC" type="MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR" category="MALICIOUS_CODE" />
+          <BugPattern abbrev="MC" type="MC_OVERRIDABLE_METHOD_CALL_IN_CLONE" category="MALICIOUS_CODE" />
 </FindbugsPlugin>

--- a/spotbugs/etc/findbugs.xml
+++ b/spotbugs/etc/findbugs.xml
@@ -651,6 +651,8 @@
                     reports="JUA_DONT_ASSERT_INSTANCEOF_IN_TESTS"/>
           <Detector class="edu.umd.cs.findbugs.detect.FindBadEndOfStreamCheck" speed="fast"
                     reports="EOS_BAD_END_OF_STREAM_CHECK"/>
+          <Detector class="edu.umd.cs.findbugs.detect.FindOverridableMethodCall"
+                    reports="MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR,MC_OVERRIDABLE_METHOD_CALL_IN_CLONE"/>
             <!-- Bug Categories -->
            <BugCategory category="NOISE" hidden="true"/>
 
@@ -1254,4 +1256,6 @@
           <BugPattern abbrev="NP" type="NP_METHOD_PARAMETER_TIGHTENS_ANNOTATION" category="STYLE" />
           <BugPattern abbrev="NP" type="NP_METHOD_PARAMETER_RELAXING_ANNOTATION" category="STYLE" deprecated="true" />
           <BugPattern abbrev="EOS" type="EOS_BAD_END_OF_STREAM_CHECK" category="CORRECTNESS" />
+          <BugPattern abbrev="MC" type="MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR" category="BAD_PRACTICE" />
+          <BugPattern abbrev="MC" type="MC_OVERRIDABLE_METHOD_CALL_IN_CLONE" category="BAD_PRACTICE" />
 </FindbugsPlugin>

--- a/spotbugs/etc/messages.xml
+++ b/spotbugs/etc/messages.xml
@@ -1689,6 +1689,18 @@ factory pattern to create these objects.</p>
       ]]>
     </Details>
   </Detector>
+  <Detector class="edu.umd.cs.findbugs.detect.FindOverridableMethodCall">
+    <Details>
+      <![CDATA[
+            <p>Detector for patterns where a constructor or a clone() method calls an overridable
+               method.</p>
+            <p>
+               Calling an overridalbe method from a constructor may result in the use of
+               uninitialized data. Calling such method from a clone() method is insecure.
+            </p>
+      ]]>
+    </Details>
+  </Detector>
   <!--
   **********************************************************************
   BugPatterns
@@ -8490,6 +8502,34 @@ after the call to initLogging, the logger configuration is lost
       </p>]]>
     </Details>
   </BugPattern>
+
+  <BugPattern type="MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR">
+    <ShortDescription>An overridable method is called from a constructor</ShortDescription>
+    <LongDescription>Overridable method {2} is called from constructor {1}.</LongDescription>
+    <Details>
+      <![CDATA[<p>
+      Calling an overridable method during in a constructor may result in the use of uninitialized data. It may also
+      leak the this reference of the partially constructed object. Only static, final or private methods shoud be
+      invoked from a constructor.</p>
+      <p>
+      See SEI CERT rule <a href="https://wiki.sei.cmu.edu/confluence/display/java/MET05-J.+Ensure+that+constructors+do+not+call+overridable+methods">MET05-J. Ensure that constructors do not call overridable methods</a>.
+      </p>]]>
+    </Details>
+  </BugPattern>
+
+  <BugPattern type="MC_OVERRIDABLE_METHOD_CALL_IN_CLONE">
+    <ShortDescription>An overridable method is called from the clone() method.</ShortDescription>
+    <LongDescription>Overridable method {2} is called from method clone() in class {0}.</LongDescription>
+    <Details>
+      <![CDATA[<p>
+      Calling overridable methods from the clone() method is insecure because a subclass could override the method,
+      affecting the behavior of clone(). It can also observe or modify the clone object in a partially initialized
+      state. Only static, final or private methods should be invoked from the clone() method.</p>
+      <p>
+      See SEI CERT rule <a href="https://wiki.sei.cmu.edu/confluence/pages/viewpage.action?pageId=88487921">MET06-J. Do not invoke overridable methods in clone()</a>.
+      </p>]]>
+    </Details>
+  </BugPattern>
   <!--
   **********************************************************************
    BugCodes
@@ -8635,4 +8675,5 @@ after the call to initLogging, the logger configuration is lost
   <BugCode abbrev="DL">Unintended contention or possible deadlock due to locking on shared objects</BugCode>
   <BugCode abbrev="JUA">Problems in JUnit Assertions</BugCode>
   <BugCode abbrev="EOS">Bad End of Stream check</BugCode>
+  <BugCode abbrev="MC">Dangerous call to overridable method</BugCode>
 </MessageCollection>

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindOverridableMethodCall.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindOverridableMethodCall.java
@@ -55,7 +55,7 @@ public class FindOverridableMethodCall extends OpcodeStackDetector {
                 if (item.getRegisterNumber() == 0
                         && Const.CONSTRUCTOR_NAME.equals(getMethodName())) {
                     bugAccumulator.accumulateBug(new BugInstance(this,
-                            "MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR", NORMAL_PRIORITY)
+                            "MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR", LOW_PRIORITY)
                                     .addClassAndMethod(this).addString(method.getName()), this);
 
                 } else if ("clone".equals(getMethodName())

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindOverridableMethodCall.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindOverridableMethodCall.java
@@ -1,0 +1,89 @@
+/*
+ * SpotBugs - Find bugs in Java programs
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+package edu.umd.cs.findbugs.detect;
+
+import org.apache.bcel.Const;
+import org.apache.bcel.classfile.JavaClass;
+
+import edu.umd.cs.findbugs.BugAccumulator;
+import edu.umd.cs.findbugs.BugInstance;
+import edu.umd.cs.findbugs.BugReporter;
+import edu.umd.cs.findbugs.OpcodeStack;
+import edu.umd.cs.findbugs.ba.AnalysisContext;
+import edu.umd.cs.findbugs.ba.XClass;
+import edu.umd.cs.findbugs.ba.XMethod;
+import edu.umd.cs.findbugs.bcel.OpcodeStackDetector;
+import edu.umd.cs.findbugs.classfile.CheckedAnalysisException;
+import edu.umd.cs.findbugs.classfile.ClassDescriptor;
+
+public class FindOverridableMethodCall extends OpcodeStackDetector {
+    private final BugAccumulator bugAccumulator;
+
+    public FindOverridableMethodCall(BugReporter bugReporter) {
+        this.bugAccumulator = new BugAccumulator(bugReporter);
+    }
+
+    @Override
+    public void visitAfter(JavaClass obj) {
+        bugAccumulator.reportAccumulatedBugs();
+    }
+
+    @Override
+    public void sawOpcode(int seen) {
+        if (seen == Const.INVOKEINTERFACE || seen == Const.INVOKEVIRTUAL) {
+            XMethod method = getXMethodOperand();
+            OpcodeStack.Item item = stack.getStackItem(0);
+
+            // The method operand may be null, if a class needed for the analysis is missing.
+            if (method != null && !method.isPrivate() && !method.isFinal()) {
+                if (item.getRegisterNumber() == 0
+                        && Const.CONSTRUCTOR_NAME.equals(getMethodName())) {
+                    bugAccumulator.accumulateBug(new BugInstance(this,
+                            "MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR", NORMAL_PRIORITY)
+                                    .addClassAndMethod(this).addString(method.getName()), this);
+
+                } else if ("clone".equals(getMethodName())
+                        && (("()" + getClassDescriptor().getSignature()).equals(getMethodSig())
+                                || "()Ljava.lang.Object;".equals(getMethodSig()))
+                        && item.getReturnValueOf() != null
+                        && item.getReturnValueOf().equals(superClone(getXClass()))) {
+                    bugAccumulator.accumulateBug(new BugInstance(this,
+                            "MC_OVERRIDABLE_METHOD_CALL_IN_CLONE", NORMAL_PRIORITY)
+                                    .addClassAndMethod(this).addString(method.getName()), this);
+                }
+            }
+        }
+    }
+
+    private XMethod superClone(XClass clazz) {
+        ClassDescriptor superD = clazz.getSuperclassDescriptor();
+        XClass xSuper;
+        try {
+            xSuper = superD.getXClass();
+            XMethod cloneMethod = xSuper.findMethod("clone", "()" + superD.getSignature(), false);
+            if (cloneMethod == null) {
+                cloneMethod = xSuper.findMethod("clone", "()Ljava/lang/Object;", false);
+            }
+            return cloneMethod;
+        } catch (CheckedAnalysisException e) {
+            AnalysisContext.logError("Could not find XClass object for " + superD + ".");
+            return null;
+        }
+    }
+}

--- a/spotbugsTestCases/src/java/OverridableMethodCall.java
+++ b/spotbugsTestCases/src/java/OverridableMethodCall.java
@@ -1,0 +1,37 @@
+public class OverridableMethodCall implements Cloneable {
+    OverridableMethodCall() {
+        overridableMethod();
+        privateMethod();
+        finalMethod();
+        staticMethod();
+    }
+
+    OverridableMethodCall(OverridableMethodCall other) {
+        other.overridableMethod();
+    }
+
+    @Override
+    public OverridableMethodCall clone() throws CloneNotSupportedException {
+        OverridableMethodCall omc = (OverridableMethodCall) super.clone();
+        omc.overridableMethod();
+        omc.privateMethod();
+        omc.finalMethod();
+        return omc;
+    }
+
+    void overridableMethod() {
+        System.out.println("I am overridable.");
+    }
+
+    private void privateMethod() {
+        System.out.println("I am private.");
+    }
+
+    final void finalMethod() {
+        System.out.println("I am final.");
+    }
+
+    private static void staticMethod() {
+        System.out.println("I am static.");
+    }
+}


### PR DESCRIPTION
This new detector detects invocation of overridable method in constructors
(`MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR`) and clone() method
(`MC_OVERRIDABLE_METHOD_CALL_IN_CLONE`), according to SEI CERT rules
[MET05-J. Ensure that constructors do not call overridable methods](https://wiki.sei.cmu.edu/confluence/display/java/MET05-J.+Ensure+that+constructors+do+not+call+overridable+methods)
and [MET06-J. Do not invoke overridable methods in clone()](https://wiki.sei.cmu.edu/confluence/pages/viewpage.action?pageId=88487921)

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [X] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
