### PR TITLE
Add check-project workflow

### DIFF
--- a/.github/workflows/check-projects-comment.yml
+++ b/.github/workflows/check-projects-comment.yml
@@ -1,0 +1,69 @@
+name: check-projects-comment
+
+on:
+  workflow_run:
+    workflows: ['check-projects']
+    types:
+      - completed
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    if: >
+      ${{ github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: 'Download artifact'
+        uses: actions/github-script@v3
+        with:
+          script: |
+            const fs = require('fs')
+            const artifactsQueryResult = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{ github.event.workflow_run.id }},
+            })
+            const artifacts = artifactsQueryResult.data.artifacts
+            for (const artifact of artifacts) {
+              const name = artifact.name
+              const download = await github.actions.downloadArtifact({
+                 owner: context.repo.owner,
+                 repo: context.repo.repo,
+                 artifact_id: artifact.id,
+                 archive_format: 'zip',
+              })
+              fs.writeFileSync(`${{github.workspace}}/${name}.zip`, Buffer.from(download.data))
+            }
+
+      - run: |
+          for archive in *.zip; do
+            unzip "${archive}" -d "${archive%.*}" && rm "${archive}"
+          done
+
+      - name: 'Comment on PR'
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs')
+
+            for (const projectDir of fs.readdirSync('${{github.workspace}}')) {
+              const projectName = projectDir
+              const issueNumber = Number(fs.readFileSync(`${projectDir}/prnum`))
+              const baselineTime = Number(fs.readFileSync(`${projectDir}/baseline_time`))
+              const newTime = Number(fs.readFileSync(`${projectDir}/new_time`))
+              const resultDiff = fs.readFileSync(`${projectDir}/result_diff`)
+
+              const body =
+              `${projectName}
+                 baseline time: ${baselineTime}s
+                 new time: ${newTime}s
+                 results diff: ${resultDiff ? '\n```' + resultDiff + '```' : '-'}
+              `
+              await github.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                body: body,
+              })
+            }

--- a/.github/workflows/check-projects.yml
+++ b/.github/workflows/check-projects.yml
@@ -1,0 +1,329 @@
+
+# The CI for checking open-source projects with Spotbugs consists of 2 github workflows.
+#   - check-projects is responsible for running the analysis.
+#   - check-projects-comment is responsible for publishing the results of the analysis.
+#
+# The separation of the commenting phase is due to security reasons (see https://securitylab.github.com/research/github-actions-preventing-pwn-requests/).
+#
+# Analysis goals
+#
+# The check-projects workflow builds a Spotbugs runnable from master (labelled baseline) and the current PR (labelled new).
+# The unit tests are *not* run in this job on purpose to keep it simple and allow for a fast response time.
+# After building the baseline and new versions of Spotbugs, an analysis is run on open source projects.
+# The list of projects currently analyzed:
+#   - spotbugs
+#   - matsim-libs
+#   - jenkins
+#
+# The workflow analyses these projects via the baseline and the new versions of Spotbugs and produces a diff of analysis results for each one.
+# The diff of the analysis results can be used to see if the PR produces new results and/or old results are gone.
+# Time of analysis is also measured in order to catch performance regressions.
+#
+# Installation
+#
+# These workflows are intended to be installed on a Spotbugs fork.
+# On the default branch of the repository (main or master by default) the workflow description files should be placed into the `.github/workflows` directory.
+# Both check-projects.yml and check-projects-comment files should be there and must be committed.
+#
+# Usage
+#
+# Once installed you can use the workflows by creating a feature branch in your fork, and creating a pull-request from that branch to your fork's master branch.
+# The outcome of the analysis is seen on the job status of the PR, and the diff of the results can be seen as PR comment.
+
+name: check-projects
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  check-spotbugs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - name: Checkout Baseline
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          path: spotbugs-baseline
+          persist-credentials: false
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v1
+        with:
+          java-version: '17.0.x'
+
+      - name: Cache Gradle
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Quick-build new Spotbugs
+        run: ./gradlew installDist --no-daemon
+
+      - name: Quick-build baseline Spotbugs
+        run: ./gradlew installDist --no-daemon
+        working-directory: spotbugs-baseline
+
+      - name: Cache analyzed Spotbugs
+        uses: actions/cache@v2
+        with:
+          path: spotbugs-4.4.1.jar
+          key: ${{ runner.os }}-targets-spotbugs-${{ hashFiles('spotbugs-4.4.1.jar') }}
+          restore-keys: |
+            ${{ runner.os }}-targets-spotbugs-
+
+      - name: Download Spotbugs to analyze
+        run: |
+          [[ ! -f spotbugs-4.4.1.jar ]] && \
+            wget -nv https://repo1.maven.org/maven2/com/github/spotbugs/spotbugs/4.4.1/spotbugs-4.4.1.jar -O spotbugs-4.4.1.jar
+
+      - name: Check Spotbugs with baseline
+        run: |
+          baseline_start="$(date +%s)"
+          spotbugs-baseline/spotbugs/build/install/spotbugs/bin/spotbugs -textui \
+            spotbugs-4.4.1.jar \
+          | tee results_baseline
+          baseline_end="$(date +%s)"
+          echo "$((baseline_end - baseline_start))" > baseline_time
+
+      - name: Check Spotbugs with new
+        run: |
+          new_start="$(date +%s)"
+          spotbugs/build/install/spotbugs/bin/spotbugs -textui \
+            spotbugs-4.4.1.jar \
+          | tee results_new
+          new_end="$(date +%s)"
+          echo "$((new_end - new_start))" > new_time
+
+      - name: Generate Spotbugs diff
+        id: report-diff
+        run: |
+          diff -u results_baseline results_new | \
+            sed -Ee '/^(\+\+\+|@| )/d' | tee result_diff
+
+      - name: Package artifacts
+        run: |
+          mkdir -p ./spotbugs
+          echo ${{ github.event.number }} > ./spotbugs/prnum
+          mv result_diff spotbugs/
+          mv baseline_time spotbugs/
+          mv new_time spotbugs/
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: spotbugs
+          path: spotbugs/
+
+  check-matsim:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - name: Checkout Baseline
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          path: spotbugs-baseline
+          persist-credentials: false
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v1
+        with:
+          java-version: '17.0.x'
+
+      - name: Cache Gradle
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Quick-build new Spotbugs
+        run: ./gradlew installDist --no-daemon
+
+      - name: Quick-build baseline Spotbugs
+        run: ./gradlew installDist --no-daemon
+        working-directory: spotbugs-baseline
+
+      - name: Cache analyzed Matsim
+        uses: actions/cache@v2
+        with:
+          path: matsim-12.0-2020w02-avoev.0.jar
+          key: ${{ runner.os }}-targets-matsim-${{ hashFiles('matsim-12.0-2020w02-avoev.0.jar') }}
+          restore-keys: |
+            ${{ runner.os }}-targets-matsim-
+
+      - name: Download Matsim to analyze
+        run: |
+          [[ ! -f matsim-12.0-2020w02-avoev.0.jar ]] && \
+            wget -nv https://jcenter.bintray.com/org/matsim/matsim/12.0-2020w02-avoev.0/matsim-12.0-2020w02-avoev.0.jar -O matsim-12.0-2020w02-avoev.0.jar
+
+      - name: Check Matsim with baseline
+        run: |
+          baseline_start="$(date +%s)"
+          spotbugs-baseline/spotbugs/build/install/spotbugs/bin/spotbugs -textui \
+            matsim-12.0-2020w02-avoev.0.jar \
+          | tee results_baseline
+          baseline_end="$(date +%s)"
+          echo "$((baseline_end - baseline_start))" > baseline_time
+
+      - name: Check Matsim with new
+        run: |
+          new_start="$(date +%s)"
+          spotbugs/build/install/spotbugs/bin/spotbugs -textui \
+            matsim-12.0-2020w02-avoev.0.jar \
+          | tee results_new
+          new_end="$(date +%s)"
+          echo "$((new_end - new_start))" > new_time
+
+      - name: Generate Matsim diff
+        id: report-diff
+        run: |
+          diff -u results_baseline results_new | \
+            sed -Ee '/^(\+\+\+|@| )/d' | tee result_diff
+
+      - name: Package artifacts
+        run: |
+          mkdir -p ./matsim
+          echo ${{ github.event.number }} > ./matsim/prnum
+          mv result_diff matsim/
+          mv baseline_time matsim/
+          mv new_time matsim/
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: matsim
+          path: matsim/
+
+  check-jenkins:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - name: Checkout Baseline
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          path: spotbugs-baseline
+          persist-credentials: false
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v1
+        with:
+          java-version: '17.0.x'
+
+      - name: Cache Gradle
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Quick-build new Spotbugs
+        run: ./gradlew installDist --no-daemon
+
+      - name: Quick-build baseline Spotbugs
+        run: ./gradlew installDist --no-daemon
+        working-directory: spotbugs-baseline
+
+      - name: Cache analyzed Jenkins
+        uses: actions/cache@v2
+        with:
+          path: jenkins-war-2.314.war
+          key: ${{ runner.os }}-targets-jenkins-${{ hashFiles('jenkins-war-2.314.war') }}
+          restore-keys: |
+            ${{ runner.os }}-targets-jenkins-
+
+      - name: Download Jenkins to analyze
+        run: |
+          [[ ! -f jenkins-war-2.314.war ]] && \
+            wget -nv https://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-war/2.314/jenkins-war-2.314.war -O jenkins-war-2.314.war
+
+      - name: Check Jenkins with baseline
+        run: |
+          baseline_start="$(date +%s)"
+          spotbugs-baseline/spotbugs/build/install/spotbugs/bin/spotbugs -textui \
+            jenkins-war-2.314.war \
+          | tee results_baseline
+          baseline_end="$(date +%s)"
+          echo "$((baseline_end - baseline_start))" > baseline_time
+
+      - name: Check Jenkins with new
+        run: |
+          new_start="$(date +%s)"
+          spotbugs/build/install/spotbugs/bin/spotbugs -textui \
+            jenkins-war-2.314.war \
+          | tee results_new
+          new_end="$(date +%s)"
+          echo "$((new_end - new_start))" > new_time
+
+      - name: Generate Jenkins diff
+        id: report-diff
+        run: |
+          diff -u results_baseline results_new | \
+            sed -Ee '/^(\+\+\+|@| )/d' | tee result_diff
+
+      - name: Package artifacts
+        run: |
+          mkdir -p ./jenkins
+          echo ${{ github.event.number }} > ./jenkins/prnum
+          mv result_diff jenkins/
+          mv baseline_time jenkins/
+          mv new_time jenkins/
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: jenkins
+          path: jenkins/


### PR DESCRIPTION
Create a workflow for analyzing Java projects via PR versions of
Spotbugs. Baseline diff and time measurement features are added to
monitor the impact of PRs (result set changes or possible regressions).
Open-source projects spotbugs, matsim and jenkins are added as test
subjects.



----

Make sure these boxes are checked before submitting your PR -- thank you!

- [ ] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
