### PR TITLE
Replace deprecated org.junit.Assert.assertThat() with org.hamcrest.MatcherAssert.assertThat() in the tests

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue1254Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue1254Test.java
@@ -3,7 +3,7 @@ package edu.umd.cs.findbugs.ba;
 import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
 import static org.hamcrest.number.OrderingComparison.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeThat;
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue1464Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue1464Test.java
@@ -1,7 +1,7 @@
 package edu.umd.cs.findbugs.ba;
 
 import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue371Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue371Test.java
@@ -1,7 +1,7 @@
 package edu.umd.cs.findbugs.ba;
 
 import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue389Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue389Test.java
@@ -1,7 +1,7 @@
 package edu.umd.cs.findbugs.ba;
 
 import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue408Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue408Test.java
@@ -4,7 +4,7 @@ import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.number.OrderingComparison.greaterThanOrEqualTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeThat;
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue413Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue413Test.java
@@ -1,7 +1,7 @@
 package edu.umd.cs.findbugs.ba;
 
 import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue429Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue429Test.java
@@ -1,7 +1,7 @@
 package edu.umd.cs.findbugs.ba;
 
 import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.nio.file.Paths;
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue516Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue516Test.java
@@ -1,7 +1,7 @@
 package edu.umd.cs.findbugs.ba;
 
 import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue527Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue527Test.java
@@ -2,7 +2,7 @@ package edu.umd.cs.findbugs.ba;
 
 import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue547Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue547Test.java
@@ -2,7 +2,7 @@ package edu.umd.cs.findbugs.ba;
 
 import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue688Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue688Test.java
@@ -19,7 +19,7 @@
 package edu.umd.cs.findbugs.ba;
 
 import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue758Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue758Test.java
@@ -19,7 +19,7 @@
 package edu.umd.cs.findbugs.ba;
 
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindBadEndOfStreamCheckTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindBadEndOfStreamCheckTest.java
@@ -2,7 +2,7 @@ package edu.umd.cs.findbugs.detect;
 
 import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
 import static org.hamcrest.Matchers.hasItem;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindUnsatisfiedObligationTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindUnsatisfiedObligationTest.java
@@ -2,7 +2,7 @@ package edu.umd.cs.findbugs.detect;
 
 import static org.hamcrest.collection.IsEmptyIterable.emptyIterable;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.nio.file.Paths;
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/IncorrectSelfComparisonInstanceOfPatternMatchingTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/IncorrectSelfComparisonInstanceOfPatternMatchingTest.java
@@ -2,7 +2,7 @@ package edu.umd.cs.findbugs.detect;
 
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.number.OrderingComparison.greaterThanOrEqualTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeThat;
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1472Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1472Test.java
@@ -6,7 +6,7 @@ import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 import org.junit.Test;
 
 import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 
 /**

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue374Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue374Test.java
@@ -24,7 +24,7 @@ import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 import org.junit.Test;
 
 import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 
 /**

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue463Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue463Test.java
@@ -1,7 +1,7 @@
 package edu.umd.cs.findbugs.detect;
 
 import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue484Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue484Test.java
@@ -1,7 +1,7 @@
 package edu.umd.cs.findbugs.detect;
 
 import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue500Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue500Test.java
@@ -19,7 +19,7 @@
 package edu.umd.cs.findbugs.detect;
 
 import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue582Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue582Test.java
@@ -1,7 +1,7 @@
 package edu.umd.cs.findbugs.detect;
 
 import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue595Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue595Test.java
@@ -1,7 +1,7 @@
 package edu.umd.cs.findbugs.detect;
 
 import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Rule;
 import org.junit.Test;

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue603Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue603Test.java
@@ -19,7 +19,7 @@
 package edu.umd.cs.findbugs.detect;
 
 import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue744Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue744Test.java
@@ -1,7 +1,7 @@
 package edu.umd.cs.findbugs.detect;
 
 import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue79Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue79Test.java
@@ -6,7 +6,7 @@ import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 import org.junit.Test;
 
 import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * SpotBugs should remove the ResultSet obligation from all set

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/OverridingMethodMustInvokeSuperTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/OverridingMethodMustInvokeSuperTest.java
@@ -6,7 +6,7 @@ import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 import org.junit.Test;
 
 import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class OverridingMethodMustInvokeSuperTest extends AbstractIntegrationTest {
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/PreconditionsCheckNotNullCanIgnoreReturnValueTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/PreconditionsCheckNotNullCanIgnoreReturnValueTest.java
@@ -9,7 +9,7 @@ import java.nio.file.Paths;
 
 import static org.hamcrest.collection.IsEmptyIterable.emptyIterable;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class PreconditionsCheckNotNullCanIgnoreReturnValueTest {
     @Rule

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/ResolveMethodReferencesTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/ResolveMethodReferencesTest.java
@@ -3,7 +3,7 @@ package edu.umd.cs.findbugs.detect;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.collection.IsEmptyIterable.emptyIterable;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.nio.file.Paths;
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/integration/FindNullDerefIntegrationTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/integration/FindNullDerefIntegrationTest.java
@@ -21,7 +21,7 @@ package edu.umd.cs.findbugs.integration;
 
 import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
 import static org.hamcrest.Matchers.hasItem;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/nullness/AndroidNullabilityTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/nullness/AndroidNullabilityTest.java
@@ -2,7 +2,7 @@ package edu.umd.cs.findbugs.nullness;
 
 import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
 import static org.hamcrest.Matchers.emptyIterable;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.nio.file.Paths;
 

--- a/spotbugs/src/test/java/edu/umd/cs/findbugs/ba/FrameTest.java
+++ b/spotbugs/src/test/java/edu/umd/cs/findbugs/ba/FrameTest.java
@@ -2,7 +2,7 @@ package edu.umd.cs.findbugs.ba;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 

--- a/spotbugs/src/test/java/edu/umd/cs/findbugs/ba/generic/GenericUtilitiesTest.java
+++ b/spotbugs/src/test/java/edu/umd/cs/findbugs/ba/generic/GenericUtilitiesTest.java
@@ -22,7 +22,7 @@ package edu.umd.cs.findbugs.ba.generic;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.List;
 

--- a/spotbugs/src/test/java/edu/umd/cs/findbugs/filter/RelationalOpTest.java
+++ b/spotbugs/src/test/java/edu/umd/cs/findbugs/filter/RelationalOpTest.java
@@ -20,7 +20,7 @@ package edu.umd.cs.findbugs.filter;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;

--- a/spotbugs/src/test/java/edu/umd/cs/findbugs/filter/SignatureUtilTest.java
+++ b/spotbugs/src/test/java/edu/umd/cs/findbugs/filter/SignatureUtilTest.java
@@ -20,7 +20,7 @@ package edu.umd.cs.findbugs.filter;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 

--- a/spotbugs/src/test/java/edu/umd/cs/findbugs/log/ProfileSummaryTest.java
+++ b/spotbugs/src/test/java/edu/umd/cs/findbugs/log/ProfileSummaryTest.java
@@ -20,7 +20,7 @@ package edu.umd.cs.findbugs.log;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;


### PR DESCRIPTION




----

Make sure these boxes are checked before submitting your PR -- thank you!

- [ ] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
