### PR TITLE
Upgrade SpotBugs gradle plugin to the beta6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
   id "org.sonarqube" version "3.3"
   id "com.diffplug.spotless" version "5.17.1"
   id "org.gradle.crypto.checksum" version "1.2.0"
-  id "com.github.spotbugs" version "5.0.0-beta.5"
+  id "com.github.spotbugs" version "5.0.0-beta.6"
   id "io.github.gradle-nexus.publish-plugin" version "1.1.0"
 }
 

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -29,7 +29,7 @@ spotbugs {
 tasks.withType(SpotBugsTask).configureEach {
     reports {
         html {
-            enabled = true
+            required = true
             stylesheet = 'fancy-hist.xsl'
         }
     }


### PR DESCRIPTION
Upgrade the gradle plugin to the latest beta release. It deprecated `report.enabled` property so we need to replace it with `report.required`.