### PR TITLE
Release 4.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased - 2021-??-??
+## 4.5.0 - 2021-11-05
 ### Changed
 - Replace "分析" with "解析" in Japanese document ([#1573](https://github.com/spotbugs/spotbugs/issues/1573))
 - Add a section to document how to integrate find-sec-bugs into spotbugs-maven-plugin ([#540](https://github.com/spotbugs/spotbugs/issues/540))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased - 2021-??-??
+
 ## 4.5.0 - 2021-11-05
 ### Changed
 - Replace "分析" with "解析" in Japanese document ([#1573](https://github.com/spotbugs/spotbugs/issues/1573))

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'com.github.spotbugs'
-version = '4.5.0'
+version = '4.5.1-SNAPSHOT'
 
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/jacoco.gradle"

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'com.github.spotbugs'
-version = '4.4.3-SNAPSHOT'
+version = '4.5.0'
 
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/jacoco.gradle"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,10 +16,10 @@ import sys
 import os
 
 html_context = {
-  'version' : '4.4',
-  'full_version' : '4.4.2',
-  'maven_plugin_version' : '4.4.1',
-  'gradle_plugin_version' : '4.7.6',
+  'version' : '4.5',
+  'full_version' : '4.5.0',
+  'maven_plugin_version' : '4.4.2.2',
+  'gradle_plugin_version' : '4.7.9',
   'archetype_version' : '0.2.4'
 }
 


### PR DESCRIPTION
Release the next minor release 4.5.0 which contains several new features and detectors. Waiting #1741, #1785, and #1541 to be merged.

[//]: # (rtdbot-start)

URL of RTD documents:
en: https://spotbugs.readthedocs.io/en/release-4.5.0/
ja: https://spotbugs.readthedocs.io/ja/release-4.5.0/
pt_BR: https://spotbugs.readthedocs.io/pt_BR/release-4.5.0/

[//]: # (rtdbot-end)
