### PR TITLE
Make the governance policy for this repo clear

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -14,3 +14,8 @@ Just three steps to follow:
 ## Before you propose new rules
 
 Please consider to follow the same points with ***Before reporting problem in detectors***.
+
+## Before you submit a pull request
+
+1. Run `./gradlew spotlessApply build smoketest` in your local to verify your change.
+2. Make sure you updated the `CHANGELOG.md` accordingly. Detailed requirements are explained at the beginning of the changelog.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -12,7 +12,7 @@ The GitHub team for SpotBugs Team is `@spotbugs/core-devs`. Members of the SpotB
 
 Both SpotBugs Core Team and SpotBugs user can propose changes to the SpotBugs project via GitHub pull requests. Refer to `.github/CONTRIBUTING.md` to know more detailed requirements for your proposal.
 
-Once a pull request gets two approvals from members of SpotBugs Core Team, pull request will be merged and shipped in the next release. Approver should not be the same as the author(s) of the change.
+Once a pull request gets two approvals from members of SpotBugs Core Team, pull request will be merged and shipped in the next release.
 
 If pull request cannot get enough approvals during 30 days, it will be labeled as stale pull request. Stale pull requests will be closed after another 30 days.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -2,9 +2,9 @@
 
 This document provides the governance policy for the SpotBugs Project.
 
-## SpotBugs Core Term
+## SpotBugs Core Team
 
-The SpotBugs Core Team maintain the spotbugs/spotbugs GitHub repository.
+The SpotBugs Core Team maintains the spotbugs/spotbugs GitHub repository.
 
 The GitHub team for SpotBugs Team is `@spotbugs/core-devs`. Members of the SpotBugs Core Team have write access to the repository.
 
@@ -12,18 +12,18 @@ The GitHub team for SpotBugs Team is `@spotbugs/core-devs`. Members of the SpotB
 
 Both SpotBugs Core Team and SpotBugs user can propose changes to the SpotBugs project via GitHub pull requests. Refer to `.github/CONTRIBUTING.md` to know more detailed requirements for your proposal.
 
-Once a pull request gets two approvals from members of SpotBugs Core Team, pull request will be merged and shipped in the next release.
+Once a pull request gets two approvals from members of SpotBugs Core Team, pull request can be merged and shipped in the next release.
 
-If pull request cannot get enough approvals during 30 days, it will be labeled as stale pull request. Stale pull requests will be closed after another 30 days.
+If pull request cannot get enough approvals during 30 days, it can be labeled as stale pull request. Stale pull requests can be closed after another 30 days.
 
 ## Issue Management Policy
 
-Both SpotBugs Core Team and SpotBugs user can create issue at GitHub Issues. Refer to `.github/CONTRIBUTING.md` to know more detailed requirements for your proposal.
+Both SpotBugs Core Team and SpotBugs users can create issues at GitHub Issues. Refer to `.github/CONTRIBUTING.md` to get more detailed requirements for your proposal.
 
-If issue has no updated for 30 days from when it is labeled as 'need info', SpotBugs Core Team will closed it.
+If issue is not updated for 30 days from when it was labeled as 'need info', SpotBugs Core Team can close it.
 
 ## Nomination to the SpotBugs Core Team
 
 Members of SpotBugs Core Team can nominate new members. The nomination process is held at [GitHub Team Discussions](https://docs.github.com/en/organizations/collaborating-with-your-team/about-team-discussions).
 
-We set no clear condition to nominate, but usually nominate from active contributors.
+We set no clear condition for nomination, but usually nominate from active contributors.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -12,7 +12,7 @@ The GitHub team for SpotBugs Team is `@spotbugs/core-devs`. Members of the SpotB
 
 Both SpotBugs Core Team and SpotBugs user can propose changes to the SpotBugs project via GitHub pull requests. Refer to `.github/CONTRIBUTING.md` to know more detailed requirements for your proposal.
 
-Once a pull request got two approvals from members of SpotBugs Core Team, pull request will be merged and shipped in the next release. Approver should not be the same to authors of the change.
+Once a pull request gets two approvals from members of SpotBugs Core Team, pull request will be merged and shipped in the next release. Approver should not be the same as the author(s) of the change.
 
 If pull request cannot get enough approvals during 30 days, it will be labeled as stale pull request. Stale pull requests will be closed after another 30 days.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,29 @@
+# Governance Policy
+
+This document provides the governance policy for the SpotBugs Project.
+
+## SpotBugs Core Term
+
+The SpotBugs Core Team maintain the spotbugs/spotbugs GitHub repository.
+
+The GitHub team for SpotBugs Team is `@spotbugs/core-devs`. Members of the SpotBugs Core Team have write access to the repository.
+
+## How we propose changes
+
+Both SpotBugs Core Team and SpotBugs user can propose changes to the SpotBugs project via GitHub pull requests. Refer to `.github/CONTRIBUTING.md` to know more detailed requirements for your proposal.
+
+Once a pull request got two approvals from members of SpotBugs Core Team, pull request will be merged and shipped in the next release. Approver should not be the same to authors of the change.
+
+If pull request cannot get enough approvals during 30 days, it will be labeled as stale pull request. Stale pull requests will be closed after another 30 days.
+
+## Issue Management Policy
+
+Both SpotBugs Core Team and SpotBugs user can create issue at GitHub Issues. Refer to `.github/CONTRIBUTING.md` to know more detailed requirements for your proposal.
+
+If issue has no updated for 30 days from when it is labeled as 'need info', SpotBugs Core Team will closed it.
+
+## Nomination to the SpotBugs Core Team
+
+Members of SpotBugs Core Team can nominate new members. The nomination process is held at [GitHub Team Discussions](https://docs.github.com/en/organizations/collaborating-with-your-team/about-team-discussions).
+
+We set no clear condition to nominate, but usually nominate from active contributors.

--- a/README.md
+++ b/README.md
@@ -33,4 +33,4 @@ SpotBugs can be used standalone and through several integrations, including:
 * [IntelliJ IDEA](https://github.com/JetBrains/spotbugs-intellij-plugin)
 
 # Questions?
-You can contact us using [our general purpose mailing list](https://github.com/spotbugs/discuss/issues?q=).
+You can contact us using [GitHub Discussions](https://github.com/spotbugs/spotbugs/discussions).


### PR DESCRIPTION
To solve problems caused by our unclear governance policy for this project, create a `GOVERNANCE.md` at the root directory.
I referred to [The nodejs governance policy](https://github.com/nodejs/node/blob/c93a639788145d45f96e788ab169cd3d8a5e251e/GOVERNANCE.md) and the [Minimum Viable Governance from GitHub](https://github.com/github/MVG/tree/3e2371415353a96097974e32407c2af097004b8d/), but the content is made from scratch to enable our small start.

After we merge this change, I will configure the branch protection rule to change the number of necessary approval from 1 to 2. Other automations such as [stale action](https://github.com/actions/stale) and auto-merge will come next.