### PR TITLE
Issue 574

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased - 2021-??-??
+### Changed
+- Update UnreadFields detector to ignore warnings for fields with certain annotations ([#574](https://github.com/spotbugs/spotbugs/issues/574))
+
 ### Fixed
 - Ant task does not produce XML anymore ([#1827](https://github.com/spotbugs/spotbugs/issues/1827))
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue574Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue574Test.java
@@ -1,0 +1,33 @@
+package edu.umd.cs.findbugs.detect;
+
+import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
+
+/**
+ * SpotBugs should suppress "UNF_UNREAD_FIELD" warning when triggering fields have certain annotations.
+ *
+ * @see <a href="https://github.com/spotbugs/spotbugs/issues/574">GitHub issue</a>
+ * @since 4.4.2
+ */
+public class Issue574Test extends AbstractIntegrationTest {
+    private static final String DESIRED_BUG_TYPE = "URF_UNREAD_FIELD";
+
+    /**
+     * Expects 0 "URF_UNREAD_FIELD" error in the "Issue574Errors.class" file.
+     */
+    @Test
+    public void testClassWithErrors() {
+        performAnalysis("ghIssues/Issue574Errors.class");
+        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
+                .bugType(DESIRED_BUG_TYPE)
+                .build();
+        assertThat(getBugCollection(), containsExactly(0, bugTypeMatcher));
+    }
+
+}

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue574Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue574Test.java
@@ -19,15 +19,26 @@ public class Issue574Test extends AbstractIntegrationTest {
     private static final String DESIRED_BUG_TYPE = "URF_UNREAD_FIELD";
 
     /**
-     * Expects 0 "URF_UNREAD_FIELD" error in the "Issue574Errors.class" file.
+     * Expects 0 "URF_UNREAD_FIELD" errors in the "Issue574SerializedName.class" file.
      */
     @Test
-    public void testClassWithErrors() {
-        performAnalysis("ghIssues/Issue574Errors.class");
+    public void testSerializedNameAnnotation() {
+        performAnalysis("ghIssues/Issue574SerializedName.class");
         BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
                 .bugType(DESIRED_BUG_TYPE)
                 .build();
         assertThat(getBugCollection(), containsExactly(0, bugTypeMatcher));
     }
 
+    /**
+     * Expects 2 "URF_UNREAD_FIELD" errors in the "Issue574XmlElement.class" file.
+     */
+    @Test
+    public void testXmlElementAnnotation() {
+        performAnalysis("ghIssues/Issue574XmlElement.class");
+        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
+                .bugType(DESIRED_BUG_TYPE)
+                .build();
+        assertThat(getBugCollection(), containsExactly(0, bugTypeMatcher));
+    }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue574Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue574Test.java
@@ -13,13 +13,13 @@ import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
  * SpotBugs should suppress "UNF_UNREAD_FIELD" warning when triggering fields have certain annotations.
  *
  * @see <a href="https://github.com/spotbugs/spotbugs/issues/574">GitHub issue</a>
- * @since 4.4.2
  */
 public class Issue574Test extends AbstractIntegrationTest {
     private static final String DESIRED_BUG_TYPE = "URF_UNREAD_FIELD";
 
     /**
      * Expects 0 "URF_UNREAD_FIELD" errors in the "Issue574SerializedName.class" file.
+     * Tests @SerializedName annotation.
      */
     @Test
     public void testSerializedNameAnnotation() {
@@ -31,11 +31,25 @@ public class Issue574Test extends AbstractIntegrationTest {
     }
 
     /**
-     * Expects 2 "URF_UNREAD_FIELD" errors in the "Issue574XmlElement.class" file.
+     * Expects 0 "URF_UNREAD_FIELD" errors in the "Issue574XmlElement.class" file.
+     * Tests @XmlElement, @XmlAttribute, and @XmlValue annotations.
      */
     @Test
     public void testXmlElementAnnotation() {
         performAnalysis("ghIssues/Issue574XmlElement.class");
+        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
+                .bugType(DESIRED_BUG_TYPE)
+                .build();
+        assertThat(getBugCollection(), containsExactly(0, bugTypeMatcher));
+    }
+
+    /**
+     * Expects 0 "URF_UNREAD_FIELD" errors in the "Issue574RegisterExtension.class" file.
+     * Tests @RegisterExtension annotation.
+     */
+    @Test
+    public void testRegisterExtensionAnnotation() {
+        performAnalysis("ghIssues/Issue574RegisterExtension.class");
         BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
                 .bugType(DESIRED_BUG_TYPE)
                 .build();

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -76,7 +76,6 @@ dependencies {
     exclude group: 'jaxen',            module: 'jaxen'
     exclude group: 'javax.xml.stream', module: 'stax-api'
     exclude group: 'net.java.dev.msv', module: 'xsdlib'
-    exclude group: 'javax.xml.bind',   module: 'jaxb-api'
     exclude group: 'pull-parser',      module: 'pull-parser'
     exclude group: 'xpp3',             module: 'xpp3'
   }

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -93,6 +93,7 @@ dependencies {
   api project(':spotbugs-annotations')
 
   api "com.google.code.gson:gson:2.8.9"
+  api 'org.junit.jupiter:junit-jupiter:5.8.2'
   testImplementation 'junit:junit:4.13.1'
   testImplementation 'org.apache.ant:ant:1.10.12'
   testImplementation 'org.apache.logging.log4j:log4j-slf4j18-impl:2.14.0'

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UnreadFields.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UnreadFields.java
@@ -78,6 +78,7 @@ import edu.umd.cs.findbugs.ba.vna.ValueNumberDataflow;
 import edu.umd.cs.findbugs.ba.vna.ValueNumberFrame;
 import edu.umd.cs.findbugs.bcel.BCELUtil;
 import edu.umd.cs.findbugs.bcel.OpcodeStackDetector;
+import edu.umd.cs.findbugs.classfile.analysis.AnnotationValue;
 import edu.umd.cs.findbugs.classfile.CheckedAnalysisException;
 import edu.umd.cs.findbugs.classfile.ClassDescriptor;
 import edu.umd.cs.findbugs.classfile.DescriptorFactory;
@@ -1082,6 +1083,20 @@ public class UnreadFields extends OpcodeStackDetector {
             if (dontComplainAbout.matcher(fieldName).find()) {
                 continue;
             }
+
+            ClassDescriptor skipAnnotation =
+                    DescriptorFactory.createClassDescriptor(com.google.gson.annotations.SerializedName.class);
+
+            int skipAnnotationFlag = 0;
+            for (AnnotationValue a : f.getAnnotations()){
+                if (a.getAnnotationClass().equals(skipAnnotation)){
+                    skipAnnotationFlag = 1;
+                }
+            }
+            if (skipAnnotationFlag == 1){
+                continue;
+            }
+
             if (lastDollar >= 0 && (fieldName.startsWith("this$") || fieldName.startsWith("this+"))) {
                 String outerClassName = className.substring(0, lastDollar);
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UnreadFields.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UnreadFields.java
@@ -78,7 +78,6 @@ import edu.umd.cs.findbugs.ba.vna.ValueNumberDataflow;
 import edu.umd.cs.findbugs.ba.vna.ValueNumberFrame;
 import edu.umd.cs.findbugs.bcel.BCELUtil;
 import edu.umd.cs.findbugs.bcel.OpcodeStackDetector;
-import edu.umd.cs.findbugs.classfile.analysis.AnnotationValue;
 import edu.umd.cs.findbugs.classfile.CheckedAnalysisException;
 import edu.umd.cs.findbugs.classfile.ClassDescriptor;
 import edu.umd.cs.findbugs.classfile.DescriptorFactory;
@@ -1202,7 +1201,7 @@ public class UnreadFields extends OpcodeStackDetector {
                             (f.isPublic() || f.isProtected()) ? "UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD" : "UUF_UNUSED_FIELD",
                             NORMAL_PRIORITY).addClass(className).addField(f).lowerPriorityIfDeprecated());
                 } else if (UnreadFieldsAnnotationChecker.containsSpecialAnnotation(f.getAnnotations())) {
-                    // ignore it
+                    continue;
                 } else if (f.getName().toLowerCase().indexOf("guardian") < 0) {
                     int priority = NORMAL_PRIORITY;
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/UnreadFieldsAnnotationChecker.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/UnreadFieldsAnnotationChecker.java
@@ -4,8 +4,6 @@ import java.util.Collection;
 import java.util.Set;
 import java.util.HashSet;
 
-import java.lang.UnsupportedOperationException;
-
 import edu.umd.cs.findbugs.classfile.analysis.AnnotationValue;
 import edu.umd.cs.findbugs.classfile.ClassDescriptor;
 import edu.umd.cs.findbugs.classfile.DescriptorFactory;
@@ -13,6 +11,7 @@ import edu.umd.cs.findbugs.classfile.DescriptorFactory;
 /**
  * Utility class checking for presence of certain annotations. If one of the listed annotations is associated with
  * a given field, then the "URF_UNREAD_FIELD" detector should be skipped for the field.
+ * @see <a href="https://github.com/spotbugs/spotbugs/issues/574">GitHub issue</a>
  */
 public final class UnreadFieldsAnnotationChecker {
 
@@ -27,9 +26,11 @@ public final class UnreadFieldsAnnotationChecker {
      * Array of annotations which, if present, signal that "URF_UNREAD_FIELD" detector should be skipped.
      */
     private static final Class[] IGNORE_RULE_FOR_THESE_ANNOTATIONS = {
-            com.google.gson.annotations.SerializedName.class,
-            javax.xml.bind.annotation.XmlAttribute.class,
-            javax.xml.bind.annotation.XmlValue.class,
+        com.google.gson.annotations.SerializedName.class,
+        javax.xml.bind.annotation.XmlElement.class,
+        javax.xml.bind.annotation.XmlAttribute.class,
+        javax.xml.bind.annotation.XmlValue.class,
+        org.junit.jupiter.api.extension.RegisterExtension.class
     };
 
     private static final Set<ClassDescriptor> IGNORE_RULE_FOR_THESE_CLASS_DESCRIPTORS =
@@ -40,10 +41,11 @@ public final class UnreadFieldsAnnotationChecker {
      * the "URF_UNREAD_FIELD" detector should be skipped.
      * @param annotationsToCheck Collections of annotations associated with given element.
      * @return If true, "URF_UNREAD_FIELD" detector should be ignored for given field.
+     * @see <a href="https://github.com/spotbugs/spotbugs/issues/574">GitHub issue</a>
      */
-    public static boolean containsSpecialAnnotation (Collection<AnnotationValue> annotationsToCheck){
-        for (AnnotationValue annotationValue : annotationsToCheck){
-            if (IGNORE_RULE_FOR_THESE_CLASS_DESCRIPTORS.contains(annotationValue.getAnnotationClass())){
+    public static boolean containsSpecialAnnotation(Collection<AnnotationValue> annotationsToCheck) {
+        for (AnnotationValue annotationValue : annotationsToCheck) {
+            if (IGNORE_RULE_FOR_THESE_CLASS_DESCRIPTORS.contains(annotationValue.getAnnotationClass())) {
                 return true;
             }
         }
@@ -52,7 +54,7 @@ public final class UnreadFieldsAnnotationChecker {
 
     private static Set<ClassDescriptor> annotationToClassDescriptorBuilder(Class[] annotationsToCheck) {
         Set<ClassDescriptor> tempSet = new HashSet<ClassDescriptor>();
-        for (Class annotation : annotationsToCheck){
+        for (Class annotation : annotationsToCheck) {
             tempSet.add(DescriptorFactory.createClassDescriptor(annotation));
         }
         return tempSet;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/UnreadFieldsAnnotationChecker.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/UnreadFieldsAnnotationChecker.java
@@ -1,0 +1,61 @@
+package edu.umd.cs.findbugs.util;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.HashSet;
+
+import java.lang.UnsupportedOperationException;
+
+import edu.umd.cs.findbugs.classfile.analysis.AnnotationValue;
+import edu.umd.cs.findbugs.classfile.ClassDescriptor;
+import edu.umd.cs.findbugs.classfile.DescriptorFactory;
+
+/**
+ * Utility class checking for presence of certain annotations. If one of the listed annotations is associated with
+ * a given field, then the "URF_UNREAD_FIELD" detector should be skipped for the field.
+ */
+public final class UnreadFieldsAnnotationChecker {
+
+    /**
+     * Private constructor to prevent instantiation given utility class.
+     */
+    private UnreadFieldsAnnotationChecker() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Array of annotations which, if present, signal that "URF_UNREAD_FIELD" detector should be skipped.
+     */
+    private static final Class[] IGNORE_RULE_FOR_THESE_ANNOTATIONS = {
+            com.google.gson.annotations.SerializedName.class,
+            javax.xml.bind.annotation.XmlAttribute.class,
+            javax.xml.bind.annotation.XmlValue.class,
+    };
+
+    private static final Set<ClassDescriptor> IGNORE_RULE_FOR_THESE_CLASS_DESCRIPTORS =
+            annotationToClassDescriptorBuilder(IGNORE_RULE_FOR_THESE_ANNOTATIONS);
+
+    /**
+     * Checks whether the collection of annotations associated with a given element include annotations that indicate
+     * the "URF_UNREAD_FIELD" detector should be skipped.
+     * @param annotationsToCheck Collections of annotations associated with given element.
+     * @return If true, "URF_UNREAD_FIELD" detector should be ignored for given field.
+     */
+    public static boolean containsSpecialAnnotation (Collection<AnnotationValue> annotationsToCheck){
+        for (AnnotationValue annotationValue : annotationsToCheck){
+            if (IGNORE_RULE_FOR_THESE_CLASS_DESCRIPTORS.contains(annotationValue.getAnnotationClass())){
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static Set<ClassDescriptor> annotationToClassDescriptorBuilder(Class[] annotationsToCheck) {
+        Set<ClassDescriptor> tempSet = new HashSet<ClassDescriptor>();
+        for (Class annotation : annotationsToCheck){
+            tempSet.add(DescriptorFactory.createClassDescriptor(annotation));
+        }
+        return tempSet;
+    }
+
+}

--- a/spotbugsTestCases/src/java/ghIssues/issue574/BypassFileNotFoundExceptionExtension.java
+++ b/spotbugsTestCases/src/java/ghIssues/issue574/BypassFileNotFoundExceptionExtension.java
@@ -1,0 +1,30 @@
+package ghIssues;
+
+import java.io.FileNotFoundException;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestExecutionExceptionHandler;
+
+
+/**
+ * Creates test extension for the @RegisterExtension test for Issue 574 on GitHub
+ * @see <a href="https://github.com/spotbugs/spotbugs/issues/574">GitHub issue</a>
+ */
+
+public class BypassFileNotFoundExceptionExtension implements TestExecutionExceptionHandler {
+
+    /**
+     * Basic extension implementation for @RegisterExtension test.
+     * @param context
+     * @param throwable
+     * @throws Throwable
+     */
+    @Override
+    public void handleTestExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
+        if (throwable instanceof FileNotFoundException) {
+            return;
+        }
+        throw throwable;
+    }
+
+}

--- a/spotbugsTestCases/src/java/ghIssues/issue574/Issue574Errors.java
+++ b/spotbugsTestCases/src/java/ghIssues/issue574/Issue574Errors.java
@@ -1,0 +1,38 @@
+package ghIssues;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+import com.google.gson.*;
+import com.google.gson.annotations.SerializedName;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+
+/**
+ * @see <a href="https://github.com/spotbugs/spotbugs/issues/574">GitHub issue</a>
+ */
+public final class Issue574Errors {
+
+    @SerializedName("name")
+    private String stringA;
+
+    @SerializedName(value="name1", alternate={"name2", "name3"})
+    private String stringB;
+
+    public Issue574Errors(String a, String b){
+        this.stringA = a;
+        this.stringB = b;
+    }
+
+    @Test
+    public static void testSerializedNameExample1() {
+        Issue574Errors target = new Issue574Errors("v1", "v2");
+        Gson gson = new Gson();
+        String json = gson.toJson(target);
+        System.out.println(json);
+        String output = "{'name':'v1','name1':'v2'}";
+        assertEquals(json, output);
+    }
+}

--- a/spotbugsTestCases/src/java/ghIssues/issue574/Issue574RegisterExtension.java
+++ b/spotbugsTestCases/src/java/ghIssues/issue574/Issue574RegisterExtension.java
@@ -1,0 +1,16 @@
+package ghIssues;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+/**
+ * Tests that "URF_UNREAD_FIELD" warning is suppressed for fields with @RegisterExtension annotation.
+ * @see <a href="https://github.com/spotbugs/spotbugs/issues/574">GitHub issue</a>
+ */
+
+
+public final class Issue574RegisterExtension {
+
+    @RegisterExtension
+    static BypassFileNotFoundExceptionExtension testExtension = new BypassFileNotFoundExceptionExtension();
+
+}

--- a/spotbugsTestCases/src/java/ghIssues/issue574/Issue574SerializedName.java
+++ b/spotbugsTestCases/src/java/ghIssues/issue574/Issue574SerializedName.java
@@ -6,14 +6,10 @@ import org.junit.Test;
 import com.google.gson.*;
 import com.google.gson.annotations.SerializedName;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-
-
 /**
  * @see <a href="https://github.com/spotbugs/spotbugs/issues/574">GitHub issue</a>
  */
-public final class Issue574Errors {
+public final class Issue574SerializedName {
 
     @SerializedName("name")
     private String stringA;
@@ -21,14 +17,14 @@ public final class Issue574Errors {
     @SerializedName(value="name1", alternate={"name2", "name3"})
     private String stringB;
 
-    public Issue574Errors(String a, String b){
+    public Issue574SerializedName(String a, String b){
         this.stringA = a;
         this.stringB = b;
     }
 
     @Test
     public static void testSerializedNameExample1() {
-        Issue574Errors target = new Issue574Errors("v1", "v2");
+        Issue574SerializedName target = new Issue574SerializedName("v1", "v2");
         Gson gson = new Gson();
         String json = gson.toJson(target);
         System.out.println(json);

--- a/spotbugsTestCases/src/java/ghIssues/issue574/Issue574SerializedName.java
+++ b/spotbugsTestCases/src/java/ghIssues/issue574/Issue574SerializedName.java
@@ -1,12 +1,12 @@
 package ghIssues;
 
-import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 
 import com.google.gson.*;
 import com.google.gson.annotations.SerializedName;
 
 /**
+ * Tests that "URF_UNREAD_FIELD" warning is suppressed for fields with @SerializedName annotation.
  * @see <a href="https://github.com/spotbugs/spotbugs/issues/574">GitHub issue</a>
  */
 public final class Issue574SerializedName {
@@ -17,18 +17,24 @@ public final class Issue574SerializedName {
     @SerializedName(value="name1", alternate={"name2", "name3"})
     private String stringB;
 
+    /**
+     * Constructor for test class.
+     * @param a
+     * @param b
+     */
     public Issue574SerializedName(String a, String b){
         this.stringA = a;
         this.stringB = b;
     }
 
+    /**
+     * Test case for @SerializedName annotation. Creates JSON representation of test object.
+     */
     @Test
-    public static void testSerializedNameExample1() {
+    public static void testSerializedName() {
         Issue574SerializedName target = new Issue574SerializedName("v1", "v2");
         Gson gson = new Gson();
         String json = gson.toJson(target);
         System.out.println(json);
-        String output = "{'name':'v1','name1':'v2'}";
-        assertEquals(json, output);
     }
 }

--- a/spotbugsTestCases/src/java/ghIssues/issue574/Issue574XmlElement.java
+++ b/spotbugsTestCases/src/java/ghIssues/issue574/Issue574XmlElement.java
@@ -1,0 +1,34 @@
+package ghIssues;
+
+import org.junit.Test;
+
+import javax.xml.bind.annotation.*;
+
+/**
+ * @see <a href="https://github.com/spotbugs/spotbugs/issues/574">GitHub issue</a>
+ */
+
+@XmlRootElement
+public final class Issue574XmlElement {
+
+    @XmlAttribute
+    private String type;
+
+    @XmlAttribute
+    private String gender;
+
+    @XmlValue
+    private String description;
+
+    public Issue574XmlElement(String type, String gender, String description){
+        this.type = type;
+        this.gender = gender;
+        this.description = description;
+    }
+
+    @Test
+    public void test1(){
+        Issue574XmlElement testObject = new Issue574XmlElement("test","male","swimming");
+    }
+
+}

--- a/spotbugsTestCases/src/java/ghIssues/issue574/Issue574XmlElement.java
+++ b/spotbugsTestCases/src/java/ghIssues/issue574/Issue574XmlElement.java
@@ -1,34 +1,37 @@
 package ghIssues;
 
-import org.junit.Test;
-
-import javax.xml.bind.annotation.*;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlValue;
 
 /**
+ * Tests that "URF_UNREAD_FIELD" warning is suppressed for fields with @XmlElement, @XmlAttribute, and @XmlValue
+ * annotations.
  * @see <a href="https://github.com/spotbugs/spotbugs/issues/574">GitHub issue</a>
  */
 
 @XmlRootElement
 public final class Issue574XmlElement {
 
-    @XmlAttribute
-    private String type;
+    @XmlElement
+    private String element;
 
     @XmlAttribute
-    private String gender;
+    private String attribute;
 
     @XmlValue
-    private String description;
+    private String value;
 
-    public Issue574XmlElement(String type, String gender, String description){
-        this.type = type;
-        this.gender = gender;
-        this.description = description;
+    /**
+     * Constructor for test class.
+     * @param element
+     * @param attribute
+     * @param value
+     */
+    public Issue574XmlElement(String element, String attribute, String value){
+        this.element = element;
+        this.attribute = attribute;
+        this.value = value;
     }
-
-    @Test
-    public void test1(){
-        Issue574XmlElement testObject = new Issue574XmlElement("test","male","swimming");
-    }
-
 }


### PR DESCRIPTION
Attempt at addressing #574 to ignore URF_UNREAD_FIELD warning for fields with certain annotations (e.g. @SerializedName, @XmlElement, and @RegisterExtension). New contributor / completed as part of university project.

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
