### PR TITLE
Update log4j-slf4j18-impl for Eclipse plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased - 2022-??-??
+### Fixed
+- Remove duplicated logging frameworks from the Eclipse plugin distribution ([#1868](https://github.com/spotbugs/spotbugs/issues/1868))
 
 ## 4.5.2 - 2021-12-13
 ### Security

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -96,7 +96,7 @@ dependencies {
   api "com.google.code.gson:gson:2.8.9"
   testImplementation 'junit:junit:4.13.1'
   testImplementation 'org.apache.ant:ant:1.10.12'
-  testImplementation 'org.apache.logging.log4j:log4j-slf4j18-impl:2.15.0'
+  testImplementation 'org.apache.logging.log4j:log4j-slf4j18-impl:2.16.0'
   testImplementation 'com.google.errorprone:error_prone_annotations:2.10.0'
 
   guiImplementation sourceSets.main.runtimeClasspath

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -12,6 +12,7 @@ configurations {
 
 ext {
   asmVersion = '9.2'
+  log4jVersion = '2.16.0'
 }
 
 sourceSets {
@@ -85,7 +86,7 @@ dependencies {
   api 'org.apache.commons:commons-text:1.9'
   api 'org.slf4j:slf4j-api:1.8.0-beta4'
   implementation 'net.sf.saxon:Saxon-HE:10.6'
-  logBinding ('org.apache.logging.log4j:log4j-slf4j18-impl:2.16.0') {
+  logBinding ("org.apache.logging.log4j:log4j-slf4j18-impl:$log4jVersion") {
     exclude group: 'org.slf4j'
   }
 
@@ -96,7 +97,7 @@ dependencies {
   api "com.google.code.gson:gson:2.8.9"
   testImplementation 'junit:junit:4.13.1'
   testImplementation 'org.apache.ant:ant:1.10.12'
-  testImplementation 'org.apache.logging.log4j:log4j-slf4j18-impl:2.16.0'
+  testImplementation "org.apache.logging.log4j:log4j-slf4j18-impl:$log4jVersion"
   testImplementation 'com.google.errorprone:error_prone_annotations:2.10.0'
 
   guiImplementation sourceSets.main.runtimeClasspath


### PR DESCRIPTION
Eclipse plugin unexpectedly contains both 2.15.0 and 2.16.0. This is because the `copyLibsForEclipse` task copies not only runtime dependencies but also test runtime dependencies. And when we release SpotBugs 4.5.2, test runtime dependencies have `log4j-slf4j18-impl` version 2.15.0.

By updating this dependency, we can solve this duplicated libraries in Eclipse plugin. I confirmed that generated `eclipsePlugin/META-INF/MANIFEST.MF` contains no vulnerable libraries as follows:

```
Bundle-ClassPath: .,spotbugs-plugin.jar,lib/asm-9.2.jar,lib/asm-analysis
 -9.2.jar,lib/asm-commons-9.2.jar,lib/asm-tree-9.2.jar,lib/asm-util-9.2.
 jar,lib/bcel-6.5.0.jar,lib/commons-lang3-3.12.0.jar,lib/commons-text-1.
 9.jar,lib/dom4j-2.1.3.jar,lib/error_prone_annotations-2.10.0.jar,lib/gs
 on-2.8.9.jar,lib/jaxen-1.2.0.jar,lib/jcip-annotations-1.0.jar,lib/jsr30
 5-3.0.2.jar,lib/junit-4.13.1.jar,lib/log4j-api-2.16.0.jar,lib/log4j-cor
 e-2.16.0.jar,lib/log4j-slf4j18-impl-2.16.0.jar,lib/slf4j-api-1.8.0-beta
 4.jar,lib/spotbugs-4.5.1-SNAPSHOT-javadoc.jar,lib/spotbugs-4.5.1-SNAPSH
 OT-sources.jar,lib/spotbugs-4.5.2-SNAPSHOT-javadoc.jar,lib/spotbugs-4.5
 .2-SNAPSHOT-sources.jar,lib/spotbugs-annotations-4.5.1-SNAPSHOT-javadoc
 .jar,lib/spotbugs-annotations-4.5.1-SNAPSHOT-sources.jar,lib/spotbugs-a
 nnotations-4.5.2-SNAPSHOT-javadoc.jar,lib/spotbugs-annotations-4.5.2-SN
 APSHOT-sources.jar,lib/spotbugs-annotations.jar,lib/spotbugs.jar
```

refs https://github.com/spotbugs/spotbugs/issues/1868#issuecomment-993710855
