### PR TITLE
Automate management regarding stale PR and issues

### DIFF
--- a/.github/workflows/ticket-management.yml
+++ b/.github/workflows/ticket-management.yml
@@ -1,0 +1,26 @@
+name: 'Automated ticket management'
+on:
+  schedule:
+    # Run the check every day.
+    # We use the release date of the first SpotBugs release,
+    # just to avoid periods of high load.
+    # https://github.com/spotbugs/spotbugs/releases/tag/3.1.0
+    - cron: '25 10 * * *'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale-pr-and-issue:
+    # Mark stale issues and PRs, then close them 30 days later.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4
+        with:
+          days-before-stale: 30
+          days-before-close: 30
+          stale-pr-label: 'Stale'
+          stale-issue-label: 'need info'
+          only-issue-labels: 'need info'
+          exempt-all-pr-assignees: true


### PR DESCRIPTION
Introduce the [`actions/stale` action](https://github.com/actions/stale#stale-pr-label) to automate issue/PR management policy documented by #1856.
This change will run the following operation daily:

1. Label PRs as 'Stale' 30 days the PR has been updated.
2. Close 'Stale' PRs 30 days after the PR has been labeled as 'Stale'.
3. Close 'need info' issues 30 days after the ticket has been labeled as 'need info'.