### PR TITLE
Remove \u200b from FindOverridableMethodCall.visitBootstrapMethods()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased - 2022-??-??
+### Fixed
+- Fixed spotbugs build with ecj compiler ([#1903](https://github.com/spotbugs/spotbugs/issues/1903))
 
 ## 4.5.3 - 2022-01-04
 ### Security

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindOverridableMethodCall.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindOverridableMethodCall.java
@@ -98,7 +98,7 @@ public class FindOverridableMethodCall extends OpcodeStackDetector {
     }
 
     @Override
-    public void visitBootstrapMethods​(BootstrapMethods obj) {
+    public void visitBootstrapMethods(BootstrapMethods obj) {
         if (getXClass().isFinal()) {
             return;
         }


### PR DESCRIPTION
The method ends with `\u200b` unicode character and Eclipse compiler
assumes that this method can't override the visitBootstrapMethods
defined in the org.apache.bcel.classfile.Visitor.visitBootstrapMethods(BootstrapMethods)

Since this character is invisible, it was added by mistake and should be
removed to allow SpotBugs compilation in Eclipse.

This fixes issue #1903.

----


- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
