### PR TITLE
Added new detector for rule LCK06

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Fixed spotbugs build with ecj compiler ([#1903](https://github.com/spotbugs/spotbugs/issues/1903))
 - Moved tests from spotbugs project to spotbugs-tests project ([#1914](https://github.com/spotbugs/spotbugs/issues/1914))
 
+### Added
+* New detector `FindInstanceLockOnSharedStaticData` for new bug type `SSD_DO_NOT_USE_INSTANCE_LOCK_ON_SHARED_STATIC_DATA`. This detector reports a bug if an instance level lock is used to modify a shared static data. (See [SEI CERT rule LCK06-J](https://wiki.sei.cmu.edu/confluence/display/java/LCK06-J.+Do+not+use+an+instance+lock+to+protect+shared+static+data))
+
 ## 4.5.3 - 2022-01-04
 ### Security
 - Bumped log4j from 2.16.0 to 2.17.1 to address [CVE-2021-45105](https://nvd.nist.gov/vuln/detail/CVE-2021-45105) and [CVE-2021-44832](https://nvd.nist.gov/vuln/detail/CVE-2021-44832) ([#1885](https://github.com/spotbugs/spotbugs/pull/1885), [#1897](https://github.com/spotbugs/spotbugs/pull/1897))

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindInstanceLockOnSharedStaticDataCheckTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindInstanceLockOnSharedStaticDataCheckTest.java
@@ -1,0 +1,54 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
+import org.junit.Test;
+
+import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+
+public class FindInstanceLockOnSharedStaticDataCheckTest extends AbstractIntegrationTest {
+
+    @Test
+    public void findSSDBugInClass_InstanceLevelLockOnSharedStaticData() {
+        performAnalysis("instanceLockOnSharedStaticData/InstanceLevelLockObject.class");
+
+        assertNumOfSSDBugs(1);
+
+        assertSSDBug("InstanceLevelLockObject", "methodWithBug", 12);
+    }
+
+    @Test
+    public void findSSDBugInClass_InstanceLevelSynchronizedMethod() {
+        performAnalysis("instanceLockOnSharedStaticData/InstanceLevelSynchronizedMethod.class");
+
+        assertNumOfSSDBugs(1);
+
+        assertSSDBug("InstanceLevelSynchronizedMethod", "methodWithBug", 10);
+    }
+
+    @Test
+    public void findNoSSDBugInClass_StaticLockObjectOnStaticSharedData() {
+        performAnalysis("instanceLockOnSharedStaticData/StaticLockObjectOnStaticSharedData.class");
+
+        assertNumOfSSDBugs(0);
+    }
+
+    private void assertNumOfSSDBugs(int num) {
+        final BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
+                .bugType("SSD_DO_NOT_USE_INSTANCE_LOCK_ON_SHARED_STATIC_DATA").build();
+        assertThat(getBugCollection(), containsExactly(num, bugTypeMatcher));
+    }
+
+    private void assertSSDBug(String className, String methodName, int line) {
+        final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
+                .bugType("SSD_DO_NOT_USE_INSTANCE_LOCK_ON_SHARED_STATIC_DATA")
+                .inClass(className)
+                .inMethod(methodName)
+                .atLine(line)
+                .build();
+        assertThat(getBugCollection(), hasItem(bugInstanceMatcher));
+    }
+}

--- a/spotbugs/etc/findbugs.xml
+++ b/spotbugs/etc/findbugs.xml
@@ -657,6 +657,8 @@
                     reports="REFLC_REFLECTION_MAY_INCREASE_ACCESSIBILITY_OF_CLASS,REFLF_REFLECTION_MAY_INCREASE_ACCESSIBILITY_OF_FIELD"/>
           <Detector class="edu.umd.cs.findbugs.detect.FindOverridableMethodCall"
                     reports="MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR,MC_OVERRIDABLE_METHOD_CALL_IN_CLONE"/>
+          <Detector class="edu.umd.cs.findbugs.detect.FindInstanceLockOnSharedStaticData" speed="fast"
+                    reports="SSD_DO_NOT_USE_INSTANCE_LOCK_ON_SHARED_STATIC_DATA"/>
             <!-- Bug Categories -->
            <BugCategory category="NOISE" hidden="true"/>
 
@@ -1266,4 +1268,5 @@
           <BugPattern abbrev="REFLF" type="REFLF_REFLECTION_MAY_INCREASE_ACCESSIBILITY_OF_FIELD" category="MALICIOUS_CODE" />
           <BugPattern abbrev="MC" type="MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR" category="MALICIOUS_CODE" />
           <BugPattern abbrev="MC" type="MC_OVERRIDABLE_METHOD_CALL_IN_CLONE" category="MALICIOUS_CODE" />
+          <BugPattern abbrev="SSD" type="SSD_DO_NOT_USE_INSTANCE_LOCK_ON_SHARED_STATIC_DATA" category="CORRECTNESS" />
 </FindbugsPlugin>

--- a/spotbugs/etc/messages.xml
+++ b/spotbugs/etc/messages.xml
@@ -1718,6 +1718,21 @@ factory pattern to create these objects.</p>
       ]]>
     </Details>
   </Detector>
+  <Detector class="edu.umd.cs.findbugs.detect.FindInstanceLockOnSharedStaticData">
+    <Details>
+      <![CDATA[
+            <p>
+              Detector for patterns where a shared static data is modified by either an instance level non-static synchronized
+              method, or inside a synchronized block, which used a non-static lock object.
+            </p>
+            <p>
+               Programs must not use instance locks to protect static shared data because instance locks are ineffective
+               when two or more instances of the class are created.
+               Consequently, failure to use a static lock object leaves the shared state unprotected against concurrent access.
+            </p>
+      ]]>
+    </Details>
+  </Detector>
   <!--
   **********************************************************************
   BugPatterns
@@ -8612,6 +8627,20 @@ after the call to initLogging, the logger configuration is lost
       </p>]]>
     </Details>
   </BugPattern>
+  <BugPattern type="SSD_DO_NOT_USE_INSTANCE_LOCK_ON_SHARED_STATIC_DATA">
+    <ShortDescription>Instance level lock was used on a shared static data</ShortDescription>
+    <LongDescription>Static field "{1}" is modified by an instance level {2}.</LongDescription>
+    <Details>
+      <![CDATA[<p>
+        Instance level synchronization, that modifies a static shared object could cause security leaks.
+        If the lock or the method is not static, that modifies the static field, and is synchronized,
+        that could leave the shared static data unprotected against concurrent access.
+        This could occur in two ways, if a synchronization method uses a non-static lock object,
+        or a synchronized method is declared as non-static. Both ways are ineffective.
+        Best solution is to use a private static final lock object to secure the shared static data.
+      </p>]]>
+    </Details>
+  </BugPattern>
   <!--
   **********************************************************************
    BugCodes
@@ -8761,4 +8790,5 @@ after the call to initLogging, the logger configuration is lost
   <BugCode abbrev="REFLC">Reflection increasing accessibility of classes</BugCode>
   <BugCode abbrev="REFLF">Reflection increasing accessibility of fields</BugCode>
   <BugCode abbrev="MC">Dangerous call to overridable method</BugCode>
+  <BugCode abbrev="SSD">Do not use an instance lock to protect shared static data</BugCode>
 </MessageCollection>

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindInstanceLockOnSharedStaticData.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindInstanceLockOnSharedStaticData.java
@@ -1,0 +1,105 @@
+/*
+ * SpotBugs - Find bugs in Java programs
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.BugAccumulator;
+import edu.umd.cs.findbugs.BugInstance;
+import edu.umd.cs.findbugs.BugReporter;
+import edu.umd.cs.findbugs.OpcodeStack;
+import edu.umd.cs.findbugs.ba.XField;
+import edu.umd.cs.findbugs.ba.XMethod;
+import edu.umd.cs.findbugs.bcel.OpcodeStackDetector;
+import org.apache.bcel.Const;
+import org.apache.bcel.classfile.JavaClass;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+public class FindInstanceLockOnSharedStaticData extends OpcodeStackDetector {
+
+    private final BugAccumulator bugAccumulator;
+    private boolean isInsideSynchronizedBlock;
+    private Optional<XField> maybeLockObject;
+
+    public FindInstanceLockOnSharedStaticData(BugReporter bugReporter) {
+        this.bugAccumulator = new BugAccumulator(bugReporter);
+        isInsideSynchronizedBlock = false;
+        maybeLockObject = Optional.empty();
+    }
+
+    @Override
+    public void sawOpcode(int seen) {
+
+        if (seen == Const.MONITORENTER) {
+            isInsideSynchronizedBlock = true;
+            OpcodeStack.Item lockObject = stack.getStackItem(0);
+            maybeLockObject = Optional.ofNullable(lockObject.getXField());
+            return;
+        } else if (seen == Const.MONITOREXIT) {
+            isInsideSynchronizedBlock = false;
+            maybeLockObject = Optional.empty();
+            return;
+        }
+
+        if (seen == Const.PUTSTATIC) {
+            XMethod modificationMethod = getXMethod();
+            Optional<XField> fieldToModify = Optional.ofNullable(getXFieldOperand());
+            if (fieldToModify.isPresent() && modificationMethod.isSynchronized() && !modificationMethod.isStatic()) {
+                bugAccumulator.accumulateBug(
+                        new BugInstance(this, "SSD_DO_NOT_USE_INSTANCE_LOCK_ON_SHARED_STATIC_DATA", NORMAL_PRIORITY)
+                                .addClassAndMethod(this)
+                                .addMethod(modificationMethod)
+                                .addField(fieldToModify.get())
+                                .addString(fieldToModify.get().getName())
+                                .addString("synchronized method"),
+                        this);
+                return;
+            }
+
+            boolean isLockObjectAppropriate = maybeLockObject.map(XField::isStatic).orElse(false);
+            if (fieldToModify.isPresent() && isInsideSynchronizedBlock && !isLockObjectAppropriate) {
+                bugAccumulator.accumulateBug(
+                        new BugInstance(this, "SSD_DO_NOT_USE_INSTANCE_LOCK_ON_SHARED_STATIC_DATA", NORMAL_PRIORITY)
+                                .addClassAndMethod(this)
+                                .addMethod(modificationMethod)
+                                .addField(fieldToModify.get())
+                                .addString(fieldToModify.get().getName())
+                                .addString("synchronization lock"),
+                        this);
+            }
+        }
+
+    }
+
+    @Override
+    public void visitAfter(JavaClass obj) {
+        bugAccumulator.reportAccumulatedBugs();
+    }
+
+    @Override
+    public void visit(JavaClass obj) {
+        boolean classIsInteresting = Stream.of(obj.getFields()).anyMatch(field -> field.isStatic() && !field.isFinal());
+        if (classIsInteresting) {
+            isInsideSynchronizedBlock = false;
+            maybeLockObject = Optional.empty();
+            super.visit(obj);
+        }
+    }
+
+}

--- a/spotbugsTestCases/src/java/instanceLockOnSharedStaticData/InstanceLevelLockObject.java
+++ b/spotbugsTestCases/src/java/instanceLockOnSharedStaticData/InstanceLevelLockObject.java
@@ -1,0 +1,15 @@
+package instanceLockOnSharedStaticData;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+public class InstanceLevelLockObject {
+    private static int counter;
+    private final Object lock = new Object();
+
+    @SuppressFBWarnings("ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD")
+    public void methodWithBug() {
+        synchronized (lock) {
+            counter++;
+        }
+    }
+}

--- a/spotbugsTestCases/src/java/instanceLockOnSharedStaticData/InstanceLevelSynchronizedMethod.java
+++ b/spotbugsTestCases/src/java/instanceLockOnSharedStaticData/InstanceLevelSynchronizedMethod.java
@@ -1,0 +1,12 @@
+package instanceLockOnSharedStaticData;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+public class InstanceLevelSynchronizedMethod {
+    private static volatile int counter;
+
+    @SuppressFBWarnings("ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD")
+    public synchronized void methodWithBug() {
+        counter++;
+    }
+}

--- a/spotbugsTestCases/src/java/instanceLockOnSharedStaticData/StaticLockObjectOnStaticSharedData.java
+++ b/spotbugsTestCases/src/java/instanceLockOnSharedStaticData/StaticLockObjectOnStaticSharedData.java
@@ -1,0 +1,16 @@
+package instanceLockOnSharedStaticData;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+public class StaticLockObjectOnStaticSharedData {
+    private static int counter;
+    private static final Object lock = new Object();
+
+    @SuppressFBWarnings("ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD")
+    public void methodWithoutBugs() {
+        synchronized (lock) {
+            counter++;
+        }
+    }
+
+}


### PR DESCRIPTION
Introducing a new detector for CERT rule [LCK06](https://wiki.sei.cmu.edu/confluence/display/java/LCK06-J.+Do+not+use+an+instance+lock+to+protect+shared+static+data). The point of this detector is to not use instance level lock to protect shared static data. This can occur in two different ways:
* using a nonstatic lock object
* using a nonstatic synchronized method

To test the detector, added a test class with the following test cases:
* Static field modification from **instance level** `synchronized` method
* Static field modification from a `snychronized` block whit an **instance level** lock object
* Static field modification from a `synchronized` block with a `static final` lock object

Changes:
* Aligned `CHANGELOG.md`
* Added new detector in `spotbugs` project
* Added new test in `spotbugs-tests` project
* Added test cases under `spotbugs/spotbugsTestCases/src/java/instanceLockOnSharedStaticData`
* Added the required descriptions to `findbugs.xml` and `messages.xml`

- [X] As the [contributing guideline](https://github.com/spotbugs/spotbugs/blob/31375986d170956c5a26f657752879b282601c1f/.github/CONTRIBUTING.md) says, I ran `./gradlew spotlessApply build smoketest` locally