### PR TITLE
Eclipse: fix freezes in decorator due marker queries on UI thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 ### Fixed
 - Fixed spotbugs build with ecj compiler ([#1903](https://github.com/spotbugs/spotbugs/issues/1903))
 - Moved tests from spotbugs project to spotbugs-tests project ([#1914](https://github.com/spotbugs/spotbugs/issues/1914))
+- Fixed UI freezes in Eclipse on bug count decorations update ([#285](https://github.com/spotbugs/spotbugs/issues/285))
 
 ### Added
 * New detector `FindInstanceLockOnSharedStaticData` for new bug type `SSD_DO_NOT_USE_INSTANCE_LOCK_ON_SHARED_STATIC_DATA`. This detector reports a bug if an instance level lock is used to modify a shared static data. (See [SEI CERT rule LCK06-J](https://wiki.sei.cmu.edu/confluence/display/java/LCK06-J.+Do+not+use+an+instance+lock+to+protect+shared+static+data))

--- a/eclipsePlugin/src/de/tobject/findbugs/builder/WorkItem.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/builder/WorkItem.java
@@ -381,6 +381,13 @@ public class WorkItem {
         return Archive.isArchiveFileName(file.getName());
     }
 
+    /**
+     * @return true if this work item corresponds to a project
+     */
+    public boolean isProject() {
+        return resource instanceof IProject || javaElt instanceof IJavaProject;
+    }
+
     @Override
     public String toString() {
         return getName();

--- a/eclipsePlugin/src/de/tobject/findbugs/decorators/ResourceBugCountDecorator.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/decorators/ResourceBugCountDecorator.java
@@ -18,12 +18,32 @@
  */
 package de.tobject.findbugs.decorators;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.ListenerList;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jface.viewers.ILabelDecorator;
 import org.eclipse.jface.viewers.ILabelProviderListener;
+import org.eclipse.jface.viewers.LabelProviderChangedEvent;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.ui.IWorkingSet;
+import org.eclipse.ui.progress.WorkbenchJob;
 
 import de.tobject.findbugs.builder.ResourceUtils;
 import de.tobject.findbugs.builder.WorkItem;
@@ -34,9 +54,261 @@ import de.tobject.findbugs.util.Util;
  * resources. There are 3 different decorators configured via plugin.xml
  * (project/folder/file), current implementation is the same for all.
  *
- * @author Andrei
+ * @author Andrey
  */
 public class ResourceBugCountDecorator implements ILabelDecorator {
+
+    final class BugCountUpdateJob extends WorkbenchJob {
+
+        private final Set<WorkItem> queue;
+
+        public BugCountUpdateJob() {
+            super("Bug count decoration update..."); //$NON-NLS-1$
+            this.queue = ConcurrentHashMap.newKeySet();
+            setSystem(true);
+            setPriority(DECORATE);
+        }
+
+        @Override
+        public boolean belongsTo(Object family) {
+            return ResourceBugCountDecorator.class == family;
+        }
+
+        @Override
+        public IStatus runInUIThread(IProgressMonitor monitor) {
+            List<WorkItem> changed = new ArrayList<>(queue);
+            queue.removeAll(changed);
+            Set<IResource> set = changed.stream().map(WorkItem::getProject).filter(Objects::nonNull)
+                    .collect(Collectors.toSet());
+            if (!set.isEmpty()) {
+                fireProblemsChanged(set.toArray(new IResource[set.size()]));
+            }
+            if (monitor.isCanceled()) {
+                queue.clear();
+                return Status.CANCEL_STATUS;
+            } else if (!queue.isEmpty()) {
+                schedule(100);
+            }
+            return Status.OK_STATUS;
+        }
+
+        void schedule(Set<WorkItem> resources) {
+            if (queue.addAll(resources)) {
+                schedule(100);
+            }
+        }
+    }
+
+    static final class BugCountCacheManager {
+
+        static final BugCountCacheManager instance = new BugCountCacheManager();
+
+        final Set<ResourceBugCountDecorator> listeners;
+
+        /**
+         * Cache for projects status, key is resource, value is known bug count
+         */
+        final Map<IProject, Integer> bugCountCache;
+
+        /** Job to compute bug counts for container resources in background */
+        final BugCountCalculationJob bugCountJob;
+
+        public BugCountCacheManager() {
+            bugCountCache = new ConcurrentHashMap<>();
+            bugCountJob = new BugCountCalculationJob();
+            listeners = Collections.synchronizedSet(new LinkedHashSet<>());
+        }
+
+        static void scheduleTask(Set<WorkItem> resources, BugCountUpdateJob uiUpdate) {
+            for (WorkItem workItem : resources) {
+                scheduleTask(workItem, uiUpdate);
+            }
+        }
+
+        static void scheduleTask(WorkItem workItem, BugCountUpdateJob uiUpdate) {
+            instance.bugCountJob.schedule(new BugCountTask(workItem), uiUpdate);
+        }
+
+        static Integer getBugCount(IProject project) {
+            return instance.bugCountCache.get(project);
+        }
+
+        static Integer setBugCount(IProject project, int bugCount) {
+            return instance.bugCountCache.put(project, Integer.valueOf(bugCount));
+        }
+
+        static void register(ResourceBugCountDecorator decorator) {
+            instance.listeners.add(decorator);
+        }
+
+        static void deregister(ResourceBugCountDecorator decorator) {
+            instance.listeners.remove(decorator);
+            if (instance.listeners.isEmpty()) {
+                instance.bugCountJob.cancel();
+                instance.bugCountCache.clear();
+            }
+        }
+    }
+
+    static final class BugCountCalculationJob extends Job {
+
+        private final LinkedHashMap<BugCountTask, Set<BugCountUpdateJob>> queue;
+
+        public BugCountCalculationJob() {
+            super("Bug count decoration calculation..."); //$NON-NLS-1$
+            this.queue = new LinkedHashMap<>();
+            setSystem(true);
+            setPriority(DECORATE);
+        }
+
+        @Override
+        public boolean belongsTo(Object family) {
+            return ResourceBugCountDecorator.class == family;
+        }
+
+        @Override
+        protected IStatus run(IProgressMonitor monitor) {
+            Map<BugCountUpdateJob, Set<WorkItem>> changed = new LinkedHashMap<>();
+            Entry<BugCountTask, Set<BugCountUpdateJob>> next;
+            while ((next = poll()) != null && !monitor.isCanceled()) {
+                BugCountTask task = next.getKey();
+                task.run();
+                if (task.isBugCountChanged()) {
+                    final WorkItem resource = task.workItem;
+                    Set<BugCountUpdateJob> jobs = next.getValue();
+                    for (BugCountUpdateJob job : jobs) {
+                        changed.compute(job, (k, v) -> {
+                            if (v == null) {
+                                v = new LinkedHashSet<>();
+                            }
+                            v.add(resource);
+                            return v;
+                        });
+                    }
+                }
+            }
+            if (!changed.isEmpty() && !monitor.isCanceled()) {
+                for (Entry<BugCountUpdateJob, Set<WorkItem>> entry : changed.entrySet()) {
+                    BugCountUpdateJob job = entry.getKey();
+                    Set<WorkItem> resources = entry.getValue();
+                    job.schedule(resources);
+                }
+            }
+            synchronized (queue) {
+                if (monitor.isCanceled()) {
+                    queue.clear();
+                    return Status.CANCEL_STATUS;
+                } else if (!queue.isEmpty()) {
+                    schedule(100);
+                }
+            }
+            return Status.OK_STATUS;
+        }
+
+        private Entry<BugCountTask, Set<BugCountUpdateJob>> poll() {
+            Entry<BugCountTask, Set<BugCountUpdateJob>> next = null;
+            synchronized (queue) {
+                if (!queue.isEmpty()) {
+                    Iterator<Entry<BugCountTask, Set<BugCountUpdateJob>>> iterator = queue.entrySet().iterator();
+                    next = iterator.next();
+                    iterator.remove();
+                }
+            }
+            return next;
+        }
+
+        void schedule(BugCountTask task, BugCountUpdateJob job) {
+            synchronized (queue) {
+                queue.compute(task, (k, v) -> {
+                    if (v == null) {
+                        v = new LinkedHashSet<>();
+                    }
+                    if (v.add(job)) {
+                        schedule(100);
+                    }
+                    return v;
+                });
+            }
+        }
+    }
+
+    static final class BugCountTask {
+
+        final WorkItem workItem;
+        volatile int oldBugCount;
+        volatile int newBugCount;
+
+        public BugCountTask(WorkItem workItem) {
+            this.workItem = workItem;
+        }
+
+        @Override
+        public int hashCode() {
+            return workItem.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (!(obj instanceof BugCountTask)) {
+                return false;
+            }
+            BugCountTask other = (BugCountTask) obj;
+            return workItem.equals(other.workItem);
+        }
+
+        void run() {
+            IProject project = workItem.getProject();
+            if (project == null) {
+                return;
+            }
+            try {
+                newBugCount = workItem.getMarkerCount(true);
+            } finally {
+                Integer old = BugCountCacheManager.setBugCount(project, newBugCount);
+                if (old != null) {
+                    oldBugCount = old.intValue();
+                }
+            }
+        }
+
+        boolean isBugCountChanged() {
+            return newBugCount != oldBugCount;
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder builder = new StringBuilder();
+            builder.append("BugCountTask ["); //$NON-NLS-1$
+            if (workItem != null) {
+                builder.append("resource="); //$NON-NLS-1$
+                builder.append(workItem);
+                builder.append(", "); //$NON-NLS-1$
+            }
+            builder.append("newBugCount="); //$NON-NLS-1$
+            builder.append(newBugCount);
+            builder.append(", oldBugCount="); //$NON-NLS-1$
+            builder.append(oldBugCount);
+            builder.append("]"); //$NON-NLS-1$
+            return builder.toString();
+        }
+    }
+
+    private final ListenerList<ILabelProviderListener> listeners;
+
+    /** Job to update bug counts for container resources in UI thread */
+    private final BugCountUpdateJob bugCountUpdateJob;
+
+    /**
+     * Default constructor
+     */
+    public ResourceBugCountDecorator() {
+        listeners = new ListenerList<>();
+        bugCountUpdateJob = new BugCountUpdateJob();
+        BugCountCacheManager.register(this);
+    }
 
     @Override
     public Image decorateImage(Image image, Object element) {
@@ -53,7 +325,7 @@ public class ResourceBugCountDecorator implements ILabelDecorator {
             }
             return text;
         }
-        return decorateText(text, item.getMarkerCount(false));
+        return decorateText(text, getMarkerCount(item));
     }
 
     private static String decorateText(String text, int markerCount) {
@@ -63,23 +335,42 @@ public class ResourceBugCountDecorator implements ILabelDecorator {
         return text + " (" + markerCount + ")";
     }
 
-    private static String decorateText(String text, IWorkingSet workingSet) {
+    private String decorateText(String text, IWorkingSet workingSet) {
         Set<WorkItem> resources = ResourceUtils.getResources(workingSet);
         int markerCount = 0;
         for (WorkItem workItem : resources) {
-            markerCount += workItem.getMarkerCount(true);
+            markerCount += getMarkerCount(workItem);
         }
         return decorateText(text, markerCount);
     }
 
+    private int getMarkerCount(WorkItem workItem) {
+        if (workItem.isProject() && workItem.getProject() != null) {
+            Integer cachedCount = BugCountCacheManager.getBugCount(workItem.getProject());
+            BugCountCacheManager.scheduleTask(workItem, bugCountUpdateJob);
+            return cachedCount != null ? cachedCount.intValue() : 0;
+        }
+        return workItem.getMarkerCount(false);
+    }
+
+    void fireProblemsChanged(IResource[] changedResources) {
+        if (!listeners.isEmpty()) {
+            LabelProviderChangedEvent event = new LabelProviderChangedEvent(this, changedResources);
+            for (ILabelProviderListener listener : listeners) {
+                listener.labelProviderChanged(event);
+            }
+        }
+    }
+
     @Override
     public void addListener(ILabelProviderListener listener) {
-        // noop
+        listeners.add(listener);
     }
 
     @Override
     public void dispose() {
-        // noop
+        BugCountCacheManager.deregister(this);
+        listeners.clear();
     }
 
     @Override
@@ -89,7 +380,7 @@ public class ResourceBugCountDecorator implements ILabelDecorator {
 
     @Override
     public void removeListener(ILabelProviderListener listener) {
-        // noop
+        listeners.remove(listener);
     }
 
 }

--- a/eclipsePlugin/src/de/tobject/findbugs/reporter/MarkerReporter.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/reporter/MarkerReporter.java
@@ -125,6 +125,9 @@ public class MarkerReporter implements IWorkspaceRunnable {
                 oldMarker.delete();
             }
         }
+        // XXX With Eclipse 4.19, we could use *single* method to create marker with attribures
+        // see https://bugs.eclipse.org/bugs/show_bug.cgi?id=570914
+        // We can use that once we have 4.19 as minimum platform
         IMarker newMarker = markerTarget.createMarker(mp.markerType);
         newMarker.setAttributes(attributes);
     }

--- a/eclipsePlugin/src/de/tobject/findbugs/reporter/MarkerUtil.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/reporter/MarkerUtil.java
@@ -36,6 +36,7 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IResourceStatus;
 import org.eclipse.core.resources.WorkspaceJob;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IAdaptable;
@@ -48,6 +49,7 @@ import org.eclipse.jdt.core.IField;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IOpenable;
+import org.eclipse.jdt.core.IOrdinaryClassFile;
 import org.eclipse.jdt.core.IParent;
 import org.eclipse.jdt.core.ISourceRange;
 import org.eclipse.jdt.core.IType;
@@ -578,7 +580,10 @@ public final class MarkerUtil {
                 return DetectorFactoryCollection.instance().getBugCode((String) bugCode);
             }
         } catch (CoreException e) {
-            FindbugsPlugin.getDefault().logException(e, "Marker does not contain bug code");
+            int errorCode = e.getStatus().getCode();
+            if (errorCode != IResourceStatus.MARKER_NOT_FOUND && errorCode != IResourceStatus.RESOURCE_NOT_FOUND) {
+                FindbugsPlugin.getDefault().logException(e, "Marker does not contain bug code");
+            }
             return null;
         }
         return null;
@@ -614,7 +619,10 @@ public final class MarkerUtil {
         try {
             return (String) marker.getAttribute(FindBugsMarker.BUG_TYPE);
         } catch (CoreException e) {
-            FindbugsPlugin.getDefault().logException(e, "Marker does not contain pattern id");
+            int errorCode = e.getStatus().getCode();
+            if (errorCode != IResourceStatus.MARKER_NOT_FOUND && errorCode != IResourceStatus.RESOURCE_NOT_FOUND) {
+                FindbugsPlugin.getDefault().logException(e, "Marker does not contain pattern id");
+            }
             return null;
         }
     }
@@ -626,7 +634,10 @@ public final class MarkerUtil {
                 return JavaCore.create((String) elementId);
             }
         } catch (CoreException e) {
-            FindbugsPlugin.getDefault().logException(e, "Marker does not contain valid java element id");
+            int errorCode = e.getStatus().getCode();
+            if (errorCode != IResourceStatus.MARKER_NOT_FOUND && errorCode != IResourceStatus.RESOURCE_NOT_FOUND) {
+                FindbugsPlugin.getDefault().logException(e, "Marker does not contain valid java element id");
+            }
             return null;
         }
         return null;
@@ -639,7 +650,10 @@ public final class MarkerUtil {
                 return DetectorFactoryCollection.instance().getPluginById((String) pluginId);
             }
         } catch (CoreException e) {
-            FindbugsPlugin.getDefault().logException(e, "Marker does not contain valid plugin id");
+            int errorCode = e.getStatus().getCode();
+            if (errorCode != IResourceStatus.MARKER_NOT_FOUND && errorCode != IResourceStatus.RESOURCE_NOT_FOUND) {
+                FindbugsPlugin.getDefault().logException(e, "Marker does not contain valid plugin id");
+            }
             return null;
         }
         return null;
@@ -669,7 +683,10 @@ public final class MarkerUtil {
                     markers.add(marker);
                 }
             } catch (CoreException e) {
-                FindbugsPlugin.getDefault().logException(e, "Marker does not contain valid java element id");
+                int errorCode = e.getStatus().getCode();
+                if (errorCode != IResourceStatus.MARKER_NOT_FOUND && errorCode != IResourceStatus.RESOURCE_NOT_FOUND) {
+                    FindbugsPlugin.getDefault().logException(e, "Marker does not contain valid java element id");
+                }
                 continue;
             }
         }
@@ -882,10 +899,10 @@ public final class MarkerUtil {
             allMarkers = getMarkers(resource, IResource.DEPTH_ZERO);
         } else {
             IClassFile classFile = (IClassFile) editor.getEditorInput().getAdapter(IClassFile.class);
-            if (classFile == null) {
+            if (!(classFile instanceof IOrdinaryClassFile)) {
                 return null;
             }
-            Set<IMarker> markers = getMarkers(classFile.getType());
+            Set<IMarker> markers = getMarkers(((IOrdinaryClassFile) classFile).getType());
             allMarkers = markers.toArray(new IMarker[markers.size()]);
         }
         // if editor contains only one FB marker, do some cheating and always
@@ -954,7 +971,10 @@ public final class MarkerUtil {
                     marker.exists() &&
                     marker.isSubtypeOf(FindBugsMarker.NAME);
         } catch (CoreException e) {
-            FindbugsPlugin.getDefault().logException(e, "Exception while checking SpotBugs type on marker.");
+            int errorCode = e.getStatus().getCode();
+            if (errorCode != IResourceStatus.MARKER_NOT_FOUND && errorCode != IResourceStatus.RESOURCE_NOT_FOUND) {
+                FindbugsPlugin.getDefault().logException(e, "Exception while checking SpotBugs type on marker.");
+            }
         }
         return false;
     }
@@ -997,7 +1017,10 @@ public final class MarkerUtil {
         try {
             return fileOrFolder.findMarkers(FindBugsMarker.NAME, true, depth);
         } catch (CoreException e) {
-            FindbugsPlugin.getDefault().logException(e, "Cannot collect SpotBugs warnings from: " + fileOrFolder);
+            int errorCode = e.getStatus().getCode();
+            if (errorCode != IResourceStatus.MARKER_NOT_FOUND && errorCode != IResourceStatus.RESOURCE_NOT_FOUND) {
+                FindbugsPlugin.getDefault().logException(e, "Cannot collect SpotBugs warnings from: " + fileOrFolder);
+            }
         }
         return EMPTY;
     }


### PR DESCRIPTION
See for detailed discussion and used solution approach
https://bugs.eclipse.org/bugs/show_bug.cgi?id=450663#c69

In short: one should not run any resource related operations on UI
thread while decorating bug counts, because resource operations can take
longer and UI will be frozen.

The patch ports basically JDT fix for ProblemsLabelDecorator (see
https://git.eclipse.org/r/c/jdt/eclipse.jdt.ui/+/190484) into the
Spotbugs ResourceBugCountDecorator. The "only" difference is that we
don't care about markers severities but want markers count, the rest is
almost identical.

Fixes issue #285



----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
