### PR TITLE
Excluded locking on java.lang.Class objects from SSD bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 ### Fixed
 - Bumped Saxon-HE from 10.6 to 11.2 ([#1955](https://github.com/spotbugs/spotbugs/pull/1955))
 - Fixed traversal of nested archives governed by `-nested:true` ([#1930](https://github.com/spotbugs/spotbugs/pull/1930))
+- Fixed false positive SSD bug for locking on java.lang.Class objects ([#1978](https://github.com/spotbugs/spotbugs/issues/1978))
 
 ## 4.6.0 - 2022-03-08
 ### Fixed

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindInstanceLockOnSharedStaticDataCheckTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindInstanceLockOnSharedStaticDataCheckTest.java
@@ -30,6 +30,13 @@ public class FindInstanceLockOnSharedStaticDataCheckTest extends AbstractIntegra
     }
 
     @Test
+    public void findNoSSDBugInClass_LockingOnJavaLangClassObject() {
+        performAnalysis("instanceLockOnSharedStaticData/LockingOnJavaLangClassObject.class");
+
+        assertNumOfSSDBugs(0);
+    }
+
+    @Test
     public void findNoSSDBugInClass_StaticLockObjectOnStaticSharedData() {
         performAnalysis("instanceLockOnSharedStaticData/StaticLockObjectOnStaticSharedData.class");
 

--- a/spotbugsTestCases/src/java/instanceLockOnSharedStaticData/LockingOnJavaLangClassObject.java
+++ b/spotbugsTestCases/src/java/instanceLockOnSharedStaticData/LockingOnJavaLangClassObject.java
@@ -1,0 +1,11 @@
+package instanceLockOnSharedStaticData;
+
+public class LockingOnJavaLangClassObject {
+    private static int counter = 0;
+
+    public static int incrementCounter() {
+        synchronized (LockingOnJavaLangClassObject.class) {
+            return counter++;
+        }
+    }
+}


### PR DESCRIPTION
Fixed bug reported by [issue-1978](https://github.com/spotbugs/spotbugs/issues/1978).

SSD bug instance does not get reported if the lock object is from `java.lang.Class`, since there is only a single instance of the class object.

- Extended unit tests with a test case for such scenario
- Aligned `CHANGELOG.md`
