### PR TITLE
fix: let Plugin implement AutoCloseable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 ## Unreleased - 2022-??-??
 ### Changed
 - Updated documentation by adding parenthesis `()` to the negative odd check message ([#1995](https://github.com/spotbugs/spotbugs/issues/1995))
+- Let the Plugin class implement AutoCloseable so we can release the .jar file ([#2024](https://github.com/spotbugs/spotbugs/issues/2024))
 
 ### Fixed
 - Bumped Saxon-HE from 10.6 to 11.3 ([#1955](https://github.com/spotbugs/spotbugs/pull/1955), [#1999](https://github.com/spotbugs/spotbugs/pull/1999))

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/Plugin.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/Plugin.java
@@ -20,10 +20,12 @@
 package edu.umd.cs.findbugs;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -53,7 +55,7 @@ import edu.umd.cs.findbugs.util.DualKeyHashMap;
  * @see PluginLoader
  * @author David Hovemeyer
  */
-public class Plugin {
+public class Plugin implements AutoCloseable {
 
 
     private static final String USE_FINDBUGS_VERSION = "USE_FINDBUGS_VERSION";
@@ -696,4 +698,12 @@ public class Plugin {
         DetectorFactoryCollection.instance().unLoadPlugin(plugin);
     }
 
+    /**
+     * Closes the underlying {@link PluginLoader}, in turn this closes the {@link URLClassLoader}.
+     * When loading a custom plugin from a .jar file this method needs to be called to release the reference on that file.
+     */
+    @Override
+    public void close() throws IOException {
+        pluginLoader.close();
+    }
 }


### PR DESCRIPTION
Proposed fix for https://github.com/spotbugs/spotbugs/issues/2024

When a custom plugin is loaded from a .jar file PluginLoader creates URLClassLoader and never closes it. This leaves a lock (a RandomAccessFile) on the .jar file and it cannot be deleted or renamed until the JVM process stops.

Keep track of the URLClassLoader created by the PluginLoader so we can close them when we are done with the Plugin


It is up to the code using these custom plugins to call `.close()` once the analysis is completed. The current code uses static initialization for the core plugin so I couldn't find a clean way (for instance using try-with-resources blocks) to close the plugins.

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
