### PR TITLE
Avoid unnecessary false positives generated by the recently introduce…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 ## Unreleased - 2022-??-??
 ### Fixed
 - Fixed False positives for `RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE` on try-with-resources with interface references ([#1931](https://github.com/spotbugs/spotbugs/issues/1931))
+- Fixed False positives for `THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION` and `THROWS_METHOD_THROWS_CLAUSE_THROWABLE` on evaluating synthetic classes ([#2040](https://github.com/spotbugs/spotbugs/issues/2040))
 
 ## 4.7.0 - 2022-04-14
 ### Changed

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/ThrowingExceptionsTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/ThrowingExceptionsTest.java
@@ -10,7 +10,7 @@ import edu.umd.cs.findbugs.AbstractIntegrationTest;
 import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
 import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
-public class CheckThrowingExceptions extends AbstractIntegrationTest {
+public class ThrowingExceptionsTest extends AbstractIntegrationTest {
     @Test
     public void throwingExceptionsTests() {
         performAnalysis("MethodsThrowingExceptions.class");
@@ -26,6 +26,13 @@ public class CheckThrowingExceptions extends AbstractIntegrationTest {
         assertNumOfTHROWSBugs("THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION", 0, "MethodsThrowingExceptions", "methodThrowingIOException");
 
         assertNumOfTHROWSBugs("THROWS_METHOD_THROWS_CLAUSE_THROWABLE", 1, "MethodsThrowingExceptions", "methodThrowingThrowable");
+    }
+
+    @Test
+    public void testNestedInterface() {
+        performAnalysis("MethodsThrowingExceptions$ThrowThrowable.class");
+
+        assertNumOfTHROWSBugs("THROWS_METHOD_THROWS_CLAUSE_THROWABLE", 1);
     }
 
     private void assertNumOfTHROWSBugs(String bugType, int num) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ThrowingExceptions.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ThrowingExceptions.java
@@ -20,15 +20,21 @@ public class ThrowingExceptions extends OpcodeStackDetector {
 
     @Override
     public void visit(Method obj) {
+        if (obj.isSynthetic()) {
+            return;
+        }
+
         ExceptionTable exceptionTable = obj.getExceptionTable();
-        if (exceptionTable != null) {
-            String[] exceptionNames = exceptionTable.getExceptionNames();
-            for (String exception : exceptionNames) {
-                if ("java.lang.Exception".equals(exception)) {
-                    reportBug("THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION", getXMethod());
-                } else if ("java.lang.Throwable".equals(exception)) {
-                    reportBug("THROWS_METHOD_THROWS_CLAUSE_THROWABLE", getXMethod());
-                }
+        if (exceptionTable == null) {
+            return;
+        }
+
+        String[] exceptionNames = exceptionTable.getExceptionNames();
+        for (String exception : exceptionNames) {
+            if ("java.lang.Exception".equals(exception)) {
+                reportBug("THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION", getXMethod());
+            } else if ("java.lang.Throwable".equals(exception)) {
+                reportBug("THROWS_METHOD_THROWS_CLAUSE_THROWABLE", getXMethod());
             }
         }
     }

--- a/spotbugsTestCases/src/java/MethodsThrowingExceptions.java
+++ b/spotbugsTestCases/src/java/MethodsThrowingExceptions.java
@@ -1,5 +1,7 @@
 import java.io.IOException;
+import java.util.concurrent.Callable;
 
+@SuppressWarnings({"RedundantThrows", "unused", "Convert2Lambda"})
 public class MethodsThrowingExceptions {
     boolean isCapitalizedThrowingRuntimeException(String s) {
         if (s == null) {
@@ -35,5 +37,53 @@ public class MethodsThrowingExceptions {
     
     private void methodThrowingThrowable() throws Throwable {
         System.out.println("Method throwing Throwable");
+    }
+
+    private void methodThatUsesAnonymousThatImplementsMethodThatThrowsException() {
+        final Callable<String> callable = new Callable<String>() {
+            public String call() {
+                return "test";
+            }
+        };
+
+        acceptCallable(callable);
+    }
+
+    private void methodThatUsesSyntheticThatThrowsException() {
+        acceptCallable(() -> "test2");
+    }
+
+    private void methodThatUsesAnonymousThatImplementsMethodThatThrowsThrowable() {
+        final ThrowThrowable runnable = new ThrowThrowable() {
+            public void run() {
+            }
+        };
+
+        acceptThrowingRunnable(runnable);
+    }
+
+    private void methodThatUsesSyntheticThatThrowsThrowable() {
+        acceptThrowingRunnable(() -> {});
+    }
+
+    private void acceptCallable(Callable<String> callable) {
+        try {
+            System.out.println(callable.call());
+        } catch (Exception e) {
+            System.err.println(e.getMessage());
+        }
+    }
+
+    private void acceptThrowingRunnable(ThrowThrowable runnable) {
+        try {
+            runnable.run();
+        } catch (Throwable e) {
+            System.err.println(e.getMessage());
+        }
+    }
+
+    @FunctionalInterface
+    interface ThrowThrowable {
+        void run() throws Throwable;
     }
 }


### PR DESCRIPTION
Avoid unnecessary false positives generated by the recently introduced `THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION` and `THROWS_METHOD_THROWS_CLAUSE_THROWABLE` checks.

These were throwing even for methods on synthetic classes, i.e. for methods generated by the compiler. For example:

```java
interface SomeInterface() {
  void doIt() throws Exception();  // Method throwing exception
}

private void accept(SomeInterface thing) {
  ...
}

private void test() {
  accept(() -> {});     // Previous red herring due to synthetic class creation
}
```

Previously, not only did the above code create an error for `SomeInterface.doIt()`, as it throws `Exception`, it also created an error on the `accept(() -> {})` line, due to the synthetic class
the compiler is generating to handle the lambda. This synthetic class will also have a method with signature `void doIt() throws Exception()`, causing the issue.

Methods on synthetic classes are now excluded.

The following false positives still exist (which is why I still think this check should be disabled https://github.com/spotbugs/spotbugs/pull/2063):

1. Generic exceptions in the signatures of overriding methods.

If an overriding method follows the signature of the throwing declaration in the superclass then a bug report is still raised. Really, the issue should be raised on the superclass declaration of the method (if part of the code being analysed).

2. Generic exceptions in the signature of methods that make calls to methods that throw generic exceptions.

```java
public void myOtherMethod throws Exception {
  doTheThing();  // this method throws Exception
}
```

To compile the method must throw the generic exception, so this should not be a bug.

3. Finally, given this check would report on bug on JDK types like `Callable`, as it `throws Exception`, I'm struggling to understand how this check can be considered valid at all.  When defining a library interface like `Callable` it seems reasonable to be able to mark the method as being allowed to throw any exception it likes, checked or otherwise.