### PR TITLE
Fixed false positive SSD bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Fixed False positives for `RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE` on try-with-resources with interface references ([#1931](https://github.com/spotbugs/spotbugs/issues/1931))
 - Disabled detector `ThrowingExceptions` by default to avoid many false positives ([#2040](https://github.com/spotbugs/spotbugs/issues/2040))
 - Fixed False positives for `THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION` and `THROWS_METHOD_THROWS_CLAUSE_THROWABLE` on evaluating synthetic classes ([#2040](https://github.com/spotbugs/spotbugs/issues/2040))
+- Fixed False positive for `SSD_DO_NOT_USE_INSTANCE_LOCK_ON_SHARED_STATIC_DATA` on proper protection by using static lock for synchronized block, but inside an unsecured (synchronized and not static) method ([#2089](https://github.com/spotbugs/spotbugs/issues/2089))
 
 ## 4.7.0 - 2022-04-14
 ### Changed

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindInstanceLockOnSharedStaticDataCheckTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindInstanceLockOnSharedStaticDataCheckTest.java
@@ -30,6 +30,13 @@ public class FindInstanceLockOnSharedStaticDataCheckTest extends AbstractIntegra
     }
 
     @Test
+    public void findNoSSDBugInClass_StaticLockInsideNotStaticSynchronizedMethod() {
+        performAnalysis("instanceLockOnSharedStaticData/StaticLockInsideNotStaticSynchronizedMethod.class");
+
+        assertNumOfSSDBugs(0);
+    }
+
+    @Test
     public void findNoSSDBugInClass_LockingOnJavaLangClassObject() {
         performAnalysis("instanceLockOnSharedStaticData/LockingOnJavaLangClassObject.class");
 

--- a/spotbugs/etc/findbugs.xml
+++ b/spotbugs/etc/findbugs.xml
@@ -1278,7 +1278,7 @@
           <BugPattern abbrev="REFLF" type="REFLF_REFLECTION_MAY_INCREASE_ACCESSIBILITY_OF_FIELD" category="MALICIOUS_CODE" />
           <BugPattern abbrev="MC" type="MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR" category="MALICIOUS_CODE" />
           <BugPattern abbrev="MC" type="MC_OVERRIDABLE_METHOD_CALL_IN_CLONE" category="MALICIOUS_CODE" />
-          <BugPattern abbrev="SSD" type="SSD_DO_NOT_USE_INSTANCE_LOCK_ON_SHARED_STATIC_DATA" category="CORRECTNESS" />
+          <BugPattern abbrev="SSD" type="SSD_DO_NOT_USE_INSTANCE_LOCK_ON_SHARED_STATIC_DATA" category="MT_CORRECTNESS" />
           <BugPattern abbrev="FL" type="FL_FLOATS_AS_LOOP_COUNTERS" category="CORRECTNESS" />
           <BugPattern abbrev="THROWS" type="THROWS_METHOD_THROWS_RUNTIMEEXCEPTION" category="BAD_PRACTICE" />
           <BugPattern abbrev="THROWS" type="THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION" category="BAD_PRACTICE" />

--- a/spotbugs/etc/messages.xml
+++ b/spotbugs/etc/messages.xml
@@ -8672,11 +8672,10 @@ object explicitly.</p>
 
   <BugPattern type="SSD_DO_NOT_USE_INSTANCE_LOCK_ON_SHARED_STATIC_DATA">
     <ShortDescription>Instance level lock was used on a shared static data</ShortDescription>
-    <LongDescription>Static field "{1}" is modified by an instance level {2}.</LongDescription>
+    <LongDescription>Static field "{2}" is modified by an instance level {3}.</LongDescription>
     <Details>
       <![CDATA[<p>
-        Instance level synchronization, that modifies a static shared object could cause security leaks.
-        If the lock or the method is not static, that modifies the static field, and is synchronized,
+        If the lock or the synchronized method is not static, that modifies the static field,
         that could leave the shared static data unprotected against concurrent access.
         This could occur in two ways, if a synchronization method uses a non-static lock object,
         or a synchronized method is declared as non-static. Both ways are ineffective.

--- a/spotbugsTestCases/src/java/instanceLockOnSharedStaticData/StaticLockInsideNotStaticSynchronizedMethod.java
+++ b/spotbugsTestCases/src/java/instanceLockOnSharedStaticData/StaticLockInsideNotStaticSynchronizedMethod.java
@@ -1,0 +1,15 @@
+package instanceLockOnSharedStaticData;
+
+public class StaticLockInsideNotStaticSynchronizedMethod {
+
+    private static final Object lock = new Object();
+    private static int x = 0;
+    private static int y = 0;
+
+    public synchronized void foo() {
+        synchronized (lock) {
+            x++;
+            y++;
+        }
+    }
+}


### PR DESCRIPTION
Fixed bug reported by [issue-2089](https://github.com/spotbugs/spotbugs/issues/2089).

SSD bug instance does not get reported if there is a synchronized block with a static lock object inside a non-static synchronized method.

- Added new unit test to verify changes
- Aligned `CHANGELOG.md` with the fix