### PR TITLE
Specify explicit source compliance for ToolFactory.createScanner() API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased - 2022-??-??
+### Fixed
+- Fixed InvalidInputException in Eclipse while bug reporting ([#2134](https://github.com/spotbugs/spotbugs/issues/2134))
 
 ## 4.7.1 - 2022-06-26
 ### Fixed

--- a/eclipsePlugin/src/de/tobject/findbugs/reporter/MarkerUtil.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/reporter/MarkerUtil.java
@@ -437,7 +437,15 @@ public final class MarkerUtil {
         if (charContent == null) {
             return null;
         }
-        IScanner scanner = ToolFactory.createScanner(false, false, false, true);
+        IScanner scanner;
+        IJavaProject project = source.getJavaProject();
+        if (project != null) {
+            String sourceLevel = project.getOption(JavaCore.COMPILER_SOURCE, true);
+            String complianceLevel = project.getOption(JavaCore.COMPILER_COMPLIANCE, true);
+            scanner = ToolFactory.createScanner(false, false, true, sourceLevel, complianceLevel);
+        } else {
+            scanner = ToolFactory.createScanner(false, false, false, true);
+        }
         scanner.setSource(charContent);
         int offset = range.getOffset();
         try {


### PR DESCRIPTION
This avoids org.eclipse.jdt.core.compiler.InvalidInputException in
MarkerUtil.initScanner() where JDT can't parse code that is perfectly
compilable because the old API used too low default source level.

Fixes https://github.com/spotbugs/spotbugs/issues/2134