### PR TITLE
Use stable SLF4J API instead of unstable 1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 ## Unreleased - 2022-??-??
 ### Fixed
 - Bumped gson from 2.9.0 to 2.9.1 ([#2136](https://github.com/spotbugs/spotbugs/pull/2136))
+- Bump up SLF4J API to `2.0.0`
 - Fixed InvalidInputException in Eclipse while bug reporting ([#2134](https://github.com/spotbugs/spotbugs/issues/2134))
 
 ## 4.7.1 - 2022-06-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 ### Fixed
 - Bumped gson from 2.9.0 to 2.9.1 ([#2136](https://github.com/spotbugs/spotbugs/pull/2136))
 - Bump up SLF4J API to `2.0.0`
+- Bump up logback to `1.4.0`
 - Bump up log4j2 binding to `2.18.0`
 - Fixed InvalidInputException in Eclipse while bug reporting ([#2134](https://github.com/spotbugs/spotbugs/issues/2134))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 ### Fixed
 - Bumped gson from 2.9.0 to 2.9.1 ([#2136](https://github.com/spotbugs/spotbugs/pull/2136))
 - Bump up SLF4J API to `2.0.0`
+- Bump up log4j2 binding to `2.18.0`
 - Fixed InvalidInputException in Eclipse while bug reporting ([#2134](https://github.com/spotbugs/spotbugs/issues/2134))
 
 ## 4.7.1 - 2022-06-26

--- a/buildSrc/src/main/kotlin/constraints.gradle.kts
+++ b/buildSrc/src/main/kotlin/constraints.gradle.kts
@@ -7,14 +7,14 @@ dependencies {
         implementation("org.apache.logging.log4j:log4j-core") {
             version {
                 strictly("[2.17.1, 3[")
-                prefer("2.17.1")
+                prefer("2.18.0")
             }
             because("CVE-2021-44228, CVE-2021-45046, CVE-2021-45105, CVE-2021-44832: Log4j vulnerable to remote code execution and other critical security vulnerabilities")
         }
         implementation("ch.qos.logback:logback-core") {
             version {
                 strictly("[1.2.9, 2[")
-                prefer("1.2.10")
+                prefer("1.4.0")
             }
             because("CVE-2021-42550: Logback vulnerable to remote code execution vulnerabilities")
         }

--- a/spotbugs-tests/build.gradle
+++ b/spotbugs-tests/build.gradle
@@ -2,7 +2,7 @@ apply from: "$rootDir/gradle/checkstyle.gradle"
 apply from: "$rootDir/gradle/jacoco.gradle"
 
 ext {
-  log4jVersion = '2.17.2'
+  log4jVersion = '2.18.0'
 }
 
 dependencies {

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -86,7 +86,7 @@ dependencies {
   implementation 'jaxen:jaxen:1.2.0' // only transitive through dom4j:dom4j:1.6.1, which has an *optional* dependency on jaxen:jaxen.
   api 'org.apache.commons:commons-lang3:3.12.0'
   api 'org.apache.commons:commons-text:1.9'
-  api 'org.slf4j:slf4j-api:1.8.0-beta4'
+  api 'org.slf4j:slf4j-api:2.0.0'
   implementation 'net.sf.saxon:Saxon-HE:11.3'
   logBinding ("org.apache.logging.log4j:log4j-slf4j18-impl:$log4jVersion") {
     exclude group: 'org.slf4j'

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -357,14 +357,14 @@ dependencies {
     logBinding("org.apache.logging.log4j:log4j-core") {
       version {
         strictly("[2.17.1, 3[")
-        prefer("2.17.1")
+        prefer("2.18.0")
       }
       because("CVE-2021-44228, CVE-2021-45046, CVE-2021-45105, CVE-2021-44832: Log4j vulnerable to remote code execution and other critical security vulnerabilities")
     }
     logBinding("ch.qos.logback:logback-core") {
       version {
         strictly("[1.2.9, 2[")
-        prefer("1.2.10")
+        prefer("1.4.0")
       }
       because("CVE-2021-42550: Logback vulnerable to remote code execution vulnerabilities")
     }

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -24,7 +24,7 @@ configurations {
 
 ext {
   asmVersion = '9.3'
-  log4jVersion = '2.17.2'
+  log4jVersion = '2.18.0'
 }
 
 sourceSets {


### PR DESCRIPTION
SLF4J released a stable API v2.0.0, so migrate our dependency on unstable 1.8 with it.
It's a kind of drop-in replacement so we do not have to update our code, in theory.

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
