### PR TITLE
Report bug `SA_FIELD_SELF_ASSIGNMENT` in nested classes as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Bump up logback to `1.4.0`
 - Bump up log4j2 binding to `2.18.0`
 - Fixed InvalidInputException in Eclipse while bug reporting ([#2134](https://github.com/spotbugs/spotbugs/issues/2134))
+- Bug `SA_FIELD_SELF_ASSIGNMENT` is now reported from nested classes as well ([#2142](https://github.com/spotbugs/spotbugs/issues/2142))
 
 ## 4.7.1 - 2022-06-26
 ### Fixed

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2142Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2142Test.java
@@ -1,0 +1,38 @@
+package edu.umd.cs.findbugs.detect;
+
+import org.junit.Test;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
+
+import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class Issue2142Test extends AbstractIntegrationTest {
+    @Test
+    public void test() {
+        performAnalysis("ghIssues/Issue2142.class",
+                "ghIssues/Issue2142$Inner.class");
+        BugInstanceMatcher matcher = new BugInstanceMatcherBuilder()
+                .bugType("SA_FIELD_SELF_ASSIGNMENT").build();
+        assertThat(getBugCollection(), containsExactly(2, matcher));
+
+        matcher = new BugInstanceMatcherBuilder()
+                .bugType("SA_FIELD_SELF_ASSIGNMENT")
+                .inClass("Issue2142")
+                .inMethod("foo1")
+                .atLine(6)
+                .build();
+        assertThat(getBugCollection(), hasItem(matcher));
+
+        matcher = new BugInstanceMatcherBuilder()
+                .bugType("SA_FIELD_SELF_ASSIGNMENT")
+                .inClass("Issue2142$Inner")
+                .inMethod("foo2")
+                .atLine(10)
+                .build();
+        assertThat(getBugCollection(), hasItem(matcher));
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindFieldSelfAssignment.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindFieldSelfAssignment.java
@@ -29,6 +29,7 @@ import edu.umd.cs.findbugs.BugInstance;
 import edu.umd.cs.findbugs.BugReporter;
 import edu.umd.cs.findbugs.LocalVariableAnnotation;
 import edu.umd.cs.findbugs.OpcodeStack;
+import edu.umd.cs.findbugs.OpcodeStack.CustomUserValue;
 import edu.umd.cs.findbugs.OpcodeStack.Item;
 import edu.umd.cs.findbugs.Priorities;
 import edu.umd.cs.findbugs.StatelessDetector;
@@ -36,10 +37,12 @@ import edu.umd.cs.findbugs.SystemProperties;
 import edu.umd.cs.findbugs.ba.XField;
 import edu.umd.cs.findbugs.bcel.OpcodeStackDetector;
 
+@CustomUserValue
 public class FindFieldSelfAssignment extends OpcodeStackDetector implements StatelessDetector {
     private final BugReporter bugReporter;
 
     private static final boolean DEBUG = SystemProperties.getBoolean("fsa.debug");
+    private static final int NO_REGISTER = -1;
     int state;
 
     public FindFieldSelfAssignment(BugReporter bugReporter) {
@@ -69,7 +72,7 @@ public class FindFieldSelfAssignment extends OpcodeStackDetector implements Stat
 
     XField possibleOverwrite;
 
-    private int parentInstanceLoadFromRegister = -1;
+    private int parentInstanceLoadFromRegister = NO_REGISTER;
 
     @Override
     public void sawOpcode(int seen) {
@@ -184,10 +187,10 @@ public class FindFieldSelfAssignment extends OpcodeStackDetector implements Stat
     public void afterOpcode(int seen) {
         super.afterOpcode(seen);
 
-        if (seen == Const.GETFIELD && parentInstanceLoadFromRegister > -1) {
+        if (seen == Const.GETFIELD && parentInstanceLoadFromRegister > NO_REGISTER) {
             OpcodeStack.Item top = stack.getStackItem(0);
             top.setUserValue(parentInstanceLoadFromRegister);
-            parentInstanceLoadFromRegister = -1;
+            parentInstanceLoadFromRegister = NO_REGISTER;
         }
     }
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindFieldSelfAssignment.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindFieldSelfAssignment.java
@@ -97,7 +97,7 @@ public class FindFieldSelfAssignment extends OpcodeStackDetector implements Stat
                 if (f2 != null && f2.equals(getXFieldOperand())
                         && ((registerNumber2 >= 0 && registerNumber2 == third.getFieldLoadedFromRegister())
                                 || (loadedFromRegister2 >= 0 && third.getUserValue() instanceof Integer
-                                        && loadedFromRegister2 == (Integer) third.getUserValue()))
+                                        && loadedFromRegister2 == ((Integer) third.getUserValue()).intValue()))
                         && !third.sameValue(top) && (third.getPC() == -1 || third.getPC() > lastMethodCall)) {
                     possibleOverwrite = f2;
                 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindFieldSelfAssignment.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindFieldSelfAssignment.java
@@ -96,8 +96,7 @@ public class FindFieldSelfAssignment extends OpcodeStackDetector implements Stat
                 int loadedFromRegister2 = fourth.getFieldLoadedFromRegister();
                 if (f2 != null && f2.equals(getXFieldOperand())
                         && ((registerNumber2 >= 0 && registerNumber2 == third.getFieldLoadedFromRegister())
-                                || (loadedFromRegister2 >= 0 && third.getUserValue() != null
-                                        && third.getUserValue() instanceof Integer
+                                || (loadedFromRegister2 >= 0 && third.getUserValue() instanceof Integer
                                         && loadedFromRegister2 == (Integer) third.getUserValue()))
                         && !third.sameValue(top) && (third.getPC() == -1 || third.getPC() > lastMethodCall)) {
                     possibleOverwrite = f2;

--- a/spotbugsTestCases/src/java/ghIssues/Issue2142.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue2142.java
@@ -1,0 +1,13 @@
+package ghIssues;
+
+public class Issue2142 {
+    int foo;
+    void foo1() {
+        foo = foo++;  // can report a warning in this line
+    }
+    class Inner {
+        void foo2() {
+            foo = foo++; // should report a warning in this line
+        }
+    }    
+}


### PR DESCRIPTION
Bug `SA_FIELD_SELF_ASSIGNMENT` was not reported in nested classes, only in the outer class. This lead to inconsistent behavior. See issue ([#2142](https://github.com/spotbugs/spotbugs/issues/2142)). This PR fixes this issue.



----

Make sure these boxes are checked before submitting your PR -- thank you!

- [X] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
