### PR TITLE
Fix of detector `DontUseFloatsAsLoopCounters` to prevent false positives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased - 2022-??-??
+### Fixed
+- Fixed detector `DontUseFloatsAsLoopCounters` to prevent false positives. ([#2126](https://github.com/spotbugs/spotbugs/issues/2126))
 
 ## 4.7.2 - 2022-09-02
 ### Fixed

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/DontUseFloatsAsLoopCountersTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/DontUseFloatsAsLoopCountersTest.java
@@ -15,9 +15,9 @@ public class DontUseFloatsAsLoopCountersTest extends AbstractIntegrationTest {
     public void testChecks() {
         performAnalysis("DontUseFloatsAsLoopCounters.class");
         assertNumOfEOSBugs(3);
-        assertBug("test1", 6);
-        assertBug("test2", 13);
-        assertBug("test3", 19);
+        assertBug("test1", 8);
+        assertBug("test2", 15);
+        assertBug("test3", 21);
     }
 
     private void assertBug(String method, int line) {

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/DontUseFloatsAsLoopCountersTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/DontUseFloatsAsLoopCountersTest.java
@@ -8,16 +8,16 @@ import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
 import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
 import static org.hamcrest.Matchers.hasItem;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class DontUseFloatsAsLoopCountersTest extends AbstractIntegrationTest {
     @Test
     public void testChecks() {
         performAnalysis("DontUseFloatsAsLoopCounters.class");
         assertNumOfEOSBugs(3);
-        assertBug("main", 5);
-        assertBug("main", 9);
-        assertBug("main", 12);
+        assertBug("test1", 6);
+        assertBug("test2", 13);
+        assertBug("test3", 19);
     }
 
     private void assertBug(String method, int line) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DontUseFloatsAsLoopCounters.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DontUseFloatsAsLoopCounters.java
@@ -8,6 +8,7 @@ import edu.umd.cs.findbugs.StatelessDetector;
 import edu.umd.cs.findbugs.bcel.OpcodeStackDetector;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -17,28 +18,32 @@ public class DontUseFloatsAsLoopCounters extends OpcodeStackDetector implements 
 
     private final BugReporter bugReporter;
 
-    private static final Map<Integer, Integer> FLOAT_LOADERS = new HashMap<>();
+    private static final Map<Integer, Integer> FLOAT_LOADERS;
     static {
-        FLOAT_LOADERS.put((int) Const.FLOAD, 2);
-        FLOAT_LOADERS.put((int) Const.FLOAD_0, 1);
-        FLOAT_LOADERS.put((int) Const.FLOAD_1, 1);
-        FLOAT_LOADERS.put((int) Const.FLOAD_2, 1);
-        FLOAT_LOADERS.put((int) Const.FLOAD_3, 1);
-        FLOAT_LOADERS.put((int) Const.DLOAD, 2);
-        FLOAT_LOADERS.put((int) Const.DLOAD_0, 1);
-        FLOAT_LOADERS.put((int) Const.DLOAD_1, 1);
-        FLOAT_LOADERS.put((int) Const.DLOAD_2, 1);
-        FLOAT_LOADERS.put((int) Const.DLOAD_3, 1);
+        Map<Integer, Integer> tmp = new HashMap<>();
+        tmp.put((int) Const.FLOAD, 2);
+        tmp.put((int) Const.FLOAD_0, 1);
+        tmp.put((int) Const.FLOAD_1, 1);
+        tmp.put((int) Const.FLOAD_2, 1);
+        tmp.put((int) Const.FLOAD_3, 1);
+        tmp.put((int) Const.DLOAD, 2);
+        tmp.put((int) Const.DLOAD_0, 1);
+        tmp.put((int) Const.DLOAD_1, 1);
+        tmp.put((int) Const.DLOAD_2, 1);
+        tmp.put((int) Const.DLOAD_3, 1);
+        FLOAT_LOADERS = Collections.unmodifiableMap(tmp);
     }
 
-    private static final Map<Integer, Integer> FLOAT_CONSTANT_PUSHERS = new HashMap<>();
+    private static final Map<Integer, Integer> FLOAT_CONSTANT_PUSHERS;
     static {
-        FLOAT_CONSTANT_PUSHERS.put((int) Const.FCONST_1, 1);
-        FLOAT_CONSTANT_PUSHERS.put((int) Const.FCONST_2, 1);
-        FLOAT_CONSTANT_PUSHERS.put((int) Const.DCONST_1, 1);
-        FLOAT_CONSTANT_PUSHERS.put((int) Const.LDC, 2);
-        FLOAT_CONSTANT_PUSHERS.put((int) Const.LDC_W, 3);
-        FLOAT_CONSTANT_PUSHERS.put((int) Const.LDC2_W, 3);
+        Map<Integer, Integer> tmp = new HashMap<>();
+        tmp.put((int) Const.FCONST_1, 1);
+        tmp.put((int) Const.FCONST_2, 1);
+        tmp.put((int) Const.DCONST_1, 1);
+        tmp.put((int) Const.LDC, 2);
+        tmp.put((int) Const.LDC_W, 3);
+        tmp.put((int) Const.LDC2_W, 3);
+        FLOAT_CONSTANT_PUSHERS = Collections.unmodifiableMap(tmp);
     }
 
     private static final Set<Integer> FLOAT_COMPARERS = new HashSet<>(Arrays.asList(
@@ -80,11 +85,8 @@ public class DontUseFloatsAsLoopCounters extends OpcodeStackDetector implements 
     }
 
     private boolean checkLoopEnd() {
-        if (!FLOAT_STORERS.contains(getPrevOpcode(1))) {
-            return false;
-        }
-
-        return FLOAT_ADDITIVE_OPS.contains(getPrevOpcode(2));
+        return FLOAT_STORERS.contains(getPrevOpcode(1)) &&
+                FLOAT_ADDITIVE_OPS.contains(getPrevOpcode(2));
     }
 
     private boolean checkLoopStart(int startPC) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DontUseFloatsAsLoopCounters.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DontUseFloatsAsLoopCounters.java
@@ -6,11 +6,64 @@ import edu.umd.cs.findbugs.BugInstance;
 import edu.umd.cs.findbugs.BugReporter;
 import edu.umd.cs.findbugs.StatelessDetector;
 import edu.umd.cs.findbugs.bcel.OpcodeStackDetector;
-import java.util.stream.Stream;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 public class DontUseFloatsAsLoopCounters extends OpcodeStackDetector implements StatelessDetector {
 
     private final BugReporter bugReporter;
+
+    private static final Map<Integer, Integer> FLOAT_LOADERS = new HashMap<>();
+    static {
+        FLOAT_LOADERS.put((int) Const.FLOAD, 2);
+        FLOAT_LOADERS.put((int) Const.FLOAD_0, 1);
+        FLOAT_LOADERS.put((int) Const.FLOAD_1, 1);
+        FLOAT_LOADERS.put((int) Const.FLOAD_2, 1);
+        FLOAT_LOADERS.put((int) Const.FLOAD_3, 1);
+        FLOAT_LOADERS.put((int) Const.DLOAD, 2);
+        FLOAT_LOADERS.put((int) Const.DLOAD_0, 1);
+        FLOAT_LOADERS.put((int) Const.DLOAD_1, 1);
+        FLOAT_LOADERS.put((int) Const.DLOAD_2, 1);
+        FLOAT_LOADERS.put((int) Const.DLOAD_3, 1);
+    }
+
+    private static final Map<Integer, Integer> FLOAT_CONSTANT_PUSHERS = new HashMap<>();
+    static {
+        FLOAT_CONSTANT_PUSHERS.put((int) Const.FCONST_1, 1);
+        FLOAT_CONSTANT_PUSHERS.put((int) Const.FCONST_2, 1);
+        FLOAT_CONSTANT_PUSHERS.put((int) Const.DCONST_1, 1);
+        FLOAT_CONSTANT_PUSHERS.put((int) Const.LDC, 2);
+        FLOAT_CONSTANT_PUSHERS.put((int) Const.LDC_W, 3);
+        FLOAT_CONSTANT_PUSHERS.put((int) Const.LDC2_W, 3);
+    }
+
+    private static final Set<Integer> FLOAT_COMPARERS = new HashSet<>(Arrays.asList(
+            (int) Const.FCMPG,
+            (int) Const.FCMPL,
+            (int) Const.DCMPG,
+            (int) Const.DCMPL));
+
+    private static final Set<Integer> FLOAT_STORERS = new HashSet<>(Arrays.asList(
+            (int) Const.FSTORE,
+            (int) Const.FSTORE_0,
+            (int) Const.FSTORE_1,
+            (int) Const.FSTORE_2,
+            (int) Const.FSTORE_3,
+            (int) Const.DSTORE,
+            (int) Const.DSTORE_0,
+            (int) Const.DSTORE_1,
+            (int) Const.DSTORE_2,
+            (int) Const.DSTORE_3));
+
+    private static final Set<Integer> FLOAT_ADDITIVE_OPS = new HashSet<>(Arrays.asList(
+            (int) Const.FADD,
+            (int) Const.FSUB,
+            (int) Const.DADD,
+            (int) Const.DSUB));
 
     public DontUseFloatsAsLoopCounters(BugReporter bugReporter) {
         this.bugReporter = bugReporter;
@@ -19,10 +72,38 @@ public class DontUseFloatsAsLoopCounters extends OpcodeStackDetector implements 
     @Override
     public void sawOpcode(int seen) {
         if ((seen == Const.GOTO || seen == Const.GOTO_W) &&
-                Stream.of(Const.FLOAD, Const.FLOAD_0, Const.FLOAD_1, Const.FLOAD_2, Const.FLOAD_3, Const.DLOAD, Const.DLOAD_0, Const.DLOAD_1,
-                        Const.DLOAD_2, Const.DLOAD_3).anyMatch(x -> x == getCodeByte(getBranchTarget())) && (getBranchTarget() < getPC())) {
+                getBranchTarget() < getPC() &&
+                checkLoopEnd() && checkLoopStart(getBranchTarget())) {
             bugReporter.reportBug(new BugInstance(this, "FL_FLOATS_AS_LOOP_COUNTERS", NORMAL_PRIORITY)
                     .addClassAndMethod(this).addSourceLine(this, getBranchTarget()));
         }
+    }
+
+    private boolean checkLoopEnd() {
+        if (!FLOAT_STORERS.contains(getPrevOpcode(1))) {
+            return false;
+        }
+
+        return FLOAT_ADDITIVE_OPS.contains(getPrevOpcode(2));
+    }
+
+    private boolean checkLoopStart(int startPC) {
+        if (!FLOAT_LOADERS.containsKey(getCodeByte(startPC))) {
+            return false;
+        }
+
+        int nextPC = startPC + FLOAT_LOADERS.get(getCodeByte(startPC));
+
+        if (!FLOAT_CONSTANT_PUSHERS.containsKey(getCodeByte(nextPC))) {
+            return false;
+        }
+
+        nextPC += FLOAT_CONSTANT_PUSHERS.get(getCodeByte(nextPC));
+
+        if (!FLOAT_COMPARERS.contains(getCodeByte(nextPC++))) {
+            return false;
+        }
+
+        return isBranch(getCodeByte(nextPC));
     }
 }

--- a/spotbugsTestCases/src/java/DontUseFloatsAsLoopCounters.java
+++ b/spotbugsTestCases/src/java/DontUseFloatsAsLoopCounters.java
@@ -1,34 +1,103 @@
+import java.util.Random;
+
 class DontUseFloatsAsLoopCounters {
-  public static void main(String[] args) {
-    //noncompliant
-    float x = 0.1f;
-    while (x<10){
-      System.out.println(x);
-      x++;
+    // Noncompliant
+
+    public static void test1() {
+        float x = 0.1f;
+        while (x<10){
+            System.out.println(x);
+            x++;
+        }
     }
-    for (float y = 0.2f; y <= 1.0f; y += 0.1f) {
-        System.out.println(y);
-      }
-    for (double d = 0.2d; d <= 1.0d; d += 0.1d) {
-        System.out.println(d);
-      }
-    //compliant
-      for (int count = 1; count <= 10; count += 1) {
-        float q = count/10.0f;
-        System.out.println(q);
-        System.out.println(count);
-      }
-      int c = 0;
-      while (c<5){
-        c++;
-      }
-      boolean b = true;
-      while (b){
-        b = false;
-      }
-      int p = 1;
-      while (p<9){
-        p*=2;
-      }
-}
+
+    public static void test2() {
+        for (float y = 0.2f; y <= 1.0f; y += 0.1f) {
+            System.out.println(y);
+        }
+    }
+
+    public static void test3() {
+        for (double d = 0.2d; d <= 1.0d; d += 0.1d) {
+            System.out.println(d);
+        }
+    }
+
+    // Compliant
+    public static void test4() {
+        for (int count = 1; count <= 10; count += 1) {
+            float q = count/10.0f;
+            System.out.println(q);
+            System.out.println(count);
+        }
+    }
+
+    public static void test5() {
+        int c = 0;
+        while (c<5){
+            c++;
+            System.out.println(c);
+        }
+    }
+
+    public static void test6() {
+        boolean b = true;
+        while (b){
+            b = false;
+            System.out.println(b);
+        }
+    }
+
+    public static void test7() {
+        int p = 1;
+        while (p<9){
+            p*=2;
+            System.out.println(p);
+        }
+    }
+
+    private static Random rnd = new Random();
+
+    public static double test8() {
+        double total = 0;
+
+        for (int attempt = 1;; attempt++) {
+            total += rnd.nextDouble();
+
+            if (rnd.nextDouble() < 0.5) {
+                System.out.println(attempt);
+                break;
+            }
+        }
+
+        return total;
+    }
+
+    public static void test9(boolean someOtherCondition) {
+        double y = Double.NaN;
+        while (Double.isNaN(y) && someOtherCondition) {
+            System.out.println("y before" + y);
+            y = Double.parseDouble(System.console().readLine());
+            System.out.println("y after" + y);
+        }
+    }
+
+    public static double test10(double t) {
+        double kmin = 0, kmax = 1;
+        while (Math.log(1 + 2 * kmax) - 2 * Math.log(1 + kmax) < t) {
+            kmin = kmax;
+            kmax *= 2;
+        }
+
+        double k = (kmin + kmax) / 2;
+        while (kmin < k && k < kmax) {
+            if (Math.log(1 + 2 * k) - 2 * Math.log(1 + k) < t) {
+                kmin = k;
+            } else {
+                kmax = k;
+            }
+            k = (kmin + kmax) / 2;
+        }
+        return k;
+    }
 }


### PR DESCRIPTION
Bug `FL_FLOATS_AS_LOOP_COUNTERS` was reported for several cases where floating-point types appear in the loops but not as loop counters. See issue ([#2126](https://github.com/spotbugs/spotbugs/issues/2126)).



----

Make sure these boxes are checked before submitting your PR -- thank you!

- [X] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
