### PR TITLE
Fix for detector `UncallableMethodOfAnonymousClass` to not report unused methods of method-local enumerations and records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 ## Unreleased - 2022-??-??
 ### Fixed
 - Fixed detector `DontUseFloatsAsLoopCounters` to prevent false positives. ([#2126](https://github.com/spotbugs/spotbugs/issues/2126))
+- Fixed detector `UncallableMethodOfAnonymousClass` to not report unused methods of method-local enumerations and records ([#2120](https://github.com/spotbugs/spotbugs/issues/2120))
 
 ## 4.7.2 - 2022-09-02
 ### Fixed

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2120Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2120Test.java
@@ -24,7 +24,9 @@ public class Issue2120Test extends AbstractIntegrationTest {
 
     @Test
     public void test() {
-        performAnalysis("../java14/Issue2120.class");
+        performAnalysis("../java14/Issue2120.class",
+                "../java14/Issue2120$1MyEnum.class",
+                "../java14/Issue2120$1MyRecord.class");
         BugInstanceMatcher matcher = new BugInstanceMatcherBuilder()
                 .bugType("UMAC_UNCALLABLE_METHOD_OF_ANONYMOUS_CLASS").build();
         assertThat(getBugCollection(), containsExactly(0, matcher));

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2120Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2120Test.java
@@ -1,0 +1,32 @@
+package edu.umd.cs.findbugs.detect;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
+
+import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.number.OrderingComparison.greaterThanOrEqualTo;
+
+public class Issue2120Test extends AbstractIntegrationTest {
+    @Before
+    public void verifyJavaVersion() {
+        assumeFalse(System.getProperty("java.specification.version").startsWith("1."));
+        int javaVersion = Integer.parseInt(System.getProperty("java.specification.version"));
+        assumeThat(javaVersion, is(greaterThanOrEqualTo(11)));
+    }
+
+    @Test
+    public void test() {
+        performAnalysis("../java14/Issue2120.class");
+        BugInstanceMatcher matcher = new BugInstanceMatcherBuilder()
+                .bugType("UMAC_UNCALLABLE_METHOD_OF_ANONYMOUS_CLASS").build();
+        assertThat(getBugCollection(), containsExactly(0, matcher));
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UncallableMethodOfAnonymousClass.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UncallableMethodOfAnonymousClass.java
@@ -59,6 +59,11 @@ public class UncallableMethodOfAnonymousClass extends BytecodeScanningDetector {
 
     @Override
     public void visitJavaClass(JavaClass obj) {
+        if (Values.DOTTED_JAVA_LANG_ENUM.equals(obj.getSuperclassName()) ||
+                Values.DOTTED_JAVA_LANG_RECORD.equals(obj.getSuperclassName())) {
+            return;
+        }
+
         try {
             obj.getSuperClass();
         } catch (ClassNotFoundException e) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UncallableMethodOfAnonymousClass.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UncallableMethodOfAnonymousClass.java
@@ -19,6 +19,7 @@
 
 package edu.umd.cs.findbugs.detect;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -59,11 +60,6 @@ public class UncallableMethodOfAnonymousClass extends BytecodeScanningDetector {
 
     @Override
     public void visitJavaClass(JavaClass obj) {
-        if (Values.DOTTED_JAVA_LANG_ENUM.equals(obj.getSuperclassName()) ||
-                Values.DOTTED_JAVA_LANG_RECORD.equals(obj.getSuperclassName())) {
-            return;
-        }
-
         try {
             obj.getSuperClass();
         } catch (ClassNotFoundException e) {
@@ -161,7 +157,18 @@ public class UncallableMethodOfAnonymousClass extends BytecodeScanningDetector {
         if (obj.isAbstract()) {
             return true;
         }
-
+        if (Values.SLASHED_JAVA_LANG_ENUM.equals(getSuperclassName()) &&
+                (("values".equals(obj.getName()) &&
+                        ("()[L" + getClassName() + ";").equals(obj.getSignature())) ||
+                        ("valueOf".equals(obj.getName())) &&
+                                ("(Ljava/lang/String;)L" + getClassName() + ";").equals(obj.getSignature()))) {
+            return true;
+        }
+        if (Values.SLASHED_JAVA_LANG_RECORD.equals(getSuperclassName()) &&
+                (Arrays.stream(getThisClass().getFields()).anyMatch(f -> f.getName().equals(obj.getName()))) &&
+                (obj.getSignature().startsWith("()"))) {
+            return true;
+        }
         String methodName = obj.getName();
         String sig = obj.getSignature();
         if (Const.CONSTRUCTOR_NAME.equals(methodName)) {
@@ -170,6 +177,7 @@ public class UncallableMethodOfAnonymousClass extends BytecodeScanningDetector {
         if (Const.STATIC_INITIALIZER_NAME.equals(methodName)) {
             return true;
         }
+
         if ("()Ljava/lang/Object;".equals(sig) && ("readResolve".equals(methodName) || "writeReplace".equals(methodName))) {
             return true;
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/Values.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/Values.java
@@ -54,6 +54,10 @@ public final class Values {
     @DottedClassName
     public static final String DOTTED_JAVA_LANG_STRINGBUFFER = "java.lang.StringBuffer";
     @DottedClassName
+    public static final String DOTTED_JAVA_LANG_ENUM = "java.lang.Enum";
+    @DottedClassName
+    public static final String DOTTED_JAVA_LANG_RECORD = "java.lang.Record";
+    @DottedClassName
     public static final String DOTTED_JAVA_IO_FILE = "java.io.File";
     @DottedClassName
     public static final String DOTTED_JAVA_NIO_PATH = "java.nio.file.Path";

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/Values.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/Values.java
@@ -54,10 +54,6 @@ public final class Values {
     @DottedClassName
     public static final String DOTTED_JAVA_LANG_STRINGBUFFER = "java.lang.StringBuffer";
     @DottedClassName
-    public static final String DOTTED_JAVA_LANG_ENUM = "java.lang.Enum";
-    @DottedClassName
-    public static final String DOTTED_JAVA_LANG_RECORD = "java.lang.Record";
-    @DottedClassName
     public static final String DOTTED_JAVA_IO_FILE = "java.io.File";
     @DottedClassName
     public static final String DOTTED_JAVA_NIO_PATH = "java.nio.file.Path";
@@ -96,6 +92,10 @@ public final class Values {
     public static final String SLASHED_JAVA_LANG_CHARACTER = "java/lang/Character";
     @SlashedClassName
     public static final String SLASHED_JAVA_LANG_BOOLEAN = "java/lang/Boolean";
+    @SlashedClassName
+    public static final String SLASHED_JAVA_LANG_ENUM = "java/lang/Enum";
+    @SlashedClassName
+    public static final String SLASHED_JAVA_LANG_RECORD = "java/lang/Record";
     @SlashedClassName
     public static final String SLASHED_JAVA_UTIL_COMPARATOR = "java/util/Comparator";
     @SlashedClassName

--- a/spotbugsTestCases/src/java14/Issue2120.java
+++ b/spotbugsTestCases/src/java14/Issue2120.java
@@ -1,0 +1,12 @@
+public class Issue2120 {
+    static void method() {
+        record MyRecord(int from, int to) { /**/ }
+        
+        enum MyEnum {
+            RED, BLUE;
+        }
+        
+        System.out.println(new MyRecord(1, 2));
+        System.out.println(MyEnum.RED);
+    }
+}


### PR DESCRIPTION
During compilation, enumerations and records are turned into Java classes with some auto-generated methods. Some of these methods are called by the code but some of them not. However, this is not a programming error or bad practice, these methods must not be considered as dead code because their generation cannot be prevented. Therefore no bug report `UMAC_UNCALLABLE_METHOD_OF_ANONYMOUS_CLASS` must be issued to such classes even if they are defined inside a method. See issue ([#2120](https://github.com/spotbugs/spotbugs/issues/2120))



----

Make sure these boxes are checked before submitting your PR -- thank you!

- [X] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
