### PR TITLE
Issue2147

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 ## Unreleased - 2022-??-??
 ### Fixed
 - Fixed detector `DontUseFloatsAsLoopCounters` to prevent false positives. ([#2126](https://github.com/spotbugs/spotbugs/issues/2126))
+- Fixed regression in `4.7.2` caused by ([#2141](https://github.com/spotbugs/spotbugs/pull/2141))
 
 ## 4.7.2 - 2022-09-02
 ### Fixed

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2147Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2147Test.java
@@ -1,0 +1,23 @@
+package edu.umd.cs.findbugs.detect;
+
+import org.junit.Test;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
+
+import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class Issue2147Test extends AbstractIntegrationTest {
+    @Test
+    public void test() {
+        performAnalysis("ghIssues/Issue2147.class",
+                "ghIssues/Issue2147A.class",
+                "ghIssues/Issue2147B.class",
+                "ghIssues/Issue2147C.class");
+        BugInstanceMatcher matcher = new BugInstanceMatcherBuilder()
+                .bugType("URF_UNREAD_FIELD").build();
+        assertThat(getBugCollection(), containsExactly(0, matcher));
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/OpcodeStack.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/OpcodeStack.java
@@ -2671,7 +2671,7 @@ public class OpcodeStack {
                 }
                 Item result;
                 if (requestParameter != null && JAVA_UTIL_ARRAYS_ARRAY_LIST.equals(requestParameter.getSignature())) {
-                    result = new Item("Ljava/util/Collections$UnmodifiableRandomAccessList");
+                    result = new Item("Ljava/util/Collections$UnmodifiableRandomAccessList;");
                 } else {
                     result = new Item(returnTypeName);
                 }

--- a/spotbugsTestCases/src/java/ghIssues/Issue2147.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue2147.java
@@ -1,0 +1,49 @@
+package ghIssues;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class Issue2147 {
+    private Object object = new Object();
+
+    private static final List<String> PIN_LIST = Collections
+            .unmodifiableList(Arrays.asList("1", "2", "3", "4"));
+
+    public static void fillConstantAssignments(Map<String, String> map, Issue2147A state) {
+    	Issue2147B[] assignments = state.info.getAssignments();
+
+        for (Issue2147B assignment : assignments) {
+            StringBuilder key = new StringBuilder();
+            if (PIN_LIST.contains(assignment.getId())) {
+                key.append("p");
+            }
+            map.put(key.toString(), null);
+        }
+    }
+
+    public void method1() {
+        object = new Object();
+    }
+
+    public Object getObject() {
+        return object;
+    }
+}
+
+class Issue2147A {
+	Issue2147C info = new Issue2147C();
+}
+
+class Issue2147B {
+	public String getId() {
+		return "";
+	}
+}
+
+class Issue2147C {
+	Issue2147B[] getAssignments() {
+		return new Issue2147B[0];
+	}
+}

--- a/spotbugsTestCases/src/java11/Issue1771.java
+++ b/spotbugsTestCases/src/java11/Issue1771.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
@@ -27,6 +28,10 @@ public class Issue1771 {
         List<String> l = new ArrayList<>();
         l.add("foo");
         l.add("bar");
+
+        List<String> l2 = new LinkedList<>();
+        l2.add("foo");
+        l2.add("bar");
 
         Map<String, String> m = new HashMap();
         m.put("FOO", "foo");
@@ -53,6 +58,7 @@ public class Issue1771 {
         ss.add("bar");
 
         list3 = Collections.unmodifiableList(l);
+        list3a = Collections.unmodifiableList(l2);
         map3 = Collections.unmodifiableMap(m);
         navigableMap3 = Collections.unmodifiableNavigableMap(nm);
         sortedMap3 = Collections.unmodifiableSortedMap(sm);
@@ -82,6 +88,7 @@ public class Issue1771 {
     private final Set<String> set2;
 
     private final List<String> list3;
+    private final List<String> list3a;
     private final Map<String, String> map3;
     private final NavigableMap<String, String> navigableMap3;
     private final SortedMap<String, String> sortedMap3;
@@ -127,6 +134,10 @@ public class Issue1771 {
 
     public List<String> getList3() {
         return list3;
+    }
+
+    public List<String> getList3a() {
+        return list3a;
     }
 
     public Map<String, String> getMap3() {


### PR DESCRIPTION
A  typo in the signature of `java.util.Collections.UnmodifiableRandomAccessList` caused uncaught exceptions and false positives. The correct signature is `Ljava/util/Collections$UnmodifiableRandomAccessList;` but the semicolon was missing from the end. This PR fixes this bug. See issue ([#2174](https://github.com/spotbugs/spotbugs/issues/2174)).



----

Make sure these boxes are checked before submitting your PR -- thank you!

- [X] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
