### PR TITLE
Fix detector StringConcatenation to detect bug SBSC_USE_STRINGBUFFER_CONCATENATION also in Java 11 and above

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 ### Fixed
 - Fixed detector `DontUseFloatsAsLoopCounters` to prevent false positives. ([#2126](https://github.com/spotbugs/spotbugs/issues/2126))
 - Fixed regression in `4.7.2` caused by ([#2141](https://github.com/spotbugs/spotbugs/pull/2141))
+- Fixed detector `StringConcatenation` to detect bug `SBSC_USE_STRINGBUFFER_CONCATENATION` also in Java 11 and above ([#2182](https://github.com/spotbugs/spotbugs/issues/2182))
 
 ## 4.7.2 - 2022-09-02
 ### Fixed

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2182Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2182Test.java
@@ -1,0 +1,36 @@
+package edu.umd.cs.findbugs.detect;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
+
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.number.OrderingComparison.greaterThanOrEqualTo;
+
+public class Issue2182Test extends AbstractIntegrationTest {
+    @Before
+    public void verifyJavaVersion() {
+        assumeFalse(System.getProperty("java.specification.version").startsWith("1."));
+        int javaVersion = Integer.parseInt(System.getProperty("java.specification.version"));
+        assumeThat(javaVersion, is(greaterThanOrEqualTo(11)));
+    }
+
+    @Test
+    public void test() {
+        performAnalysis("../java11/ghIssues/Issue2182.class");
+        BugInstanceMatcher matcher = new BugInstanceMatcherBuilder()
+                .bugType("SBSC_USE_STRINGBUFFER_CONCATENATION")
+                .inClass("Issue2182")
+                .inMethod("test")
+                .atLine(22)
+                .build();
+        assertThat(getBugCollection(), hasItem(matcher));
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/StringConcatenation.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/StringConcatenation.java
@@ -184,22 +184,23 @@ public class StringConcatenation extends OpcodeStackDetector implements Stateles
             break;
 
         case SEEN_NEW:
+            int registerOnStack = getRegisterOnStack();
             if (seen == Const.INVOKESPECIAL && Const.CONSTRUCTOR_NAME.equals(getNameConstantOperand())
                     && "(Ljava/lang/String;)V".equals(getSigConstantOperand())
-                    && getClassConstantOperand().startsWith("java/lang/StringBu") && getRegisterOnStack() >= 0) {
+                    && getClassConstantOperand().startsWith("java/lang/StringBu") && registerOnStack >= 0) {
                 state = SEEN_APPEND1;
-                stringSource = getRegisterOnStack();
+                stringSource = registerOnStack;
             } else if (seen == Const.INVOKEVIRTUAL && "append".equals(getNameConstantOperand())
                     && getClassConstantOperand().startsWith("java/lang/StringBu")) {
                 if (DEBUG) {
-                    System.out.println("Saw string being appended from register " + getRegisterOnStack());
+                    System.out.println("Saw string being appended from register " + registerOnStack);
                 }
-                if (getSigConstantOperand().startsWith("(Ljava/lang/String;)") && getRegisterOnStack() >= 0) {
+                if (getSigConstantOperand().startsWith("(Ljava/lang/String;)") && registerOnStack >= 0) {
                     if (DEBUG) {
-                        System.out.println("Saw string being appended, source = " + getRegisterOnStack());
+                        System.out.println("Saw string being appended, source = " + registerOnStack);
                     }
                     state = SEEN_APPEND1;
-                    stringSource = getRegisterOnStack();
+                    stringSource = registerOnStack;
                 } else {
                     reset();
                 }
@@ -282,7 +283,6 @@ public class StringConcatenation extends OpcodeStackDetector implements Stateles
         if (seen == Const.INVOKESTATIC && "valueOf".equals(getNameConstantOperand())
                 && "java/lang/String".equals(getClassConstantOperand())
                 && "(Ljava/lang/Object;)Ljava/lang/String;".equals(getSigConstantOperand())) {
-            // leave getRegisterOnStack() unchanged
         }
         if (DEBUG && state != oldState) {
             System.out.println("At PC " + getPC() + " changing from state " + oldState + " to state " + state + ", regOnStack = "

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/StringConcatenation.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/StringConcatenation.java
@@ -29,9 +29,10 @@ import org.apache.bcel.classfile.Method;
 
 import edu.umd.cs.findbugs.BugInstance;
 import edu.umd.cs.findbugs.BugReporter;
-import edu.umd.cs.findbugs.BytecodeScanningDetector;
 import edu.umd.cs.findbugs.StatelessDetector;
 import edu.umd.cs.findbugs.SystemProperties;
+import edu.umd.cs.findbugs.OpcodeStack.Item;
+import edu.umd.cs.findbugs.bcel.OpcodeStackDetector;
 import edu.umd.cs.findbugs.visitclass.DismantleBytecode;
 
 /**
@@ -42,7 +43,7 @@ import edu.umd.cs.findbugs.visitclass.DismantleBytecode;
  * @author Dave Brosius
  * @author William Pugh
  */
-public class StringConcatenation extends BytecodeScanningDetector implements StatelessDetector {
+public class StringConcatenation extends OpcodeStackDetector implements StatelessDetector {
     private static final boolean DEBUG = SystemProperties.getBoolean("sbsc.debug");
 
     static final int SEEN_NOTHING = 0;
@@ -60,8 +61,6 @@ public class StringConcatenation extends BytecodeScanningDetector implements Sta
     private final BugReporter bugReporter;
 
     private boolean reportedThisMethod;
-
-    private int registerOnStack = -1;
 
     private int stringSource = -1;
 
@@ -91,7 +90,6 @@ public class StringConcatenation extends BytecodeScanningDetector implements Sta
     private void reset() {
         state = SEEN_NOTHING;
         createPC = -1;
-        registerOnStack = -1;
         stringSource = -1;
 
         // For debugging: print what call to reset() is being invoked.
@@ -117,6 +115,23 @@ public class StringConcatenation extends BytecodeScanningDetector implements Sta
         default:
             return false;
         }
+    }
+
+    private int getRegisterOnStack() {
+        return getRegisterOnStack(0);
+    }
+
+    private int getRegisterOnStack(int idx) {
+        if (idx >= stack.getStackDepth()) {
+            return -1;
+        }
+
+        Item item = stack.getStackItem(idx);
+        if (item == null) {
+            return -1;
+        }
+
+        return item.getRegisterNumber();
     }
 
     @Override
@@ -161,26 +176,30 @@ public class StringConcatenation extends BytecodeScanningDetector implements Sta
             if ((seen == Const.NEW) && getClassConstantOperand().startsWith("java/lang/StringBu")) {
                 state = SEEN_NEW;
                 createPC = getPC();
+            } else if (seen == Const.INVOKEDYNAMIC && "makeConcatWithConstants".equals(getNameConstantOperand())) {
+                state = CONSTRUCTED_STRING_ON_STACK;
+                stringSource = getRegisterOnStack(1);
+                createPC = getPC();
             }
             break;
 
         case SEEN_NEW:
             if (seen == Const.INVOKESPECIAL && Const.CONSTRUCTOR_NAME.equals(getNameConstantOperand())
                     && "(Ljava/lang/String;)V".equals(getSigConstantOperand())
-                    && getClassConstantOperand().startsWith("java/lang/StringBu") && registerOnStack >= 0) {
+                    && getClassConstantOperand().startsWith("java/lang/StringBu") && getRegisterOnStack() >= 0) {
                 state = SEEN_APPEND1;
-                stringSource = registerOnStack;
+                stringSource = getRegisterOnStack();
             } else if (seen == Const.INVOKEVIRTUAL && "append".equals(getNameConstantOperand())
                     && getClassConstantOperand().startsWith("java/lang/StringBu")) {
                 if (DEBUG) {
-                    System.out.println("Saw string being appended from register " + registerOnStack);
+                    System.out.println("Saw string being appended from register " + getRegisterOnStack());
                 }
-                if (getSigConstantOperand().startsWith("(Ljava/lang/String;)") && registerOnStack >= 0) {
+                if (getSigConstantOperand().startsWith("(Ljava/lang/String;)") && getRegisterOnStack() >= 0) {
                     if (DEBUG) {
-                        System.out.println("Saw string being appended, source = " + registerOnStack);
+                        System.out.println("Saw string being appended, source = " + getRegisterOnStack());
                     }
                     state = SEEN_APPEND1;
-                    stringSource = registerOnStack;
+                    stringSource = getRegisterOnStack();
                 } else {
                     reset();
                 }
@@ -263,32 +282,11 @@ public class StringConcatenation extends BytecodeScanningDetector implements Sta
         if (seen == Const.INVOKESTATIC && "valueOf".equals(getNameConstantOperand())
                 && "java/lang/String".equals(getClassConstantOperand())
                 && "(Ljava/lang/Object;)Ljava/lang/String;".equals(getSigConstantOperand())) {
-            // leave registerOnStack unchanged
-        } else {
-            registerOnStack = -1;
-            switch (seen) {
-            case Const.ALOAD_0:
-                registerOnStack = 0;
-                break;
-            case Const.ALOAD_1:
-                registerOnStack = 1;
-                break;
-            case Const.ALOAD_2:
-                registerOnStack = 2;
-                break;
-            case Const.ALOAD_3:
-                registerOnStack = 3;
-                break;
-            case Const.ALOAD:
-                registerOnStack = getRegisterOperand();
-                break;
-            default:
-                break;
-            }
+            // leave getRegisterOnStack() unchanged
         }
         if (DEBUG && state != oldState) {
             System.out.println("At PC " + getPC() + " changing from state " + oldState + " to state " + state + ", regOnStack = "
-                    + registerOnStack);
+                    + getRegisterOnStack());
         }
     }
 }

--- a/spotbugsTestCases/src/java11/Issue2182.java
+++ b/spotbugsTestCases/src/java11/Issue2182.java
@@ -18,8 +18,9 @@ public class Issue2182 {
         String add = "";
         while (it.hasNext()) {
             String retrieve = it.next();
-            if (retrieve != null && !"".equals(retrieve))
+            if (retrieve != null && !"".equals(retrieve)) {
                 add += retrieve;
+            }
             System.out.println(add);
         }
     }

--- a/spotbugsTestCases/src/java11/Issue2182.java
+++ b/spotbugsTestCases/src/java11/Issue2182.java
@@ -1,0 +1,27 @@
+package ghIssues;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+public class Issue2182 {
+
+    public void test() {
+        List<String> A = new ArrayList<String>();
+        A.add("Alex");
+        A.add("john");
+        A.add("lily");
+        A.add("tracy");
+        Iterator <String>it = A.iterator();
+
+        it = A.iterator();
+        String add = "";
+        while (it.hasNext()) {
+            String retrieve = it.next();
+            if (retrieve != null && !"".equals(retrieve))
+                add += retrieve;
+            System.out.println(add);
+        }
+    }
+
+}


### PR DESCRIPTION
Instead of using `StringBuffer` or `StringBuilder` internally, Java 11 and above uses a dynamic call to `makeConcatWithConstants()` to append strings. However, in case of loops, this is still less efficient than creating a `StringBuffer` or `StringBuilder` outside the loop and using it inside to build the string. Previously, the `StringConcatenation` detector missed all the cases in Java 11 and higher, but this PR fixes this. See issue [https://github.com/spotbugs/spotbugs/issues/2182](https://github.com/spotbugs/spotbugs/issues/2182).

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [X] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
