### PR TITLE
Fix detector FindSqlInjection to detect bug SQL_NONCONSTANT_STRING_PASSED_TO_EXECUTE with high priority also in Java 11 and above

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 ### Fixed
 - Fixed detector `DontUseFloatsAsLoopCounters` to prevent false positives. ([#2126](https://github.com/spotbugs/spotbugs/issues/2126))
 - Fixed regression in `4.7.2` caused by ([#2141](https://github.com/spotbugs/spotbugs/pull/2141))
+- Fixed detector `FindSqlInjection` to detect bug `SQL_NONCONSTANT_STRING_PASSED_TO_EXECUTE SQL` with high priority in case of unsafe appends also in Java 11 and above ([#2183](https://github.com/spotbugs/spotbugs/issues/2183))
 
 ## 4.7.2 - 2022-09-02
 ### Fixed

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2183Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2183Test.java
@@ -1,0 +1,38 @@
+package edu.umd.cs.findbugs.detect;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import edu.umd.cs.findbugs.annotations.Confidence;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
+
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.number.OrderingComparison.greaterThanOrEqualTo;
+
+public class Issue2183Test extends AbstractIntegrationTest {
+    @Before
+    public void verifyJavaVersion() {
+        assumeFalse(System.getProperty("java.specification.version").startsWith("1."));
+        int javaVersion = Integer.parseInt(System.getProperty("java.specification.version"));
+        assumeThat(javaVersion, is(greaterThanOrEqualTo(11)));
+    }
+
+    @Test
+    public void test() {
+        performAnalysis("../java11/ghIssues/Issue2183.class");
+        BugInstanceMatcher matcher = new BugInstanceMatcherBuilder()
+                .bugType("SQL_NONCONSTANT_STRING_PASSED_TO_EXECUTE")
+                .inClass("Issue2183")
+                .inMethod("test")
+                .atLine(11)
+                .withConfidence(Confidence.HIGH)
+                .build();
+        assertThat(getBugCollection(), hasItem(matcher));
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindSqlInjection.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindSqlInjection.java
@@ -27,12 +27,19 @@ import java.util.regex.Pattern;
 
 import javax.annotation.CheckForNull;
 
+import org.apache.bcel.classfile.Attribute;
+import org.apache.bcel.classfile.BootstrapMethod;
+import org.apache.bcel.classfile.BootstrapMethods;
+import org.apache.bcel.classfile.ConstantInvokeDynamic;
+import org.apache.bcel.classfile.ConstantPool;
+import org.apache.bcel.classfile.ConstantString;
 import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.classfile.Method;
 import org.apache.bcel.generic.AALOAD;
 import org.apache.bcel.generic.ConstantPoolGen;
 import org.apache.bcel.generic.GETFIELD;
 import org.apache.bcel.generic.GETSTATIC;
+import org.apache.bcel.generic.INVOKEDYNAMIC;
 import org.apache.bcel.generic.INVOKEVIRTUAL;
 import org.apache.bcel.generic.Instruction;
 import org.apache.bcel.generic.InstructionHandle;
@@ -259,6 +266,15 @@ public class FindSqlInjection implements Detector {
         return false;
     }
 
+    private boolean isJava9AndAboveStringAppend(Instruction ins, ConstantPoolGen cpg) {
+        if (ins instanceof INVOKEDYNAMIC) {
+            INVOKEDYNAMIC invoke = (INVOKEDYNAMIC) ins;
+            return "makeConcatWithConstants".equals(invoke.getMethodName(cpg));
+        }
+
+        return false;
+    }
+
     private boolean isConstantStringLoad(Location location, ConstantPoolGen cpg) {
         Instruction ins = location.getHandle().getInstruction();
         if (ins instanceof LDC) {
@@ -307,7 +323,50 @@ public class FindSqlInjection implements Detector {
         return stringAppendState;
     }
 
-    private StringAppendState getStringAppendState(CFG cfg, ConstantPoolGen cpg) throws CFGBuilderException {
+    private StringAppendState updateJava9AndAboveStringAppendState(ClassContext ctx, Location location, ConstantPoolGen cpg,
+            StringAppendState stringAppendState) {
+        InstructionHandle handle = location.getHandle();
+        Instruction ins = handle.getInstruction();
+        if (!(ins instanceof INVOKEDYNAMIC)) {
+            throw new IllegalArgumentException("instruction must be INVOKEDYNAMIC");
+        }
+        INVOKEDYNAMIC invoke = (INVOKEDYNAMIC) ins;
+
+        ConstantPool cp = cpg.getConstantPool();
+        ConstantInvokeDynamic bmidx = (ConstantInvokeDynamic) cp.getConstant(invoke.getIndex());
+
+        JavaClass clazz = ctx.getJavaClass();
+        for (Attribute attr : clazz.getAttributes()) {
+            if (attr instanceof BootstrapMethods) {
+                BootstrapMethod bm = ((BootstrapMethods) attr).getBootstrapMethods()[bmidx.getBootstrapMethodAttrIndex()];
+                String concatArg = ((ConstantString) cp.getConstant(bm.getBootstrapArguments()[0])).getBytes(cp);
+                int u0001idx = concatArg.indexOf('\u0001');
+                if (u0001idx >= 0) {
+                    String before = concatArg.substring(0, u0001idx).trim();
+                    if (before.startsWith(",") || before.endsWith(",")) {
+                        stringAppendState.setSawComma(handle);
+                    }
+                    if (isOpenQuote(before)) {
+                        stringAppendState.setSawOpenQuote(handle);
+                    }
+
+                    String after = concatArg.substring(u0001idx + 1).trim();
+                    if (after.startsWith(",") || after.endsWith(",")) {
+                        stringAppendState.setSawComma(handle);
+                    }
+                    if (isCloseQuote(after) && stringAppendState.getSawOpenQuote(handle)) {
+                        stringAppendState.setSawCloseQuote(handle);
+                    }
+                }
+                break;
+            }
+        }
+
+        return stringAppendState;
+    }
+
+    private StringAppendState getStringAppendState(ClassContext ctx, CFG cfg, ConstantPoolGen cpg)
+            throws CFGBuilderException {
         StringAppendState stringAppendState = new StringAppendState();
         String sig = method.getSignature();
         sig = sig.substring(0, sig.indexOf(')'));
@@ -328,7 +387,15 @@ public class FindSqlInjection implements Detector {
                 if (prevLocation != null && !isSafeValue(prevLocation, cpg)) {
                     stringAppendState.setSawUnsafeAppend(handle);
                 }
+            } else if (isJava9AndAboveStringAppend(ins, cpg)) {
+                stringAppendState.setSawAppend(handle);
 
+                Location prevLocation = getPreviousLocation(cfg, location, true);
+                if (prevLocation != null && !isSafeValue(prevLocation, cpg)) {
+                    stringAppendState.setSawUnsafeAppend(handle);
+                }
+
+                stringAppendState = updateJava9AndAboveStringAppendState(ctx, location, cpg, stringAppendState);
             } else if (ins instanceof InvokeInstruction) {
                 InvokeInstruction inv = (InvokeInstruction) ins;
                 String sig1 = inv.getSignature(cpg);
@@ -502,7 +569,7 @@ public class FindSqlInjection implements Detector {
         ConstantPoolGen cpg = methodGen.getConstantPool();
         CFG cfg = classContext.getCFG(method);
 
-        StringAppendState stringAppendState = getStringAppendState(cfg, cpg);
+        StringAppendState stringAppendState = getStringAppendState(classContext, cfg, cpg);
 
         ConstantDataflow dataflow = classContext.getConstantDataflow(method);
         for (Iterator<Location> i = cfg.locationIterator(); i.hasNext();) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindSqlInjection.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindSqlInjection.java
@@ -268,7 +268,7 @@ public class FindSqlInjection implements Detector {
 
     private boolean isJava9AndAboveStringAppend(Instruction ins, ConstantPoolGen cpg) {
         return ins instanceof INVOKEDYNAMIC
-            && "makeConcatWithConstants".equals(((INVOKEDYNAMIC) ins).getMethodName(cpg));
+                && "makeConcatWithConstants".equals(((INVOKEDYNAMIC) ins).getMethodName(cpg));
     }
 
     private boolean isConstantStringLoad(Location location, ConstantPoolGen cpg) {

--- a/spotbugsTestCases/src/java11/Issue2183.java
+++ b/spotbugsTestCases/src/java11/Issue2183.java
@@ -1,0 +1,13 @@
+package ghIssues;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+public class Issue2183 {
+    ResultSet test(Connection conn, String name) throws SQLException {
+        Statement statement = conn.createStatement(ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_READ_ONLY);
+        return statement.executeQuery("FOO '" + name + "'");
+    }
+}

--- a/spotbugsTestCases/src/java11/module-info.java
+++ b/spotbugsTestCases/src/java11/module-info.java
@@ -1,3 +1,4 @@
 module com.github.spotbugs.testcases {
     requires java.base;
+    requires java.sql;
 }


### PR DESCRIPTION
Instead of using `StringBuffer` or `StringBuilder` internally, Java 11 and above uses a dynamic call to `makeConcatWithConstants()` to append strings. However, in case of loops, this is still less efficient than creating a `StringBuffer` or `StringBuilder` outside the loop and using it inside to build the string. Previously, the `FindSqlInjection` detector assigned low priority in Java 11 and higher in the same cases where it assigned high priority in Java 8. This PR fixes this. See issue [#2183](https://github.com/spotbugs/spotbugs/issues/2183).



----

Make sure these boxes are checked before submitting your PR -- thank you!

- [X] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
