### PR TITLE
Improve compatibility with later version of jdk (>= 13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 ### Fixed
 - Fixed detector `DontUseFloatsAsLoopCounters` to prevent false positives. ([#2126](https://github.com/spotbugs/spotbugs/issues/2126))
 - Fixed regression in `4.7.2` caused by ([#2141](https://github.com/spotbugs/spotbugs/pull/2141))
+- improve compatibility with later version of jdk (>= 13). ([#2188](https://github.com/spotbugs/spotbugs/issues/2188))
 
 ## 4.7.2 - 2022-09-02
 ### Fixed

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/SourceFinder.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/SourceFinder.java
@@ -358,7 +358,7 @@ public class SourceFinder implements AutoCloseable {
 
         public ZipSourceRepository(@WillCloseWhenClosed ZipFile zipFile) throws IOException {
             this.zipFile = zipFile;
-            this.zipFileSystem = FileSystems.newFileSystem(Paths.get(zipFile.getName()), null);
+            this.zipFileSystem = FileSystems.newFileSystem(Paths.get(zipFile.getName()), (ClassLoader) null);
         }
 
         @Override


### PR DESCRIPTION
A method with signature **newFileSystem(Path path, Map<String,?> env)** was introduced in version 13, which results in the conflict in SourceFinder.java:361. According to FileSystems.java in version 8 (which is recommended to compile this project), **newFileSystem(Path path, ClassLoader loader)** should be used in this context. So an explicit cast should be used here.

([issue #2188](https://github.com/spotbugs/spotbugs/issues/2188))

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
