### PR TITLE
Bump log4j to 2.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Fixed detector `DontUseFloatsAsLoopCounters` to prevent false positives. ([#2126](https://github.com/spotbugs/spotbugs/issues/2126))
 - Fixed regression in `4.7.2` caused by ([#2141](https://github.com/spotbugs/spotbugs/pull/2141))
 - improve compatibility with later version of jdk (>= 13). ([#2188](https://github.com/spotbugs/spotbugs/issues/2188))
+- Bump up log4j2 binding to `2.19.0`
 
 ## 4.7.2 - 2022-09-02
 ### Fixed

--- a/buildSrc/src/main/kotlin/constraints.gradle.kts
+++ b/buildSrc/src/main/kotlin/constraints.gradle.kts
@@ -7,7 +7,7 @@ dependencies {
         implementation("org.apache.logging.log4j:log4j-core") {
             version {
                 strictly("[2.17.1, 3[")
-                prefer("2.18.0")
+                prefer("2.19.0")
             }
             because("CVE-2021-44228, CVE-2021-45046, CVE-2021-45105, CVE-2021-44832: Log4j vulnerable to remote code execution and other critical security vulnerabilities")
         }

--- a/spotbugs-tests/build.gradle
+++ b/spotbugs-tests/build.gradle
@@ -2,7 +2,7 @@ apply from: "$rootDir/gradle/checkstyle.gradle"
 apply from: "$rootDir/gradle/jacoco.gradle"
 
 ext {
-  log4jVersion = '2.18.0'
+  log4jVersion = '2.19.0'
 }
 
 dependencies {
@@ -18,7 +18,8 @@ dependencies {
   implementation 'junit:junit:4.13.2'
   implementation 'org.hamcrest:hamcrest-all:1.3'
   implementation 'org.apache.ant:ant:1.10.12'
-  implementation "org.apache.logging.log4j:log4j-slf4j18-impl:$log4jVersion"
+  implementation "org.apache.logging.log4j:log4j-core:$log4jVersion"
+  implementation "org.apache.logging.log4j:log4j-slf4j2-impl:$log4jVersion"
   implementation 'com.google.errorprone:error_prone_annotations:2.15.0'
   implementation files(project(":spotbugs").sourceSets.gui.output)
 }

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -24,7 +24,7 @@ configurations {
 
 ext {
   asmVersion = '9.3'
-  log4jVersion = '2.18.0'
+  log4jVersion = '2.19.0'
 }
 
 sourceSets {
@@ -88,7 +88,8 @@ dependencies {
   api 'org.apache.commons:commons-text:1.9'
   api 'org.slf4j:slf4j-api:2.0.0'
   implementation 'net.sf.saxon:Saxon-HE:11.4'
-  logBinding ("org.apache.logging.log4j:log4j-slf4j18-impl:$log4jVersion") {
+  implementation "org.apache.logging.log4j:log4j-core:$log4jVersion"
+  logBinding ("org.apache.logging.log4j:log4j-slf4j2-impl:$log4jVersion") {
     exclude group: 'org.slf4j'
   }
 
@@ -357,7 +358,7 @@ dependencies {
     logBinding("org.apache.logging.log4j:log4j-core") {
       version {
         strictly("[2.17.1, 3[")
-        prefer("2.18.0")
+        prefer("2.19.0")
       }
       because("CVE-2021-44228, CVE-2021-45046, CVE-2021-45105, CVE-2021-44832: Log4j vulnerable to remote code execution and other critical security vulnerabilities")
     }


### PR DESCRIPTION
Resolves https://github.com/spotbugs/spotbugs/issues/2176
```
Unexpected problem occured during version sanity check
Reported exception:
java.lang.AbstractMethodError: Receiver class org.apache.logging.slf4j.SLF4JServiceProvider does not define or inherit an implementation of the resolved method 'abstract java.lang.String getRequestedApiVersion()' of interface org.slf4j.spi.SLF4JServiceProvider.
	at org.slf4j.LoggerFactory.versionSanityCheck(LoggerFactory.java:297)
...
```

The issue is log4j 2.x broke compatibility (renamed method that had a grammatic typo) and slf4j-impl 2.18.0 still being on 1.x.

2.19.0 is now released with fix of
https://issues.apache.org/jira/browse/LOG4J2-3139

Changing `log4j-slf4j18-impl` to `log4j-slf4j2-impl`, see https://logging.apache.org/log4j/2.x/log4j-slf4j-impl/index.html

Adding explicit (runtime) dependency on log4j-core because `log4j-slf4j2-impl` doesn't have it and it'd otherwise cause
```
ERROR StatusLogger Log4j2 could not find a logging implementation. Please add log4j-core to the classpath. Using SimpleLogger to log to the console...
```

Tested with
```console
$ rm ./spotbugs/.libs/*
$ gradle assemble
$ java -cp "./spotbugs/.libs/*:./spotbugs/build/libs/spotbugs.jar" edu.umd.cs.findbugs.LaunchAppropriateUI -textui
...log4j errors are not showing up now...
```



----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
