### PR TITLE
Fix for test detector ViewCFG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Bump up log4j2 binding to `2.19.0`
 - Bump ObjectWeb ASM from 9.3 to 9.4 supporting JDK 20 ([#2200](https://github.com/spotbugs/spotbugs/pull/2200))
 - Bump up commons-text to 1.10.0 ([#2197](https://github.com/spotbugs/spotbugs/pull/2197))
+- Fixed debug detector `ViewCFG` to generate file names that are also valid on Windows ([#2209](https://github.com/spotbugs/spotbugs/issues/2209))
 
 ## 4.7.2 - 2022-09-02
 ### Fixed

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ViewCFG.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ViewCFG.java
@@ -171,13 +171,14 @@ public class ViewCFG implements Detector {
     }
 
     private Path getMethodFile(Path classDir, String methodName) {
-        String methodFileName = SPECIAL_METHOD.matcher(methodName).replaceAll("____$1");
+        String methodFileNameBase = SPECIAL_METHOD.matcher(methodName).replaceAll("____$1");
         Path methodFile;
         int index = 0;
 
+        String methodFileName = methodFileNameBase;
         do {
             methodFile = Paths.get(classDir.toString(), methodFileName + ".dot");
-            methodFileName = methodName + ++index;
+            methodFileName = methodFileNameBase + ++index;
         } while (Files.exists(methodFile));
         return methodFile;
     }


### PR DESCRIPTION
The ViewCFG detector generates files with names containing the `<` and the `>` characters for classes containing more than one constructor. Since these characters are illegal in file names on `Windows` the analysis fails with an exception. Since all the detectors (even those which are disabled by default) are enabled during testing, the build fails on `Windows`. See issue [#2209](https://github.com/spotbugs/spotbugs/issues/2209). This PR fixes this issue.



----

Make sure these boxes are checked before submitting your PR -- thank you!

- [X] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
