### PR TITLE
fix: Disable access to external entities in XML parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 ### Fixed
 - Bump up slf4j-api to 2.0.3 ([#2220](https://github.com/spotbugs/spotbugs/pull/2220))
 
+#### Security
+- Disable access to external entities when processing XML ([#2217](https://github.com/spotbugs/spotbugs/pull/2217))
+
 ## 4.7.3 - 2022-10-15
 ### Fixed
 - Fixed detector `DontUseFloatsAsLoopCounters` to prevent false positives. ([#2126](https://github.com/spotbugs/spotbugs/issues/2126))

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/HTMLBugReporter.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/HTMLBugReporter.java
@@ -33,6 +33,8 @@ import javax.xml.transform.stream.StreamSource;
 import org.dom4j.Document;
 import org.dom4j.io.DocumentSource;
 
+import edu.umd.cs.findbugs.xml.XMLUtil;
+
 public class HTMLBugReporter extends BugCollectionBugReporter {
     private String stylesheet;
 
@@ -64,7 +66,7 @@ public class HTMLBugReporter extends BugCollectionBugReporter {
             xsl.setSystemId(stylesheet);
 
             // Create a transformer using the stylesheet
-            TransformerFactory factory = TransformerFactory.newInstance("net.sf.saxon.TransformerFactoryImpl", null);
+            TransformerFactory factory = XMLUtil.buildTransformerFactory();
             Transformer transformer = factory.newTransformer(xsl);
 
             // Source document is the XML generated from the BugCollection

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/PluginLoader.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/PluginLoader.java
@@ -1198,7 +1198,7 @@ public class PluginLoader implements AutoCloseable {
             throw new PluginDoesntContainMetadataException((corePlugin ? "Core plugin" : "Plugin ") + jarName
                     + " doesn't contain findbugs.xml; got " + findbugsXML_URL + " from " + classloaderName);
         }
-        SAXReader reader = new SAXReader();
+        SAXReader reader = XMLUtil.buildSAXReader();
 
         try (InputStream input = IO.openNonCachedStream(findbugsXML_URL);
                 Reader r = UTF8.bufferedReader(input)) {
@@ -1326,7 +1326,7 @@ public class PluginLoader implements AutoCloseable {
     private void addCollection(List<Document> messageCollectionList, String filename) throws PluginException {
         URL messageURL = getResource(filename);
         if (messageURL != null) {
-            SAXReader reader = new SAXReader();
+            SAXReader reader = XMLUtil.buildSAXReader();
             try (InputStream input = IO.openNonCachedStream(messageURL);
                     Reader stream = UTF8.bufferedReader(input)) {
                 Document messageCollection;
@@ -1629,7 +1629,7 @@ public class PluginLoader implements AutoCloseable {
     private static Document parseDocument(@WillClose InputStream in) throws DocumentException {
         Reader r = UTF8.bufferedReader(in);
         try {
-            SAXReader reader = new SAXReader();
+            SAXReader reader = XMLUtil.buildSAXReader();
             Document d = reader.read(r);
             return d;
         } finally {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ProjectStats.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ProjectStats.java
@@ -57,6 +57,7 @@ import edu.umd.cs.findbugs.log.Profiler;
 import edu.umd.cs.findbugs.workflow.FileBugHash;
 import edu.umd.cs.findbugs.xml.OutputStreamXMLOutput;
 import edu.umd.cs.findbugs.xml.XMLOutput;
+import edu.umd.cs.findbugs.xml.XMLUtil;
 import edu.umd.cs.findbugs.xml.XMLWriteable;
 
 /**
@@ -509,7 +510,7 @@ public class ProjectStats implements XMLWriteable, Cloneable {
         }
         StreamSource xsl = new StreamSource(xslInputStream);
 
-        TransformerFactory tf = TransformerFactory.newInstance("net.sf.saxon.TransformerFactoryImpl", null);
+        TransformerFactory tf = XMLUtil.buildTransformerFactory();
         Transformer transformer = tf.newTransformer(xsl);
         transformer.transform(in, out);
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/xml/XMLUtil.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/xml/XMLUtil.java
@@ -27,7 +27,6 @@ import javax.xml.transform.TransformerFactory;
 import org.dom4j.Node;
 import org.dom4j.io.SAXReader;
 
-import edu.umd.cs.findbugs.FindBugs;
 
 /**
  * @author pugh
@@ -50,7 +49,7 @@ public class XMLUtil {
 
         return reader;
     }
-    
+
     public static TransformerFactory buildTransformerFactory() {
         TransformerFactory factory = TransformerFactory.newInstance("net.sf.saxon.TransformerFactoryImpl", null);
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/xml/XMLUtil.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/xml/XMLUtil.java
@@ -21,7 +21,13 @@ package edu.umd.cs.findbugs.xml;
 
 import java.util.List;
 
+import javax.xml.XMLConstants;
+import javax.xml.transform.TransformerFactory;
+
 import org.dom4j.Node;
+import org.dom4j.io.SAXReader;
+
+import edu.umd.cs.findbugs.FindBugs;
 
 /**
  * @author pugh
@@ -33,4 +39,28 @@ public class XMLUtil {
         return (List<T>) node.selectNodes(arg0);
     }
 
+    public static SAXReader buildSAXReader() {
+        SAXReader reader = new SAXReader();
+
+        try {
+            reader.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        } catch (Exception e) {
+            throw new IllegalArgumentException(e);
+        }
+
+        return reader;
+    }
+    
+    public static TransformerFactory buildTransformerFactory() {
+        TransformerFactory factory = TransformerFactory.newInstance("net.sf.saxon.TransformerFactoryImpl", null);
+
+        try {
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+        } catch (Exception e) {
+            throw new IllegalArgumentException(e);
+        }
+
+        return factory;
+    }
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/xml/XMLUtil.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/xml/XMLUtil.java
@@ -44,7 +44,7 @@ public class XMLUtil {
         try {
             reader.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
         } catch (Exception e) {
-            throw new IllegalArgumentException(e);
+            throw new RuntimeException("Error while disabling XML external entities", e);
         }
 
         return reader;
@@ -57,7 +57,7 @@ public class XMLUtil {
             factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
             factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
         } catch (Exception e) {
-            throw new IllegalArgumentException(e);
+            throw new RuntimeException("Error while disabling XML external entities", e);
         }
 
         return factory;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/xml/XPathFind.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/xml/XPathFind.java
@@ -66,7 +66,7 @@ public abstract class XPathFind {
         String fileName = argv[0];
         String xpath = argv[1];
 
-        SAXReader reader = new SAXReader();
+        SAXReader reader = XMLUtil.buildSAXReader();
         Document document = reader.read(fileName);
 
         XPathFind finder = new XPathFind(document) {


### PR DESCRIPTION
Fixes security issues detected by sonarcloud such as: https://sonarcloud.io/project/issues?issues=AXDRMcroPCexr-BXKaE_&open=AXDRMcroPCexr-BXKaE_&id=com.github.spotbugs.spotbugs

> XML standard allows the use of entities, declared in the DOCTYPE of the document, which can be [internal](https://www.w3.org/TR/xml/#sec-internal-ent) or [external](https://www.w3.org/TR/xml/#sec-external-ent).
> 
> When parsing the XML file, the content of the external entities is retrieved from an external storage such as the file system or network, which may lead, if no restrictions are put in place, to arbitrary file disclosures or [server-side request forgery (SSRF)](https://owasp.org/www-community/attacks/Server_Side_Request_Forgery) vulnerabilities.

Added methods in `XMLUtil` to setup XML objects with more secure options