### PR TITLE
Try to check coverage of subprojects

### DIFF
--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -1,3 +1,4 @@
+apply from: "$rootDir/gradle/jacoco.gradle"
 apply from: "$rootDir/gradle/maven.gradle"
 apply from: "$rootDir/gradle/checkstyle.gradle"
 apply from: "$rootDir/gradle/javadoc.gradle"

--- a/test-harness-jupiter/build.gradle
+++ b/test-harness-jupiter/build.gradle
@@ -1,3 +1,4 @@
+apply from: "$rootDir/gradle/jacoco.gradle"
 apply from: "$rootDir/gradle/checkstyle.gradle"
 apply from: "$rootDir/gradle/javadoc.gradle"
 apply from: "$rootDir/gradle/maven.gradle"


### PR DESCRIPTION
Currently, SonarQube does not check the coverage except the `spotbugs-ant` submodule:
https://sonarcloud.io/component_measures?id=com.github.spotbugs.spotbugs&metric=coverage

I found that `test-harness-jupiter/build.gradle` does not enable the `jacoco` plugin, from its beginning:
https://github.com/spotbugs/spotbugs/commit/fda4e9fd752d2ec29b53036198e5320553f3342c#diff-564e47d4d39ec9ca61bbf267c77b00681e9f6d0b540e7d676898716321f9d949

By the change suggested in this PR, the jacoco HTML report can include coverage from spotbugs and test-harness-jupiter submodules:
https://github.com/spotbugs/spotbugs/commit/fda4e9fd752d2ec29b53036198e5320553f3342c#diff-564e47d4d39ec9ca61bbf267c77b00681e9f6d0b540e7d676898716321f9d949

so I expect that SonarQube can handle coverages of these submodules correctly.