### PR TITLE
Stop exposing junit-bom to consumers (#2255)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ### Fixed
 - Fixed missing classes not in report if using IErrorLogger.reportMissingClass(ClassDescriptor) ([#219](https://github.com/spotbugs/spotbugs/issues/219))
+- Stop exposing junit-bom to consumers ([#2255](https://github.com/spotbugs/spotbugs/pull/2255))
 
 #### Security
 - Disable access to external entities when processing XML ([#2217](https://github.com/spotbugs/spotbugs/pull/2217))

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,9 @@ allprojects {
     mavenCentral()
   }
   dependencies {
-    implementation platform('org.junit:junit-bom:5.9.1')
+    def junitVersion = '5.9.1'
+    compileOnly platform("org.junit:junit-bom:$junitVersion")
+    testImplementation platform("org.junit:junit-bom:$junitVersion")
   }
 }
 


### PR DESCRIPTION
Fixes #2255 by limiting the scope where the JUnit-bom is visible.

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
