### PR TITLE
Only run release action on 'spotbugs' and update eclipse to match that of build 4.14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       contents: write # to push pages branch (peaceiris/actions-gh-pages)
 
+    if: github.repository_owner == 'spotbugs'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,8 @@ jobs:
       - uses: gradle/wrapper-validation-action@v1
       - name: Download Eclipse
         run: |
-          wget 'https://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops4/R-4.6.3-201703010400/eclipse-SDK-4.6.3-linux-gtk-x86_64.tar.gz&r=1' -O eclipse-SDK-4.6.3-linux-gtk-x86_64.tar.gz
-          tar xzvf eclipse-SDK-4.6.3-linux-gtk-x86_64.tar.gz eclipse
+          wget 'https://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops4/R-4.14-201912100610/eclipse-SDK-4.14-linux-gtk-x86_64.tar.gz&r=1' -O eclipse-SDK-4.14-linux-gtk-x86_64.tar.gz
+          tar xzvf eclipse-SDK-4.14-linux-gtk-x86_64.tar.gz eclipse
           echo "eclipseRoot.dir=$(pwd)/eclipse" > eclipsePlugin/local.properties
       - name: Build
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Bump Eclipse from 4.6.3 to 4.14 ([#2314](https://github.com/spotbugs/spotbugs/pull/2314))
 - Use jakarta annotation 1.3.5 instead of legacy javax annotation 1.3.2 ([#2315](https://github.com/spotbugs/spotbugs/pull/2315))
 - Change hamcrest-all to hamcrest-core as that is what was actually used and then update to 2.2 ([#2316](https://github.com/spotbugs/spotbugs/pull/2316))
+- Only run release action on 'spotbugs' and use Eclipse 4.14 ([#2317](https://github.com/spotbugs/spotbugs/pull/2317))
 
 ## 4.7.3 - 2022-10-15
 ### Fixed


### PR DESCRIPTION
fixes issue that this runs on forks and fails.  This disables its run and also updates to same eclipse change from build.
----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x ] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
