### PR TITLE
Unused field not reported due to assumed reflection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Stop exposing junit-bom to consumers ([#2255](https://github.com/spotbugs/spotbugs/pull/2255))
 - Fixed AbstractBugReporter emits wrong non-sensical debug output during filtering ([#184](https://github.com/spotbugs/spotbugs/issues/184))
 - Added support for jakarta namespace ([#2289](https://github.com/spotbugs/spotbugs/pull/2289))
+- Report a low priority bug for an unread field in reflective classes ([#2325](https://github.com/spotbugs/spotbugs/issues/2325))
 
 ### Security
 - Disable access to external entities when processing XML ([#2217](https://github.com/spotbugs/spotbugs/pull/2217))

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/UnreadFieldsTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/UnreadFieldsTest.java
@@ -1,18 +1,21 @@
 package edu.umd.cs.findbugs.detect;
 
-import edu.umd.cs.findbugs.BugCollection;
-import edu.umd.cs.findbugs.BugInstance;
-import edu.umd.cs.findbugs.test.SpotBugsRule;
-import org.junit.Rule;
-import org.junit.Test;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.nio.file.Paths;
 import java.util.Optional;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import org.junit.Rule;
+import org.junit.Test;
+
+import edu.umd.cs.findbugs.BugCollection;
+import edu.umd.cs.findbugs.BugInstance;
+import edu.umd.cs.findbugs.Priorities;
+import edu.umd.cs.findbugs.test.SpotBugsRule;
 
 public class UnreadFieldsTest {
     @Rule
@@ -31,5 +34,27 @@ public class UnreadFieldsTest {
                 .findAny();
         assertTrue(reportedBug.isPresent());
         assertThat(reportedBug.get().getPrimarySourceLineAnnotation().getStartLine(), is(not(-1)));
+    }
+
+    /**
+     * {@code URF_UNREAD_FIELD} should be reported also in reflective classes.
+     *
+     * @see <a href="https://github.com/spotbugs/spotbugs/issues/2325">GitHub Issue</a>
+     */
+    @Test
+    public void unreadFieldInReflectiveClass() {
+        BugCollection bugCollection = spotbugs.performAnalysis(Paths.get("../spotbugsTestCases/build/classes/java/main/ghIssues/Issue2325.class"));
+
+        Optional<BugInstance> reportedBug = bugCollection.getCollection().stream()
+                .filter(bug -> "UUF_UNUSED_FIELD".equals(bug.getBugPattern().getType())).findAny();
+        assertTrue("Expected unused field bug, but got: " + bugCollection.getCollection(), reportedBug.isPresent());
+        assertEquals("Expected low priority unused field bug", Priorities.LOW_PRIORITY,
+                reportedBug.get().getPriority());
+
+        reportedBug = bugCollection.getCollection().stream()
+                .filter(bug -> "URF_UNREAD_FIELD".equals(bug.getBugPattern().getType())).findAny();
+        assertTrue("Expected unread field bug, but got: " + bugCollection.getCollection(), reportedBug.isPresent());
+        assertEquals("Expected low priority unread field bug", Priorities.LOW_PRIORITY,
+                reportedBug.get().getPriority());
     }
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UnreadFields.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UnreadFields.java
@@ -865,8 +865,8 @@ public class UnreadFields extends OpcodeStackDetector {
         XFactory xFactory = AnalysisContext.currentXFactory();
         for (XField f : AnalysisContext.currentXFactory().allFields()) {
             ClassDescriptor classDescriptor = f.getClassDescriptor();
-            if (currentAnalysisContext.isApplicationClass(classDescriptor) && !currentAnalysisContext.isTooBig(classDescriptor)
-                    && !xFactory.isReflectiveClass(classDescriptor)) {
+            if (currentAnalysisContext.isApplicationClass(classDescriptor)
+                    && !currentAnalysisContext.isTooBig(classDescriptor)) {
                 declaredFields.add(f);
             }
         }
@@ -986,6 +986,9 @@ public class UnreadFields extends OpcodeStackDetector {
             String fieldSignature = f.getSignature();
             if (f.isResolved() && !data.fieldsOfNativeClasses.contains(f)) {
                 int priority = NORMAL_PRIORITY;
+                if (xFactory.isReflectiveClass(f.getClassDescriptor())) {
+                    priority++;
+                }
                 if (!(fieldSignature.charAt(0) == 'L' || fieldSignature.charAt(0) == '[')) {
                     priority++;
                 }
@@ -1044,6 +1047,9 @@ public class UnreadFields extends OpcodeStackDetector {
                 } else {
                     priority--;
                 }
+                if (xFactory.isReflectiveClass(f.getClassDescriptor())) {
+                    priority++;
+                }
                 String pattern = (f.isPublic() || f.isProtected()) ? "NP_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD"
                         : "NP_UNWRITTEN_FIELD";
                 for (ProgramPoint p : assumedNonNullAt) {
@@ -1053,6 +1059,9 @@ public class UnreadFields extends OpcodeStackDetector {
                 }
 
             } else {
+                if (xFactory.isReflectiveClass(f.getClassDescriptor())) {
+                    priority++;
+                }
                 if (f.isStatic()) {
                     priority++;
                 }
@@ -1199,11 +1208,18 @@ public class UnreadFields extends OpcodeStackDetector {
                 } else if (data.fieldsOfSerializableOrNativeClassed.contains(f)) {
                     // ignore it
                 } else if (!data.writtenFields.contains(f)) {
+                    int priority = NORMAL_PRIORITY;
+                    if (xFactory.isReflectiveClass(f.getClassDescriptor())) {
+                        priority++;
+                    }
                     bugReporter.reportBug(new BugInstance(this,
                             (f.isPublic() || f.isProtected()) ? "UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD" : "UUF_UNUSED_FIELD",
-                            NORMAL_PRIORITY).addClass(className).addField(f).lowerPriorityIfDeprecated());
+                            priority).addClass(className).addField(f).lowerPriorityIfDeprecated());
                 } else if (f.getName().toLowerCase().indexOf("guardian") < 0) {
                     int priority = NORMAL_PRIORITY;
+                    if (xFactory.isReflectiveClass(f.getClassDescriptor())) {
+                        priority++;
+                    }
                     if (f.isStatic()) {
                         priority++;
                     }

--- a/spotbugsTestCases/src/java/ghIssues/Issue2325.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue2325.java
@@ -1,0 +1,12 @@
+package ghIssues;
+
+public class Issue2325 {
+
+	public static Class<?> cl = Issue2325.class;
+	private String unusedField;
+	private String unreadField;
+
+	public void setUnreadField(String unreadField) {
+		this.unreadField = unreadField;
+	}
+}


### PR DESCRIPTION
This change ensures an unused field is reported despite assumptions on reflection use for the defining class.

If reflection is assumed, the priority of the created spotbugs problem is lowered.

Fixes: #2325



----

Make sure these boxes are checked before submitting your PR -- thank you!

- [ ] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
