### PR TITLE
Fix for "Unhandled event loop exception" opening Bug Filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased - 2022-??-??
+## Unreleased - 2023-??-??
 ### Changed
 - Bump up Apache Commons BCEL to the version 6.6.1 ([#2223](https://github.com/spotbugs/spotbugs/pull/2223))
 - Bump up slf4j-api to 2.0.3 ([#2220](https://github.com/spotbugs/spotbugs/pull/2220))
@@ -16,6 +16,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Fixed AbstractBugReporter emits wrong non-sensical debug output during filtering ([#184](https://github.com/spotbugs/spotbugs/issues/184))
 - Added support for jakarta namespace ([#2289](https://github.com/spotbugs/spotbugs/pull/2289))
 - Report a low priority bug for an unread field in reflective classes ([#2325](https://github.com/spotbugs/spotbugs/issues/2325))
+- Fixed "Unhandled event loop exception" opening Bug Filter Configuration dialog in Eclipse ([#2327](https://github.com/spotbugs/spotbugs/issues/2327))
 
 ### Security
 - Disable access to external entities when processing XML ([#2217](https://github.com/spotbugs/spotbugs/pull/2217))

--- a/eclipsePlugin/src/de/tobject/findbugs/view/explorer/FilterBugsDialog.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/view/explorer/FilterBugsDialog.java
@@ -632,7 +632,9 @@ public class FilterBugsDialog extends SelectionDialog {
             txt = getPatternTypeDescription(code);
         }
         Rectangle size = htmlControl.getClientArea();
-        txt = presenter.updatePresentation(getShell().getDisplay(), txt, presentation, size.width, size.height);
+        if (size.width > 0 && size.height > 0) {
+            txt = presenter.updatePresentation(getShell().getDisplay(), txt, presentation, size.width, size.height);
+        }
         htmlControl.setText(txt);
     }
 


### PR DESCRIPTION
Configuration dialog in Eclipse

Simply don't pass zero values to the
IInformationPresenterExtension.updatePresentation(), they are not allowed anymore.

Fixes https://github.com/spotbugs/spotbugs/issues/2327