### PR TITLE
minor: make private class final with default constructor

### DIFF
--- a/eclipsePlugin-junit/src/test/java/de/tobject/findbugs/reporter/ThrottledProgressMonitorTest.java
+++ b/eclipsePlugin-junit/src/test/java/de/tobject/findbugs/reporter/ThrottledProgressMonitorTest.java
@@ -42,7 +42,7 @@ public class ThrottledProgressMonitorTest {
         verify(delegate).worked(2 + 4);
     }
 
-    private static class Clock {
+    private static final class Clock {
         private long currentTime;
 
         protected long getCurrentTime() {

--- a/eclipsePlugin-test/src/org/eclipse/jdt/testplugin/JavaProjectHelper.java
+++ b/eclipsePlugin-test/src/org/eclipse/jdt/testplugin/JavaProjectHelper.java
@@ -683,13 +683,13 @@ public class JavaProjectHelper {
         }
     }
 
-    private static class ImportOverwriteQuery implements IOverwriteQuery {
+    private static final class ImportOverwriteQuery implements IOverwriteQuery {
         @Override
         public String queryOverwrite(String file) {
             return ALL;
         }
     }
 
-    private static class Requestor extends TypeNameRequestor {
+    private static final class Requestor extends TypeNameRequestor {
     }
 }

--- a/spotbugs/src/gui/main/edu/umd/cs/findbugs/gui2/AnalyzingDialog.java
+++ b/spotbugs/src/gui/main/edu/umd/cs/findbugs/gui2/AnalyzingDialog.java
@@ -238,7 +238,7 @@ public final class AnalyzingDialog extends FBDialog implements FindBugsProgress 
         updateCount(0, numClasses);
     }
 
-    private class AnalysisThread extends Thread {
+    private final class AnalysisThread extends Thread {
         {
             // Give the analysis thread its (possibly user-defined) priority.
             // The default is a slightly lower priority than the UI.

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DumbMethods.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DumbMethods.java
@@ -83,7 +83,7 @@ public class DumbMethods extends OpcodeStackDetector {
         abstract public void sawOpcode(int seen);
     }
 
-    private class InvalidMinMaxSubDetector extends SubDetector {
+    private final class InvalidMinMaxSubDetector extends SubDetector {
         Number lowerBound, upperBound;
 
         @Override
@@ -130,7 +130,7 @@ public class DumbMethods extends OpcodeStackDetector {
         }
     }
 
-    private class NullMethodsSubDetector extends SubDetector {
+    private final class NullMethodsSubDetector extends SubDetector {
 
         @Override
         public void sawOpcode(int seen) {
@@ -201,7 +201,7 @@ public class DumbMethods extends OpcodeStackDetector {
         }
     }
 
-    private class FutilePoolSizeSubDetector extends SubDetector {
+    private final class FutilePoolSizeSubDetector extends SubDetector {
         @Override
         public void sawOpcode(int seen) {
             if (seen == Const.INVOKEVIRTUAL && "java/util/concurrent/ScheduledThreadPoolExecutor".equals(getClassConstantOperand())
@@ -213,7 +213,7 @@ public class DumbMethods extends OpcodeStackDetector {
         }
     }
 
-    private class RangeCheckSubDetector extends SubDetector {
+    private final class RangeCheckSubDetector extends SubDetector {
 
 
 
@@ -373,7 +373,7 @@ public class DumbMethods extends OpcodeStackDetector {
         }
     }
 
-    private class UrlCollectionSubDetector extends SubDetector {
+    private final class UrlCollectionSubDetector extends SubDetector {
         @Override
         public void sawOpcode(int seen) {
             if ((seen == Const.INVOKEVIRTUAL && "java/util/HashMap".equals(getClassConstantOperand()) && "get".equals(getNameConstantOperand()))
@@ -391,7 +391,7 @@ public class DumbMethods extends OpcodeStackDetector {
         }
     }
 
-    private class VacuousComparisonSubDetector extends SubDetector {
+    private final class VacuousComparisonSubDetector extends SubDetector {
         @Override
         public void sawOpcode(int seen) {
             boolean foundVacuousComparison = false;
@@ -428,7 +428,7 @@ public class DumbMethods extends OpcodeStackDetector {
         }
     }
 
-    private class BadCastInEqualsSubDetector extends SubDetector {
+    private final class BadCastInEqualsSubDetector extends SubDetector {
         private boolean isEqualsObject;
 
         private boolean sawInstanceofCheck;
@@ -482,7 +482,7 @@ public class DumbMethods extends OpcodeStackDetector {
     @SlashedClassName
     private static final String CLASS_NAME_RANDOM = "java/util/Random";
 
-    private class RandomOnceSubDetector extends SubDetector {
+    private final class RandomOnceSubDetector extends SubDetector {
         /**
          * True if a freshly created {@code Random} instance exists on ToS (Top op Stack)
          */

--- a/spotbugs/src/tools/edu/umd/cs/findbugs/tools/html/PrettyPrintBugDescriptions.java
+++ b/spotbugs/src/tools/edu/umd/cs/findbugs/tools/html/PrettyPrintBugDescriptions.java
@@ -46,7 +46,7 @@ public class PrettyPrintBugDescriptions extends PlainPrintBugDescriptions {
 
     private static final String[] TABLE_COLORS = new String[] { "#eeeeee", "#ffffff" };
 
-    private static class BugPatternComparator implements Comparator<BugPattern>, Serializable {
+    private static final class BugPatternComparator implements Comparator<BugPattern>, Serializable {
         @Override
         public int compare(BugPattern a, BugPattern b) {
             int cmp = a.getCategory().compareTo(b.getCategory());


### PR DESCRIPTION
minor: make private class final with default constructor

This is part of https://github.com/checkstyle/checkstyle/pull/12737

According to the https://docs.oracle.com/javase/specs/jls/se17/html/jls-8.html#jls-8.8.9 The default constructor has the same access modifier as the class.
and according to the check https://checkstyle.org/config_design.html#FinalClass a class that has only private constructors and has no descendant classes is declared as final.