### PR TITLE
Fix guava update by updating tests to the new type

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/RegressionIdeas20110722Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/RegressionIdeas20110722Test.java
@@ -1,0 +1,70 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
+import org.junit.Test;
+
+import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+
+public class RegressionIdeas20110722Test extends AbstractIntegrationTest {
+    @Test
+    public void testArgumentAssertions() {
+        performAnalysis("bugIdeas/Ideas_2011_07_22.class");
+
+        assertNumOfBugs("NP_NULL_ON_SOME_PATH", 0);
+        assertNumOfBugs("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE", 4);
+        assertNumOfBugs("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE", 2);
+
+        assertNoNpBugInMethod("getHashCode");
+        assertNoNpBugInMethod("getHashCode1");
+        assertNoNpBugInMethod("getHashCode2");
+        assertNoNpBugInMethod("getHashCode3");
+        assertRCNBug("getHashCode3", "x", 34);
+        assertNoNpBugInMethod("getHashCode4");
+        assertRCNBug("getHashCode4", "x", 41);
+        assertNoNpBugInMethod("getHashCode5");
+        assertRCNBug("getHashCode5", "x", 48);
+        assertRCNBug("getHashCode6", "x", 55);
+        assertNpParamBug("getHashCode6", "x");
+        assertNpParamBug("getHashCode7", "x");
+    }
+
+    private void assertNumOfBugs(String error, int num) {
+        final BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
+                .bugType(error).build();
+        assertThat(getBugCollection(), containsExactly(num, bugTypeMatcher));
+    }
+
+    private void assertNoNpBugInMethod(String method) {
+        final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
+                .bugType("NP_NULL_ON_SOME_PATH")
+                .inClass("Ideas_2011_07_22")
+                .inMethod(method)
+                .build();
+        assertThat(getBugCollection(), containsExactly(0, bugInstanceMatcher));
+    }
+
+    private void assertRCNBug(String method, String var, int line) {
+        final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
+                .bugType("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
+                .inClass("Ideas_2011_07_22")
+                .inMethod(method)
+                .atVariable(var)
+                .atLine(line)
+                .build();
+        assertThat(getBugCollection(), hasItem(bugInstanceMatcher));
+    }
+
+    private void assertNpParamBug(String method, String var) {
+        final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
+                .bugType("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
+                .inClass("Ideas_2011_07_22")
+                .inMethod(method)
+                .atVariable(var)
+                .build();
+        assertThat(getBugCollection(), hasItem(bugInstanceMatcher));
+    }
+}

--- a/spotbugsTestCases/src/java/bugIdeas/Ideas_2011_07_22.java
+++ b/spotbugsTestCases/src/java/bugIdeas/Ideas_2011_07_22.java
@@ -4,14 +4,9 @@ import javax.annotation.Nullable;
 
 import com.google.common.base.Preconditions;
 
-import edu.umd.cs.findbugs.annotations.DesireNoWarning;
 import edu.umd.cs.findbugs.annotations.DesireWarning;
-import edu.umd.cs.findbugs.annotations.ExpectWarning;
-import edu.umd.cs.findbugs.annotations.NoWarning;
 
 public class Ideas_2011_07_22 {
-
-    @DesireNoWarning("NP_NULL_ON_SOME_PATH")
     public int getHashCode(Object x, Object y) {
         Preconditions.checkArgument(x != null && y != null, "arguments must be nonnull");
         return x.hashCode() + y.hashCode();
@@ -24,36 +19,31 @@ public class Ideas_2011_07_22 {
             System.out.println("Good");
         return x.hashCode();
     }
-    @DesireNoWarning("NP_NULL_ON_SOME_PATH")
-    public int getHashCode(Object x) {
+
+    public int getHashCode1(Object x) {
         Preconditions.checkArgument(x != null, "x is null");
         return x.hashCode();
     }
 
-    @NoWarning("NP_NULL_ON_SOME_PATH")
     public int getHashCode2(Object x) {
         Preconditions.checkNotNull(x, "x is null");
         return x.hashCode();
     }
 
-    @NoWarning("NP_NULL_ON_SOME_PATH")
-    @ExpectWarning("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
     public int getHashCode3(Object x) {
         Preconditions.checkNotNull(x, "x is null");
         if (x == null)
             System.out.println("huh?");
         return x.hashCode();
     }
-    @NoWarning("NP_NULL_ON_SOME_PATH")
-    @ExpectWarning("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
+
     public int getHashCode4(Object x) {
         Preconditions.checkNotNull(x);
         if (x == null)
             System.out.println("huh?");
         return x.hashCode();
     }
-    @NoWarning("NP_NULL_ON_SOME_PATH")
-    @ExpectWarning("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
+
     public int getHashCode5(Object x) {
         Preconditions.checkNotNull(x, "x is null %d", 42);
         if (x == null)
@@ -61,7 +51,6 @@ public class Ideas_2011_07_22 {
         return x.hashCode();
     }
 
-    @ExpectWarning("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE,RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
     public int getHashCode6(@Nullable Object x) {
         Preconditions.checkNotNull(x, "x is null %d", 42);
         if (x == null)
@@ -69,10 +58,8 @@ public class Ideas_2011_07_22 {
         return x.hashCode();
     }
 
-    @ExpectWarning("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
     public int getHashCode7(@Nullable Object x) {
         Preconditions.checkNotNull(x, "x is null %d", 42);
        return 42;
     }
-
 }


### PR DESCRIPTION
The https://github.com/spotbugs/spotbugs/pull/2229 PR upgrades [com.google.guava:guava](https://github.com/google/guava) from [30.1.1](https://github.com/google/guava/releases/tag/v30.1.1) to [32.0.0](https://github.com/google/guava/releases/tag/v32.0.0), but the build [failed](https://github.com/spotbugs/spotbugs/actions/runs/5095922565/jobs/9161308971?pr=2229). More specifically the regression tests in the [Ideas_2011_07_22.java](https://github.com/spotbugs/spotbugs/blob/master/spotbugsTestCases/src/java/bugIdeas/Ideas_2011_07_22.java) file fail.
At first, the underlying cause seemed to be the modifications of the Nullness annotation in guava from 30.1.1 to [31.0](https://github.com/google/guava/releases/tag/v31.0), which affect the `Preconditions.checkNotNull()` functions as well: the `@NonNullDecl` annotations got replaced by `@CheckForNull`.
However, updating the tests in the [Ideas_2011_07_22.java](https://github.com/spotbugs/spotbugs/blob/master/spotbugsTestCases/src/java/bugIdeas/Ideas_2011_07_22.java) file from the deprecated annotation-based to the `AbstractIntegrationTest` based ones, seems like a solution to the problem. I'm not sure why exactly, but the build is successful this way using the newest guava. If anyone has any idea why, I would love to hear about it.

P.S. I left one of the tests (`getHashCode0()` function) as is, since it's annotated by `@DesireWarning`, which is rather a todo-like soft-expectation and it's still a todo, and I couldn't find such a soft-check in the newer type of tests.

P.S.2. I opened this PR to the [renovate/major-guava-monorepo](https://github.com/spotbugs/spotbugs/tree/renovate/major-guava-monorepo) branch, which is the branch for the corresponding https://github.com/spotbugs/spotbugs/pull/2229 PR. If this is not the proper way to do it, please let me know about the preferred procedure.

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
