### PR TITLE
Partial fix org.apache.bcel:bcel dependency update

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Bug3107916Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Bug3107916Test.java
@@ -1,0 +1,56 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
+import org.junit.Test;
+
+import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+
+public class Bug3107916Test extends AbstractIntegrationTest {
+    @Test
+    public void test() {
+        performAnalysis("sfBugs/Bug3107916.class");
+
+        assertNpBugInMethod("doCompare", 20);
+        assertNoNpBugInMethod("doCompare2");
+    }
+
+    private void assertNoNpBugInMethod(String method) {
+        final String[] bugtypes = new String[] {
+            "NP_SYNC_AND_NULL_CHECK_FIELD", "NP_BOOLEAN_RETURN_NULL", "NP_OPTIONAL_RETURN_NULL",
+            "NP_NONNULL_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR", "NP_ARGUMENT_MIGHT_BE_NULL",
+            "NP_EQUALS_SHOULD_HANDLE_NULL_ARGUMENT", "NP_DEREFERENCE_OF_READLINE_VALUE",
+            "NP_IMMEDIATE_DEREFERENCE_OF_READLINE", "NP_UNWRITTEN_FIELD", "NP_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD",
+            "NP_ALWAYS_NULL", "NP_CLOSING_NULL", "NP_STORE_INTO_NONNULL_FIELD", "NP_ALWAYS_NULL_EXCEPTION",
+            "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE", "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE",
+            "NP_NULL_ON_SOME_PATH_MIGHT_BE_INFEASIBLE", "NP_NULL_ON_SOME_PATH", "NP_NULL_ON_SOME_PATH_EXCEPTION",
+            "NP_NULL_PARAM_DEREF", "NP_NULL_PARAM_DEREF_NONVIRTUAL", "NP_NULL_PARAM_DEREF_ALL_TARGETS_DANGEROUS",
+            "NP_NONNULL_PARAM_VIOLATION", "NP_NONNULL_RETURN_VIOLATION", "NP_TOSTRING_COULD_RETURN_NULL",
+            "NP_CLONE_COULD_RETURN_NULL", "NP_LOAD_OF_KNOWN_NULL_VALUE", "NP_GUARANTEED_DEREF",
+            "NP_GUARANTEED_DEREF_ON_EXCEPTION_PATH", "NP_NULL_INSTANCEOF", "BC_NULL_INSTANCEOF",
+            "NP_METHOD_RETURN_RELAXING_ANNOTATION", "NP_METHOD_PARAMETER_TIGHTENS_ANNOTATION",
+            "NP_METHOD_PARAMETER_RELAXING_ANNOTATION",
+        };
+        for (int i = 0; i < bugtypes.length; i++) {
+            final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
+                    .bugType(bugtypes[i])
+                    .inClass("Bug3107916")
+                    .inMethod(method)
+                    .build();
+            assertThat(getBugCollection(), containsExactly(0, bugInstanceMatcher));
+        }
+    }
+
+    private void assertNpBugInMethod(String method, int line) {
+        final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
+                .bugType("NP_NULL_ON_SOME_PATH_MIGHT_BE_INFEASIBLE")
+                .inClass("Bug3107916")
+                .inMethod(method)
+                .atLine(line)
+                .build();
+        assertThat(getBugCollection(), hasItem(bugInstanceMatcher));
+    }
+}

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Bug3277814Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Bug3277814Test.java
@@ -1,0 +1,56 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
+import org.junit.Test;
+
+import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+
+public class Bug3277814Test extends AbstractIntegrationTest {
+    @Test
+    public void test() {
+        performAnalysis("sfBugs/Bug3277814.class");
+
+        assertNoNpBugInMethod("test");
+        assertNpBugInMethod("test2", 44);
+    }
+
+    private void assertNoNpBugInMethod(String method) {
+        final String[] bugtypes = new String[] {
+            "NP_SYNC_AND_NULL_CHECK_FIELD", "NP_BOOLEAN_RETURN_NULL", "NP_OPTIONAL_RETURN_NULL",
+            "NP_NONNULL_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR", "NP_ARGUMENT_MIGHT_BE_NULL",
+            "NP_EQUALS_SHOULD_HANDLE_NULL_ARGUMENT", "NP_DEREFERENCE_OF_READLINE_VALUE",
+            "NP_IMMEDIATE_DEREFERENCE_OF_READLINE", "NP_UNWRITTEN_FIELD", "NP_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD",
+            "NP_ALWAYS_NULL", "NP_CLOSING_NULL", "NP_STORE_INTO_NONNULL_FIELD", "NP_ALWAYS_NULL_EXCEPTION",
+            "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE", "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE",
+            "NP_NULL_ON_SOME_PATH_MIGHT_BE_INFEASIBLE", "NP_NULL_ON_SOME_PATH", "NP_NULL_ON_SOME_PATH_EXCEPTION",
+            "NP_NULL_PARAM_DEREF", "NP_NULL_PARAM_DEREF_NONVIRTUAL", "NP_NULL_PARAM_DEREF_ALL_TARGETS_DANGEROUS",
+            "NP_NONNULL_PARAM_VIOLATION", "NP_NONNULL_RETURN_VIOLATION", "NP_TOSTRING_COULD_RETURN_NULL",
+            "NP_CLONE_COULD_RETURN_NULL", "NP_LOAD_OF_KNOWN_NULL_VALUE", "NP_GUARANTEED_DEREF",
+            "NP_GUARANTEED_DEREF_ON_EXCEPTION_PATH", "NP_NULL_INSTANCEOF", "BC_NULL_INSTANCEOF",
+            "NP_METHOD_RETURN_RELAXING_ANNOTATION", "NP_METHOD_PARAMETER_TIGHTENS_ANNOTATION",
+            "NP_METHOD_PARAMETER_RELAXING_ANNOTATION",
+        };
+        for (int i = 0; i < bugtypes.length; i++) {
+            final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
+                    .bugType(bugtypes[i])
+                    .inClass("Bug3277814")
+                    .inMethod(method)
+                    .build();
+            assertThat(getBugCollection(), containsExactly(0, bugInstanceMatcher));
+        }
+    }
+
+    private void assertNpBugInMethod(String method, int line) {
+        final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
+                .bugType("NP_NULL_ON_SOME_PATH")
+                .inClass("Bug3277814")
+                .inMethod(method)
+                .atLine(line)
+                .build();
+        assertThat(getBugCollection(), hasItem(bugInstanceMatcher));
+    }
+}

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/RegressionIdeas2008091415Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/RegressionIdeas2008091415Test.java
@@ -1,0 +1,30 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
+import org.junit.Test;
+
+import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class RegressionIdeas2008091415Test extends AbstractIntegrationTest {
+    @Test
+    public void test() {
+        performAnalysis("bugIdeas/Ideas_2008_09_14.class", "bugIdeas/Ideas_2008_09_15.class");
+
+        assertBugInMethod("Ideas_2008_09_14", "foo", 6);
+        assertBugInMethod("Ideas_2008_09_15", "alternativesToInstanceof", 6);
+        assertBugInMethod("Ideas_2008_09_15", "alternativesToInstanceofAndCheckedCast", 12);
+    }
+
+    private void assertBugInMethod(String className, String method, int line) {
+        final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
+                .bugType("BC_IMPOSSIBLE_CAST")
+                .inClass(className)
+                .inMethod(method)
+                .atLine(line)
+                .build();
+        assertThat(getBugCollection(), containsExactly(1, bugInstanceMatcher));
+    }
+}

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/RegressionIdeas20111219Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/RegressionIdeas20111219Test.java
@@ -1,0 +1,65 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
+import org.junit.Test;
+
+import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+
+public class RegressionIdeas20111219Test extends AbstractIntegrationTest {
+    @Test
+    public void test() {
+        performAnalysis("bugIdeas/Ideas_2011_12_19.class");
+
+        assertNoNpBugInMethod("f");
+        assertBugInMethod("NP_ALWAYS_NULL", "f2", 21);
+        assertBugInMethod("NP_LOAD_OF_KNOWN_NULL_VALUE", "f2", 21);
+        assertNoNpBugInMethod("f3");
+        assertNoNpBugInMethod("f4");
+        assertBugInMethod("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", "f5a", 48);
+        assertNoNpBugInMethod("f5b");
+        assertNoNpBugInMethod("f5c");
+        assertNoNpBugInMethod("f5e");
+        assertNoNpBugInMethod("f5f");
+        assertBugInMethod("NP_NULL_ON_SOME_PATH", "f5g", 81);
+    }
+
+    private void assertNoNpBugInMethod(String method) {
+        final String[] bugtypes = new String[] {
+            "NP_SYNC_AND_NULL_CHECK_FIELD", "NP_BOOLEAN_RETURN_NULL", "NP_OPTIONAL_RETURN_NULL",
+            "NP_NONNULL_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR", "NP_ARGUMENT_MIGHT_BE_NULL",
+            "NP_EQUALS_SHOULD_HANDLE_NULL_ARGUMENT", "NP_DEREFERENCE_OF_READLINE_VALUE",
+            "NP_IMMEDIATE_DEREFERENCE_OF_READLINE", "NP_UNWRITTEN_FIELD", "NP_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD",
+            "NP_ALWAYS_NULL", "NP_CLOSING_NULL", "NP_STORE_INTO_NONNULL_FIELD", "NP_ALWAYS_NULL_EXCEPTION",
+            "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE", "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE",
+            "NP_NULL_ON_SOME_PATH_MIGHT_BE_INFEASIBLE", "NP_NULL_ON_SOME_PATH", "NP_NULL_ON_SOME_PATH_EXCEPTION",
+            "NP_NULL_PARAM_DEREF", "NP_NULL_PARAM_DEREF_NONVIRTUAL", "NP_NULL_PARAM_DEREF_ALL_TARGETS_DANGEROUS",
+            "NP_NONNULL_PARAM_VIOLATION", "NP_NONNULL_RETURN_VIOLATION", "NP_TOSTRING_COULD_RETURN_NULL",
+            "NP_CLONE_COULD_RETURN_NULL", "NP_LOAD_OF_KNOWN_NULL_VALUE", "NP_GUARANTEED_DEREF",
+            "NP_GUARANTEED_DEREF_ON_EXCEPTION_PATH", "NP_NULL_INSTANCEOF", "BC_NULL_INSTANCEOF",
+            "NP_METHOD_RETURN_RELAXING_ANNOTATION", "NP_METHOD_PARAMETER_TIGHTENS_ANNOTATION",
+            "NP_METHOD_PARAMETER_RELAXING_ANNOTATION",
+        };
+        for (int i = 0; i < bugtypes.length; i++) {
+            final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
+                    .bugType(bugtypes[i])
+                    .inClass("Bug3277814")
+                    .inMethod(method)
+                    .build();
+            assertThat(getBugCollection(), containsExactly(0, bugInstanceMatcher));
+        }
+    }
+
+    private void assertBugInMethod(String bugtype, String method, int line) {
+        final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
+                .bugType(bugtype)
+                .inClass("Ideas_2011_12_19")
+                .inMethod(method)
+                .atLine(line)
+                .build();
+        assertThat(getBugCollection(), hasItem(bugInstanceMatcher));
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/visitclass/Util.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/visitclass/Util.java
@@ -122,10 +122,14 @@ public class Util {
         }
         for (CodeException catchBlock : code.getExceptionTable()) {
             if (vmNameOfExceptionClass != null) {
-                Constant catchType = constantPool.getConstant(catchBlock.getCatchType());
-                if (catchType == null && !vmNameOfExceptionClass.isEmpty() || catchType instanceof ConstantClass
-                        && !((ConstantClass) catchType).getBytes(constantPool).equals(vmNameOfExceptionClass)) {
+                if (catchBlock.getCatchType() == 0) {
                     continue;
+                } else {
+                    Constant catchType = constantPool.getConstant(catchBlock.getCatchType());
+                    if (catchType == null && !vmNameOfExceptionClass.isEmpty() || catchType instanceof ConstantClass
+                            && !((ConstantClass) catchType).getBytes(constantPool).equals(vmNameOfExceptionClass)) {
+                        continue;
+                    }
                 }
             }
             int startPC = catchBlock.getStartPC();

--- a/spotbugsTestCases/src/java/bugIdeas/Ideas_2008_09_14.java
+++ b/spotbugsTestCases/src/java/bugIdeas/Ideas_2008_09_14.java
@@ -1,10 +1,6 @@
 package bugIdeas;
 
-import edu.umd.cs.findbugs.annotations.ExpectWarning;
-
 public class Ideas_2008_09_14 {
-
-    @ExpectWarning(value="BC_IMPOSSIBLE_CAST", num = 1)
     public String foo(Object o) {
         if (Integer.class.isInstance(o))
             return (String) o;

--- a/spotbugsTestCases/src/java/bugIdeas/Ideas_2008_09_15.java
+++ b/spotbugsTestCases/src/java/bugIdeas/Ideas_2008_09_15.java
@@ -1,17 +1,12 @@
 package bugIdeas;
 
-import edu.umd.cs.findbugs.annotations.ExpectWarning;
-
 public class Ideas_2008_09_15 {
-
-    @ExpectWarning(value="BC_IMPOSSIBLE_CAST", num = 1)
     public String alternativesToInstanceof(Object x) {
         if (Integer.class.isInstance(x))
             return (String) x;
         return "";
     }
 
-    @ExpectWarning(value="BC_IMPOSSIBLE_CAST", num = 1)
     public String alternativesToInstanceofAndCheckedCast(Object x) {
         if (Integer.class.isInstance(x))
             return String.class.cast(x);

--- a/spotbugsTestCases/src/java/bugIdeas/Ideas_2011_12_19.java
+++ b/spotbugsTestCases/src/java/bugIdeas/Ideas_2011_12_19.java
@@ -4,35 +4,28 @@ import java.util.logging.Logger;
 
 import javax.annotation.CheckForNull;
 
-import edu.umd.cs.findbugs.annotations.DesireNoWarning;
 import edu.umd.cs.findbugs.annotations.DesireWarning;
-import edu.umd.cs.findbugs.annotations.ExpectWarning;
-import edu.umd.cs.findbugs.annotations.NoWarning;
 import junit.framework.Assert;
 
 public class Ideas_2011_12_19 {
 
     static final Logger LOG = Logger.getLogger(Ideas_2011_12_19.class.getName());
 
-    @NoWarning("NP")
     int f(Object x) {
         assert x != null;
         return x.hashCode();
     }
 
-    @ExpectWarning("NP")
     int f2(Object x) {
         assert x == null;
         return x.hashCode();
     }
 
-    @DesireNoWarning("NP")
     int f3(Object x) {
         Assert.assertTrue(x != null);
         return x.hashCode();
     }
 
-    @DesireNoWarning("NP")
     int f4(Object x) {
         Assert.assertFalse(x == null);
         return x.hashCode();
@@ -50,27 +43,23 @@ public class Ideas_2011_12_19 {
         return x.hashCode();
     }
 
-    @ExpectWarning("NP")
     int f5a() {
         Object o = h("a");
         return o.hashCode();
     }
 
-    @NoWarning("NP")
     int f5b() {
         Object o = h("a");
         assert o != null;
         return o.hashCode();
     }
 
-    @NoWarning("NP")
     int f5c() {
         Object o = h("a");
         Assert.assertTrue(o != null);
         return o.hashCode();
     }
 
-    @NoWarning("NP")
     int f5e(Object o) {
         if (o == null)
             System.out.println("oops");
@@ -78,7 +67,6 @@ public class Ideas_2011_12_19 {
         return o.hashCode();
     }
 
-    @NoWarning("NP")
     int f5f(Object o) {
         if (o == null)
             System.out.println("oops");
@@ -86,7 +74,6 @@ public class Ideas_2011_12_19 {
         return o.hashCode();
     }
 
-    @ExpectWarning("NP")
     int f5g(Object o) {
         if (o == null)
             System.out.println("oops");

--- a/spotbugsTestCases/src/java/sfBugs/Bug3107916.java
+++ b/spotbugsTestCases/src/java/sfBugs/Bug3107916.java
@@ -1,8 +1,5 @@
 package sfBugs;
 
-import edu.umd.cs.findbugs.annotations.ExpectWarning;
-import edu.umd.cs.findbugs.annotations.NoWarning;
-
 public class Bug3107916 {
 
     public static void main(String[] args) {
@@ -11,7 +8,6 @@ public class Bug3107916 {
         doCompare(s1, s2);
     }
 
-    @ExpectWarning("NP_NULL_ON_SOME_PATH_MIGHT_BE_INFEASIBLE")
     public static int doCompare(String s1, String s2) {
         int result;
         if (s1 == null && s2 == null) {
@@ -27,7 +23,8 @@ public class Bug3107916 {
         }
         return result;
     }
-    @NoWarning("NP")
+
+
     public static int doCompare2(String s1, String s2) {
         int result;
         if (s1 == null && s2 == null) {

--- a/spotbugsTestCases/src/java/sfBugs/Bug3277814.java
+++ b/spotbugsTestCases/src/java/sfBugs/Bug3277814.java
@@ -1,11 +1,7 @@
 package sfBugs;
 
-import edu.umd.cs.findbugs.annotations.ExpectWarning;
-import edu.umd.cs.findbugs.annotations.NoWarning;
-
 public class Bug3277814 {
 
-    @NoWarning("NP")
     public void test() {
         String var = "";
         int index = 2;
@@ -31,7 +27,6 @@ public class Bug3277814 {
         }
     }
 
-    @ExpectWarning("NP")
     public void test2() {
         String var = "";
         int index = 2;


### PR DESCRIPTION
This is a partial fix to the org.apache.bcel:bcel dependency update (https://github.com/spotbugs/spotbugs/pull/2278), since to solve it completely we will also need a new, currently unreleased version of bcel.

There are several issues with updating to the newest bcel version currently as @nbauma109 already mentioned (https://github.com/spotbugs/spotbugs/pull/2278#issuecomment-1532038444):
- the Constant Pool doesn not allow 0, or anything right after an 8 byte constant*,
- a problem introduced to bcel in https://github.com/apache/commons-bcel/pull/171.
    - @nbauma109 already created a PR for solving this problem: https://github.com/apache/commons-bcel/pull/221
    - I tested it on my machine, it does solve the problem.

This PR in itself only solves the first problem, since the second one is in bcel itself, and there is already a working solution for it.
Using a snapshot bcel version with the mentioned PR (https://github.com/apache/commons-bcel/pull/221) and the changes in this PR, spotbugs builds successfully on my machine.
So for a successful bcel dependency version update, we will need a new version of bcel containing the mentioned PR, and the changes in this PR.

*Quote from the JVM specification: "All eight byte constants take up two spots in the constant pool. If this is the n'th byte in the constant pool, then the next item will be numbered n+2"

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
