### PR TITLE
Fix gradle update by adding missing dependencies

### DIFF
--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -190,6 +190,8 @@ def jar = tasks.named('jar', Jar) {
                'Class-Path': project.providers.provider { jarInClasspath.collect{it.getName()}.join(' ') + ' config/' }
   }
 }
+tasks.spotbugsMain.dependsOn(jar)
+tasks.spotbugsGui.dependsOn(jar)
 
 // Populate bin folder with scripts
 def scripts = tasks.register('scripts', Copy) {


### PR DESCRIPTION
The spotbugsMain and spotbugsGui tasks depend on the jar task, but this wasn't declared either explicitly nor implicitly.

When building spotbugs the following message informs about this:
```
Execution optimizations have been disabled for task ':spotbugs:spotbugsMain' to ensure correctness due to the following reasons:
  - Gradle detected a problem with the following location: '/home/runner/work/spotbugs/spotbugs/spotbugs/build/libs/spotbugs.jar'. Reason: Task ':spotbugs:spotbugsMain' uses this output of task ':spotbugs:jar' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.6.2/userguide/validation_problems.html#implicit_dependency for more details about this problem.
```

When running with `--warning-mode all` with this additional info: 
```This behaviour has been deprecated and is schedulaed to be removed in Gradle 8.0. Execution optimizations are disabled to ensure correctness.```

This seems to solve [the gradle update to version 8](https://github.com/spotbugs/spotbugs/pull/2351) build fail on my machine. (There will be other deprecated features when updating to v9.)
However when running these tasks `SpotBugs ended with exit code 1`, but it is a same before and after, and this doesn't effect the success of the build.


----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
