### PR TITLE
Fix gradle update eclipse dependency

### DIFF
--- a/eclipsePlugin/build.gradle
+++ b/eclipsePlugin/build.gradle
@@ -362,6 +362,8 @@ def siteHtml = tasks.register('siteHtml', Copy) {
     // even if we have generated file, we should rerun this task to overwrite it.
     false
   }
+  dependsOn(pluginCandidateJar)
+  dependsOn(testPluginJar)
 }
 
 def siteCandidateHtml = tasks.register('siteCandidateHtml', Copy) {


### PR DESCRIPTION
I tried to reproduce the build fail of the gradle updating #2351 on my local machine, but couldn't. Tried on both Linux and Windows, even with a fresh pull to not have any earlier data effecting the outcome, but the build was successful every time. Of course, on my local machine, I don't have the secrets, so I could only run ```./gradlew spotlessCheck build smoketest```  instead of ```./gradlew spotlessCheck build smoketest ${SONAR_LOGIN:+sonarqube} --no-daemon -Dsonar.login=$SONAR_LOGIN --scan```.
This modification _should_ solve the build fail, but there may be some other issues. Of course, this PR succesfully built on my machine, but I couldn't reproduce the earlier problem either.
I suspect that maybe some other similar tasks (e.g. `:eclipsePlugin:siteCandidateHtml`, `:eclipsePlugin:siteDailyHtml`) may cause issues like this, but didn't want to add unnecessary dependencies.


----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
