### PR TITLE
[junit] Use junit vintage instead of junit legacy fixes #2330

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Use jakarta annotation 1.3.5 instead of legacy javax annotation 1.3.2 ([#2315](https://github.com/spotbugs/spotbugs/pull/2315))
 - Change hamcrest-all to hamcrest-core as that is what was actually used and then update to 2.2 ([#2316](https://github.com/spotbugs/spotbugs/pull/2316))
 - Only run release action on 'spotbugs' and use Eclipse 4.14 ([#2317](https://github.com/spotbugs/spotbugs/pull/2317))
-- Switch junit 4 for junit 5 vintage engine
+- Switch junit 4 for junit 5 vintage engine ([#2483](https://github.com/spotbugs/spotbugs/pull/2483))
 
 ## 4.7.3 - 2022-10-15
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Use jakarta annotation 1.3.5 instead of legacy javax annotation 1.3.2 ([#2315](https://github.com/spotbugs/spotbugs/pull/2315))
 - Change hamcrest-all to hamcrest-core as that is what was actually used and then update to 2.2 ([#2316](https://github.com/spotbugs/spotbugs/pull/2316))
 - Only run release action on 'spotbugs' and use Eclipse 4.14 ([#2317](https://github.com/spotbugs/spotbugs/pull/2317))
+- Switch junit 4 for junit 5 vintage engine
 
 ## 4.7.3 - 2022-10-15
 ### Fixed

--- a/eclipsePlugin-junit/build.gradle
+++ b/eclipsePlugin-junit/build.gradle
@@ -11,7 +11,7 @@ tasks.named('compileJava', JavaCompile).configure {
 
 dependencies {
   implementation project(':eclipsePlugin')
-  testImplementation 'junit:junit:4.13.2'
+  testImplementation 'org.junit.vintage:junit-vintage-engine:5.9.0'
   testImplementation 'org.mockito:mockito-core:5.4.0'
 }
 

--- a/spotbugs-ant/build.gradle
+++ b/spotbugs-ant/build.gradle
@@ -8,7 +8,7 @@ dependencies {
   compileOnly 'org.apache.ant:ant:1.10.13'
 
   testImplementation 'org.apache.ant:ant:1.10.13'
-  testImplementation 'junit:junit:4.13.2'
+  testImplementation 'org.junit.vintage:junit-vintage-engine:5.9.3'
   testImplementation 'org.hamcrest:hamcrest-core:2.2'
 }
 

--- a/spotbugs-tests/build.gradle
+++ b/spotbugs-tests/build.gradle
@@ -11,7 +11,7 @@ dependencies {
   implementation project(':spotbugsTestCases')
   implementation project(':test-harness')
 
-  implementation 'junit:junit:4.13.2'
+  implementation 'org.junit.vintage:junit-vintage-engine:5.9.3'
   implementation 'org.hamcrest:hamcrest-core:2.2'
   implementation 'org.apache.ant:ant:1.10.13'
   implementation libs.log4j.core

--- a/spotbugsTestCases/build.gradle
+++ b/spotbugsTestCases/build.gradle
@@ -29,7 +29,7 @@ dependencies {
   compileOnly 'jakarta.annotation:jakarta.annotation-api:1.3.5'
   implementation 'org.checkerframework:checker-qual:3.36.0'
 
-  implementation 'junit:junit:4.13.2'
+  implementation 'org.junit.vintage:junit-vintage-engine:5.9.3'
   implementation 'org.testng:testng:7.8.0'
 
   implementation project(':spotbugs')

--- a/test-harness/build.gradle
+++ b/test-harness/build.gradle
@@ -3,7 +3,7 @@ apply from: "$rootDir/gradle/javadoc.gradle"
 apply from: "$rootDir/gradle/maven.gradle"
 
 dependencies {
-  compileOnly 'junit:junit:4.13.2'
+  compileOnly 'org.junit.vintage:junit-vintage-engine:5.9.3'
   testImplementation project(':spotbugs')
   api project(':test-harness-core')
 }


### PR DESCRIPTION
behaves the same but stops directly using legacy parts so that we are firmly using modern api.  Any junit 4 left then needs separately migrated to 5 as we should no longer support junit 4 in our builds. Fixes #2330



----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x ] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
