### PR TITLE
[eclipse] Set eclipse to release 4.14.0 in eclipse-convention.gradle.kts

### DIFF
--- a/buildSrc/src/main/kotlin/eclipse-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/eclipse-convention.gradle.kts
@@ -7,7 +7,7 @@ val pdeTool by configurations.creating {
 }
 
 eclipseMavenCentral {
-  release("4.12.0") {
+  release("4.14.0") {
     compileOnly("org.eclipse.ant.core")
     compileOnly("org.eclipse.core.resources")
     compileOnly("org.eclipse.core.runtime")


### PR DESCRIPTION
missed from original change as versions did not align correctly


Already in change log for this one, so did not update further.  Everything was moved to 4.14, but discovered two parts that were not properly on the older version listed elsewhere.  So now all will be 4.14.0
