### PR TITLE
Fix gradle update by fixing sonarqube

### DIFF
--- a/gradle/jacoco.gradle
+++ b/gradle/jacoco.gradle
@@ -7,6 +7,7 @@ jacoco {
 jacocoTestReport {
   reports {
     html.required = true
+    xml.required = true
   }
 }
 

--- a/gradle/sonar.gradle
+++ b/gradle/sonar.gradle
@@ -2,7 +2,6 @@ apply plugin: 'org.sonarqube'
 
 sonarqube {
     properties {
-        property 'sonar.coverage.jacoco.xmlReportPaths', jacocoRootReport.reports.xml.destination
         property 'sonar.host.url', 'https://sonarcloud.io'
         property 'sonar.organization', 'spotbugs'
         property 'sonar.projectKey', 'com.github.spotbugs.spotbugs'


### PR DESCRIPTION
I could reproduce this issue on my local machine, and this PR tries to fix it. It seems like the `reports.xml.destination` property got modified in jacoco, but if we don't modify the default report output location in jacoco, then [no further configuration required](https://community.sonarsource.com/t/coverage-test-data-importing-jacoco-coverage-report-in-xml-format/12151) in connection with this in sonarqube. So it should work like this. Tested it on my machine as much as I could, the `:sonarqube` task didn't fail at the same point as before, but because I don't have the sonarqube secrets on my machine.


----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
