### PR TITLE
[release] Replace all indications on travis to github GHA

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ SpotBugs is built using [Gradle](https://gradle.org). The recommended way to obt
 
 To see a list of build options, run `gradle tasks` (or `gradlew tasks`). The `build` task will perform a full build and test.
 
-To build the SpotBugs plugin for Eclipse, you'll need to create the file `eclipsePlugin/local.properties`, containing a property `eclipseRoot.dir` that points to an Eclipse installation's root directory (see `.travis.yml` for an example), then run the build.
+To build the SpotBugs plugin for Eclipse, you'll need to create the file `eclipsePlugin/local.properties`, containing a property `eclipseRoot.dir` that points to an Eclipse installation's root directory (see `.github/workflows/release.yml` for an example), then run the build.
 To prepare Eclipse environment only, run `./gradlew eclipse`. See also [detailed steps](https://github.com/spotbugs/spotbugs/blob/release-3.1/eclipsePlugin/doc/building_spotbugs_plugin.txt).
 
 # Using SpotBugs

--- a/RELEASE_PROCEDURE.md
+++ b/RELEASE_PROCEDURE.md
@@ -14,12 +14,12 @@ When we push a tag, the build result on GitHub Actions will be deployed to the [
 
 ## Release to Eclipse Update Site
 
-It's automated by Travis CI.
+It's automated by Github CI.
 
 When we push tag, the build result will be deployed to [eclipse-candidate repository](https://github.com/spotbugs/eclipse-candidate).
 When we push tag and its name doesn't contain `_RC`, the build result will be deployed to [eclipse repository](https://github.com/spotbugs/eclipse).
 
-See `deploy` phase in `.travis.yml` for detail.
+See `deploy` phase in `.github/workflows/release.yml` for detail.
 
 ## Release to Eclipse Marketplace
 
@@ -27,9 +27,9 @@ Update version in [Eclipse Marketplace page](https://marketplace.eclipse.org/con
 
 ## Release to Gradle Plugin Portal
 
-No action necessary. When we push tag, the build result on Travis CI will be deployed to Gradle Plugin Portal.
+No action necessary. When we push tag, the build result on Github CI will be deployed to Gradle Plugin Portal.
 
-See `deploy` phase in `.travis.yml` for detail.
+See `deploy` phase in `.github/workflows/release.yml` for detail.
 
 ## Update installation manual
 

--- a/eclipsePlugin-junit/README.md
+++ b/eclipsePlugin-junit/README.md
@@ -1,7 +1,7 @@
 # JUnit test cases for SpotBugs Eclipse Plugin
 
 This file hosts JUnit test cases which does not need Eclipse to run.
-Travis CI will run test in this project automatically.
+Github CI will run test in this project automatically.
 
 We have another project `eclipsePlugin-test`, to test SpotBugs Eclipse Plugin with Eclipse.
 Ideally we should migrate this `eclipsePlugin-junit` project to that.

--- a/eclipsePlugin-test/README.txt
+++ b/eclipsePlugin-test/README.txt
@@ -8,5 +8,5 @@ that can be found at: http://www.eclipse.org/legal/epl-v10.html
 
 ## About difference with this project and eclipsePlugin-junit project
 
-Currently tests in this project cannot run in Travis CI build.
+Currently tests in this project cannot run in Github CI build.
 If you want to add JUnit test which can run without Eclipse, add test case to eclipsePlugin-junit project.


### PR DESCRIPTION
while not complete based on what I'm seeing, it appears only Eclipse auto releases and some claim of tagging will do rest but not exactly seeing how.  At any rate, we don't use travis so it should not state travis.


did not add change log as minor doc correctly and didn't feel necessary here.  If others think its necessary will add it.
----

Make sure these boxes are checked before submitting your PR -- thank you!

- [no] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
