### PR TITLE
fix: modified MS_SHOULD_BE_FINAL description to mention protected fields

### DIFF
--- a/spotbugs/etc/messages.xml
+++ b/spotbugs/etc/messages.xml
@@ -4175,7 +4175,7 @@ defined in an interface references a mutable
     <Details>
 <![CDATA[
    <p>
-This static field public but not final, and
+This <code>public static</code> or <code>protected static</code> field is not final, and
 could be changed by malicious code or
 by accident from another package.
 The field could be made final to avoid
@@ -4191,7 +4191,7 @@ to the field, so doing so will require some refactoring.
     <Details>
 <![CDATA[
    <p>
-This static field public but not final, and
+This <code>public static</code> or <code>protected static</code> field is not final, and
 could be changed by malicious code or
         by accident from another package.
         The field could be made final to avoid

--- a/spotbugs/etc/messages_fr.xml
+++ b/spotbugs/etc/messages_fr.xml
@@ -1710,12 +1710,23 @@ synchronized() {}
 ]]>
   </Details>
  </BugPattern>
+ <BugPattern type="MS_SHOULD_BE_REFACTORED_TO_BE_FINAL">
+  <ShortDescription>Un champ n'est pas final alors qu'il devrait refactorisé pour l'être</ShortDescription>
+  <LongDescription>{1} n'est pas final mais devrait être refactorisé pour l'être</LongDescription>
+  <Details>
+<![CDATA[
+<p>Un champ <code>public static</code> ou <code>protected static</code> peut-être changé par accident ou par du code malveillant d'un autre paquetage. Le champ devrait être final pour éviter cette vulnérabilité.
+Cependant l'initialisation du champ comporte plusieurs écriture, ce qui requiererait donc un refactor.</p>
+]]>
+  </Details>
+ </BugPattern>
+ </BugPattern>
  <BugPattern type="MS_SHOULD_BE_FINAL">
   <ShortDescription>Un champ n'est pas final alors qu'il devrait l'être</ShortDescription>
   <LongDescription>{1} n'est pas final mais devrait l'être</LongDescription>
   <Details>
 <![CDATA[
-<p>Un champ statique modifiable peut-être changé par accident ou par du code malveillant d'un autre paquetage. Le champ devrait être final pour éviter cette vulnérabilité.</p>
+<p>Un champ <code>public static</code> ou <code>protected static</code> peut-être changé par accident ou par du code malveillant d'un autre paquetage. Le champ devrait être final pour éviter cette vulnérabilité.</p>
 ]]>
   </Details>
  </BugPattern>

--- a/spotbugs/etc/messages_ja.xml
+++ b/spotbugs/etc/messages_ja.xml
@@ -4474,7 +4474,7 @@ private Long getNotificationSequenceNumber() {
     <Details>
 <![CDATA[
 <p>
-<code>final</code> ではない <code>public static</code> フィールドは悪意のあるコードや別のパッケージによって思いがけず変更される可能性があります。
+<code>final</code> ではない <code>public static</code> または <code>protected static</code> フィールドは悪意のあるコードや別のパッケージによって思いがけず変更される可能性があります。
 脆弱性を回避するためにフィールドを <code>final</code> にします。
 しかしながら，スタティックイニシャライザには複数のフィールドへの書き込みがあるので，何らかのリファクタリングを必要とするでしょう。
 </p>
@@ -4488,7 +4488,7 @@ private Long getNotificationSequenceNumber() {
     <Details>
 <![CDATA[
 <p>
-<code>final</code> ではない <code>public static</code> フィールドは悪意のあるコードや別のパッケージによって思いがけず変更される可能性があります。
+<code>final</code> ではない <code>public static</code> または <code>protected static</code> フィールドは悪意のあるコードや別のパッケージによって思いがけず変更される可能性があります。
 脆弱性を回避するためにフィールドを <code>final</code> にします。
 </p>
 ]]>


### PR DESCRIPTION
MutableStaticFields reports issues for public and protected fields but the bug description was only for public fields.

This should fix #1015 