### PR TITLE
Fix gradle dependencies of createChecksums

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,6 +84,24 @@ createChecksums.configure {
   if (publishTask != null) {
     dependsOn publishTask
   }
+  subprojects.each {
+    dependsOn("${it.name}:jar")
+  }
+
+  dependsOn(":spotbugs:javadocJar")
+  dependsOn(":spotbugs:sourcesJar")
+  dependsOn(":spotbugs-annotations:javadocJar")
+  dependsOn(":spotbugs-annotations:sourcesJar")
+  dependsOn(":spotbugs-ant:javadocJar")
+  dependsOn(":spotbugs-ant:sourcesJar")
+  dependsOn(":test-harness:javadocJar")
+  dependsOn(":test-harness:sourcesJar")
+  dependsOn(":test-harness-core:javadocJar")
+  dependsOn(":test-harness-core:sourcesJar")
+  dependsOn(":test-harness-jupiter:javadocJar")
+  dependsOn(":test-harness-jupiter:sourcesJar")
+  dependsOn(":spotbugs:distZip")
+  dependsOn(":spotbugs:distTar")
 }
 createReleaseBody.configure {
   inputs.files fileTree("$buildDir/checksums").matching {


### PR DESCRIPTION
The `./gradlew createReleaseBody` command fails (see https://github.com/spotbugs/spotbugs/actions/runs/6087746260/job/16516939281), because gradle 8 removed some execution optimizations (similarly to https://github.com/spotbugs/spotbugs/issues/1911), this issue blocks the next release.

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
