### PR TITLE
Update templates

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,10 +2,10 @@
 
 Before you submit issue or pull request, please check the following points.
 
-** Do not open intellij plugin issues here, open them at [intellij-plugin](https://github.com/JetBrains/spotbugs-intellij-plugin) **
-** Search existing issues and pull requests to see if the issue was already discussed.
-** Check our discussions to see if the issue was already discussed.
-** Check for specific project we support to raise issue on, under [spotbugs](https://github.com/spotbugs)
+* Search existing issues and pull requests to see if the issue was already discussed.
+* Check our discussions to see if the issue was already discussed.
+* Check for specific project we support to raise issue on, under [spotbugs](https://github.com/spotbugs)
+* Do not open intellij plugin issues here, open them at [intellij-plugin](https://github.com/JetBrains/spotbugs-intellij-plugin)
 
 ## Before reporting a problem with detectors
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,9 +1,9 @@
 Before opening 'bug'
 
-** Do not open intellij plugin issues here, open them at [intellij-plugin](https://github.com/JetBrains/spotbugs-intellij-plugin) **
-** Search existing issues and pull requests to see if the issue was already discussed.
-** Check our discussions to see if the issue was already discussed.
-** Check for specific project we support to raise issue on, under [spotbugs](https://github.com/spotbugs)
+* Search existing issues and pull requests to see if the issue was already discussed.
+* Check our discussions to see if the issue was already discussed.
+* Check for specific project we support to raise issue on, under [spotbugs](https://github.com/spotbugs)
+* Do not open intellij plugin issues here, open them at [intellij-plugin](https://github.com/JetBrains/spotbugs-intellij-plugin)
 
 ---
 name: Bug report

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,8 +1,9 @@
 Before opening 'pull request'
 
-** Search existing issues and pull requests to see if the issue was already discussed.
-** Check our discussions to see if the issue was already discussed.
-** Check for specific project we support to raise issue on, under [spotbugs](https://github.com/spotbugs)
+* Search existing issues and pull requests to see if the issue was already discussed.
+* Check our discussions to see if the issue was already discussed.
+* Check for specific project we support to raise issue on, under [spotbugs](https://github.com/spotbugs)
+* Do not open intellij plugin issues here, open them at [intellij-plugin](https://github.com/JetBrains/spotbugs-intellij-plugin)
 
 ---
 name: Feature request

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,9 @@
 Before opening a 'pull request'
 
-** Search existing issues and pull requests to see if the issue was already discussed.
-** Check our discussions to see if the issue was already discussed.
-** Check for specific project we support to raise the issue on, under [spotbugs](https://github.com/spotbugs)
+* Search existing issues and pull requests to see if the issue was already discussed.
+* Check our discussions to see if the issue was already discussed.
+* Check for specific project we support to raise the issue on, under [spotbugs](https://github.com/spotbugs)
+* Do not open intellij plugin issues here, open them at [intellij-plugin](https://github.com/JetBrains/spotbugs-intellij-plugin) *
 
 ----
 


### PR DESCRIPTION
note: Appears direct updates didn't quite make it and some where messed up.  There were branches for these that github created, so clearing those out and bringing in on one.  While the intellij item could be seen as redundant these are all just following same info indicating to everyone that sees that we don't support intellij plugin as well as guiding to where to update.