### PR TITLE
Update eclipse.rst

### DIFF
--- a/docs/eclipse.rst
+++ b/docs/eclipse.rst
@@ -14,7 +14,7 @@ Installation
 ------------
 
 We provide update sites that allow you to automatically install SpotBugs into Eclipse and also query and install updates.
-There are three different update sites:
+There are four different update sites:
 
 https://spotbugs.github.io/eclipse/
   Only provides official releases of SpotBugs Eclipse plugin.


### PR DESCRIPTION
documentation change: update the explanation of Installation, replaced three with four, as it mentions four different links.
