### PR TITLE
Add build support for jdk 11 - fixes #2598

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
         include:
          - os: flyci-macos-large-latest-m1
            java: 21
-        java: [17, 21]
+        java: [11, 17, 21]
       max-parallel: 6
     runs-on: ${{ matrix.os }}
     continue-on-error: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,22 +31,22 @@ jobs:
       - name: Download Eclipse on Ubuntu
         if: matrix.os == 'ubuntu-latest'
         run: |
-          curl -L 'https://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops4/R-4.29-202309031000/eclipse-SDK-4.29-linux-gtk-x86_64.tar.gz&r=1' --output eclipse-SDK-4.29-linux-gtk-x86_64.tar.gz
-          tar xzf eclipse-SDK-4.29-linux-gtk-x86_64.tar.gz eclipse
+          curl -L 'https://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops4/R-4.24-202206070700/eclipse-SDK-4.24-linux-gtk-x86_64.tar.gz&r=1' --output eclipse-SDK-4.24-linux-gtk-x86_64.tar.gz
+          tar xzf eclipse-SDK-4.24-linux-gtk-x86_64.tar.gz eclipse
           echo "eclipseRoot.dir=$(pwd)/eclipse" | tee eclipsePlugin/local.properties
       - name: Download Eclipse on Windows
         if: matrix.os == 'windows-latest'
         run: |
-          curl 'https://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops4/R-4.29-202309031000/eclipse-SDK-4.29-win32-x86_64.zip&r=1' -o eclipse-SDK-4.29-win32-x86_64.zip
-          Expand-Archive "eclipse-SDK-4.29-win32-x86_64.zip" -DestinationPath "." -Force
+          curl 'https://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops4/R-4.24-202206070700/eclipse-SDK-4.24-win32-x86_64.zip&r=1' -o eclipse-SDK-4.24-win32-x86_64.zip
+          Expand-Archive "eclipse-SDK-4.24-win32-x86_64.zip" -DestinationPath "." -Force
           $escapedPwd = $pwd.Path -replace '\\', '\\'
           [System.IO.File]::WriteAllLines("$pwd\\eclipsePlugin\\local.properties", "eclipseRoot.dir=$escapedPwd\\eclipse")
         shell: powershell
       - name: Download Eclipse on Mac
         if: matrix.os == 'macos-latest'
         run: |
-          curl -L 'https://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops4/R-4.29-202309031000/eclipse-SDK-4.29-macosx-cocoa-x86_64.dmg&r=1' --output eclipse-SDK-4.29-macosx-cocoa-x86_64.dmg
-          hdiutil attach eclipse-SDK-4.29-macosx-cocoa-x86_64.dmg
+          curl -L 'https://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops4/R-4.24-202206070700/eclipse-SDK-4.24-macosx-cocoa-x86_64.dmg&r=1' --output eclipse-SDK-4.24-macosx-cocoa-x86_64.dmg
+          hdiutil attach eclipse-SDK-4.24-macosx-cocoa-x86_64.dmg
           cp -r /Volumes/Eclipse/Eclipse.app /Applications/
           hdiutil detach /Volumes/Eclipse
           echo "eclipseRoot.dir=/Applications/Eclipse.app" | tee eclipsePlugin/local.properties

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,8 +51,8 @@ jobs:
       - uses: gradle/wrapper-validation-action@v2
       - name: Download Eclipse
         run: |
-          curl -L 'https://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops4/R-4.29-202309031000/eclipse-SDK-4.29-linux-gtk-x86_64.tar.gz&r=1' --output eclipse-SDK-4.29-linux-gtk-x86_64.tar.gz
-          tar xzvf eclipse-SDK-4.29-linux-gtk-x86_64.tar.gz eclipse
+          curl -L 'https://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops4/R-4.24-202206070700/eclipse-SDK-4.24-linux-gtk-x86_64.tar.gz&r=1' --output eclipse-SDK-4.24-linux-gtk-x86_64.tar.gz
+          tar xzvf eclipse-SDK-4.24-linux-gtk-x86_64.tar.gz eclipse
           echo "eclipseRoot.dir=$(pwd)/eclipse" > eclipsePlugin/local.properties
       - name: Build on tag
         if: (github.ref_type == 'tag') && (github.event.base_ref == 'refs/heads/master')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Fix sonar coverage for project ([#2796](https://github.com/spotbugs/spotbugs/issues/2796))
 - Upgraded the build to compile bug samples using Java 21 language features ([#2813](https://github.com/spotbugs/spotbugs/pull/2813))
 - Add 'configurations.checkstyle resolution starategy' to control bug in gradle on exclusions not being excluded properly as seen in checkstyle usage.  See https://github.com/checkstyle/checkstyle/issues/14211 for more information. ([#2798](https://github.com/spotbugs/spotbugs/issues/2798))
+- Allow our builds to work with jdk 11 with drop back on Eclipse to 4.24 and spring to 5.3.31.  ([#2604](https://github.com/spotbugs/spotbugs/pull/2604/))
 
 ## 4.8.3 - 2023-12-12
 ### Fixed

--- a/buildSrc/src/main/kotlin/eclipse-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/eclipse-convention.gradle.kts
@@ -7,7 +7,7 @@ val pdeTool by configurations.creating {
 }
 
 eclipseMavenCentral {
-  release("4.29.0") {
+  release("4.24.0") {
     compileOnly("org.eclipse.ant.core")
     compileOnly("org.eclipse.core.resources")
     compileOnly("org.eclipse.core.runtime")

--- a/spotbugsTestCases/build.gradle
+++ b/spotbugsTestCases/build.gradle
@@ -89,13 +89,19 @@ def classesJava21 = tasks.register('classesJava21', JavaCompile) {
   source = file('src/java21')
 }
 
+def jvmVersion = JavaVersion.current()
 tasks.named('classes').configure {
   dependsOn classesJava8
   dependsOn classesJava11
-  dependsOn classesJava17
-  
-  if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_21)) {
+  if (jvmVersion.isCompatibleWith(JavaVersion.VERSION_17)) {
+    dependsOn classesJava17
+  } else {
+    println "skip tests for Java 17 features"
+  }
+  if (jvmVersion.isCompatibleWith(JavaVersion.VERSION_21)) {
     dependsOn classesJava21
+  } else {
+    println "skip tests for Java 21 features"
   }
 }
 

--- a/spotbugsTestCases/build.gradle
+++ b/spotbugsTestCases/build.gradle
@@ -24,7 +24,7 @@ dependencies {
   implementation 'com.google.truth:truth:1.4.0'
   implementation 'joda-time:joda-time:2.12.6'
   api 'com.github.stephenc.jcip:jcip-annotations:1.0-1'
-  implementation 'org.springframework:spring-core:6.1.3'
+  implementation 'org.springframework:spring-core:5.3.31'
   compileOnly 'jakarta.annotation:jakarta.annotation-api:1.3.5'
   implementation 'org.checkerframework:checker-qual:3.42.0'
 


### PR DESCRIPTION
fixes #2598
- Moved to 'zulu' for builds
- Run in parallel 4 max
- Drop Eclipse back to 4.25 to allow jdk 11 on build
- Drop toolchains back to prior usage to allow jdk 11 (github doesn't have toolchains on jdk 11 installed so they fail with toolchains)
- Drop spring back to 5.3.30 as project is not on jakartaEE yet