### PR TITLE
build: install readthedocs requirements

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -30,6 +30,6 @@ sphinx:
 # Optional but recommended, declare the Python requirements required
 # to build your documentation
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-# python:
-#    install:
-#    - requirements: docs/requirements.txt
+python:
+  install:
+    - requirements: docs/requirements.txt


### PR DESCRIPTION
The template readthedocs v2 configuration file had the requirements install commented out. Enable it so we install the theme.