### PR TITLE
Fix first batch of Gradle buildDir deprecations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ def publishTask = tasks.findByName("publish")
 if (publishTask == null) {
   publishTask = tasks.findByName("publishToMavenLocal")
 }
-def outputFile = file("$buildDir/release.md")
+def outputFile = layout.buildDirectory.file("release.md")
 def inputFile =  subprojects.collect {
   it.hasProperty('publishing') ? it.publishing.publications.maven.artifacts : []
 }.flatten().collect {
@@ -103,14 +103,14 @@ createChecksums.configure {
   dependsOn(":spotbugs:distTar")
 }
 createReleaseBody.configure {
-  inputs.files fileTree("$buildDir/checksums").matching {
+  inputs.files fileTree(layout.buildDirectory.dir("checksums")).matching {
     include "*.sha256"
   }
   outputs.file outputFile
   dependsOn createChecksums
 
   doLast {
-    outputFile.delete()
+    outputFile.get().asFile.delete()
     outputFile << """SpotBugs ${project.version}
 
 ### CHANGELOG
@@ -120,7 +120,7 @@ createReleaseBody.configure {
 | file | checksum (sha256) |
 | ---- | ----------------- |
 """
-    fileTree("$buildDir/checksums").matching {
+    fileTree(layout.buildDirectory.dir("checksums")).matching {
       include "*.sha256"
     }.sort {
       it.name

--- a/buildSrc/src/main/kotlin/eclipse-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/eclipse-convention.gradle.kts
@@ -34,13 +34,14 @@ eclipseMavenCentral {
 /**
  * Unzip "org.eclipse.pde.build" package into the outputDir.
  */
+val pdeToolDir = layout.buildDirectory.dir("pdeTool")
 val unzipPdeTool = tasks.register<Copy>("unzipPdeTool") {
   from(zipTree(pdeTool.singleFile))
-  into("$buildDir/pdeTool")
+  into(pdeToolDir)
 }
 
 dependencies {
-  compileOnly(files("$buildDir/pdeTool/pdebuild.jar"){
+  compileOnly(files(pdeToolDir.map { it.file("pdebuild.jar") }){
     builtBy(unzipPdeTool)
   })
 }

--- a/eclipsePlugin/build.gradle
+++ b/eclipsePlugin/build.gradle
@@ -130,7 +130,7 @@ def updateManifest = tasks.register('updateManifest') {
 
   dependsOn ':spotbugs:updateManifest', copyLibsForEclipse
   doLast {
-    def manifestSpec = manifest {
+    def manifestSpec = java.manifest {
       from "$projectDir/META-INF/MANIFEST-TEMPLATE.MF"
       attributes 'Bundle-SymbolicName': "$eclipsePluginId; singleton:=true",
                  'Bundle-Version': project.version,
@@ -138,7 +138,7 @@ def updateManifest = tasks.register('updateManifest') {
                       projectDir.toPath().relativize(it.toPath()).toString().replace('\\', '/') }.join(',')
     }
 
-    def distManifestSpec = manifest {
+    def distManifestSpec = java.manifest {
       from "$projectDir/META-INF/MANIFEST-TEMPLATE.MF"
       attributes 'Bundle-SymbolicName': "$eclipsePluginId; singleton:=true",
                  'Bundle-Version': project.version,
@@ -266,20 +266,20 @@ def pluginJar = tasks.register('pluginJar', Zip) { // use Zip task, we already p
   with distSpec
   dependsOn jar
   archiveFileName = "${eclipsePluginId}_${project.version}.jar"
-  destinationDirectory = file("${buildDir}/site/eclipse/plugins/")
+  destinationDirectory.set(layout.buildDirectory.dir("site/eclipse/plugins/"))
   finalizedBy testPluginJar
 }
 
 def pluginCandidateJar = tasks.register('pluginCandidateJar', Copy) {
   dependsOn pluginJar
   from pluginJar.map { it.outputs.files }
-  into "${buildDir}/site/eclipse-candidate/plugins/"
+  into layout.buildDirectory.dir("site/eclipse-candidate/plugins/")
 }
 
 def pluginDailyJar = tasks.register('pluginDailyJar', Copy) {
   dependsOn pluginJar
   from pluginJar.map { it.outputs.files }
-  into "${buildDir}/site/eclipse-daily/plugins/"
+  into layout.buildDirectory.dir("site/eclipse-daily/plugins/")
   mustRunAfter(siteHtml)
   mustRunAfter(siteXml)
 }
@@ -287,7 +287,7 @@ def pluginDailyJar = tasks.register('pluginDailyJar', Copy) {
 def pluginStableLatestJar = tasks.register('pluginStableLatestJar', Copy) {
   dependsOn pluginJar
   from pluginJar.map { it.outputs.files }
-  into "${buildDir}/site/eclipse-stable-latest/plugins/"
+  into layout.buildDirectory.dir("site/eclipse-stable-latest/plugins/")
   mustRunAfter(siteHtml)
   mustRunAfter(siteXml)
 }
@@ -310,7 +310,7 @@ def featureJar = tasks.register('featureJar', Zip) {
     filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
     rename { 'p2.inf' }
   }
-  destinationDirectory = file("${buildDir}/site/eclipse/features/")
+  destinationDirectory = layout.buildDirectory.dir("site/eclipse/features/")
 }
 
 def featureCandidateJar = tasks.register('featureCandidateJar', Zip) {
@@ -324,7 +324,7 @@ def featureCandidateJar = tasks.register('featureCandidateJar', Zip) {
     filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
     rename { 'p2.inf' }
   }
-  destinationDirectory = file("${buildDir}/site/eclipse-candidate/features/")
+  destinationDirectory = layout.buildDirectory.dir("site/eclipse-candidate/features/")
 }
 
 def featureDailyJar = tasks.register('featureDailyJar', Zip) {
@@ -338,7 +338,7 @@ def featureDailyJar = tasks.register('featureDailyJar', Zip) {
     filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
     rename { 'p2.inf' }
   }
-  destinationDirectory = file("${buildDir}/site/eclipse-daily/features/")
+  destinationDirectory = layout.buildDirectory.dir("site/eclipse-daily/features/")
 }
 
 def featureStableLatestJar = tasks.register('featureStableLatestJar', Zip) {
@@ -352,7 +352,7 @@ def featureStableLatestJar = tasks.register('featureStableLatestJar', Zip) {
     filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
     rename { 'p2.inf' }
   }
-  destinationDirectory = file("${buildDir}/site/eclipse-stable-latest/features/")
+  destinationDirectory = layout.buildDirectory.dir("site/eclipse-stable-latest/features/")
 }
 
 def siteHtml = tasks.register('siteHtml', Copy) {
@@ -360,7 +360,7 @@ def siteHtml = tasks.register('siteHtml', Copy) {
     'URL': 'https://spotbugs.github.io/eclipse/'
   ] + siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
   from 'plugin_site.html'
-  destinationDir = file("${buildDir}/site/eclipse")
+  destinationDirectory = layout.buildDirectory.dir("site/eclipse")
   rename { 'index.html' }
   outputs.upToDateWhen {
     // even if we have generated file, we should rerun this task to overwrite it.
@@ -375,7 +375,7 @@ def siteCandidateHtml = tasks.register('siteCandidateHtml', Copy) {
     'URL': 'https://spotbugs.github.io/eclipse-candidate/'
   ] + siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
   from 'plugin_site.html'
-  destinationDir = file("${buildDir}/site/eclipse-candidate")
+  destinationDirectory = layout.buildDirectory.dir("site/eclipse-candidate")
   rename { 'index.html' }
   outputs.upToDateWhen {
     // even if we have generated file, we should rerun this task to overwrite it.
@@ -388,7 +388,7 @@ def siteDailyHtml = tasks.register('siteDailyHtml', Copy) {
     'URL': 'https://spotbugs.github.io/eclipse-latest/'
   ] + siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
   from 'plugin_site.html'
-  destinationDir = file("${buildDir}/site/eclipse-daily")
+  destinationDirectory = layout.buildDirectory.dir("site/eclipse-daily")
   rename { 'index.html' }
   outputs.upToDateWhen {
     // even if we have generated file, we should rerun this task to overwrite it.
@@ -401,7 +401,7 @@ def siteStableLatestHtml = tasks.register('siteStableLatestHtml', Copy) {
     'URL': 'https://spotbugs.github.io/eclipse-stable-latest/'
   ] + siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
   from 'plugin_site.html'
-  destinationDir = file("${buildDir}/site/eclipse-stable-latest")
+  destinationDirectory = layout.buildDirectory.dir("site/eclipse-stable-latest")
   rename { 'index.html' }
   outputs.upToDateWhen {
     // even if we have generated file, we should rerun this task to overwrite it.
@@ -412,7 +412,7 @@ def siteStableLatestHtml = tasks.register('siteStableLatestHtml', Copy) {
 def siteXml = tasks.register('siteXml', Copy) {
   filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
   from 'plugin_site.xml'
-  destinationDir = file("${buildDir}/site/eclipse")
+  destinationDirectory = layout.buildDirectory.dir("site/eclipse")
   rename { 'site.xml' }
   outputs.upToDateWhen {
     // even if we have generated file, we should rerun this task to overwrite it.
@@ -425,7 +425,7 @@ def siteXml = tasks.register('siteXml', Copy) {
 def siteCandidateXml = tasks.register('siteCandidateXml', Copy) {
   filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
   from 'plugin_site-candidate.xml'
-  destinationDir = file("${buildDir}/site/eclipse-candidate")
+  destinationDirectory = layout.buildDirectory.dir("site/eclipse-candidate")
   rename { 'site.xml' }
   outputs.upToDateWhen {
     // even if we have generated file, we should rerun this task to overwrite it.
@@ -436,7 +436,7 @@ def siteCandidateXml = tasks.register('siteCandidateXml', Copy) {
 def siteDailyXml = tasks.register('siteDailyXml', Copy) {
   filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
   from 'plugin_site-daily.xml'
-  destinationDir = file("${buildDir}/site/eclipse-daily")
+  destinationDirectory = layout.buildDirectory.dir("site/eclipse-daily")
   rename { 'site.xml' }
   outputs.upToDateWhen {
     // even if we have generated file, we should rerun this task to overwrite it.
@@ -447,7 +447,7 @@ def siteDailyXml = tasks.register('siteDailyXml', Copy) {
 def siteStableLatestXml = tasks.register('siteStableLatestXml', Copy) {
   filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
   from 'plugin_site-stable_latest.xml'
-  destinationDir = file("${buildDir}/site/eclipse-stable-latest")
+  destinationDirectory = layout.buildDirectory.dir("site/eclipse-stable-latest")
   rename { 'site.xml' }
   outputs.upToDateWhen {
     // even if we have generated file, we should rerun this task to overwrite it.
@@ -489,9 +489,10 @@ def confirmEclipse = tasks.register('confirmEclipse') {
 
 def generateP2Metadata = tasks.register('generateP2Metadata', Exec) {
   doFirst {
-    project.delete "${buildDir}/site/eclipse/artifacts.xml"
-    project.delete "${buildDir}/site/eclipse/content.xml"
-    signJar(file("${buildDir}/site/eclipse"))
+    def eclipseSiteDir = layout.buildDirectory.dir("site/eclipse")
+    project.delete eclipseSiteDir.map { it.file("artifacts.xml") }
+    project.delete eclipseSiteDir.map { it.file("content.xml") }
+    signJar(eclipseSiteDir.get().asFile)
   }
   inputs.file 'local.properties'
   dependsOn confirmEclipse, pluginJar, featureJar, siteXml, siteHtml
@@ -504,9 +505,10 @@ def generateP2Metadata = tasks.register('generateP2Metadata', Exec) {
 
 def generateCandidateP2Metadata = tasks.register('generateCandidateP2Metadata', Exec) {
   doFirst {
-    project.delete "${buildDir}/site/eclipse-candidate/artifacts.xml"
-    project.delete "${buildDir}/site/eclipse-candidate/content.xml"
-    signJar(file("${buildDir}/site/eclipse-candidate"))
+    def eclipseSiteDir = layout.buildDirectory.dir("site/eclipse-candidate")
+    project.delete eclipseSiteDir.map { it.file("artifacts.xml") }
+    project.delete eclipseSiteDir.map { it.file("content.xml") }
+    signJar(file(eclipseSiteDir.get().asFile))
   }
   inputs.file 'local.properties'
   dependsOn confirmEclipse, pluginCandidateJar, featureCandidateJar, siteCandidateXml, siteCandidateHtml
@@ -519,9 +521,10 @@ def generateCandidateP2Metadata = tasks.register('generateCandidateP2Metadata', 
 
 def generateP2MetadataDaily = tasks.register('generateP2MetadataDaily', Exec) {
   doFirst {
-    project.delete "${buildDir}/site/eclipse-daily/artifacts.xml"
-    project.delete "${buildDir}/site/eclipse-daily/content.xml"
-    signJar(file("${buildDir}/site/eclipse-daily"))
+    def eclipseSiteDir = layout.buildDirectory.dir("site/eclipse-daily")
+    project.delete eclipseSiteDir.map { it.file("artifacts.xml") }
+    project.delete eclipseSiteDir.map { it.file("content.xml") }
+    signJar(eclipseSiteDir.get().asFile)
   }
   inputs.file 'local.properties'
   dependsOn confirmEclipse, pluginDailyJar, featureDailyJar, siteDailyXml, siteDailyHtml
@@ -534,9 +537,10 @@ def generateP2MetadataDaily = tasks.register('generateP2MetadataDaily', Exec) {
 
 def generateP2MetadataStableLatest = tasks.register('generateP2MetadataStableLatest', Exec) {
   doFirst {
-    project.delete "${buildDir}/site/eclipse-stable-latest/artifacts.xml"
-    project.delete "${buildDir}/site/eclipse-stable-latest/content.xml"
-    signJar(file("${buildDir}/site/eclipse-stable-latest"))
+    def eclipseSiteDir = layout.buildDirectory.dir("site/eclipse-stable-latest")
+    project.delete eclipseSiteDir.map { it.file("artifacts.xml") }
+    project.delete eclipseSiteDir.map { it.file("content.xml") }
+    signJar(eclipseSiteDir.get().asFile)
   }
   inputs.file 'local.properties'
   dependsOn confirmEclipse, pluginStableLatestJar, featureStableLatestJar, siteStableLatestXml, siteStableLatestHtml
@@ -554,7 +558,7 @@ def eclipseSite = tasks.register('eclipseSite') {
 // create zip file to upload to GitHub release page
 def eclipseSiteZip = tasks.register('eclipseSiteZip', Zip) {
   dependsOn eclipseSite
-  from("${buildDir}/site/eclipse")
+  from layout.buildDirectory.dir("site/eclipse")
   archiveFileName = "eclipsePlugin.zip"
 }
 

--- a/eclipsePlugin/build.gradle
+++ b/eclipsePlugin/build.gradle
@@ -375,7 +375,7 @@ def siteCandidateHtml = tasks.register('siteCandidateHtml', Copy) {
     'URL': 'https://spotbugs.github.io/eclipse-candidate/'
   ] + siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
   from 'plugin_site.html'
-  destinationDirectory = layout.buildDirectory.dir("site/eclipse-candidate")
+  into layout.buildDirectory.dir("site/eclipse-candidate")
   rename { 'index.html' }
   outputs.upToDateWhen {
     // even if we have generated file, we should rerun this task to overwrite it.
@@ -388,7 +388,7 @@ def siteDailyHtml = tasks.register('siteDailyHtml', Copy) {
     'URL': 'https://spotbugs.github.io/eclipse-latest/'
   ] + siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
   from 'plugin_site.html'
-  destinationDirectory = layout.buildDirectory.dir("site/eclipse-daily")
+  into layout.buildDirectory.dir("site/eclipse-daily")
   rename { 'index.html' }
   outputs.upToDateWhen {
     // even if we have generated file, we should rerun this task to overwrite it.
@@ -401,7 +401,7 @@ def siteStableLatestHtml = tasks.register('siteStableLatestHtml', Copy) {
     'URL': 'https://spotbugs.github.io/eclipse-stable-latest/'
   ] + siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
   from 'plugin_site.html'
-  destinationDirectory = layout.buildDirectory.dir("site/eclipse-stable-latest")
+  into layout.buildDirectory.dir("site/eclipse-stable-latest")
   rename { 'index.html' }
   outputs.upToDateWhen {
     // even if we have generated file, we should rerun this task to overwrite it.
@@ -412,7 +412,7 @@ def siteStableLatestHtml = tasks.register('siteStableLatestHtml', Copy) {
 def siteXml = tasks.register('siteXml', Copy) {
   filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
   from 'plugin_site.xml'
-  destinationDirectory = layout.buildDirectory.dir("site/eclipse")
+  into layout.buildDirectory.dir("site/eclipse")
   rename { 'site.xml' }
   outputs.upToDateWhen {
     // even if we have generated file, we should rerun this task to overwrite it.
@@ -425,7 +425,7 @@ def siteXml = tasks.register('siteXml', Copy) {
 def siteCandidateXml = tasks.register('siteCandidateXml', Copy) {
   filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
   from 'plugin_site-candidate.xml'
-  destinationDirectory = layout.buildDirectory.dir("site/eclipse-candidate")
+  into layout.buildDirectory.dir("site/eclipse-candidate")
   rename { 'site.xml' }
   outputs.upToDateWhen {
     // even if we have generated file, we should rerun this task to overwrite it.
@@ -436,7 +436,7 @@ def siteCandidateXml = tasks.register('siteCandidateXml', Copy) {
 def siteDailyXml = tasks.register('siteDailyXml', Copy) {
   filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
   from 'plugin_site-daily.xml'
-  destinationDirectory = layout.buildDirectory.dir("site/eclipse-daily")
+  into layout.buildDirectory.dir("site/eclipse-daily")
   rename { 'site.xml' }
   outputs.upToDateWhen {
     // even if we have generated file, we should rerun this task to overwrite it.
@@ -447,7 +447,7 @@ def siteDailyXml = tasks.register('siteDailyXml', Copy) {
 def siteStableLatestXml = tasks.register('siteStableLatestXml', Copy) {
   filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
   from 'plugin_site-stable_latest.xml'
-  destinationDirectory = layout.buildDirectory.dir("site/eclipse-stable-latest")
+  into layout.buildDirectory.dir("site/eclipse-stable-latest")
   rename { 'site.xml' }
   outputs.upToDateWhen {
     // even if we have generated file, we should rerun this task to overwrite it.

--- a/eclipsePlugin/build.gradle
+++ b/eclipsePlugin/build.gradle
@@ -360,7 +360,7 @@ def siteHtml = tasks.register('siteHtml', Copy) {
     'URL': 'https://spotbugs.github.io/eclipse/'
   ] + siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
   from 'plugin_site.html'
-  destinationDirectory = layout.buildDirectory.dir("site/eclipse")
+  into layout.buildDirectory.dir("site/eclipse")
   rename { 'index.html' }
   outputs.upToDateWhen {
     // even if we have generated file, we should rerun this task to overwrite it.

--- a/spotbugs-annotations/build.gradle
+++ b/spotbugs-annotations/build.gradle
@@ -21,7 +21,7 @@ dependencies {
   api 'com.google.code.findbugs:jsr305:3.0.2'
 }
 
-def manifestSpec = manifest {
+def manifestSpec = java.manifest {
   attributes 'Bundle-Name': 'spotbugs-annotations',
                'Bundle-SymbolicName': 'spotbugs-annotations',
                'Bundle-Version': project.version.replace('-', '.'),

--- a/spotbugs-tests/build.gradle
+++ b/spotbugs-tests/build.gradle
@@ -37,7 +37,7 @@ tasks.named('jacocoTestReport', JacocoReport).configure {
   dependsOn('unstableTest')
   additionalSourceDirs.setFrom files(project(':spotbugs').sourceSets.main.java.srcDirs)
   additionalClassDirs.setFrom files(project(':spotbugs').sourceSets.main.output.classesDirs)
-  executionData.setFrom files("$buildDir/jacoco/unstableTest.exec", "$buildDir/jacoco/test.exec")
+  executionData.setFrom files(layout.buildDirectory.file("jacoco/unstableTest.exec"), layout.buildDirectory.file("jacoco/test.exec"))
 }
 
 // Tests below fail if executed with other tests

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -164,7 +164,7 @@ def updateManifest = tasks.register('updateManifest') {
   outputs.file "$projectDir/META-INF/MANIFEST.MF"
   dependsOn configurations.runtimeClasspath, copyLibsForEclipse
   doLast {
-    def manifestSpec = manifest {
+    def manifestSpec = java.manifest {
       from "$projectDir/META-INF/MANIFEST-TEMPLATE.MF"
       attributes 'Main-Class': 'edu.umd.cs.findbugs.LaunchAppropriateUI',
                'Bundle-Version': project.version.replace('-', '.'),
@@ -221,7 +221,7 @@ def scripts = tasks.register('scripts', Copy) {
     into 'experimental'
   }
 
-  destinationDir file("$buildDir/bin")
+  into(layout.buildDirectory.dir("bin"))
   duplicatesStrategy DuplicatesStrategy.FAIL
   fileMode 0755
 }
@@ -329,7 +329,7 @@ def smokeTest = tasks.register('smokeTest') {
               timeout:'1800000',
               outputFile:"${buildDir}/smoketest/findbugscheckAll.xml") {
       sourcePath(path:'src/main/java:src/gui/main:src/tools')
-      'class'(location:project.tasks['compileJava'].destinationDir)
+      'class'(location:project.tasks['compileJava'].destinationDirectory.get().asFile)
       configurations.compileClasspath.each { File file -> auxClasspath(path:file.path) }
     }
   }

--- a/spotbugsTestCases/build.gradle
+++ b/spotbugsTestCases/build.gradle
@@ -66,19 +66,19 @@ tasks.named('javadoc', Javadoc).configure {
 }
 
 def classesJava8 = tasks.register('classesJava8', JavaCompile) {
-  destinationDirectory.set(file("$buildDir/classes/java/java8"))
+  destinationDirectory.set(layout.buildDirectory.dir("classes/java/java8"))
   classpath = sourceSets.main.compileClasspath
   source = file('src/java8')
 }
 
 def classesJava11 = tasks.register('classesJava11', JavaCompile) {
-  destinationDirectory.set(file("$buildDir/classes/java/java11"))
+  destinationDirectory.set(layout.buildDirectory.dir("classes/java/java11"))
   classpath = sourceSets.main.compileClasspath
   source = file('src/java11')
 }
 
 def classesJava17 = tasks.register('classesJava17', JavaCompile) {
-  destinationDirectory.set(file("$buildDir/classes/java/java17"))
+  destinationDirectory.set(layout.buildDirectory.dir("classes/java/java17"))
   classpath = sourceSets.main.compileClasspath
   source = file('src/java17')
 }


### PR DESCRIPTION
Gradle recently deprecated [Project.getBuildDir()](https://docs.gradle.org/current/javadoc/org/gradle/api/Project.html#getBuildDir--). This PR removes many of the simpler usages.

Of course, this is not all. There are more usages of buildDir and even other deprecations in the build script. But this is a first step :) 