### PR TITLE
#2280 Update Eclipse plugin release number to 4.29.0

### DIFF
--- a/buildSrc/src/main/kotlin/eclipse-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/eclipse-convention.gradle.kts
@@ -7,7 +7,7 @@ val pdeTool by configurations.creating {
 }
 
 eclipseMavenCentral {
-  release("4.14.0") {
+  release("4.29.0") {
     compileOnly("org.eclipse.ant.core")
     compileOnly("org.eclipse.core.resources")
     compileOnly("org.eclipse.core.runtime")


### PR DESCRIPTION
Update to a newer Eclipse plugin release version to make the eclipseModul buildable on ARM based Apple Mac systems.

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [ ] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
