### PR TITLE
[eclipse-format] No longer supply version to spotless, use same configuration

### DIFF
--- a/gradle/spotless.gradle
+++ b/gradle/spotless.gradle
@@ -4,7 +4,7 @@ spotless {
   java {
     removeUnusedImports()
     trimTrailingWhitespace()
-    eclipse("4.13").configFile "${rootProject.projectDir}/gradle/eclipse-formatter.xml"
+    eclipse().configFile "${rootProject.projectDir}/gradle/eclipse-formatter.xml"
     endWithNewline()
   }
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/Hierarchy.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/Hierarchy.java
@@ -853,7 +853,7 @@ public class Hierarchy {
                 if (false && subTypeSet.size() > 500) {
                     new RuntimeException(receiverClassName + " has " + subTypeSet.size() + " subclasses, " + result.size()
                             + " of which implement " + methodName + methodSig + " " + invokeInstruction)
-                                    .printStackTrace(System.out);
+                            .printStackTrace(System.out);
                 }
 
             }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BadResultSetAccess.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BadResultSetAccess.java
@@ -100,7 +100,7 @@ public class BadResultSetAccess extends OpcodeStackDetector {
                         bugReporter.reportBug(new BugInstance(this,
                                 "java/sql/PreparedStatement".equals(clsConstant) ? "SQL_BAD_PREPARED_STATEMENT_ACCESS"
                                         : "SQL_BAD_RESULTSET_ACCESS", item.mustBeZero() ? HIGH_PRIORITY : NORMAL_PRIORITY)
-                                                .addClassAndMethod(this).addSourceLine(this));
+                                .addClassAndMethod(this).addSourceLine(this));
                     }
                 }
             }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DumbMethods.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DumbMethods.java
@@ -208,7 +208,7 @@ public class DumbMethods extends OpcodeStackDetector {
                     && "setMaximumPoolSize".equals(getNameConstantOperand())) {
                 accumulator.accumulateBug(new BugInstance(DumbMethods.this,
                         "DMI_FUTILE_ATTEMPT_TO_CHANGE_MAXPOOL_SIZE_OF_SCHEDULED_THREAD_POOL_EXECUTOR", HIGH_PRIORITY)
-                                .addClassAndMethod(DumbMethods.this), DumbMethods.this);
+                        .addClassAndMethod(DumbMethods.this), DumbMethods.this);
             }
         }
     }
@@ -756,7 +756,7 @@ public class DumbMethods extends OpcodeStackDetector {
                                 primitiveType.equals("Z") ? LOW_PRIORITY
                                         : primitiveType.equals("B") ? NORMAL_PRIORITY
                                                 : HIGH_PRIORITY).addClassAndMethod(this).addCalledMethod(this).addMethod(shouldCall)
-                                                        .describe(MethodAnnotation.SHOULD_CALL);
+                                .describe(MethodAnnotation.SHOULD_CALL);
                         accumulator.accumulateBug(bug, this);
                     }
                 }
@@ -1264,7 +1264,7 @@ public class DumbMethods extends OpcodeStackDetector {
 
                 accumulator.accumulateBug(new BugInstance(this, "DMI_CALLING_NEXT_FROM_HASNEXT", item.isInitialParameter()
                         && item.getRegisterNumber() == 0 ? NORMAL_PRIORITY : LOW_PRIORITY).addClassAndMethod(this)
-                                .addCalledMethod(this), this);
+                        .addCalledMethod(this), this);
 
             }
 
@@ -1422,9 +1422,9 @@ public class DumbMethods extends OpcodeStackDetector {
                                 && dblString.toUpperCase().indexOf('E') == -1;
                         bugReporter.reportBug(new BugInstance(this, "DMI_BIGDECIMAL_CONSTRUCTED_FROM_DOUBLE",
                                 scary ? NORMAL_PRIORITY : LOW_PRIORITY).addClassAndMethod(this).addCalledMethod(this)
-                                        .addMethod("java.math.BigDecimal", "valueOf", "(D)Ljava/math/BigDecimal;", true)
-                                        .describe(MethodAnnotation.METHOD_ALTERNATIVE_TARGET).addString(dblString)
-                                        .addString(bigDecimalString).addSourceLine(this));
+                                .addMethod("java.math.BigDecimal", "valueOf", "(D)Ljava/math/BigDecimal;", true)
+                                .describe(MethodAnnotation.METHOD_ALTERNATIVE_TARGET).addString(dblString)
+                                .addString(bigDecimalString).addSourceLine(this));
                     }
                 }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/EmptyZipFileEntry.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/EmptyZipFileEntry.java
@@ -71,7 +71,7 @@ public class EmptyZipFileEntry extends BytecodeScanningDetector implements State
                         .reportBug(new BugInstance(this,
                                 "java/util/zip/ZipOutputStream".equals(streamType) ? "AM_CREATES_EMPTY_ZIP_FILE_ENTRY"
                                         : "AM_CREATES_EMPTY_JAR_FILE_ENTRY", NORMAL_PRIORITY).addClassAndMethod(this)
-                                                .addSourceLine(this));
+                                .addSourceLine(this));
             }
 
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindDeadLocalStores.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindDeadLocalStores.java
@@ -427,7 +427,7 @@ public class FindDeadLocalStores implements Detector {
                         }
                         BugInstance bugInstance = new BugInstance(this, "DLS_DEAD_STORE_OF_CLASS_LITERAL",
                                 Priorities.NORMAL_PRIORITY).addClassAndMethod(methodGen, sourceFileName).add(lvAnnotation)
-                                        .addType(initializationOf);
+                                .addType(initializationOf);
                         accumulator.accumulateBug(bugInstance, sourceLineAnnotation);
                         continue;
                     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindFinalizeInvocations.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindFinalizeInvocations.java
@@ -91,7 +91,7 @@ public class FindFinalizeInvocations extends BytecodeScanningDetector implements
             bugAccumulator.accumulateBug(
                     new BugInstance(this, "FI_EXPLICIT_INVOCATION", "finalize".equals(getMethodName())
                             && "()V".equals(getMethodSig()) ? HIGH_PRIORITY : NORMAL_PRIORITY).addClassAndMethod(this)
-                                    .addCalledMethod(this), this);
+                            .addCalledMethod(this), this);
 
         }
         if (seen == Const.INVOKESPECIAL && "finalize".equals(getNameConstantOperand())) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindInconsistentSync2.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindInconsistentSync2.java
@@ -578,7 +578,7 @@ public class FindInconsistentSync2 implements Detector {
             } else {
                 bugInstance = new BugInstance(this, guardedByThis ? "IS_FIELD_NOT_GUARDED" : "IS2_INCONSISTENT_SYNC",
                         Priorities.NORMAL_PRIORITY).addClass(xfield.getClassName()).addField(xfield).addInt(printFreq)
-                                .describe(IntAnnotation.INT_SYNC_PERCENT);
+                        .describe(IntAnnotation.INT_SYNC_PERCENT);
             }
 
             propertySet.decorateBugInstance(bugInstance);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindJSR166LockMonitorenter.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindJSR166LockMonitorenter.java
@@ -233,7 +233,7 @@ public final class FindJSR166LockMonitorenter implements Detector, StatelessDete
             if (isSubtype) {
                 bugReporter.reportBug(new BugInstance(this, "JLM_JSR166_LOCK_MONITORENTER", isUtilConcurrentSig ? HIGH_PRIORITY
                         : NORMAL_PRIORITY).addClassAndMethod(classContext.getJavaClass(), method).addType(sig)
-                                .addSourceForTopStackValue(classContext, method, location).addSourceLine(classContext, method, location));
+                        .addSourceForTopStackValue(classContext, method, location).addSourceLine(classContext, method, location));
             } else if (isUtilConcurrentSig) {
 
                 int priority = "Ljava/util/concurrent/CopyOnWriteArrayList;".equals(sig) ? HIGH_PRIORITY : NORMAL_PRIORITY;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindLocalSelfAssignment2.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindLocalSelfAssignment2.java
@@ -89,7 +89,7 @@ public class FindLocalSelfAssignment2 extends BytecodeScanningDetector implement
                                 if (f.getName().equals(local.getName()) && (f.isStatic() || !getMethod().isStatic())) {
                                     bugReporter.reportBug(new BugInstance(this, "SA_LOCAL_SELF_ASSIGNMENT_INSTEAD_OF_FIELD",
                                             priority).addClassAndMethod(this).add(local).addField(f)
-                                                    .describe(FieldAnnotation.DID_YOU_MEAN_ROLE).addSourceLine(this));
+                                            .describe(FieldAnnotation.DID_YOU_MEAN_ROLE).addSourceLine(this));
                                     return;
 
                                 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNonSerializableStoreIntoSession.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNonSerializableStoreIntoSession.java
@@ -138,7 +138,7 @@ public class FindNonSerializableStoreIntoSession implements Detector {
 
                     bugAccumulator.accumulateBug(new BugInstance(this, "J2EE_STORE_OF_NON_SERIALIZABLE_OBJECT_INTO_SESSION",
                             isSerializable < 0.15 ? HIGH_PRIORITY : isSerializable > 0.5 ? LOW_PRIORITY : NORMAL_PRIORITY)
-                                    .addClassAndMethod(methodGen, sourceFile).addType(problem).describe(TypeAnnotation.FOUND_ROLE),
+                            .addClassAndMethod(methodGen, sourceFile).addType(problem).describe(TypeAnnotation.FOUND_ROLE),
                             sourceLineAnnotation);
 
                 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNonSerializableValuePassedToWriteObject.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNonSerializableValuePassedToWriteObject.java
@@ -146,8 +146,8 @@ public class FindNonSerializableValuePassedToWriteObject implements Detector {
 
                 bugReporter.reportBug(new BugInstance(this, "DMI_NONSERIALIZABLE_OBJECT_WRITTEN",
                         isSerializable < 0.15 ? HIGH_PRIORITY : isSerializable > 0.5 ? LOW_PRIORITY : NORMAL_PRIORITY)
-                                .addClassAndMethod(methodGen, sourceFile).addType(problem).describe(TypeAnnotation.FOUND_ROLE)
-                                .addSourceLine(sourceLineAnnotation));
+                        .addClassAndMethod(methodGen, sourceFile).addType(problem).describe(TypeAnnotation.FOUND_ROLE)
+                        .addSourceLine(sourceLineAnnotation));
 
             } catch (ClassNotFoundException e) {
                 // ignore

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNullDeref.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNullDeref.java
@@ -513,7 +513,7 @@ public class FindNullDeref implements Detector, UseAnnotationDatabase, NullDeref
 
                 BugInstance warning = new BugInstance(this, "NP_STORE_INTO_NONNULL_FIELD", tos.isDefinitelyNull() ? HIGH_PRIORITY
                         : NORMAL_PRIORITY).addClassAndMethod(classContext.getJavaClass(), method).addField(field)
-                                .addOptionalAnnotation(variableAnnotation).addSourceLine(classContext, method, location);
+                        .addOptionalAnnotation(variableAnnotation).addSourceLine(classContext, method, location);
 
                 bugReporter.reportBug(warning);
             }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindOverridableMethodCall.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindOverridableMethodCall.java
@@ -227,7 +227,7 @@ public class FindOverridableMethodCall extends OpcodeStackDetector {
         if (overridable != null) {
             bugAccumulator.accumulateBug(new BugInstance(this,
                     "MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR", LOW_PRIORITY)
-                            .addClass(this).addMethod(constructor).addString(overridable.getName()), sourceLine);
+                    .addClass(this).addMethod(constructor).addString(overridable.getName()), sourceLine);
             return false;
         }
         callerConstructors.put(callee, new CallerInfo(constructor, sourceLine));
@@ -240,7 +240,7 @@ public class FindOverridableMethodCall extends OpcodeStackDetector {
         if (overridable != null) {
             bugAccumulator.accumulateBug(new BugInstance(this,
                     "MC_OVERRIDABLE_METHOD_CALL_IN_CLONE", NORMAL_PRIORITY)
-                            .addClass(this).addMethod(clone).addString(overridable.getName()), sourceLine);
+                    .addClass(this).addMethod(clone).addString(overridable.getName()), sourceLine);
             return false;
         }
         callerClones.put(callee, new CallerInfo(clone, sourceLine));
@@ -252,7 +252,7 @@ public class FindOverridableMethodCall extends OpcodeStackDetector {
         if (constructor != null) {
             bugAccumulator.accumulateBug(new BugInstance(this,
                     "MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR", LOW_PRIORITY)
-                            .addClassAndMethod(constructor.method).addString(overridable.getName()),
+                    .addClassAndMethod(constructor.method).addString(overridable.getName()),
                     constructor.sourceLine);
         }
 
@@ -260,7 +260,7 @@ public class FindOverridableMethodCall extends OpcodeStackDetector {
         if (clone != null) {
             bugAccumulator.accumulateBug(new BugInstance(this,
                     "MC_OVERRIDABLE_METHOD_CALL_IN_CLONE", NORMAL_PRIORITY)
-                            .addClassAndMethod(clone.method).addString(overridable.getName()), clone.sourceLine);
+                    .addClassAndMethod(clone.method).addString(overridable.getName()), clone.sourceLine);
         }
 
         if (constructor != null || clone != null) {
@@ -281,7 +281,7 @@ public class FindOverridableMethodCall extends OpcodeStackDetector {
                 if (constructor != null) {
                     bugAccumulator.accumulateBug(new BugInstance(this,
                             "MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR", LOW_PRIORITY)
-                                    .addClassAndMethod(constructor.method).addString(overridable.getName()),
+                            .addClassAndMethod(constructor.method).addString(overridable.getName()),
                             constructor.sourceLine);
 
                 }
@@ -289,7 +289,7 @@ public class FindOverridableMethodCall extends OpcodeStackDetector {
                 if (clone != null) {
                     bugAccumulator.accumulateBug(new BugInstance(this,
                             "MC_OVERRIDABLE_METHOD_CALL_IN_CLONE", NORMAL_PRIORITY)
-                                    .addClassAndMethod(clone.method).addString(overridable.getName()),
+                            .addClassAndMethod(clone.method).addString(overridable.getName()),
                             clone.sourceLine);
                 }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindPotentialSecurityCheckBasedOnUntrustedSource.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindPotentialSecurityCheckBasedOnUntrustedSource.java
@@ -334,29 +334,29 @@ public class FindPotentialSecurityCheckBasedOnUntrustedSource extends OpcodeStac
     private void reportBug(CallPair callPair) {
         bugAccumulator.accumulateBug(new BugInstance(this, "USC_POTENTIAL_SECURITY_CHECK_BASED_ON_UNTRUSTED_SOURCE",
                 NORMAL_PRIORITY)
-                        .addClassAndMethod(this)
-                        .addSourceLine(this)
-                        .addClass(callPair.outside.calledClass.getClassName())
-                        .addCalledMethod(callPair.outside.calledClass.getClassName(),
-                                callPair.outside.calledMethod.getName(), callPair.outside.calledMethod.getSignature(),
-                                callPair.outside.calledMethod.isStatic())
-                        .addSourceLine(callPair.outside.srcLine)
-                        .addSourceLine(callPair.inside.srcLine), this);
+                .addClassAndMethod(this)
+                .addSourceLine(this)
+                .addClass(callPair.outside.calledClass.getClassName())
+                .addCalledMethod(callPair.outside.calledClass.getClassName(),
+                        callPair.outside.calledMethod.getName(), callPair.outside.calledMethod.getSignature(),
+                        callPair.outside.calledMethod.isStatic())
+                .addSourceLine(callPair.outside.srcLine)
+                .addSourceLine(callPair.inside.srcLine), this);
     }
 
     private void reportBug(JavaClass cls, XMethod method, SourceLineAnnotation srcLine,
             CalleeInfo calleInfo, SourceLineAnnotation insideSrcLine) {
         bugAccumulator.accumulateBug(new BugInstance(this, "USC_POTENTIAL_SECURITY_CHECK_BASED_ON_UNTRUSTED_SOURCE",
                 NORMAL_PRIORITY)
-                        .addClass(cls)
-                        .addMethod(method)
-                        .addSourceLine(srcLine)
-                        .addClass(calleInfo.calledClass.getClassName())
-                        .addCalledMethod(calleInfo.calledClass.getClassName(),
-                                calleInfo.calledMethod.getName(), calleInfo.calledMethod.getSignature(),
-                                calleInfo.calledMethod.isStatic())
-                        .addSourceLine(calleInfo.srcLine)
-                        .addSourceLine(insideSrcLine), this);
+                .addClass(cls)
+                .addMethod(method)
+                .addSourceLine(srcLine)
+                .addClass(calleInfo.calledClass.getClassName())
+                .addCalledMethod(calleInfo.calledClass.getClassName(),
+                        calleInfo.calledMethod.getName(), calleInfo.calledMethod.getSignature(),
+                        calleInfo.calledMethod.isStatic())
+                .addSourceLine(calleInfo.srcLine)
+                .addSourceLine(insideSrcLine), this);
     }
 
     @Override

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindPublicAttributes.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindPublicAttributes.java
@@ -116,7 +116,7 @@ public class FindPublicAttributes extends OpcodeStackDetector {
             bugReporter.reportBug(new BugInstance(this,
                     "PA_PUBLIC_PRIMITIVE_ATTRIBUTE",
                     NORMAL_PRIORITY)
-                            .addClass(this).addField(field).addSourceLine(sla));
+                    .addClass(this).addField(field).addSourceLine(sla));
             writtenFields.add(field);
         } else if (seen == Const.AASTORE) {
             XField field = stack.getStackItem(2).getXField();
@@ -141,7 +141,7 @@ public class FindPublicAttributes extends OpcodeStackDetector {
             bugReporter.reportBug(new BugInstance(this,
                     "PA_PUBLIC_ARRAY_ATTRIBUTE",
                     NORMAL_PRIORITY)
-                            .addClass(this).addField(field).addSourceLine(sla));
+                    .addClass(this).addField(field).addSourceLine(sla));
             writtenFields.add(field);
         } else if (seen == Const.INVOKEINTERFACE || seen == Const.INVOKEVIRTUAL) {
             XMethod xmo = getXMethodOperand();
@@ -188,7 +188,7 @@ public class FindPublicAttributes extends OpcodeStackDetector {
             bugReporter.reportBug(new BugInstance(this,
                     "PA_PUBLIC_MUTABLE_OBJECT_ATTRIBUTE",
                     NORMAL_PRIORITY)
-                            .addClass(this).addField(field).addSourceLine(sla));
+                    .addClass(this).addField(field).addSourceLine(sla));
             writtenFields.add(field);
         }
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindPuzzlers.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindPuzzlers.java
@@ -391,9 +391,9 @@ public class FindPuzzlers extends OpcodeStackDetector {
                                 valueOfConstantArgumentToShift < 0 ? LOW_PRIORITY
                                         : (valueOfConstantArgumentToShift == 32
                                                 && "hashCode".equals(getMethodName()) ? NORMAL_PRIORITY : HIGH_PRIORITY))
-                                                        .addClassAndMethod(this).addInt(valueOfConstantArgumentToShift).describe(
-                                                                IntAnnotation.INT_SHIFT)
-                                                        .addValueSource(stack.getStackItem(1), this), this);
+                                .addClassAndMethod(this).addInt(valueOfConstantArgumentToShift).describe(
+                                        IntAnnotation.INT_SHIFT)
+                                .addValueSource(stack.getStackItem(1), this), this);
                     }
                 }
                 if (leftHandSide instanceof Integer && ((Integer) leftHandSide) > 0) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindReturnRef.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindReturnRef.java
@@ -145,11 +145,11 @@ public class FindReturnRef extends OpcodeStackDetector {
                 bugAccumulator.accumulateBug(
                         new BugInstance(this, "EI_EXPOSE_STATIC_" + (capture == CaptureKind.BUF ? "BUF2" : "REP2"),
                                 capture == CaptureKind.REP ? NORMAL_PRIORITY : LOW_PRIORITY)
-                                        .addClassAndMethod(this)
-                                        .addReferencedField(this)
-                                        .add(LocalVariableAnnotation.getLocalVariableAnnotation(getMethod(),
-                                                top.getRegisterNumber(),
-                                                getPC(), getPC() - 1)), this);
+                                .addClassAndMethod(this)
+                                .addReferencedField(this)
+                                .add(LocalVariableAnnotation.getLocalVariableAnnotation(getMethod(),
+                                        top.getRegisterNumber(),
+                                        getPC(), getPC() - 1)), this);
             }
         }
         if (!staticMethod && seen == Const.PUTFIELD && nonPublicFieldOperand()
@@ -161,11 +161,11 @@ public class FindReturnRef extends OpcodeStackDetector {
                 bugAccumulator.accumulateBug(
                         new BugInstance(this, "EI_EXPOSE_" + (capture == CaptureKind.BUF ? "BUF2" : "REP2"),
                                 capture == CaptureKind.REP ? NORMAL_PRIORITY : LOW_PRIORITY)
-                                        .addClassAndMethod(this)
-                                        .addReferencedField(this)
-                                        .add(LocalVariableAnnotation.getLocalVariableAnnotation(getMethod(),
-                                                top.getRegisterNumber(),
-                                                getPC(), getPC() - 1)), this);
+                                .addClassAndMethod(this)
+                                .addReferencedField(this)
+                                .add(LocalVariableAnnotation.getLocalVariableAnnotation(getMethod(),
+                                        top.getRegisterNumber(),
+                                        getPC(), getPC() - 1)), this);
             }
         }
 
@@ -203,8 +203,8 @@ public class FindReturnRef extends OpcodeStackDetector {
             bugAccumulator.accumulateBug(new BugInstance(this, (staticMethod ? "MS" : "EI") + "_EXPOSE_"
                     + (isBuf ? "BUF" : "REP"),
                     (isBuf || isArrayClone) ? LOW_PRIORITY : NORMAL_PRIORITY)
-                            .addClassAndMethod(this).addField(field.getClassName(), field.getName(),
-                                    field.getSignature(), field.isStatic()), this);
+                    .addClassAndMethod(this).addField(field.getClassName(), field.getName(),
+                            field.getSignature(), field.isStatic()), this);
 
         }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindUnconditionalWait.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindUnconditionalWait.java
@@ -67,7 +67,7 @@ public class FindUnconditionalWait extends BytecodeScanningDetector implements S
             if (seen == Const.INVOKEVIRTUAL && "wait".equals(getNameConstantOperand())) {
                 bugReporter.reportBug(new BugInstance(this, "UW_UNCOND_WAIT",
                         "()V".equals(getSigConstantOperand()) ? NORMAL_PRIORITY : LOW_PRIORITY).addClassAndMethod(this)
-                                .addSourceLine(this));
+                        .addSourceLine(this));
                 stage = 2;
             }
             break;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindUseOfNonSerializableValue.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindUseOfNonSerializableValue.java
@@ -213,7 +213,7 @@ public class FindUseOfNonSerializableValue implements Detector {
 
                     bugAccumulator.accumulateBug(new BugInstance(this, pattern,
                             isSerializable < 0.15 ? HIGH_PRIORITY : isSerializable > 0.5 ? LOW_PRIORITY : NORMAL_PRIORITY)
-                                    .addClassAndMethod(methodGen, sourceFile).addType(problem).describe(TypeAnnotation.FOUND_ROLE),
+                            .addClassAndMethod(methodGen, sourceFile).addType(problem).describe(TypeAnnotation.FOUND_ROLE),
                             sourceLineAnnotation);
 
                 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindUselessControlFlow.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindUselessControlFlow.java
@@ -108,7 +108,7 @@ public class FindUselessControlFlow extends BytecodeScanningDetector implements 
                 }
                 bugAccumulator.accumulateBug(new BugInstance(this,
                         priority == HIGH_PRIORITY ? "UCF_USELESS_CONTROL_FLOW_NEXT_LINE" : "UCF_USELESS_CONTROL_FLOW", priority)
-                                .addClassAndMethod(this), this);
+                        .addClassAndMethod(this), this);
             }
         }
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/HugeSharedStringConstants.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/HugeSharedStringConstants.java
@@ -110,7 +110,7 @@ public class HugeSharedStringConstants extends BytecodeScanningDetector {
             BugInstance bug = new BugInstance(this, "HSC_HUGE_SHARED_STRING_CONSTANT",
                     overhead > 20 * SIZE_OF_HUGE_CONSTANT ? HIGH_PRIORITY
                             : (overhead > 8 * SIZE_OF_HUGE_CONSTANT ? NORMAL_PRIORITY : LOW_PRIORITY)).addClass(className)
-                                    .addField(field).addInt(length).addInt(occursIn.size()).describe(IntAnnotation.INT_OCCURRENCES);
+                    .addField(field).addInt(length).addInt(occursIn.size()).describe(IntAnnotation.INT_OCCURRENCES);
             for (String c : occursIn) {
                 if (!c.equals(className)) {
                     bug.addClass(c);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InefficientIndexOf.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InefficientIndexOf.java
@@ -77,7 +77,7 @@ public class InefficientIndexOf extends OpcodeStackDetector {
                     if (o != null && ((String) o).length() == 1) {
                         bugReporter.reportBug(new BugInstance(this, lastIndexOf ? "IIO_INEFFICIENT_LAST_INDEX_OF" : "IIO_INEFFICIENT_INDEX_OF",
                                 LOW_PRIORITY).addClassAndMethod(this)
-                                        .describe(StringAnnotation.STRING_MESSAGE).addCalledMethod(this).addSourceLine(this));
+                                .describe(StringAnnotation.STRING_MESSAGE).addCalledMethod(this).addSourceLine(this));
                     }
                 }
             }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InvalidJUnitTest.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InvalidJUnitTest.java
@@ -196,7 +196,7 @@ public class InvalidJUnitTest extends BytecodeScanningDetector {
                 if (superCode != null && superCode.getCode().length > 3) {
                     bugReporter.reportBug(new BugInstance(this, getMethodName().equals("setUp") ? "IJU_SETUP_NO_SUPER"
                             : "IJU_TEARDOWN_NO_SUPER", NORMAL_PRIORITY).addClassAndMethod(this).addMethod(we, superMethod)
-                                    .describe(MethodAnnotation.METHOD_OVERRIDDEN).addSourceLine(this, offset));
+                            .describe(MethodAnnotation.METHOD_OVERRIDDEN).addSourceLine(this, offset));
                 }
             }
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/LazyInit.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/LazyInit.java
@@ -372,7 +372,7 @@ public final class LazyInit extends ByteCodePatternDetector implements Stateless
         String sourceFile = javaClass.getSourceFileName();
         bugReporter.reportBug(new BugInstance(this, sawGetStaticAfterPutStatic ? "LI_LAZY_INIT_UPDATE_STATIC"
                 : "LI_LAZY_INIT_STATIC", priority).addClassAndMethod(methodGen, sourceFile).addField(xfield)
-                        .describe("FIELD_ON").addSourceLine(classContext, methodGen, sourceFile, start, end));
+                .describe("FIELD_ON").addSourceLine(classContext, methodGen, sourceFile, start, end));
         reported.set(testInstructionHandle.getPosition());
 
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MethodReturnCheck.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MethodReturnCheck.java
@@ -102,7 +102,7 @@ public class MethodReturnCheck extends OpcodeStackDetector implements UseAnnotat
             // it's likely that UC_USELESS_VOID_METHOD is just the consequence of the previous report
             bugAccumulator.accumulateBug(new BugInstance(this, "UC_USELESS_VOID_METHOD",
                     code.getCode().length > 40 ? HIGH_PRIORITY : code.getCode().length > 15 ? NORMAL_PRIORITY : LOW_PRIORITY)
-                            .addClassAndMethod(getMethodDescriptor()), this);
+                    .addClassAndMethod(getMethodDescriptor()), this);
         }
         sawExcludedNSECall = false;
         bugAccumulator.reportAccumulatedBugs();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MultithreadedInstanceAccess.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MultithreadedInstanceAccess.java
@@ -178,9 +178,9 @@ public class MultithreadedInstanceAccess extends OpcodeStackDetector {
                             bugReporter.reportBug(new BugInstance(this,
                                     STRUTS_ACTION_NAME.equals(mtClassName) ? "MTIA_SUSPECT_STRUTS_INSTANCE_FIELD"
                                             : "MTIA_SUSPECT_SERVLET_INSTANCE_FIELD", LOW_PRIORITY)
-                                                    .addField(
-                                                            new FieldAnnotation(getDottedClassName(), nameCons.getBytes(), typeCons.getBytes(),
-                                                                    false)).addClass(this).addSourceLine(this));
+                                    .addField(
+                                            new FieldAnnotation(getDottedClassName(), nameCons.getBytes(), typeCons.getBytes(),
+                                                    false)).addClass(this).addSourceLine(this));
                         }
                         break;
                     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/Naming.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/Naming.java
@@ -431,7 +431,7 @@ public class Naming extends PreorderVisitor implements Detector {
         if (badFieldName(obj)) {
             bugReporter.reportBug(new BugInstance(this, "NM_FIELD_NAMING_CONVENTION", classIsPublicOrProtected
                     && (obj.isPublic() || obj.isProtected()) && !hasBadFieldNames ? NORMAL_PRIORITY : LOW_PRIORITY)
-                            .addClass(this).addVisitedField(this));
+                    .addClass(this).addVisitedField(this));
         }
     }
 
@@ -542,7 +542,7 @@ public class Naming extends PreorderVisitor implements Detector {
         } else if (badMethodName(mName)) {
             bugReporter.reportBug(new BugInstance(this, "NM_METHOD_NAMING_CONVENTION", classIsPublicOrProtected
                     && (obj.isPublic() || obj.isProtected()) && !hasBadMethodNames ? NORMAL_PRIORITY : LOW_PRIORITY)
-                            .addClassAndMethod(this));
+                    .addClassAndMethod(this));
         }
 
         if (obj.isAbstract()) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/PermissionsSuper.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/PermissionsSuper.java
@@ -92,7 +92,7 @@ public class PermissionsSuper extends OpcodeStackDetector {
             }
             bugAccumulator.accumulateBug(new BugInstance(this,
                     "PERM_SUPER_NOT_CALLED_IN_GETPERMISSIONS", NORMAL_PRIORITY)
-                            .addClassAndMethod(this), this);
+                    .addClassAndMethod(this), this);
         }
     }
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ReadReturnShouldBeChecked.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ReadReturnShouldBeChecked.java
@@ -154,8 +154,8 @@ public class ReadReturnShouldBeChecked extends BytecodeScanningDetector implemen
                 accumulator.accumulateBug(
                         new BugInstance(this, "SR_NOT_CHECKED", (wasBufferedInputStream ? HIGH_PRIORITY
                                 : recentCallToAvailable ? LOW_PRIORITY : NORMAL_PRIORITY)).addClassAndMethod(this)
-                                        .addCalledMethod(lastCallClass, lastCallMethod, lastCallSig, false), SourceLineAnnotation
-                                                .fromVisitedInstruction(getClassContext(), this, locationOfCall));
+                                .addCalledMethod(lastCallClass, lastCallMethod, lastCallSig, false), SourceLineAnnotation
+                                        .fromVisitedInstruction(getClassContext(), this, locationOfCall));
             }
         }
         sawRead = false;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ReflectionIncreaseAccessibility.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ReflectionIncreaseAccessibility.java
@@ -74,7 +74,7 @@ public class ReflectionIncreaseAccessibility extends OpcodeStackDetector {
                     "()Ljava/lang/Object;".equals(met.getSignature())) {
                 bugAccumulator.accumulateBug(new BugInstance(this,
                         "REFLC_REFLECTION_MAY_INCREASE_ACCESSIBILITY_OF_CLASS", NORMAL_PRIORITY)
-                                .addClassAndMethod(this), this);
+                        .addClassAndMethod(this), this);
             } else if ("java.lang.Class".equals(cls.getClassName()) &&
                     "getDeclaredField".equals(met.getName()) &&
                     "(Ljava/lang/String;)Ljava/lang/reflect/Field;".equals(met.getSignature())) {
@@ -86,7 +86,7 @@ public class ReflectionIncreaseAccessibility extends OpcodeStackDetector {
                 if (fieldIsFromParam != null && fieldIsFromParam.booleanValue()) {
                     bugAccumulator.accumulateBug(new BugInstance(this,
                             "REFLF_REFLECTION_MAY_INCREASE_ACCESSIBILITY_OF_FIELD", NORMAL_PRIORITY)
-                                    .addClassAndMethod(this), this);
+                            .addClassAndMethod(this), this);
                 }
             } else if ("java.lang.SecurityManager".equals(cls.getClassName()) &&
                     "checkPackageAccess".equals(met.getName()) &&

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/VolatileUsage.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/VolatileUsage.java
@@ -95,7 +95,7 @@ public class VolatileUsage extends BytecodeScanningDetector {
             if (seen == Const.PUTFIELD && incrementField.equals(getXFieldOperand())) {
                 bugReporter.reportBug(new BugInstance(this, "VO_VOLATILE_INCREMENT",
                         "J".equals(incrementField.getSignature()) ? Priorities.HIGH_PRIORITY : Priorities.NORMAL_PRIORITY)
-                                .addClassAndMethod(this).addField(incrementField).addSourceLine(this));
+                        .addClassAndMethod(this).addField(incrementField).addSourceLine(this));
             }
             resetIncrementState();
             break;


### PR DESCRIPTION
far smaller subset of corrections making code easier to read.

This is not directly related to using modernized eclipse formatting.  What this does is to stop using specific called out version passed to spotless as there is little impact to letting it use the main version as typically documented.  The eclipse-formatter.xml remains.  There is no need to ignore git blame needs on this one as these are purely whitespace without any line changes which reduce the larger spaces on nesting which affected only 31 files..
