### PR TITLE
fix: Schema Location for findbugsfilter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ## Unreleased - 2022-??-??
 
+### Fixed
+- Fixed schema location for findbugsfilter.xsd ([[#1416](https://github.com/spotbugs/spotbugs/issues/1416)])
+
 ## 4.8.0 - 2023-10-11
 
 ### Changed

--- a/spotbugs/etc/findbugsfilter.xsd
+++ b/spotbugs/etc/findbugsfilter.xsd
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema targetNamespace="https://github.com/spotbugs/filter/3.0.0" elementFormDefault="unqualified"
+    xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/master/spotbugs/etc/findbugsfilter.xsd"
     xmlns="http://www.w3.org/2001/XMLSchema" xmlns:fb="https://github.com/spotbugs/filter/3.0.0">
 
     <element name="FindBugsFilter" type="fb:FindBugsFilterType"></element>


### PR DESCRIPTION
Before opening a 'pull request'

* Search existing issues and pull requests to see if the issue was already discussed.
* Check our discussions to see if the issue was already discussed.
* Check for specific project we support to raise the issue on, under [spotbugs](https://github.com/spotbugs)
* Do not open intellij plugin issues here, open them at [intellij-plugin](https://github.com/JetBrains/spotbugs-intellij-plugin) *

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code

Closes: #1416 . Added xsi:schemaLocation to solve issue.