### PR TITLE
Fix escaping exception from DumbMethods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Fixed missing null checks ([[#2629](https://github.com/spotbugs/spotbugs/issues/2629)])
 - Disabled DontReusePublicIdentifiers due to the high false positives rate ([[#2627](https://github.com/spotbugs/spotbugs/issues/2627)])
 - Removed signature of methods using UTF-8 in DefaultEncodingDetector ([[#2634](https://github.com/spotbugs/spotbugs/issues/2634)])
+- Fix exception escapes when calling functions of JUnit Assert or Assertions ([[#2640](https://github.com/spotbugs/spotbugs/issues/2640)])
 
 ## 4.8.0 - 2023-10-11
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2640Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2640Test.java
@@ -1,0 +1,12 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class Issue2640Test extends AbstractIntegrationTest {
+    @Test
+    void testIssue() {
+        Assertions.assertDoesNotThrow(() -> performAnalysis("ghIssues/Issue2640.class"));
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DumbMethods.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DumbMethods.java
@@ -169,8 +169,8 @@ public class DumbMethods extends OpcodeStackDetector {
             }
 
             if (seen == Const.INVOKESTATIC && ("junit/framework/Assert".equals(getClassConstantOperand()) || "org/junit/Assert".equals(
-                    getClassConstantOperand()) || "org/junit/jupiter/api/Assertion".equals(getClassConstantOperand())
-                            && "assertNotNull".equals(getNameConstantOperand()))) {
+                    getClassConstantOperand()) || "org/junit/jupiter/api/Assertion".equals(getClassConstantOperand()))
+                    && "assertNotNull".equals(getNameConstantOperand())) {
 
                 OpcodeStack.Item item = stack.getStackItem(0);
                 Object o = item.getConstant();

--- a/spotbugsTestCases/src/java/ghIssues/Issue2640.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue2640.java
@@ -1,0 +1,8 @@
+package ghIssues;
+
+public class Issue2640 {
+    public void testUnreachableCode() {
+        org.junit.Assert.fail();
+        System.err.println("Not reachable code");
+    }
+}


### PR DESCRIPTION
The brackets in [DumbMethods](https://github.com/spotbugs/spotbugs/pull/2605/files#diff-bb14d9be707bded935e80462e027bcb6aa99a83af5f5fa4cd39faf3cc1352a8b) in https://github.com/spotbugs/spotbugs/pull/2605 got mixed up, which caused https://github.com/spotbugs/spotbugs/issues/2640. This PR fixes this problem.

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [X] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code