### PR TITLE
Fix MethodReturnCheck FPs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Fixed missing null checks ([[#2629](https://github.com/spotbugs/spotbugs/issues/2629)])
 - Disabled DontReusePublicIdentifiers due to the high false positives rate ([[#2627](https://github.com/spotbugs/spotbugs/issues/2627)])
 - Removed signature of methods using UTF-8 in DefaultEncodingDetector ([[#2634](https://github.com/spotbugs/spotbugs/issues/2634)])
+- Fixed false positive RV_EXCEPTION_NOT_THROWN when asserting to exception throws ([[#2628](https://github.com/spotbugs/spotbugs/issues/2628)])
 
 ## 4.8.0 - 2023-10-11
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2547Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2547Test.java
@@ -21,10 +21,9 @@ class Issue2547Test extends AbstractIntegrationTest {
                 "ghIssues/issue2547/MyEx.class",
                 "ghIssues/issue2547/ExceptionFactory.class");
 
-        assertBug(3);
+        assertBug(2);
         assertBug("notThrowingExCtor", 15);
         assertBug("notThrowingExCtorCaller", 26);
-        assertBug("notThrowingExCtorCallerOutside", 37);
     }
 
     private void assertBug(int num) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MethodReturnCheck.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MethodReturnCheck.java
@@ -317,11 +317,10 @@ public class MethodReturnCheck extends OpcodeStackDetector implements UseAnnotat
                 SignatureParser methodSigParser = new SignatureParser(methodDescriptor.getSignature());
                 String returnTypeSig = methodSigParser.getReturnTypeSignature();
                 String returnType = ClassName.fromFieldSignature(returnTypeSig);
+                String mContainerClass = methodDescriptor.getClassDescriptor().getClassName();
                 if (returnType != null
                         && Subtypes2.instanceOf(ClassName.toDottedClassName(returnType), Values.DOTTED_JAVA_LANG_THROWABLE)
-                        && !("initCause".equals(methodDescriptor.getName()) && methodSigParser.getArguments().length == 1
-                                && "Ljava/lang/Throwable;".equals(methodSigParser.getArguments()[0]))
-                        && !("getCause".equals(methodDescriptor.getName()) && methodSigParser.getArguments().length == 0)) {
+                        && methodDescriptor.isStatic() && (returnType.equals(mContainerClass))) {
                     BugInstance warning = new BugInstance(this, "RV_EXCEPTION_NOT_THROWN", 1).addClassAndMethod(this).addMethod(callSeen)
                             .describe(MethodAnnotation.METHOD_CALLED);
                     bugAccumulator.accumulateBug(warning, SourceLineAnnotation.fromVisitedInstruction(this, callPC));

--- a/spotbugsTestCases/src/java/ghIssues/issue2547/Issue2547.java
+++ b/spotbugsTestCases/src/java/ghIssues/issue2547/Issue2547.java
@@ -32,7 +32,8 @@ public class Issue2547 {
         throw e;
     }
 
-    // non-compliant
+    // This could be non-compliant, but it's a false negative currently.
+    // It needs a good heuristic to not cause too many FPs.
     public void notThrowingExCtorCallerOutside() {
         ExceptionFactory.createMyException(5);
     }


### PR DESCRIPTION
The earlier solution to https://github.com/spotbugs/spotbugs/issues/2547 (https://github.com/spotbugs/spotbugs/pull/2560) causes too many FPs (see https://github.com/spotbugs/spotbugs/issues/2628). This PR fixes https://github.com/spotbugs/spotbugs/issues/2628.
I think founding the corner case (the not thrown exception is created by a separate factory class) is not worth the number of FPs it caused. However, filtering out the method calls with generic signatures does solve the particular case, but it would still cause FPs in other cases (e.g. when the user calls [catchThrowable() from AssertJ](https://github.com/assertj/assertj/blob/74e2c97180c05f9cfedcbe060c5a4c4b3d666bd2/assertj-core/src/main/java/org/assertj/core/api/ThrowableAssert.java#L65)).
So, with this PR compared to 4.7.3, we can find more cases: when the throwable is created by either the constructor or some kind of static factory method of the class of the throwable. Compared to 4.8.0, we lose the cases when the throwable is created an outer class, but not have the FPs with the `assertThrows()` methods.

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [X] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
