### PR TITLE
Fix for IndexOutOfBoundsException in sarif placeholder 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Fixed missing null checks ([[#2629](https://github.com/spotbugs/spotbugs/issues/2629)])
 - Disabled DontReusePublicIdentifiers due to the high false positives rate ([[#2627](https://github.com/spotbugs/spotbugs/issues/2627)])
 - Removed signature of methods using UTF-8 in DefaultEncodingDetector ([[#2634](https://github.com/spotbugs/spotbugs/issues/2634)])
+- Fixed an error in the SARIF export when a bug annotation is missing ([[#2632](https://github.com/spotbugs/spotbugs/issues/2632)])
 
 ## 4.8.0 - 2023-10-11
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/sarif/SarifBugReporterTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/sarif/SarifBugReporterTest.java
@@ -159,6 +159,45 @@ class SarifBugReporterTest {
         JsonArray arguments = message.getAsJsonArray("arguments");
         assertThat(arguments.get(0).getAsInt(), is(10));
     }
+    
+
+
+    @Test
+    void testRuleWithInvalidArguments() {
+        // given
+        final String EXPECTED_BUG_TYPE = "BUG_TYPE";
+        final int EXPECTED_PRIORITY = Priorities.NORMAL_PRIORITY;
+        final String EXPECTED_DESCRIPTION = "describing about this bug type...";
+        BugPattern bugPattern = new BugPattern(EXPECTED_BUG_TYPE, "abbrev", "category", false, EXPECTED_DESCRIPTION,
+                "describing about this bug type with value {1234}...", "detailText", null, 0);
+        DetectorFactoryCollection.instance().registerBugPattern(bugPattern);
+
+        // when
+        reporter.reportBug(new BugInstance(bugPattern.getType(), bugPattern.getPriorityAdjustment()).addInt(10).addClass("the/target/Class"));
+        reporter.finish();
+
+        // then
+        String json = writer.toString();
+        JsonObject jsonObject = new Gson().fromJson(json, JsonObject.class);
+        JsonObject run = jsonObject.getAsJsonArray("runs").get(0).getAsJsonObject();
+        JsonArray rules = run.getAsJsonObject("tool").getAsJsonObject("driver").getAsJsonArray("rules");
+        JsonArray results = run.getAsJsonArray("results");
+
+        assertThat(rules.size(), is(1));
+        JsonObject rule = rules.get(0).getAsJsonObject();
+        assertThat(rule.get("id").getAsString(), is(bugPattern.getType()));
+        String defaultText = rule.getAsJsonObject("messageStrings").getAsJsonObject("default").get("text").getAsString();
+        assertThat(defaultText, is("describing about this bug type with value {0}..."));
+
+        assertThat(results.size(), is(1));
+        JsonObject result = results.get(0).getAsJsonObject();
+        assertThat(result.get("ruleId").getAsString(), is(bugPattern.getType()));
+        JsonObject message = result.getAsJsonObject("message");
+        assertThat(message.get("id").getAsString(), is("default"));
+        assertThat(message.get("text").getAsString(), is(bugPattern.getShortDescription()));
+        JsonArray arguments = message.getAsJsonArray("arguments");
+        assertThat(arguments.get(0).getAsString(), is("?>?1234/2???"));
+    }
 
     @Test
     void testMissingClassNotification() {

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/sarif/SarifBugReporterTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/sarif/SarifBugReporterTest.java
@@ -159,7 +159,7 @@ class SarifBugReporterTest {
         JsonArray arguments = message.getAsJsonArray("arguments");
         assertThat(arguments.get(0).getAsInt(), is(10));
     }
-    
+
 
 
     @Test

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Placeholder.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Placeholder.java
@@ -28,6 +28,12 @@ class Placeholder {
 
     @NonNull
     String toArgument(List<? extends BugAnnotation> bugAnnotations, @Nullable ClassAnnotation primaryClass) {
-        return bugAnnotations.get(index).format(key, primaryClass);
+        if (index < 0) {
+            return "?<?" + index + "/" + bugAnnotations.size() + "???";
+        } else if (index >= bugAnnotations.size()) {
+            return "?>?" + index + "/" + bugAnnotations.size() + "???";
+        } else {
+            return bugAnnotations.get(index).format(key, primaryClass);
+        }
     }
 }


### PR DESCRIPTION
When the bug description has a placeholder for a non-existent annotation the sarif placeholder class causes a IndexOutOfBoundsException

This is most likely a side effect of #2627 

Fixes #2632 