### PR TITLE
Fix CT_CONSTRUCTOR_THROW FP when Supertype has final finalize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Fix exception escapes when calling functions of JUnit Assert or Assertions ([[#2640](https://github.com/spotbugs/spotbugs/issues/2640)])
 - Fixed an error in the SARIF export when a bug annotation is missing ([[#2632](https://github.com/spotbugs/spotbugs/issues/2632)])
 - Fixed false positive RV_EXCEPTION_NOT_THROWN when asserting to exception throws ([[#2628](https://github.com/spotbugs/spotbugs/issues/2628)])
+- Fix false positive CT_CONSTRUCTOR_THROW when supertype has final finalize ([[#2665](https://github.com/spotbugs/spotbugs/issues/2665)])
 
 ### Build
 - Fix deprecated GHA on '::set-output' by using GITHUB_OUTPUT ([[#2651](https://github.com/spotbugs/spotbugs/pull/2651)])

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/ConstructorThrowTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/ConstructorThrowTest.java
@@ -199,7 +199,7 @@ class ConstructorThrowTest extends AbstractIntegrationTest {
     @Test
     void testGoodConstructorThrowCheck13() {
         performAnalysis("constructorthrow/ConstructorThrowNegativeTest12.class",
-                 "constructorthrow/ConstructorThrowNegativeTest13.class");
+                "constructorthrow/ConstructorThrowNegativeTest13.class");
         assertNumOfCTBugs(0);
     }
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/ConstructorThrowTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/ConstructorThrowTest.java
@@ -190,6 +190,19 @@ class ConstructorThrowTest extends AbstractIntegrationTest {
         assertNumOfCTBugs(0);
     }
 
+    @Test
+    void testGoodConstructorThrowCheck12() {
+        performAnalysis("constructorthrow/ConstructorThrowNegativeTest12.class");
+        assertNumOfCTBugs(0);
+    }
+
+    @Test
+    void testGoodConstructorThrowCheck13() {
+        performAnalysis("constructorthrow/ConstructorThrowNegativeTest12.class",
+                 "constructorthrow/ConstructorThrowNegativeTest13.class");
+        assertNumOfCTBugs(0);
+    }
+
     private void assertNumOfCTBugs(int num) {
         final BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
                 .bugType("CT_CONSTRUCTOR_THROW").build();

--- a/spotbugsTestCases/src/java/constructorthrow/ConstructorThrowNegativeTest12.java
+++ b/spotbugsTestCases/src/java/constructorthrow/ConstructorThrowNegativeTest12.java
@@ -1,0 +1,13 @@
+package constructorthrow;
+
+/**
+ * However the constructor throws an unchecked exception, there is an empty finalize in this class.
+ */
+public class ConstructorThrowNegativeTest12 {
+    public ConstructorThrowNegativeTest12() {
+        throw new RuntimeException(); // No error, final finalize.
+    }
+
+    @Override
+    protected final void finalize(){}
+}

--- a/spotbugsTestCases/src/java/constructorthrow/ConstructorThrowNegativeTest13.java
+++ b/spotbugsTestCases/src/java/constructorthrow/ConstructorThrowNegativeTest13.java
@@ -1,0 +1,11 @@
+package constructorthrow;
+
+/**
+ * However there is an unchecked exception thrown from the constructor, the superclass contains a final finalize.
+ * @see <a href="https://github.com/spotbugs/spotbugs/issues/2665">GitHub issue</a>
+ */
+public class ConstructorThrowNegativeTest13 extends ConstructorThrowNegativeTest12 {
+    public ConstructorThrowNegativeTest13() {
+        throw new RuntimeException(); // No error, final finalize.
+    }
+}


### PR DESCRIPTION
This PR fixes https://github.com/spotbugs/spotbugs/issues/2665.

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [X] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
