### PR TITLE
Lower the priority of PA_PUBLIC_MUTABLE_OBJECT_ATTRIBUTE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Fix exception escapes when calling functions of JUnit Assert or Assertions ([[#2640](https://github.com/spotbugs/spotbugs/issues/2640)])
 - Fixed an error in the SARIF export when a bug annotation is missing ([[#2632](https://github.com/spotbugs/spotbugs/issues/2632)])
 - Fixed false positive RV_EXCEPTION_NOT_THROWN when asserting to exception throws ([[#2628](https://github.com/spotbugs/spotbugs/issues/2628)])
+- Lowered the priority of `PA_PUBLIC_MUTABLE_OBJECT_ATTRIBUTE` bug ([[#2652](https://github.com/spotbugs/spotbugs/issues/2652)])
 
 ### Build
 - Fix deprecated GHA on '::set-output' by using GITHUB_OUTPUT ([[#2651](https://github.com/spotbugs/spotbugs/pull/2651)])

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindPublicAttributes.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindPublicAttributes.java
@@ -187,7 +187,7 @@ public class FindPublicAttributes extends OpcodeStackDetector {
 
             bugReporter.reportBug(new BugInstance(this,
                     "PA_PUBLIC_MUTABLE_OBJECT_ATTRIBUTE",
-                    NORMAL_PRIORITY)
+                    LOW_PRIORITY)
                     .addClass(this).addField(field).addSourceLine(sla));
             writtenFields.add(field);
         }


### PR DESCRIPTION
Lowering the priority of `PA_PUBLIC_MUTABLE_OBJECT_ATTRIBUTE` bugtype from normal to low ( https://github.com/spotbugs/spotbugs/issues/2652 ) .

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [X] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
