### PR TITLE
Add more bundles for PDE classpath resolving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Fixed false positive RV_EXCEPTION_NOT_THROWN when asserting to exception throws ([[#2628](https://github.com/spotbugs/spotbugs/issues/2628)])
 - Fix false positive CT_CONSTRUCTOR_THROW when supertype has final finalize ([[#2665](https://github.com/spotbugs/spotbugs/issues/2665)])
 - Lowered the priority of `PA_PUBLIC_MUTABLE_OBJECT_ATTRIBUTE` bug ([[#2652](https://github.com/spotbugs/spotbugs/issues/2652)])
+- Eclipse: fixed startup overhead (on computing classpath) for PDE projects ([[#2671](https://github.com/spotbugs/spotbugs/pull/2671)])
 
 ### Build
 - Fix deprecated GHA on '::set-output' by using GITHUB_OUTPUT ([[#2651](https://github.com/spotbugs/spotbugs/pull/2651)])


### PR DESCRIPTION
The fix #2671 removed a bit more code as needed to fix slow PDE classpath resolving of the PDE project classpath, resulting in "The following classes needed for SpotBugs analysis on project XYZ were missing" warnings reported for few plugin projects.

This is a corner case, but not nice.

After a bit more evaluation, turned out, we do not need to manually (recursively) resolve plugins classpath looking in each dependent *workspace* PDE bundle (which caused repetitive classpath resolving and huge overhead), but we still need to add all libraries from all *bundle dependencies* (recursive), even if they do not contribute to the project runtime classpath (OSGI does that behind the scenes, so PDE doesn't include them by default).

So this patch restores some of that PDE classpath extension logic removed via #2671 (but still solves original issue reported in #2671).

See https://github.com/spotbugs/spotbugs/pull/2671


----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
