### PR TITLE
Use java.nio to load filter files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ### Fixed
 - Fixed false positive UPM_UNCALLED_PRIVATE_METHOD for method used in JUnit's MethodSource ([[#2379](https://github.com/spotbugs/spotbugs/issues/2379)])
+- Use java.nio to load filter files ([[#2684](https://github.com/spotbugs/spotbugs/pull/2684)])
 
 - tbd
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/filter/Utf8FilterFileNameTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/filter/Utf8FilterFileNameTest.java
@@ -1,0 +1,52 @@
+/*
+ * Contributions to SpotBugs
+ * Copyright (C) 2023, the SpotBugs authors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+package edu.umd.cs.findbugs.filter;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+
+/**
+ * @author gtoison
+ */
+class Utf8FilterFileNameTest {
+    @TempDir
+    private Path folderPath;
+
+    @Test
+    void loadFilter() {
+        Path filterPath = folderPath.resolve("äéàùçæð.xml");
+
+        try {
+            Files.createFile(filterPath);
+            Files.writeString(filterPath, "<FindBugsFilter/>");
+
+            Filter filter = new Filter(filterPath.toAbsolutePath().toString());
+        } catch (IOException e) {
+            fail("Error loading filter file " + filterPath, e);
+        }
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/filter/Filter.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/filter/Filter.java
@@ -20,11 +20,13 @@
 package edu.umd.cs.findbugs.filter;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Reader;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
 
@@ -204,7 +206,8 @@ public class Filter extends OrMatcher {
      * @throws ParserConfigurationException
      */
     private void parse(String fileName) throws IOException, SAXException, ParserConfigurationException {
-        FileInputStream fileInputStream = new FileInputStream(new File(fileName));
+        Path path = FileSystems.getDefault().getPath(fileName);
+        InputStream fileInputStream = Files.newInputStream(path);
         parse(fileName, fileInputStream);
     }
 


### PR DESCRIPTION
`java.io.FileInputStream` seems to be running into issues when trying to load files with non-ascii charatecter in the file name.
Other similar issues point to this happening on a Mac, so it might be dependent on the combination of OS/JDK version/user settings.
Although the test did not reproduce the problem I think that using `java.nio` should help.
Note that I'm using `FileSystems.getDefault().getPath(...)` instead of `Path.of(...)` because it is only available since JDK 11.

Originally reported here:
https://github.com/JetBrains/spotbugs-intellij-plugin/issues/1492

Other links discussing similar problems:
https://stackoverflow.com/questions/22775758/java-io-file-accessing-files-with-invalid-filename-encodings
https://ogris.de/howtos/java-utf8-filenames.html
https://stackoverflow.com/questions/14171565/java-read-write-unicode-utf-8-filenames-not-contents