### PR TITLE
FindOverridableMethodCall is not thread safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Fixed false positive UPM_UNCALLED_PRIVATE_METHOD for method used in JUnit's MethodSource ([[#2379](https://github.com/spotbugs/spotbugs/issues/2379)])
 - Use java.nio to load filter files ([[#2684](https://github.com/spotbugs/spotbugs/pull/2684)])
 - Eclipse: Do not export javax.annotation packages ([[#2699](https://github.com/spotbugs/spotbugs/pull/2699)])
+- Fixed not thread safe FindOverridableMethodCall detector ([[#2701](https://github.com/spotbugs/spotbugs/issues/2701)])
 
 - tbd
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindOverridableMethodCall.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindOverridableMethodCall.java
@@ -59,16 +59,16 @@ public class FindOverridableMethodCall extends OpcodeStackDetector {
     }
 
     // For methods called using the standard way
-    private static final Map<XMethod, CallerInfo> callerConstructors = new HashMap<>();
-    private static final Map<XMethod, CallerInfo> callerClones = new HashMap<>();
-    private static final Map<XMethod, XMethod> callsToOverridable = new HashMap<>();
-    private static final MultiMap<XMethod, XMethod> callerToCalleeMap = new MultiMap<>(ArrayList.class);
-    private static final MultiMap<XMethod, XMethod> calleeToCallerMap = new MultiMap<>(ArrayList.class);
+    private final Map<XMethod, CallerInfo> callerConstructors = new HashMap<>();
+    private final Map<XMethod, CallerInfo> callerClones = new HashMap<>();
+    private final Map<XMethod, XMethod> callsToOverridable = new HashMap<>();
+    private final MultiMap<XMethod, XMethod> callerToCalleeMap = new MultiMap<>(ArrayList.class);
+    private final MultiMap<XMethod, XMethod> calleeToCallerMap = new MultiMap<>(ArrayList.class);
 
     // For methods called using method references
-    private static final Map<Integer, CallerInfo> refCallerConstructors = new HashMap<>();
-    private static final Map<Integer, CallerInfo> refCallerClones = new HashMap<>();
-    private static final MultiMap<Integer, XMethod> refCalleeToCallerMap = new MultiMap<>(ArrayList.class);
+    private final Map<Integer, CallerInfo> refCallerConstructors = new HashMap<>();
+    private final Map<Integer, CallerInfo> refCallerClones = new HashMap<>();
+    private final MultiMap<Integer, XMethod> refCalleeToCallerMap = new MultiMap<>(ArrayList.class);
 
 
     private final BugAccumulator bugAccumulator;
@@ -303,7 +303,7 @@ public class FindOverridableMethodCall extends OpcodeStackDetector {
     }
 
     private XMethod getIndirectlyCalledOverridable(XMethod caller) {
-        return getIndirectlyCalledOverridable(caller, new HashSet<XMethod>());
+        return getIndirectlyCalledOverridable(caller, new HashSet<>());
     }
 
     private XMethod getIndirectlyCalledOverridable(XMethod caller, Set<XMethod> visited) {
@@ -334,7 +334,7 @@ public class FindOverridableMethodCall extends OpcodeStackDetector {
     }
 
     private CallerInfo getIndirectCallerSpecial(XMethod callee, Map<XMethod, CallerInfo> map) {
-        return getIndirectCallerSpecial(callee, map, new HashSet<XMethod>());
+        return getIndirectCallerSpecial(callee, map, new HashSet<>());
     }
 
     private CallerInfo getIndirectCallerSpecial(XMethod callee, Map<XMethod, CallerInfo> map, Set<XMethod> visited) {


### PR DESCRIPTION
Don't use static maps for analysis specific data, it can't work with multiple analysis running in same JVM, like it might happen in Eclipse.

Fixes https://github.com/spotbugs/spotbugs/issues/2701