### PR TITLE
Update RELEASE_PROCEDURE.md

### DIFF
--- a/RELEASE_PROCEDURE.md
+++ b/RELEASE_PROCEDURE.md
@@ -30,8 +30,6 @@ Update version in [Eclipse Marketplace page](https://marketplace.eclipse.org/con
 
 No action necessary. When we push tag, the build result on GitHub CI will be deployed to Gradle Plugin Portal.
 
-See `deploy` phase in `.github/workflows/release.yml` for detail.
-
 ## Release to ReadTheDocs
 
 See [docs/README.md](docs/README.md) for detail.

--- a/RELEASE_PROCEDURE.md
+++ b/RELEASE_PROCEDURE.md
@@ -11,15 +11,16 @@ When you release fixed version of SpotBugs, please follow these procedures.
 ## Release to Maven Central
 
 When we push a tag, the build result on GitHub Actions will be deployed to the [SonaType Nexus](https://oss.sonatype.org/), and published to the Maven Central automatically by [Gradle Nexus Publish Plugin](https://github.com/gradle-nexus/publish-plugin). Then we can find [artifacts in the Maven Central](https://repo1.maven.org/maven2/com/github/spotbugs/) after several hours.
+See the `build` phase in `.github/workflows/release.yml` calling the `publishToSonatype` and `closeSonatypeStagingRepository` gradle tasks.
 
 ## Release to Eclipse Update Site
 
-It's automated by Github CI.
+It's automated by GitHub CI.
 
 When we push tag, the build result will be deployed to [eclipse-candidate repository](https://github.com/spotbugs/eclipse-candidate).
 When we push tag and its name doesn't contain `_RC`, the build result will be deployed to [eclipse repository](https://github.com/spotbugs/eclipse).
 
-See `deploy` phase in `.github/workflows/release.yml` for detail.
+See `Deploy eclipse`, `Deploy eclipse-candidate` and `Deploy eclipse-latest` phases in `.github/workflows/release.yml` for detail.
 
 ## Release to Eclipse Marketplace
 
@@ -27,15 +28,14 @@ Update version in [Eclipse Marketplace page](https://marketplace.eclipse.org/con
 
 ## Release to Gradle Plugin Portal
 
-No action necessary. When we push tag, the build result on Github CI will be deployed to Gradle Plugin Portal.
+No action necessary. When we push tag, the build result on GitHub CI will be deployed to Gradle Plugin Portal.
 
 See `deploy` phase in `.github/workflows/release.yml` for detail.
-
-## Update installation manual
-
-`docs/installing.rst` includes link to released binaries, update them.
-It is also necessary to change filename in command line example.
 
 ## Release to ReadTheDocs
 
 See [docs/README.md](docs/README.md) for detail.
+
+## Update the Changelog at GitHub Release
+
+The `CHANGELOG` on the [GitHub release page](https://github.com/spotbugs/spotbugs/releases) only contains a link to the correct version of the `CHANGELOG.md` file (see `createReleaseBody` task in `build.gradle`). It needs to be manually updated after the new GitHub release is created.


### PR DESCRIPTION
Updating the `RELEASE_PROCEDURE.md` file according to the findings at https://github.com/spotbugs/spotbugs/discussions/2417.
I haven't added any changelog entry, since it's just keeping the documentation more up-to-date.

The issue about migrating from travis CI to GitHub Actions may be helpful: https://github.com/spotbugs/spotbugs/issues/1123


----

Make sure these boxes are checked before submitting your PR -- thank you!

- [ ] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
