### PR TITLE
Fix link stuck to earlier version

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ SpotBugs is built using [Gradle](https://gradle.org). The recommended way to obt
 To see a list of build options, run `gradle tasks` (or `gradlew tasks`). The `build` task will perform a full build and test.
 
 To build the SpotBugs plugin for Eclipse, you'll need to create the file `eclipsePlugin/local.properties`, containing a property `eclipseRoot.dir` that points to an Eclipse installation's root directory (see `.github/workflows/release.yml` for an example), then run the build.
-To prepare Eclipse environment only, run `./gradlew eclipse`. See also [detailed steps](https://github.com/spotbugs/spotbugs/blob/release-3.1/eclipsePlugin/doc/building_spotbugs_plugin.txt).
+To prepare Eclipse environment only, run `./gradlew eclipse`. See also [detailed steps](https://github.com/spotbugs/spotbugs/blob/master/eclipsePlugin/doc/building_spotbugs_plugin.txt).
 
 # Using SpotBugs
 


### PR DESCRIPTION
Just found that one link in the Readme is stuck at the 3.1 release, and I couldn't find a good reason for it.
Didn't modify the changelog, since it's only a minimal change in the documentation.

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [ ] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
