### PR TITLE
Fix FPs in ConstructorThrow when the finalizer does not run for checked exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased - 2023-??-??
-- tbd
+
+### Fixed
+- Fix FP in CT_CONSTRUCTOR_THROW when the finalizer does not run, since the exception is thrown before java.lang.Object's constructor exits for checked exceptions ([#2710](https://github.com/spotbugs/spotbugs/issues/2710))
 
 ## 4.8.2 - 2023-11-28
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/ConstructorThrowTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/ConstructorThrowTest.java
@@ -22,7 +22,7 @@ class ConstructorThrowTest extends AbstractIntegrationTest {
     void testConstructorThrowCheck2() {
         performAnalysis("constructorthrow/ConstructorThrowTest2.class");
         assertNumOfCTBugs(1);
-        assertCTBugInLine(10);
+        assertCTBugInLine(11);
     }
 
     @Test
@@ -132,6 +132,27 @@ class ConstructorThrowTest extends AbstractIntegrationTest {
     }
 
     @Test
+    void testConstructorThrowCheck18() {
+        performAnalysis("constructorthrow/ConstructorThrowTest18.class");
+        assertNumOfCTBugs(1);
+        assertCTBugInLine(11);
+    }
+
+    @Test
+    void testConstructorThrowCheck19() {
+        performAnalysis("constructorthrow/ConstructorThrowTest19.class");
+        assertNumOfCTBugs(1);
+        assertCTBugInLine(11);
+    }
+
+    @Test
+    void testConstructorThrowCheck20() {
+        performAnalysis("constructorthrow/ConstructorThrowTest20.class");
+        assertNumOfCTBugs(1);
+        assertCTBugInLine(13);
+    }
+
+    @Test
     void testGoodConstructorThrowCheck1() {
         performAnalysis("constructorthrow/ConstructorThrowNegativeTest1.class");
         assertNumOfCTBugs(0);
@@ -219,6 +240,18 @@ class ConstructorThrowTest extends AbstractIntegrationTest {
     @Test
     void testGoodConstructorThrowCheck15() {
         performAnalysis("constructorthrow/ConstructorThrowNegativeTest15.class");
+        assertNumOfCTBugs(0);
+    }
+
+    @Test
+    void testGoodConstructorThrowCheck16() {
+        performAnalysis("constructorthrow/ConstructorThrowNegativeTest16.class");
+        assertNumOfCTBugs(0);
+    }
+
+    @Test
+    void testGoodConstructorThrowCheck17() {
+        performAnalysis("constructorthrow/ConstructorThrowNegativeTest17.class");
         assertNumOfCTBugs(0);
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ConstructorThrow.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ConstructorThrow.java
@@ -111,8 +111,7 @@ public class ConstructorThrow extends OpcodeStackDetector {
 
     /**
      * 1. Check for any throw expression in the constructor.
-     * 2. Check for any unchecked exception throw inside constructor,
-     * or any of the called methods.
+     * 2. Check for any exception throw inside constructor, or any of the called methods.
      * If the class is final, we are fine, no finalizer attack can happen.
      * In the first pass the detector shouldn't report, because there could be
      * a final finalizer and a throwing constructor. Reporting in this case

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ConstructorThrow.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ConstructorThrow.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 import edu.umd.cs.findbugs.OpcodeStack;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.ba.AnalysisContext;
+import edu.umd.cs.findbugs.ba.XMethod;
 import edu.umd.cs.findbugs.internalAnnotations.DottedClassName;
 import edu.umd.cs.findbugs.util.BootstrapMethodsUtil;
 import edu.umd.cs.findbugs.util.ClassName;
@@ -36,7 +37,6 @@ import org.apache.bcel.classfile.Attribute;
 import org.apache.bcel.classfile.BootstrapMethods;
 import org.apache.bcel.classfile.ConstantInvokeDynamic;
 import org.apache.bcel.classfile.ConstantPool;
-import org.apache.bcel.classfile.ExceptionTable;
 import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.classfile.Method;
 
@@ -104,21 +104,6 @@ public class ConstructorThrow extends OpcodeStackDetector {
     }
 
     @Override
-    public void visit(Method obj) {
-        if (isFinalClass || isFinalFinalizer) {
-            return;
-        }
-        if (isConstructor()) {
-            // Check if there is a throws keyword for checked exceptions.
-            ExceptionTable tbl = obj.getExceptionTable();
-            // Check if the number of thrown exceptions is greater than 0
-            if (tbl != null && tbl.getNumberOfExceptions() > 0) {
-                accumulateBug();
-            }
-        }
-    }
-
-    @Override
     public void visitAfter(JavaClass obj) {
         super.visit(obj);
         bugAccumulator.reportAccumulatedBugs();
@@ -140,14 +125,14 @@ public class ConstructorThrow extends OpcodeStackDetector {
             return;
         }
         if (isFirstPass) {
-            collectExeptionsByMethods(seen);
+            collectExceptionsByMethods(seen);
         } else if (isConstructor()) {
             reportConstructorThrow(seen);
         }
     }
 
     /**
-     * Reports ContructorThrow bug if there is an unhandled unchecked exception thrown directly or indirectly
+     * Reports ConstructorThrow bug if there is an unhandled unchecked exception thrown directly or indirectly
      * from the currently visited method.
      * If the exception is thrown directly, the bug is reported at the throw.
      * If the exception is thrown indirectly (through a method call), the bug is reported at the call of the method
@@ -163,7 +148,7 @@ public class ConstructorThrow extends OpcodeStackDetector {
                     // in case of try-with-resources the compiler generates a nested try-catch with Throwable
                     // so filter out Throwable
                     // however this filters out Throwable explicitly thrown by the programmer, that is not so common
-                    if ("java.lang.Throwable".equals(thrownExClass.getClassName())) {
+                    if (thrownExClass == null || "java.lang.Throwable".equals(thrownExClass.getClassName())) {
                         return;
                     }
                     Set<String> caughtExes = getSurroundingCaughtExes(getConstantPool());
@@ -175,15 +160,12 @@ public class ConstructorThrow extends OpcodeStackDetector {
                 }
             }
         } else if (isMethodCall(seen)) {
-            // checked exceptions are handled when visiting the method
-            // if a called method throws a checked exception, and it is not handled, then it must appear in the `throws`
-            // here only the explicitly thrown exceptions are examined
             if (Const.CONSTRUCTOR_NAME.equals(getNameConstantOperand())) {
                 hadObjectConstructor = true;
             }
 
             String calledMethodFQN = getCalledMethodFQN(seen);
-            Set<JavaClass> unhandledExes = getUndhandledExThrowsInMethod(calledMethodFQN, new HashSet<>());
+            Set<JavaClass> unhandledExes = getUnhandledExThrowsInMethod(calledMethodFQN, new HashSet<>());
             if (hadObjectConstructor && !unhandledExes.isEmpty()) {
                 Set<String> caughtExes = getSurroundingCaughtExes(getConstantPool());
                 boolean hasNotCaughtExFromBody = unhandledExes.stream()
@@ -204,7 +186,7 @@ public class ConstructorThrow extends OpcodeStackDetector {
      * @param visitedMethods the names of the already visited methods, needed to prevent stackoverflow by recursively checking method call cycles
      * @return the JavaClasses of the Exceptions thrown from the method
      */
-    private Set<JavaClass> getUndhandledExThrowsInMethod(String method, Set<String> visitedMethods) {
+    private Set<JavaClass> getUnhandledExThrowsInMethod(String method, Set<String> visitedMethods) {
         Set<JavaClass> unhandledExesInMethod = new HashSet<>();
         if (visitedMethods.contains(method)) {
             return unhandledExesInMethod;
@@ -220,7 +202,7 @@ public class ConstructorThrow extends OpcodeStackDetector {
             Map<String, Set<String>> exHandlesByMethodCalls = exHandlesToMethodCallsByMethodsMap.get(method);
             for (Map.Entry<String, Set<String>> entry : exHandlesByMethodCalls.entrySet()) {
                 String calledMethod = entry.getKey();
-                Set<JavaClass> unhandledExes = getUndhandledExThrowsInMethod(calledMethod, visitedMethods);
+                Set<JavaClass> unhandledExes = getUnhandledExThrowsInMethod(calledMethod, visitedMethods);
                 Set<String> exHandles = entry.getValue();
                 Set<JavaClass> remainingUnhandledExes = unhandledExes.stream()
                         .filter(ex -> !isHandled(ex, exHandles))
@@ -291,7 +273,7 @@ public class ConstructorThrow extends OpcodeStackDetector {
      * Fills the inner collections while visiting the method.
      * @param seen the opcode @see #sawOpcode(int)
      */
-    private void collectExeptionsByMethods(int seen) {
+    private void collectExceptionsByMethods(int seen) {
         String containingMethod = getFullyQualifiedMethodName();
         if (seen == Const.ATHROW) {
             OpcodeStack.Item item = stack.getStackItem(0);
@@ -301,7 +283,7 @@ public class ConstructorThrow extends OpcodeStackDetector {
                     // in case of try-with-resources the compiler generates a nested try-catch with Throwable
                     // so filter out Throwable
                     // however this filters out throwable explicitly thrown by the programmer, that is not so common
-                    if ("java.lang.Throwable".equals(thrownExClass.getClassName())) {
+                    if (thrownExClass == null || "java.lang.Throwable".equals(thrownExClass.getClassName())) {
                         return;
                     }
                     Set<String> caughtExes = getSurroundingCaughtExes(getConstantPool());
@@ -313,16 +295,33 @@ public class ConstructorThrow extends OpcodeStackDetector {
                 }
             }
         } else if (isMethodCall(seen)) {
-            String calledMethod = getNameConstantOperand();
+            String calledMethodName = getNameConstantOperand();
             String calledMethodFullName = getCalledMethodFQN(seen);
             // not interested in call of the constructor or recursion
-            if (!Const.CONSTRUCTOR_NAME.equals(calledMethod) && !containingMethod.equals(calledMethodFullName)) {
+            if (!Const.CONSTRUCTOR_NAME.equals(calledMethodName) && !containingMethod.equals(calledMethodFullName)) {
                 Set<String> caughtExes = getSurroundingCaughtExes(getConstantPool());
                 if (caughtExes.isEmpty()) {
                     // No Exception is handled, then add an empty string to represent this
                     addToExHandlesToMethodCallsByMethodsMap(containingMethod, calledMethodFullName, Collections.singletonList(""));
                 } else {
                     addToExHandlesToMethodCallsByMethodsMap(containingMethod, calledMethodFullName, caughtExes);
+                }
+
+                if (seen != Const.INVOKEDYNAMIC) {
+                    XMethod calledXMethod = getXMethodOperand();
+                    if (calledXMethod != null) {
+                        String[] thrownCheckedExes = calledXMethod.getThrownExceptions();
+                        if (thrownCheckedExes != null) {
+                            for (String thrownCheckedEx : thrownCheckedExes) {
+                                try {
+                                    JavaClass exClass = AnalysisContext.currentAnalysisContext().lookupClass(thrownCheckedEx);
+                                    addToThrownExsByMethodMap(calledMethodFullName, exClass);
+                                } catch (ClassNotFoundException e) {
+                                    AnalysisContext.reportMissingClass(e);
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/spotbugsTestCases/src/java/constructorthrow/ConstructorThrowNegativeTest16.java
+++ b/spotbugsTestCases/src/java/constructorthrow/ConstructorThrowNegativeTest16.java
@@ -1,0 +1,25 @@
+package constructorthrow;
+
+import java.io.IOException;
+
+/**
+ * The Exception is thrown before the java.lang.Object constructor exits, so this is compliant, since in this case
+ * the JVM will not execute an object's finalizer.
+ * @see <a href="https://github.com/spotbugs/spotbugs/issues/2710">GitHub issue</a>
+ */
+public class ConstructorThrowNegativeTest16 {
+    public ConstructorThrowNegativeTest16() throws IOException {
+        this(verify());
+    }
+
+    private ConstructorThrowNegativeTest16(boolean secure) {
+        // secure is always true
+        // Constructor without any checks
+    }
+
+    private static boolean verify() throws IOException {
+        // Returns true if data entered is valid, else throws an Exception
+        // Assume that the attacker just enters invalid data, so this method always throws the exception
+        throw new IOException("Invalid data!");
+    }
+}

--- a/spotbugsTestCases/src/java/constructorthrow/ConstructorThrowNegativeTest17.java
+++ b/spotbugsTestCases/src/java/constructorthrow/ConstructorThrowNegativeTest17.java
@@ -1,0 +1,25 @@
+package constructorthrow;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+/**
+ * In this test case the constructor throws an checked exception from
+ * directly in a stream lambda.
+ */
+public class ConstructorThrowNegativeTest17 {
+    public ConstructorThrowNegativeTest17() {
+        Arrays.asList(1,2,3,4).stream()
+                .forEach(i -> {
+                    try {
+                        test(i);
+                    } catch (IOException e) {
+                        System.err.println("Error happened");
+                    }
+                });
+    }
+
+    public void test(int i) throws IOException {
+        throw new IOException();
+    }
+}

--- a/spotbugsTestCases/src/java/constructorthrow/ConstructorThrowNegativeTest18.java
+++ b/spotbugsTestCases/src/java/constructorthrow/ConstructorThrowNegativeTest18.java
@@ -1,0 +1,25 @@
+package constructorthrow;
+
+import java.io.IOException;
+
+/**
+ * The Exception is thrown before the java.lang.Object constructor exits, so this is compliant, since in this case
+ * the JVM will not execute an object's finalizer.
+ * @see <a href="https://github.com/spotbugs/spotbugs/issues/2710">GitHub issue</a>
+ */
+public class ConstructorThrowNegativeTest18 {
+    public ConstructorThrowNegativeTest18() throws IOException {
+        this(verify());
+    }
+
+    private ConstructorThrowNegativeTest18(boolean secure) {
+        // secure is always true
+        // Constructor without any checks
+    }
+
+    private static boolean verify() throws IOException {
+        // Returns true if data entered is valid, else throws an Exception
+        // Assume that the attacker just enters invalid data, so this method always throws the exception
+        throw new IOException("Invalid data!");
+    }
+}

--- a/spotbugsTestCases/src/java/constructorthrow/ConstructorThrowTest18.java
+++ b/spotbugsTestCases/src/java/constructorthrow/ConstructorThrowTest18.java
@@ -1,0 +1,18 @@
+package constructorthrow;
+
+import java.io.IOException;
+
+/**
+ * The constructor throws an Exception conditionally.
+ */
+public class ConstructorThrowTest18 {
+    public ConstructorThrowTest18() throws IOException {
+        if (!verify()) {
+            throw new IOException();
+        }
+    }
+
+    private boolean verify() {
+        return false;
+    }
+}

--- a/spotbugsTestCases/src/java/constructorthrow/ConstructorThrowTest19.java
+++ b/spotbugsTestCases/src/java/constructorthrow/ConstructorThrowTest19.java
@@ -1,0 +1,22 @@
+package constructorthrow;
+
+import java.io.IOException;
+
+/**
+ * The constructor throws an Exception conditionally.
+ */
+public class ConstructorThrowTest19 {
+    public ConstructorThrowTest19() throws IOException {
+        if (!verify()) {
+            throwEx();
+        }
+    }
+
+    private void throwEx() throws IOException {
+        throw new IOException();
+    }
+
+    private boolean verify() {
+        return false;
+    }
+}

--- a/spotbugsTestCases/src/java/constructorthrow/ConstructorThrowTest20.java
+++ b/spotbugsTestCases/src/java/constructorthrow/ConstructorThrowTest20.java
@@ -1,0 +1,20 @@
+package constructorthrow;
+
+import java.io.FileWriter;
+import java.io.IOException;
+
+/**
+ * The constructor throws an Exception conditionally.
+ */
+public class ConstructorThrowTest20 {
+    public ConstructorThrowTest20() throws IOException {
+        if (!verify()) {
+            FileWriter fw = new FileWriter("");
+            fw.write("string");
+        }
+    }
+
+    private boolean verify() {
+        return false;
+    }
+}


### PR DESCRIPTION
This one really fixes https://github.com/spotbugs/spotbugs/issues/2710, not just half of the problem.

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [X] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
