### PR TITLE
(SARIF) move exit code description and change behaviour of success flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ### Fixed
 - Fix FP in CT_CONSTRUCTOR_THROW when the finalizer does not run, since the exception is thrown before java.lang.Object's constructor exits for checked exceptions ([#2710](https://github.com/spotbugs/spotbugs/issues/2710))
+- Fix `executionSuccessful` flag in SARIF report being set to false when bugs were found ([#2116](https://github.com/spotbugs/spotbugs/issues/2116))
 
 ## 4.8.2 - 2023-11-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 ### Fixed
 - Fix FP in CT_CONSTRUCTOR_THROW when the finalizer does not run, since the exception is thrown before java.lang.Object's constructor exits for checked exceptions ([#2710](https://github.com/spotbugs/spotbugs/issues/2710))
 - Fix `executionSuccessful` flag in SARIF report being set to false when bugs were found ([#2116](https://github.com/spotbugs/spotbugs/issues/2116))
+- Move information contained in the SARIF property `exitSignalName` to `exitCodeDescription` ([#2739](https://github.com/spotbugs/spotbugs/issues/2739))
 
 ## 4.8.2 - 2023-11-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 ### Fixed
 - Fix FP in SE_PREVENT_EXT_OBJ_OVERWRITE when the if statement checking for null value, checking multiple variables or the method exiting in the if branch with an exception. ([#2750](https://github.com/spotbugs/spotbugs/issues/2750))
 - Fix possible null value in taxonomies of SARIF output ([#2744](https://github.com/spotbugs/spotbugs/issues/2744))
+- Fix `executionSuccessful` flag in SARIF report being set to false when bugs were found ([#2116](https://github.com/spotbugs/spotbugs/issues/2116))
+- Move information contained in the SARIF property `exitSignalName` to `exitCodeDescription` ([#2739](https://github.com/spotbugs/spotbugs/issues/2739))
 
 ## 4.8.3 - 2023-12-12
 ### Fixed
@@ -16,8 +18,6 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Applied changes for bcel 6.8.0 with adjustments to constant pool ([#2756](https://github.com/spotbugs/spotbugs/pull/2756))
     - More information bcel changes can be found on ([#2757](https://github.com/spotbugs/spotbugs/pull/2757))
 - Fix FN in CT_CONSTRUCTOR_THROW when the return value of the called method is not void or primitive type.
-- Fix `executionSuccessful` flag in SARIF report being set to false when bugs were found ([#2116](https://github.com/spotbugs/spotbugs/issues/2116))
-- Move information contained in the SARIF property `exitSignalName` to `exitCodeDescription` ([#2739](https://github.com/spotbugs/spotbugs/issues/2739))
 
 ### Changed
 - Improved Matcher checks for empty strings ([#2755](https://github.com/spotbugs/spotbugs/pull/2755))

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/sarif/SarifBugReporterTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/sarif/SarifBugReporterTest.java
@@ -417,7 +417,7 @@ class SarifBugReporterTest {
     }
 
     @Test
-    void testSuccessfulExecution() {
+    void testInvocationSuccessfulOnBugPresence() {
         BugPattern bugPattern = new BugPattern("TYPE", "abbrev", "category", false, "shortDescription",
                 "longDescription", "detailText", "https://example.com/help.html", 0);
         DetectorFactoryCollection.instance().registerBugPattern(bugPattern);

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/sarif/SarifBugReporterTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/sarif/SarifBugReporterTest.java
@@ -431,7 +431,7 @@ class SarifBugReporterTest {
         JsonObject invocation = run.getAsJsonArray("invocations").get(0).getAsJsonObject();
 
         assertThat(invocation.get("exitCode").getAsInt(), is(1));
-        assertThat(invocation.get("exitSignalName").getAsString(), is("BUGS FOUND"));
+        assertThat(invocation.get("exitCodeDescription").getAsString(), is("BUGS FOUND"));
         assertThat(invocation.get("executionSuccessful").getAsBoolean(), is(true));
     }
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/sarif/SarifBugReporterTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/sarif/SarifBugReporterTest.java
@@ -416,6 +416,25 @@ class SarifBugReporterTest {
                 is("Deserialization of Untrusted Data"));
     }
 
+    @Test
+    void testSuccessfulExecution() {
+        BugPattern bugPattern = new BugPattern("TYPE", "abbrev", "category", false, "shortDescription",
+                "longDescription", "detailText", "https://example.com/help.html", 0);
+        DetectorFactoryCollection.instance().registerBugPattern(bugPattern);
+
+        reporter.reportBug(new BugInstance(bugPattern.getType(), bugPattern.getPriorityAdjustment()).addInt(10).addClass("the/target/Class"));
+        reporter.finish();
+
+        String json = writer.toString();
+        JsonObject jsonObject = new Gson().fromJson(json, JsonObject.class);
+        JsonObject run = jsonObject.getAsJsonArray("runs").get(0).getAsJsonObject();
+        JsonObject invocation = run.getAsJsonArray("invocations").get(0).getAsJsonObject();
+
+        assertThat(invocation.get("exitCode").getAsInt(), is(1));
+        assertThat(invocation.get("exitSignalName").getAsString(), is("BUGS FOUND"));
+        assertThat(invocation.get("executionSuccessful").getAsBoolean(), is(true));
+    }
+
     Optional<String> takeFirstKey(JsonObject object) {
         return object.keySet().stream().findFirst();
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Invocation.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Invocation.java
@@ -13,8 +13,9 @@ import java.util.Objects;
  */
 class Invocation {
     private final int exitCode;
+
     @NonNull
-    private final String exitSignalName;
+    private final String exitCodeDescription;
     private final boolean executionSuccessful;
     @NonNull
     private final List<Notification> toolExecutionNotifications;
@@ -24,7 +25,7 @@ class Invocation {
     Invocation(int exitCode, @NonNull String exitSignalName, boolean executionSuccessful, @NonNull List<Notification> toolExecutionNotifications,
             @NonNull List<Notification> toolConfigurationNotifications) {
         this.exitCode = exitCode;
-        this.exitSignalName = Objects.requireNonNull(exitSignalName);
+        this.exitCodeDescription = Objects.requireNonNull(exitSignalName);
         this.executionSuccessful = executionSuccessful;
         this.toolExecutionNotifications = Collections.unmodifiableList(toolExecutionNotifications);
         this.toolConfigurationNotifications = Collections.unmodifiableList(toolConfigurationNotifications);
@@ -34,7 +35,7 @@ class Invocation {
     JsonObject toJsonObject() {
         JsonObject result = new JsonObject();
         result.addProperty("exitCode", exitCode);
-        result.addProperty("exitSignalName", exitSignalName);
+        result.addProperty("exitSignalName", exitCodeDescription);
         result.addProperty("executionSuccessful", executionSuccessful);
 
         JsonArray execNotificationArray = new JsonArray();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Invocation.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Invocation.java
@@ -22,10 +22,10 @@ class Invocation {
     @NonNull
     private final List<Notification> toolConfigurationNotifications;
 
-    Invocation(int exitCode, @NonNull String exitSignalName, boolean executionSuccessful, @NonNull List<Notification> toolExecutionNotifications,
+    Invocation(int exitCode, @NonNull String exitCodeDescription, boolean executionSuccessful, @NonNull List<Notification> toolExecutionNotifications,
             @NonNull List<Notification> toolConfigurationNotifications) {
         this.exitCode = exitCode;
-        this.exitCodeDescription = Objects.requireNonNull(exitSignalName);
+        this.exitCodeDescription = Objects.requireNonNull(exitCodeDescription);
         this.executionSuccessful = executionSuccessful;
         this.toolExecutionNotifications = Collections.unmodifiableList(toolExecutionNotifications);
         this.toolConfigurationNotifications = Collections.unmodifiableList(toolConfigurationNotifications);
@@ -35,7 +35,7 @@ class Invocation {
     JsonObject toJsonObject() {
         JsonObject result = new JsonObject();
         result.addProperty("exitCode", exitCode);
-        result.addProperty("exitSignalName", exitCodeDescription);
+        result.addProperty("exitCodeDescription", exitCodeDescription);
         result.addProperty("executionSuccessful", executionSuccessful);
 
         JsonArray execNotificationArray = new JsonArray();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/SarifBugReporter.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/SarifBugReporter.java
@@ -151,16 +151,16 @@ public class SarifBugReporter extends BugCollectionBugReporter {
         }
 
         List<String> list = new ArrayList<>();
-        if ((exitCode | ExitCodes.ERROR_FLAG) > 0) {
+        if ((exitCode & ExitCodes.ERROR_FLAG) > 0) {
             list.add("ERROR");
         }
-        if ((exitCode | ExitCodes.MISSING_CLASS_FLAG) > 0) {
+        if ((exitCode & ExitCodes.MISSING_CLASS_FLAG) > 0) {
             list.add("MISSING CLASS");
         }
-        if ((exitCode | ExitCodes.BUGS_FOUND_FLAG) > 0) {
+        if ((exitCode & ExitCodes.BUGS_FOUND_FLAG) > 0) {
             list.add("BUGS FOUND");
         }
 
-        return list.isEmpty() ? "UNKNOWN" : list.stream().collect(Collectors.joining(","));
+        return list.isEmpty() ? "UNKNOWN" : String.join(",", list);
     }
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/SarifBugReporter.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/SarifBugReporter.java
@@ -87,7 +87,7 @@ public class SarifBugReporter extends BugCollectionBugReporter {
 
         int exitCode = ExitCodes.from(getQueuedErrors().size(), missingClasses.size(), getBugCollection().getCollection().size());
         Invocation invocation = new Invocation(exitCode,
-                getSignalName(exitCode),
+                getExitCodeDescription(exitCode),
                 (exitCode | ExitCodes.BUGS_FOUND_FLAG) == ExitCodes.BUGS_FOUND_FLAG,
                 execNotifications,
                 configNotifications);
@@ -145,7 +145,7 @@ public class SarifBugReporter extends BugCollectionBugReporter {
         jsonWriter.endArray();
     }
 
-    private static String getSignalName(int exitCode) {
+    private static String getExitCodeDescription(int exitCode) {
         if (exitCode == 0) {
             return "SUCCESS";
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/SarifBugReporter.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/SarifBugReporter.java
@@ -87,8 +87,10 @@ public class SarifBugReporter extends BugCollectionBugReporter {
 
         int exitCode = ExitCodes.from(getQueuedErrors().size(), missingClasses.size(), getBugCollection().getCollection().size());
         Invocation invocation = new Invocation(exitCode,
-                getSignalName(exitCode), exitCode == 0,
-                execNotifications, configNotifications);
+                getSignalName(exitCode),
+                (exitCode | ExitCodes.BUGS_FOUND_FLAG) == ExitCodes.BUGS_FOUND_FLAG,
+                execNotifications,
+                configNotifications);
 
         jsonWriter.name("invocations").beginArray();
         gson.toJson(invocation.toJsonObject(), jsonWriter);


### PR DESCRIPTION
This PR makes changes to the `SarifBugReporter` in order to get it more in line with the [official SARIF specification](https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html).

This includes the following Issues:
- Currently, The description of the exit code is stored in the property [`exitSignalName`](https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html#_Toc141790828). This property SHALL be absent when the process did not exit due to a signal. A better place for this information would be [`exitCodeDescription`](https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html#_Toc141790827). 
Closes #2739 .
- Currently, the SARIF report claims that the execution of the tool was not successful whenever bugs were found.
This goes against the intent of the [`executionSuccessful` property](https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html#_Toc141790831) as specified by the format.
This should close #2116 .

I considered adding the idea from #1918 (setting `executionSuccessful` to false when bugs were found AND the `failOnError` flag is set) but I could not find an easy link from the Reporter to the Task containing the flag value.

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
