### PR TITLE
omit null value in SARIF taxonomies property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ### Fixed
 - Fix FP in CT_CONSTRUCTOR_THROW when the finalizer does not run, since the exception is thrown before java.lang.Object's constructor exits for checked exceptions ([#2710](https://github.com/spotbugs/spotbugs/issues/2710))
+- Fix possible null value in taxonomies of SARIF output ([#2744](https://sarifweb.azurewebsites.net/Validation))
 
 ## 4.8.2 - 2023-11-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ### Fixed
 - Fix FP in CT_CONSTRUCTOR_THROW when the finalizer does not run, since the exception is thrown before java.lang.Object's constructor exits for checked exceptions ([#2710](https://github.com/spotbugs/spotbugs/issues/2710))
-- Fix possible null value in taxonomies of SARIF output ([#2744](https://sarifweb.azurewebsites.net/Validation))
+- Fix possible null value in taxonomies of SARIF output ([#2744](https://github.com/spotbugs/spotbugs/issues/2744))
 
 ## 4.8.2 - 2023-11-28
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/sarif/SarifBugReporterTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/sarif/SarifBugReporterTest.java
@@ -1,8 +1,12 @@
 package edu.umd.cs.findbugs.sarif;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 import java.io.IOException;
@@ -15,10 +19,15 @@ import java.util.Collections;
 import java.util.Locale;
 import java.util.Optional;
 
-import com.google.gson.*;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
 
 import edu.umd.cs.findbugs.BugInstance;
 import edu.umd.cs.findbugs.BugPattern;

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/sarif/SarifBugReporterTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/sarif/SarifBugReporterTest.java
@@ -412,7 +412,7 @@ class SarifBugReporterTest {
     }
 
     @Test
-    void testNullInResultsOrTaxa() throws IOException {
+    void testNullInResultsOrTaxa() {
         reporter.finish();
 
         String json = writer.toString();

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/sarif/SarifBugReporterTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/sarif/SarifBugReporterTest.java
@@ -413,10 +413,6 @@ class SarifBugReporterTest {
 
     @Test
     void testNullInResultsOrTaxa() throws IOException {
-        Path tmpDir = Files.createTempDirectory("spotbugs");
-        new File(tmpDir.toFile(), "SampleClass.java").createNewFile();
-        SourceFinder sourceFinder = reporter.getProject().getSourceFinder();
-        sourceFinder.setSourceBaseList(Collections.singleton(tmpDir.toString()));
         reporter.finish();
 
         String json = writer.toString();

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/sarif/SarifBugReporterTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/sarif/SarifBugReporterTest.java
@@ -419,7 +419,7 @@ class SarifBugReporterTest {
         JsonObject jsonObject = new Gson().fromJson(json, JsonObject.class);
         JsonObject run = jsonObject.getAsJsonArray("runs").get(0).getAsJsonObject();
 
-        // "results" may be "null", but not missing,
+        // "results" may be empty or null, but not missing,
         // https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html#_Toc141790757
         JsonElement results = run.get("results");
         assertNotNull(results);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/SarifBugReporter.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/SarifBugReporter.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
 import com.google.gson.stream.JsonWriter;
 
 import edu.umd.cs.findbugs.BugCollectionBugReporter;
@@ -63,7 +64,10 @@ public class SarifBugReporter extends BugCollectionBugReporter {
         gson.toJson(analyser.getOriginalUriBaseIds(), jsonWriter);
 
         jsonWriter.name("taxonomies").beginArray();
-        gson.toJson(analyser.getCweTaxonomy(), jsonWriter);
+        JsonObject taxa = analyser.getCweTaxonomy();
+        if (taxa != null && !taxa.isJsonNull()) {
+            gson.toJson(taxa, jsonWriter);
+        }
         jsonWriter.endArray();
 
         jsonWriter.endObject().endArray(); // end "runs", end "runs" array


### PR DESCRIPTION
This fixes a conflict with the SARIF specification regarding [`taxonomies`](https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html#_Toc141790742) where SpotBugs would add a null value into the list if no other taxonomy was applicable. 
The current implementation can create problems with parsers that expect either an empty list or a valid object.

Closes #2744 .

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
