### PR TITLE
Fix FNs in CT_CONSTRUCTOR_THROW

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ### Fixed
 - Fix FP in CT_CONSTRUCTOR_THROW when the finalizer does not run, since the exception is thrown before java.lang.Object's constructor exits for checked exceptions ([#2710](https://github.com/spotbugs/spotbugs/issues/2710))
+- Fix FN in CT_CONSTRUCTOR_THROW when the return value of the called method is not void or primitive type.
 
 ### Changed
 - Improved Matcher checks for empty strings ([#2755](https://github.com/spotbugs/spotbugs/pull/2755))

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/ConstructorThrowTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/ConstructorThrowTest.java
@@ -139,6 +139,13 @@ class ConstructorThrowTest extends AbstractIntegrationTest {
     }
 
     @Test
+    void testConstructorThrowCheck19() {
+        performAnalysis("constructorthrow/ConstructorThrowTest19.class");
+        assertNumOfCTBugs(1);
+        assertCTBugInLine(11);
+    }
+
+    @Test
     void testConstructorThrowCheck20() {
         performAnalysis("constructorthrow/ConstructorThrowTest20.class");
         assertNumOfCTBugs(1);

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/ConstructorThrowTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/ConstructorThrowTest.java
@@ -139,17 +139,24 @@ class ConstructorThrowTest extends AbstractIntegrationTest {
     }
 
     @Test
-    void testConstructorThrowCheck19() {
-        performAnalysis("constructorthrow/ConstructorThrowTest19.class");
-        assertNumOfCTBugs(1);
-        assertCTBugInLine(11);
-    }
-
-    @Test
     void testConstructorThrowCheck20() {
         performAnalysis("constructorthrow/ConstructorThrowTest20.class");
         assertNumOfCTBugs(1);
         assertCTBugInLine(13);
+    }
+
+    @Test
+    void testConstructorThrowCheck21() {
+        performAnalysis("constructorthrow/ConstructorThrowTest21.class");
+        assertNumOfCTBugs(1);
+        assertCTBugInLine(9);
+    }
+
+    @Test
+    void testConstructorThrowCheck22() {
+        performAnalysis("constructorthrow/ConstructorThrowTest22.class");
+        assertNumOfCTBugs(1);
+        assertCTBugInLine(11);
     }
 
     @Test
@@ -252,6 +259,12 @@ class ConstructorThrowTest extends AbstractIntegrationTest {
     @Test
     void testGoodConstructorThrowCheck17() {
         performAnalysis("constructorthrow/ConstructorThrowNegativeTest17.class");
+        assertNumOfCTBugs(0);
+    }
+
+    @Test
+    void testGoodConstructorThrowCheck18() {
+        performAnalysis("constructorthrow/ConstructorThrowNegativeTest18.class");
         assertNumOfCTBugs(0);
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ConstructorThrow.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ConstructorThrow.java
@@ -375,7 +375,7 @@ public class ConstructorThrow extends OpcodeStackDetector {
             }
         } else {
             return String.format("%s.%s : %s", getDottedClassConstantOperand(), getNameConstantOperand(),
-                    getSigConstantOperand());
+                    toDotted(getSigConstantOperand()));
         }
         return "";
     }

--- a/spotbugsTestCases/src/java/constructorthrow/ConstructorThrowTest21.java
+++ b/spotbugsTestCases/src/java/constructorthrow/ConstructorThrowTest21.java
@@ -1,0 +1,15 @@
+package constructorthrow;
+
+/**
+ * Calling a static function with not void or primitive return value from the constructor,
+ * which throws an unchecked exception.
+ */
+public class ConstructorThrowTest21 {
+    public ConstructorThrowTest21() {
+        ConstructorThrowTest21.test();
+    }
+
+    private static String test() {
+        throw new IllegalStateException();
+    }
+}

--- a/spotbugsTestCases/src/java/constructorthrow/ConstructorThrowTest22.java
+++ b/spotbugsTestCases/src/java/constructorthrow/ConstructorThrowTest22.java
@@ -1,0 +1,17 @@
+package constructorthrow;
+
+import java.io.IOException;
+
+/**
+ * Calling a static function with not void or primitive return value from the constructor,
+ * which throws a checked exception.
+ */
+public class ConstructorThrowTest22 {
+    public ConstructorThrowTest22() throws IOException {
+        ConstructorThrowTest22.test();
+    }
+
+    private static String test() throws IOException {
+        throw new IOException();
+    }
+}


### PR DESCRIPTION
Run into false negatives in CT_CONSTRUCTOR_THROW, when trying to solve another issue. The method signature was inconsistently stored, in one place as dotted, at another place as slashed. This caused that if the exception was thrown from or through a method, the return type of which is not void or primitive type, then the problem is not found.
This PR solves this.


----

Make sure these boxes are checked before submitting your PR -- thank you!

- [X] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
