### PR TITLE
Fix FP in CT_CONSTRUCTOR_THROW with lambdas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Applied changes for bcel 6.8.0 with adjustments to constant pool ([#2756](https://github.com/spotbugs/spotbugs/pull/2756))
     - More information bcel changes can be found on ([#2757](https://github.com/spotbugs/spotbugs/pull/2757))
 - Fix FN in CT_CONSTRUCTOR_THROW when the return value of the called method is not void or primitive type.
+- Fix FP in CT_CONSTRUCTOR_THROW when exception throwing lambda is created, but not called in constructor ([#2695](https://github.com/spotbugs/spotbugs/issues/2695)) 
 
 ### Changed
 - Improved Matcher checks for empty strings ([#2755](https://github.com/spotbugs/spotbugs/pull/2755))

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/ConstructorThrowTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/ConstructorThrowTest.java
@@ -57,22 +57,19 @@ class ConstructorThrowTest extends AbstractIntegrationTest {
     @Test
     void testConstructorThrowCheck7() {
         performAnalysis("constructorthrow/ConstructorThrowTest7.class");
-        assertNumOfCTBugs(1);
-        assertCTBugInLine(11); // Preferable 12, but 11 is ok.
+        assertNumOfCTBugs(0); // It doesn't work for lambdas
     }
 
     @Test
     void testConstructorThrowCheck8() {
         performAnalysis("constructorthrow/ConstructorThrowTest8.class");
-        assertNumOfCTBugs(1);
-        assertCTBugInLine(11); // Preferable 12, but 11 is ok.
+        assertNumOfCTBugs(0); // It doesn't work for lambdas
     }
 
     @Test
     void testConstructorThrowCheck9() {
         performAnalysis("constructorthrow/ConstructorThrowTest9.class");
-        assertNumOfCTBugs(1);
-        assertCTBugInLine(11); // Preferable 12, but 11 is ok.
+        assertNumOfCTBugs(0); // It doesn't work for lambdas
     }
 
     @Test
@@ -169,8 +166,7 @@ class ConstructorThrowTest extends AbstractIntegrationTest {
     @Test
     void testConstructorThrowCheck23() {
         performAnalysis("constructorthrow/ConstructorThrowTest23.class");
-        assertNumOfCTBugs(1);
-        assertCTBugInLine(14);
+        assertNumOfCTBugs(0); // It doesn't work for lambdas
     }
 
     @Test

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/ConstructorThrowTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/ConstructorThrowTest.java
@@ -167,6 +167,20 @@ class ConstructorThrowTest extends AbstractIntegrationTest {
     }
 
     @Test
+    void testConstructorThrowCheck23() {
+        performAnalysis("constructorthrow/ConstructorThrowTest23.class");
+        assertNumOfCTBugs(1);
+        assertCTBugInLine(14);
+    }
+
+    @Test
+    void testConstructorThrowCheck24() {
+        performAnalysis("constructorthrow/ConstructorThrowTest24.class");
+        assertNumOfCTBugs(1);
+        assertCTBugInLine(11);
+    }
+
+    @Test
     void testGoodConstructorThrowCheck1() {
         performAnalysis("constructorthrow/ConstructorThrowNegativeTest1.class");
         assertNumOfCTBugs(0);
@@ -272,6 +286,12 @@ class ConstructorThrowTest extends AbstractIntegrationTest {
     @Test
     void testGoodConstructorThrowCheck18() {
         performAnalysis("constructorthrow/ConstructorThrowNegativeTest18.class");
+        assertNumOfCTBugs(0);
+    }
+
+    @Test
+    void testGoodConstructorThrowCheck19() {
+        performAnalysis("constructorthrow/ConstructorThrowNegativeTest19.class");
         assertNumOfCTBugs(0);
     }
 

--- a/spotbugsTestCases/src/java/constructorthrow/ConstructorThrowNegativeTest19.java
+++ b/spotbugsTestCases/src/java/constructorthrow/ConstructorThrowNegativeTest19.java
@@ -1,0 +1,19 @@
+package constructorthrow;
+
+import java.util.function.Supplier;
+
+/**
+ * The lambda which throws the exception is created and assigned to a field, but not used.
+ * @see <a href="https://github.com/spotbugs/spotbugs/issues/2695">GitHub issue #2695</a>
+ */
+public class ConstructorThrowNegativeTest19 {
+    Supplier<String> s;
+
+    public ConstructorThrowNegativeTest19() {
+        s = ConstructorThrowNegativeTest19::supplier;
+    }
+
+    private static String supplier() {
+        throw new IllegalStateException();
+    }
+}

--- a/spotbugsTestCases/src/java/constructorthrow/ConstructorThrowTest23.java
+++ b/spotbugsTestCases/src/java/constructorthrow/ConstructorThrowTest23.java
@@ -1,0 +1,20 @@
+package constructorthrow;
+
+import java.util.function.Supplier;
+
+/**
+ * The lambda which throws the exception is created and assigned to a field, and used in the Constructor.
+ * It's similar to {@link ConstructorThrowNegativeTest19}, but it throws an exception.
+ */
+public class ConstructorThrowTest23 {
+    Supplier<String> s;
+
+    public ConstructorThrowTest23() {
+        s = ConstructorThrowTest23::supplier;
+        String str = s.get();
+    }
+
+    private static String supplier() {
+        throw new IllegalStateException();
+    }
+}

--- a/spotbugsTestCases/src/java/constructorthrow/ConstructorThrowTest24.java
+++ b/spotbugsTestCases/src/java/constructorthrow/ConstructorThrowTest24.java
@@ -1,0 +1,17 @@
+package constructorthrow;
+
+/**
+ * The lambda which throws the exception is created and assigned to a field, and used in the Constructor.
+ * It's similar to {@link ConstructorThrowNegativeTest19}, but it throws an exception.
+ */
+public class ConstructorThrowTest24 {
+    String s;
+
+    public ConstructorThrowTest24() {
+        s = ConstructorThrowTest24.supplier();
+    }
+
+    private static String supplier() {
+        throw new IllegalStateException();
+    }
+}


### PR DESCRIPTION
This is a dirty fix for https://github.com/spotbugs/spotbugs/issues/2695.
This PR fixes https://github.com/spotbugs/spotbugs/issues/2695 by deleting the lambda handling parts from the ConstructorThrow detector, so it causes false negatives, since from now, if an exception is thrown through an invoke dynamic (e.g. a lamdba), it won't be able to find it. I think the false positives in the original version can be more annoying, than the false negatives this PR introduces.


I plan to propose a proper solution later, but I didn't want to wait longer for proposing a solution to this issue, so the users won't disable the rule because of its noisiness.

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [X] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
