### PR TITLE
Support negated onlyAnalyze items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 ### Fixed
 - Fix FP in CT_CONSTRUCTOR_THROW when the finalizer does not run, since the exception is thrown before java.lang.Object's constructor exits for checked exceptions ([#2710](https://github.com/spotbugs/spotbugs/issues/2710))
 
+### Changed
+- Allow 'onlyAnalyze' option to specify negative matches, such that this facility can be used to prevent a subset of classes to be excluded from analysis ([#2754](https://github.com/spotbugs/spotbugs/pull/2754))
+
 ## 4.8.2 - 2023-11-28
 
 ### Fixed

--- a/docs/locale/ja/LC_MESSAGES/running.po
+++ b/docs/locale/ja/LC_MESSAGES/running.po
@@ -429,7 +429,7 @@ msgstr ""
 "を参照してください。"
 
 #: ../../running.rst:188
-msgid "-onlyAnalyze *com.foobar.MyClass,com.foobar.mypkg.**:"
+msgid "-onlyAnalyze *com.foobar.MyClass,com.foobar.mypkg.*,!com.foobar.mypkg.ExcludedClass*:"
 msgstr ""
 
 #: ../../running.rst:184

--- a/docs/locale/pt_BR/LC_MESSAGES/running.po
+++ b/docs/locale/pt_BR/LC_MESSAGES/running.po
@@ -465,7 +465,7 @@ msgstr ""
 "filtro especificado em filterFile.xml. Veja :doc:`filter`."
 
 #: ../../running.rst:188
-msgid "-onlyAnalyze *com.foobar.MyClass,com.foobar.mypkg.**:"
+msgid "-onlyAnalyze *com.foobar.MyClass,com.foobar.mypkg.*,!com.foobar.mypkg.ExcludedClass*:"
 msgstr ""
 
 #: ../../running.rst:184

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -180,12 +180,13 @@ These options are only accepted by the Text User Interface.
   Report all bug instances except those matching the filter specified by filterFile.xml.
   See :doc:`filter`.
 
--onlyAnalyze *com.foobar.MyClass,com.foobar.mypkg.**:
+-onlyAnalyze *com.foobar.MyClass,com.foobar.mypkg.*,!com.foobar.mypkg.ExcludedClass*:
   Restrict analysis to find bugs to given comma-separated list of classes and packages.
   Unlike filtering, this option avoids running analysis on classes and packages that are not explicitly matched: for large projects, this may greatly reduce the amount of time needed to run the analysis.
   (However, some detectors may produce inaccurate results if they aren't run on the entire application.)
   Classes should be specified using their full classnames (including package), and packages should be specified in the same way they would in a Java import statement to import all classes in the package (i.e., add .* to the full name of the package).
-  Replace .* with .- to also analyze all subpackages.
+  Replace ``.*`` with ``.-`` to also analyze all subpackages.
+  Items starting with ``!`` are treated as exclusions, removing otherwise-included classes from analysis.
 
 -low:
   Report all bugs.

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ClassScreenerTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ClassScreenerTest.java
@@ -107,12 +107,62 @@ class ClassScreenerTest {
         testPackageScreener(particularPackageScreener2);
     }
 
-    private void testPackageScreener(IClassScreener screener) {
+    private static void testPackageScreener(IClassScreener screener) {
         Assertions.assertTrue(screener.matches(SOME_CLASS_FILENAME));
         Assertions.assertTrue(screener.matches(SOME_OTHER_CLASS_FILENAME));
         Assertions.assertFalse(screener.matches(UNRELATED_THING_CLASS_FILENAME));
         Assertions.assertTrue(screener.matches(SOME_CLASS_JARFILENAME));
         Assertions.assertTrue(screener.matches(SOME_OTHER_CLASS_JARFILENAME));
         Assertions.assertFalse(screener.matches(UNRELATED_THING_CLASS_JARFILENAME));
+    }
+
+    @Test
+    void testExcludeOneClass() {
+        ClassScreener screener = new ClassScreener();
+        screener.addAllowedClass("!" + SOME_CLASS);
+
+        Assertions.assertFalse(screener.vacuous());
+
+        Assertions.assertFalse(screener.matches(SOME_CLASS_FILENAME));
+        Assertions.assertTrue(screener.matches(SOME_OTHER_CLASS_FILENAME));
+        Assertions.assertTrue(screener.matches(UNRELATED_THING_CLASS_FILENAME));
+
+        Assertions.assertFalse(screener.matches(SOME_CLASS_JARFILENAME));
+        Assertions.assertTrue(screener.matches(SOME_OTHER_CLASS_JARFILENAME));
+        Assertions.assertTrue(screener.matches(UNRELATED_THING_CLASS_JARFILENAME));
+    }
+
+    @Test
+    void testExcludeHasPrecendence() {
+        ClassScreener screener = new ClassScreener();
+        screener.addAllowedClass(SOME_CLASS);
+        screener.addAllowedClass("!" + SOME_CLASS);
+
+        Assertions.assertFalse(screener.matches(SOME_CLASS_FILENAME));
+        Assertions.assertFalse(screener.matches(SOME_CLASS_JARFILENAME));
+    }
+
+    @Test
+    void testPackageClassExclude() {
+        ClassScreener screener = new ClassScreener();
+        screener.addAllowedPackage(FOOBAR_PACKAGE);
+        screener.addAllowedClass("!" + SOME_CLASS);
+
+        Assertions.assertFalse(screener.matches(SOME_CLASS_FILENAME));
+        Assertions.assertFalse(screener.matches(SOME_CLASS_JARFILENAME));
+        Assertions.assertTrue(screener.matches(SOME_OTHER_CLASS_FILENAME));
+        Assertions.assertTrue(screener.matches(SOME_OTHER_CLASS_JARFILENAME));
+    }
+
+    @Test
+    void testPrefixExcludesPackage() {
+        ClassScreener screener = new ClassScreener();
+        screener.addAllowedPackage(FOOBAR_PACKAGE);
+        screener.addAllowedPrefix("!com.");
+
+        Assertions.assertFalse(screener.matches(SOME_CLASS_FILENAME));
+        Assertions.assertFalse(screener.matches(SOME_CLASS_JARFILENAME));
+        Assertions.assertFalse(screener.matches(SOME_OTHER_CLASS_FILENAME));
+        Assertions.assertFalse(screener.matches(SOME_OTHER_CLASS_JARFILENAME));
     }
 }

--- a/spotbugs/src/doc/manual.xml
+++ b/spotbugs/src/doc/manual.xml
@@ -780,7 +780,7 @@ These options are only accepted by the Text User Interface.
   </varlistentry>
 
   <varlistentry>
-    <term><command>-onlyAnalyze</command> <replaceable>com.foobar.MyClass,com.foobar.mypkg.*</replaceable></term>
+    <term><command>-onlyAnalyze</command> <replaceable>com.foobar.MyClass,com.foobar.mypkg.*,!com.foobar.mypkg.ExcludedClass</replaceable></term>
     <listitem>
       <para>
       Restrict analysis to find bugs to given comma-separated list of
@@ -797,6 +797,9 @@ These options are only accepted by the Text User Interface.
       to the full name of the package).
       Replace <literal>.*</literal> with <literal>.-</literal> to also
       analyze all subpackages.
+      Items starting with <literal>!<literal> are treated as exclusions,
+      removing otherwise-included classes from analysis.
+
       </para>
     </listitem>
   </varlistentry>

--- a/spotbugs/src/doc/manual_ja.xml
+++ b/spotbugs/src/doc/manual_ja.xml
@@ -540,9 +540,9 @@ The second invokes the Command Line Interface (Text UI):
   </varlistentry>
 
   <varlistentry>
-    <term><command>-onlyAnalyze</command> <replaceable>com.foobar.MyClass,com.foobar.mypkg.*</replaceable></term>
+    <term><command>-onlyAnalyze</command> <replaceable>com.foobar.MyClass,com.foobar.mypkg.*,!com.foobar.mypkg.ExcludedClass</replaceable></term>
     <listitem>
-      <para>コンマ区切りで指定したクラスおよびパッケージのみに限定して、バグ検出の解析を行うようにします。フィルターと違って、このオプションを使うと一致しないクラスおよびパッケージに対する解析の実行を回避することができます。大きなプロジェクトにおいて、このオプションを活用すると解析にかかる時間を大きく削減することができる可能性があります。(しかしながら、アプリケーションの全体で実行していないために不正確な結果を出してしまうディテクタがある可能性もあります。) クラスはパッケージも含んだ完全な名前を指定する必要があります。また、パッケージは、 Java の <literal>import</literal> 文でパッケージ下のすべてのクラスをインポートするときと同じ方法で指定します。 (すなわち、パッケージの完全な名前に <literal>.*</literal> を付け加えた形です。)<literal>.*</literal> の代わりに <literal>.-</literal> を指定すると、サブパッケージも含めてすべてが解析されます。</para>
+        <para>コンマ区切りで指定したクラスおよびパッケージのみに限定して、バグ検出の解析を行うようにします。フィルターと違って、このオプションを使うと一致しないクラスおよびパッケージに対する解析の実行を回避することができます。大きなプロジェクトにおいて、このオプションを活用すると解析にかかる時間を大きく削減することができる可能性があります。(しかしながら、アプリケーションの全体で実行していないために不正確な結果を出してしまうディテクタがある可能性もあります。) クラスはパッケージも含んだ完全な名前を指定する必要があります。また、パッケージは、 Java の <literal>import</literal> 文でパッケージ下のすべてのクラスをインポートするときと同じ方法で指定します。 (すなわち、パッケージの完全な名前に <literal>.*</literal> を付け加えた形です。)<literal>.*</literal> の代わりに <literal>.-</literal> を指定すると、サブパッケージも含めてすべてが解析されます。<literal>!</literal> で始まる項目 は否定的な意味を持っているため、含まれるのではなく除外されます。 除外は、指定された順序に関係なく、包含よりも優先されます。</para>
     </listitem>
   </varlistentry>
 


### PR DESCRIPTION
Having the ability to exclude only specific files is useful where a
project needs to be partially analyzed and it is the exclusions that are
known, not the inclusions.

Update -onlyAnalyze to recognize items starting with ! as exclusions,
allowing a lot more flexibility in specification of which classes are
included.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>

Before opening a 'pull request'

* Search existing issues and pull requests to see if the issue was already discussed.
* Check our discussions to see if the issue was already discussed.
* Check for specific project we support to raise the issue on, under [spotbugs](https://github.com/spotbugs)
* Do not open intellij plugin issues here, open them at [intellij-plugin](https://github.com/JetBrains/spotbugs-intellij-plugin) *

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
