### PR TITLE
Use String.isEmpty() with null guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 ### Fixed
 - Fix FP in CT_CONSTRUCTOR_THROW when the finalizer does not run, since the exception is thrown before java.lang.Object's constructor exits for checked exceptions ([#2710](https://github.com/spotbugs/spotbugs/issues/2710))
 
+### Changed
+- Improved Matcher checks for empty strings ([#2755](https://github.com/spotbugs/spotbugs/pull/2755))
+
 ## 4.8.2 - 2023-11-28
 
 ### Fixed

--- a/spotbugs/src/gui/main/edu/umd/cs/findbugs/gui2/MainFrame.java
+++ b/spotbugs/src/gui/main/edu/umd/cs/findbugs/gui2/MainFrame.java
@@ -642,7 +642,7 @@ public class MainFrame extends FBFrame implements LogSync {
     public void updateTitle() {
         Project project = getProject();
         String name = project.getProjectName();
-        if ((name == null || "".equals(name.trim())) && saveFile != null) {
+        if ((name == null || name.trim().isEmpty()) && saveFile != null) {
             name = saveFile.getAbsolutePath();
         }
         if (name == null) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/SortedBugCollection.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/SortedBugCollection.java
@@ -615,7 +615,7 @@ public class SortedBugCollection implements BugCollection {
         // Summary HTML
         if (REPORT_SUMMARY_HTML) {
             String html = getSummaryHTML();
-            if (html != null && !"".equals(html)) {
+            if (html != null && !html.isEmpty()) {
                 xmlOutput.openTag(SUMMARY_HTML_ELEMENT_NAME);
                 xmlOutput.writeCDATA(html);
                 xmlOutput.closeTag(SUMMARY_HTML_ELEMENT_NAME);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/filter/ClassMatcher.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/filter/ClassMatcher.java
@@ -54,7 +54,7 @@ public class ClassMatcher implements Matcher {
     @Override
     public boolean match(BugInstance bugInstance) {
         ClassAnnotation classAnnotation = bugInstance.getPrimaryClass();
-        if (role != null && !"".equals(role)) {
+        if (role != null && !role.isEmpty()) {
             for (BugAnnotation a : bugInstance.getAnnotations()) {
                 if (a instanceof ClassAnnotation && role.equals(a.getDescription())) {
                     classAnnotation = (ClassAnnotation) a;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/filter/FieldMatcher.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/filter/FieldMatcher.java
@@ -52,7 +52,7 @@ public class FieldMatcher extends MemberMatcher implements Matcher {
     @Override
     public boolean match(BugInstance bugInstance) {
         FieldAnnotation fieldAnnotation = null;
-        if (role == null || "".equals(role)) {
+        if (role == null || role.isEmpty()) {
             fieldAnnotation = bugInstance.getPrimaryField();
         } else {
             for (BugAnnotation a : bugInstance.getAnnotations()) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/filter/MethodMatcher.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/filter/MethodMatcher.java
@@ -50,7 +50,7 @@ public class MethodMatcher extends MemberMatcher implements Matcher {
     public boolean match(BugInstance bugInstance) {
 
         MethodAnnotation methodAnnotation = null;
-        if (role == null || "".equals(role)) {
+        if (role == null || role.isEmpty()) {
             methodAnnotation = bugInstance.getPrimaryMethod();
         } else {
             for (BugAnnotation a : bugInstance.getAnnotations()) {


### PR DESCRIPTION
There are a few places which check for null-or-empty String, where
the empty part is performed with "".equals().

Rather than loading an explicit literal, use isEmpty() on the string
itself, as we know it is not null.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>

Before opening a 'pull request'

* Search existing issues and pull requests to see if the issue was already discussed.
* Check our discussions to see if the issue was already discussed.
* Check for specific project we support to raise the issue on, under [spotbugs](https://github.com/spotbugs)
* Do not open intellij plugin issues here, open them at [intellij-plugin](https://github.com/JetBrains/spotbugs-intellij-plugin) *

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
