### PR TITLE
#2750 Fix FP in SE_PREVENT_EXT_OBJ_OVERWRITE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Applied changes for bcel 6.8.0 with adjustments to constant pool ([#2756](https://github.com/spotbugs/spotbugs/pull/2756))
     - More information bcel changes can be found on ([#2757](https://github.com/spotbugs/spotbugs/pull/2757))
 - Fix FN in CT_CONSTRUCTOR_THROW when the return value of the called method is not void or primitive type.
-- Fix FP in SE_PREVENT_EXT_OBJ_OVERWRITE when the if statement logic or the bytecode shape of the function is different from the existing examples. ([#2750](https://github.com/spotbugs/spotbugs/issues/2750))
+- Fix FP in SE_PREVENT_EXT_OBJ_OVERWRITE when the if statement checking for null value or the method exiting in the if branch with an exception. ([#2750](https://github.com/spotbugs/spotbugs/issues/2750))
 
 ### Changed
 - Improved Matcher checks for empty strings ([#2755](https://github.com/spotbugs/spotbugs/pull/2755))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Applied changes for bcel 6.8.0 with adjustments to constant pool ([#2756](https://github.com/spotbugs/spotbugs/pull/2756))
     - More information bcel changes can be found on ([#2757](https://github.com/spotbugs/spotbugs/pull/2757))
 - Fix FN in CT_CONSTRUCTOR_THROW when the return value of the called method is not void or primitive type.
+- Fix FP in SE_PREVENT_EXT_OBJ_OVERWRITE when the if statement logic or the bytecode shape of the function is different from the existing examples. ([#2750](https://github.com/spotbugs/spotbugs/issues/2750))
 
 ### Changed
 - Improved Matcher checks for empty strings ([#2755](https://github.com/spotbugs/spotbugs/pull/2755))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Applied changes for bcel 6.8.0 with adjustments to constant pool ([#2756](https://github.com/spotbugs/spotbugs/pull/2756))
     - More information bcel changes can be found on ([#2757](https://github.com/spotbugs/spotbugs/pull/2757))
 - Fix FN in CT_CONSTRUCTOR_THROW when the return value of the called method is not void or primitive type.
-- Fix FP in SE_PREVENT_EXT_OBJ_OVERWRITE when the if statement checking for null value or the method exiting in the if branch with an exception. ([#2750](https://github.com/spotbugs/spotbugs/issues/2750))
+- Fix FP in SE_PREVENT_EXT_OBJ_OVERWRITE when the if statement checking for null value, checking multiple variables or the method exiting in the if branch with an exception. ([#2750](https://github.com/spotbugs/spotbugs/issues/2750))
 
 ### Changed
 - Improved Matcher checks for empty strings ([#2755](https://github.com/spotbugs/spotbugs/pull/2755))

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/PreventOverwriteOfExternalizableObjectTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/PreventOverwriteOfExternalizableObjectTest.java
@@ -107,6 +107,18 @@ class PreventOverwriteOfExternalizableObjectTest extends AbstractIntegrationTest
         assertNumOfBugs(0);
     }
 
+    @Test
+    void testGoodReadExternal7() {
+        performAnalysis("externalizable/GoodExternalizableTest7.class");
+        assertNumOfBugs(0);
+    }
+
+    @Test
+    void testGoodReadExternal8() {
+        performAnalysis("externalizable/GoodExternalizableTest8.class");
+        assertNumOfBugs(0);
+    }
+
     private void assertNumOfBugs(int num) {
         final BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
                 .bugType("SE_PREVENT_EXT_OBJ_OVERWRITE").build();

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/PreventOverwriteOfExternalizableObjectTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/PreventOverwriteOfExternalizableObjectTest.java
@@ -54,6 +54,24 @@ class PreventOverwriteOfExternalizableObjectTest extends AbstractIntegrationTest
     }
 
     @Test
+    void testBadReadExternal6() {
+        performAnalysis("externalizable/BadExternalizableTest6.class");
+
+        assertNumOfBugs(2);
+        assertBug("BadExternalizableTest6", 22);
+        assertBug("BadExternalizableTest6", 23);
+    }
+
+    @Test
+    void testBadReadExternal7() {
+        performAnalysis("externalizable/BadExternalizableTest7.class");
+
+        assertNumOfBugs(2);
+        assertBug("BadExternalizableTest7", 22);
+        assertBug("BadExternalizableTest7", 23);
+    }
+
+    @Test
     void testGoodReadExternal() {
         performAnalysis("externalizable/GoodExternalizableTest.class");
         assertNumOfBugs(0);
@@ -74,6 +92,18 @@ class PreventOverwriteOfExternalizableObjectTest extends AbstractIntegrationTest
     @Test
     void testGoodReadExternal4() {
         performAnalysis("externalizable/GoodExternalizableTest4.class");
+        assertNumOfBugs(0);
+    }
+
+    @Test
+    void testGoodReadExternal5() {
+        performAnalysis("externalizable/GoodExternalizableTest5.class");
+        assertNumOfBugs(0);
+    }
+
+    @Test
+    void testGoodReadExternal6() {
+        performAnalysis("externalizable/GoodExternalizableTest6.class");
         assertNumOfBugs(0);
     }
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/PreventOverwriteOfExternalizableObjectTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/PreventOverwriteOfExternalizableObjectTest.java
@@ -56,14 +56,24 @@ class PreventOverwriteOfExternalizableObjectTest extends AbstractIntegrationTest
     @Test
     void testGoodReadExternal() {
         performAnalysis("externalizable/GoodExternalizableTest.class");
-
         assertNumOfBugs(0);
     }
 
     @Test
     void testGoodReadExternal2() {
         performAnalysis("externalizable/GoodExternalizableTest2.class");
+        assertNumOfBugs(0);
+    }
 
+    @Test
+    void testGoodReadExternal3() {
+        performAnalysis("externalizable/GoodExternalizableTest3.class");
+        assertNumOfBugs(0);
+    }
+
+    @Test
+    void testGoodReadExternal4() {
+        performAnalysis("externalizable/GoodExternalizableTest4.class");
         assertNumOfBugs(0);
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SerializableIdiom.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SerializableIdiom.java
@@ -551,7 +551,8 @@ public class SerializableIdiom extends OpcodeStackDetector {
     @Override
     public void sawOpcode(int seen) {
         if ("readExternal".equals(getMethodName())) {
-            if ((seen == Const.IFEQ || seen == Const.IFNE || seen == Const.IFNULL || seen == Const.IFNONNULL) && isBranch(seen)) {
+            if ((seen == Const.IFEQ || seen == Const.IFNE || seen == Const.IFNULL || seen == Const.IFNONNULL)
+                    && initializedCheckerVariable == null && isBranch(seen)) {
                 initializedCheckerVariable = stack.getStackItem(0).getXField();
                 initializeCheckerBranchTarget = getBranchTarget();
             } else if (seen == Const.ATHROW || isReturn(seen)) {
@@ -631,7 +632,7 @@ public class SerializableIdiom extends OpcodeStackDetector {
                         // Collect the bugs and report them later, if the initializedCheckerVariable's value won't be changed
                         if (initializedCheckerVariable != xField) {
                             optionalBugsInReadExternal.put(xField, bug);
-                        } else {
+                        } else if (getPC() < initializeCheckerBranchTarget) {
                             optionalBugsInReadExternal.clear();
                         }
                         if (initializedCheckerVariable == null || sawReadExternalExit) {

--- a/spotbugsTestCases/src/java/externalizable/BadExternalizableTest6.java
+++ b/spotbugsTestCases/src/java/externalizable/BadExternalizableTest6.java
@@ -1,0 +1,31 @@
+package externalizable;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+
+public class BadExternalizableTest6 implements Externalizable {
+
+    private String name;
+    private int UID;
+
+    @Override
+    public void writeExternal(ObjectOutput out) throws IOException {
+
+    }
+
+    @Override
+    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+        Object initialized = null;
+        if (initialized == null) {
+            name = (String) in.readObject();
+            UID = in.readInt();
+            System.out.printf("name: %s, UID: %d, localVariable: %d%n", name, UID);
+
+            initialized = new Object();
+        } else {
+            throw new IllegalStateException();
+        }
+    }
+}

--- a/spotbugsTestCases/src/java/externalizable/BadExternalizableTest7.java
+++ b/spotbugsTestCases/src/java/externalizable/BadExternalizableTest7.java
@@ -1,0 +1,29 @@
+package externalizable;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+
+public class BadExternalizableTest7 implements Externalizable {
+
+    private String name;
+    private int UID;
+    private boolean initialized = false;
+
+    @Override
+    public void writeExternal(ObjectOutput out) throws IOException {
+
+    }
+
+    @Override
+    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+        if (!initialized) {
+            name = (String) in.readObject();
+            UID = in.readInt();
+        } else {
+            initialized = true;
+            throw new IllegalStateException();
+        }
+    }
+}

--- a/spotbugsTestCases/src/java/externalizable/GoodExternalizableTest3.java
+++ b/spotbugsTestCases/src/java/externalizable/GoodExternalizableTest3.java
@@ -1,0 +1,28 @@
+package externalizable;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+
+public class GoodExternalizableTest3 implements Externalizable {
+
+    private Object result;
+    private boolean initialized;
+
+    @Override
+    public void writeExternal(ObjectOutput out) throws IOException {
+
+    }
+
+    @Override
+    public final void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+        if (initialized) {
+            throw new IllegalStateException("already initialized");
+        }
+
+        // stuff and then ...
+        result = new Object();
+        initialized = true;
+    }
+}

--- a/spotbugsTestCases/src/java/externalizable/GoodExternalizableTest4.java
+++ b/spotbugsTestCases/src/java/externalizable/GoodExternalizableTest4.java
@@ -1,0 +1,26 @@
+package externalizable;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+
+public class GoodExternalizableTest4 implements Externalizable {
+
+    private Object result = null;
+
+    @Override
+    public void writeExternal(ObjectOutput out) throws IOException {
+
+    }
+
+    @Override
+    public final void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+        if (result == null) {
+            // stuff and then ...
+            result = new Object();
+        } else {
+            throw new IllegalStateException("already initialized");
+        }
+    }
+}

--- a/spotbugsTestCases/src/java/externalizable/GoodExternalizableTest5.java
+++ b/spotbugsTestCases/src/java/externalizable/GoodExternalizableTest5.java
@@ -1,0 +1,33 @@
+package externalizable;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+
+public class GoodExternalizableTest5 implements Externalizable {
+
+    private String name;
+    private int UID;
+    private Object initialized;
+
+    @Override
+    public void writeExternal(ObjectOutput out) throws IOException {
+
+    }
+
+    @Override
+    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+        int localVariable = 56;
+
+        if (initialized == null) {
+            name = (String) in.readObject();
+            UID = in.readInt();
+            System.out.printf("name: %s, UID: %d, localVariable: %d%n", name, UID, localVariable);
+
+            initialized = new Object();
+        } else {
+            throw new IllegalStateException();
+        }
+    }
+}

--- a/spotbugsTestCases/src/java/externalizable/GoodExternalizableTest6.java
+++ b/spotbugsTestCases/src/java/externalizable/GoodExternalizableTest6.java
@@ -1,0 +1,30 @@
+package externalizable;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+
+public class GoodExternalizableTest6 implements Externalizable {
+
+    private String name;
+    private int UID;
+    private boolean initialized = false;
+
+    @Override
+    public void writeExternal(ObjectOutput out) throws IOException {
+
+    }
+
+    @Override
+    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+        if (!initialized && name == null) {
+            name = (String) in.readObject();
+            UID = in.readInt();
+
+            initialized = true;
+        } else {
+            throw new IllegalStateException();
+        }
+    }
+}

--- a/spotbugsTestCases/src/java/externalizable/GoodExternalizableTest7.java
+++ b/spotbugsTestCases/src/java/externalizable/GoodExternalizableTest7.java
@@ -1,0 +1,29 @@
+package externalizable;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+
+public class GoodExternalizableTest7 implements Externalizable {
+
+    private String name;
+    private int UID;
+    private boolean initialized = false;
+
+    @Override
+    public void writeExternal(ObjectOutput out) throws IOException {
+
+    }
+
+    @Override
+    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+        if (!initialized && name == null) {
+            UID = in.readInt();
+
+            initialized = true;
+        } else {
+            throw new IllegalStateException();
+        }
+    }
+}

--- a/spotbugsTestCases/src/java/externalizable/GoodExternalizableTest8.java
+++ b/spotbugsTestCases/src/java/externalizable/GoodExternalizableTest8.java
@@ -1,0 +1,29 @@
+package externalizable;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+
+public class GoodExternalizableTest8 implements Externalizable {
+
+    private String name;
+    private int UID;
+    private boolean initialized = false;
+
+    @Override
+    public void writeExternal(ObjectOutput out) throws IOException {
+
+    }
+
+    @Override
+    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+        if (name == null || !initialized) {
+            UID = in.readInt();
+
+            initialized = true;
+        } else {
+            throw new IllegalStateException();
+        }
+    }
+}


### PR DESCRIPTION
Fix FP in SE_PREVENT_EXT_OBJ_OVERWRITE when the if statement logic or the bytecode shape of the function was different than the existing examples  
fixes [#2750](https://github.com/spotbugs/spotbugs/issues/2750)

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
