### PR TITLE
Release the sonatype staging repository

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
           echo sonatypeUsername=eller86 >> gradle.properties
           echo "sonatypePassword=${SONATYPE_PASSWORD}" >> gradle.properties
           echo "keystorepass=${KEYSTORE_PASS}" >> gradle.properties
-          ./gradlew assemble publishToSonatype closeSonatypeStagingRepository createReleaseBody --no-daemon
+          ./gradlew assemble publishToSonatype closeAndReleaseSonatypeStagingRepository createReleaseBody --no-daemon
         env:
           GPG_SECRET_PASSPHRASE: ${{ secrets.GPG_SECRET_PASSPHRASE }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}


### PR DESCRIPTION
Replaced closeSonatypeStagingRepository by
closeAndReleaseSonatypeStagingRepository so we don't have to manually close the stating.

According to [this](https://selectfrom.dev/publishing-your-first-open-source-library-with-gradle-50bd0b1cd3af) the release should happen automatically, but I couldn't test it