### PR TITLE
Update the changelog automatically when releasing

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,9 +4,3 @@ Before opening a 'pull request'
 * Check our discussions to see if the issue was already discussed.
 * Check for specific project we support to raise the issue on, under [spotbugs](https://github.com/spotbugs)
 * Do not open intellij plugin issues here, open them at [intellij-plugin](https://github.com/JetBrains/spotbugs-intellij-plugin) *
-
-----
-
-Make sure these boxes are checked before submitting your PR -- thank you!
-
-- [ ] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,31 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Get previous tag for the change log
+        id: previousTag
+        run: |
+          name=$(git --no-pager tag --sort=creatordate --merged ${{ github.ref_name }} | tail -2 | head -1)
+          echo "previousTag: $name"
+          echo "previousTag=$name" >> $GITHUB_ENV
+
+      - name: Update CHANGELOG
+        id: changelog
+        uses: requarks/changelog-action@v1
+        with:
+          token: ${{ github.token }}
+          toTag: ${{ github.ref }}
+          fromTag: ${{ env.previousTag }}
+          writeToFile: true
+        continue-on-error: true
+
+      - name: Commit CHANGELOG.md
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          branch: ${{ github.base_ref}}
+          commit_message: 'docs: update CHANGELOG.md for ${{ github.ref_name }}'
+          file_pattern: CHANGELOG.md
+
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
Here's an untested proposal to automate the update of the changelog when releasing
This should hopefully put an end to this endless source of merge conflicts

The process is using https://github.com/stefanzweifel/git-auto-commit-action and would entail that commits follow [Conventionnal commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)