### PR TITLE
Sonar deprecation fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,6 +74,6 @@ jobs:
       - name: Build
         # https://community.sonarsource.com/t/sonarcloud-now-not-updating-github-pr-and-checks/6595/17
         run: |
-          ./gradlew spotlessCheck build smoketest ${SONAR_LOGIN:+sonarqube} --no-daemon "-Dsonar.login=$SONAR_LOGIN" --scan
+          ./gradlew spotlessCheck build smoketest ${SONAR_LOGIN:+sonar} --no-daemon "-Dsonar.token=$SONAR_LOGIN" --scan
         env:
           SONAR_LOGIN: ${{ secrets.SONAR_LOGIN }}

--- a/gradle/sonar.gradle
+++ b/gradle/sonar.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'org.sonarqube'
 
-sonarqube {
+sonar {
     properties {
         property 'sonar.host.url', 'https://sonarcloud.io'
         property 'sonar.organization', 'spotbugs'
@@ -9,6 +9,6 @@ sonarqube {
     }
 }
 
-tasks.named('sonarqube').configure {
+tasks.named('sonar').configure {
     dependsOn jacocoRootReport
 }

--- a/spotbugsTestCases/build.gradle
+++ b/spotbugsTestCases/build.gradle
@@ -87,7 +87,7 @@ tasks.named('classes').configure {
   dependsOn classesJava17
 }
 
-sonarqube {
+sonar {
   // this project should not be analyzed with sonarqube
   // as it is test data, not real code
   skipProject true


### PR DESCRIPTION
The build shows these warnings:
```
 Task 'sonarqube' is deprecated. Use 'sonar' instead.
The property 'sonar.login' is deprecated and will be removed in the future. Please use the 'sonar.token' property instead when passing a token.
Could not report issue with code highlighting, using plain text instead. Check whether the product is outdated.
```

- Replace sonarqube by sonar
- Replace sonar.login by sonar.token

This error seems to safe to ignore (see [SONARKT-354](https://sonarsource.atlassian.net/browse/SONARKT-354))
```
java.lang.UnsupportedOperationException: null
	at org.sonar.api.batch.sensor.issue.internal.DefaultIssueLocation.newMessageFormatting(DefaultIssueLocation.java:97)
	at org.sonarsource.kotlin.api.checks.InputFileContextImpl.message(InputFileContextImpl.kt:93)
	at org.sonarsource.kotlin.api.checks.InputFileContextImpl.reportIssue(InputFileContextImpl.kt:68)
	at org.sonarsource.kotlin.api.checks.AbstractCheck.reportIssue(AbstractCheck.kt:69)
	at org.sonarsource.kotlin.api.checks.AbstractCheck.reportIssue$default(AbstractCheck.kt:64)
```