### PR TITLE
Optimize for incremental building

### DIFF
--- a/eclipsePlugin/build.gradle
+++ b/eclipsePlugin/build.gradle
@@ -571,3 +571,7 @@ if (eclipseExecutable == null) {
 spotbugs {
   ignoreFailures = true
 }
+
+spotbugsMain {
+  release = rootProject.version
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,6 +14,8 @@ include(":test-harness")
 include(":test-harness-core")
 include(":test-harness-jupiter")
 
+rootProject.name = "spotbugs"
+
 gradleEnterprise {
   buildScan {
     termsOfServiceUrl = "https://gradle.com/terms-of-service"

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/workflow/UnionResultsTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/workflow/UnionResultsTest.java
@@ -18,7 +18,8 @@ class UnionResultsTest {
     void testMain() throws IOException {
         //Prepare
         String fileName = createBugFile();
-        File outputFile = new File("src/test/resources/output.xml");
+        File outputFile = new File("build/tmp/test/unionresults/output.xml");
+        outputFile.getParentFile().mkdirs();
 
         //Act
         UnionResults.main(new String[] { "-withMessages", "-output", outputFile.getAbsolutePath(), fileName });
@@ -27,10 +28,6 @@ class UnionResultsTest {
         List<String> output = readOutPut(outputFile.getAbsolutePath());
         Assertions.assertTrue(output.stream().anyMatch(line -> line.contains("(Lorg/test/TestClass;Ljava/util/List;)V")));
         Assertions.assertTrue(output.stream().anyMatch(line -> line.contains("(Lorg/test/TestClass2;Ljava/util/List;)V")));
-
-        //Cleanup
-        Files.deleteIfExists(new File(fileName).toPath());
-        Files.deleteIfExists(outputFile.toPath());
     }
 
     private List<String> readOutPut(String absolutePath) throws IOException {
@@ -47,8 +44,8 @@ class UnionResultsTest {
     private static String createBugFile() throws IOException {
         Path tempFile = Files.createTempFile("spotbugs-test", ".txt");
         String fileName = tempFile.toString();
-        File firstFile = new File("src/test/resources/firstFile.xml");
-        File secondFile = new File("src/test/resources/secondFile.xml");
+        File firstFile = new File("build/tmp/test/unionresults/firstFile.xml");
+        File secondFile = new File("build/tmp/test/unionresults/secondFile.xml");
         Files.deleteIfExists(firstFile.toPath());
         Files.deleteIfExists(secondFile.toPath());
         firstFile.getParentFile().mkdirs();


### PR DESCRIPTION
Optimize builds for incremental building by making sure that task inputs are the same across builds.
- Not writing temporary test files in `src/` so those won't be copied across, but writing them in `build/` where they will also get cleaned automatically
- Providing an explicit version in the Eclipse plugin build

This allows incremental builds to run much faster than before.
