### PR TITLE
Applied the rootProject.version to spobugs config to the `release` property.

### DIFF
--- a/eclipsePlugin/build.gradle
+++ b/eclipsePlugin/build.gradle
@@ -570,8 +570,5 @@ if (eclipseExecutable == null) {
 
 spotbugs {
   ignoreFailures = true
-}
-
-spotbugsMain {
   release = rootProject.version
 }


### PR DESCRIPTION
Applied the rootProject.version to spobugs config to the `release` property in `eclipsePlugin`. Currently it's only applied to the `spotbugsMain` task, but any other `SpotBugsTask` in `eclipsePlugin` will still have the same issue. 

Note: currently it's not needed, but if you were to add timestamps to any other subprojects it will also break caching and incremental builds - to change that you could add this setting to the root `build.gradle` file in the `allprojects` block.