### PR TITLE
ci: tell sonar where the jacoco root report is

### DIFF
--- a/gradle/sonar.gradle
+++ b/gradle/sonar.gradle
@@ -6,6 +6,7 @@ sonar {
         property 'sonar.organization', 'spotbugs'
         property 'sonar.projectKey', 'com.github.spotbugs.spotbugs'
         property 'sonar.projectName', 'SpotBugs'
+        property 'sonar.coverage.jacoco.xmlReportPaths', "${buildDir}/reports/jacoco/jacocoRootReport/jacocoRootReport.xml"
     }
 }
 


### PR DESCRIPTION
The aggregated jacocoRootReport is not in one of the standard locations searched by sonar, add a property with the report file path so sonar can reflect the coverage

This should fix #2619 
