### PR TITLE
[checkstyle] Bump to 10.12.7, add spring dependency management to fix gradle exclusion defects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Minor cleanup in connection with slashed and dotted names ([#2805](https://github.com/spotbugs/spotbugs/pull/2805))
 
 ### Build
+- Fix sonar coverage for project ([#2793](https://github.com/spotbugs/spotbugs/issues/2793))
 - Add 'io.spring.dependency-managagement' to control bug in gradle on exclusions not being excluded properly as seen in checkstyle usage.  See https://github.com/checkstyle/checkstyle/issues/14211 for more information. ([#2798](https://github.com/spotbugs/spotbugs/issues/2798))
 
 ## 4.8.3 - 2023-12-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,6 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Do not report BC_UNCONFIRMED_CAST for Java 21's type switches ([#2813](https://github.com/spotbugs/spotbugs/pull/2813))
 - Remove AppleExtension library (note: menus slightly changed) ([#2823](https://github.com/spotbugs/spotbugs/pull/2823))
 
-### Build
-- Fix sonar coverage for project ([#2796](https://github.com/spotbugs/spotbugs/issues/2796))
-- Upgraded the build to compile bug samples using Java 21 language features ([#2813](https://github.com/spotbugs/spotbugs/pull/2813))
-
 ### Added
 - New detector `MultipleInstantiationsOfSingletons` and introduced new bug types:
   - `SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR` is reported in case of a non-private constructor,
@@ -35,7 +31,8 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Minor cleanup in connection with slashed and dotted names ([#2805](https://github.com/spotbugs/spotbugs/pull/2805))
 
 ### Build
-- Fix sonar coverage for project ([#2793](https://github.com/spotbugs/spotbugs/issues/2793))
+- Fix sonar coverage for project ([#2796](https://github.com/spotbugs/spotbugs/issues/2796))
+- Upgraded the build to compile bug samples using Java 21 language features ([#2813](https://github.com/spotbugs/spotbugs/pull/2813))
 - Add 'configurations.checkstyle resolution starategy' to control bug in gradle on exclusions not being excluded properly as seen in checkstyle usage.  See https://github.com/checkstyle/checkstyle/issues/14211 for more information. ([#2798](https://github.com/spotbugs/spotbugs/issues/2798))
 
 ## 4.8.3 - 2023-12-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ### Build
 - Fix sonar coverage for project ([#2793](https://github.com/spotbugs/spotbugs/issues/2793))
-- Add 'io.spring.dependency-managagement' to control bug in gradle on exclusions not being excluded properly as seen in checkstyle usage.  See https://github.com/checkstyle/checkstyle/issues/14211 for more information. ([#2798](https://github.com/spotbugs/spotbugs/issues/2798))
+- Add 'configuratinos.checkstyle resolution starategy' to control bug in gradle on exclusions not being excluded properly as seen in checkstyle usage.  See https://github.com/checkstyle/checkstyle/issues/14211 for more information. ([#2798](https://github.com/spotbugs/spotbugs/issues/2798))
 
 ## 4.8.3 - 2023-12-12
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 ### Changed
 - Minor cleanup in connection with slashed and dotted names ([#2805](https://github.com/spotbugs/spotbugs/pull/2805))
 
+### Build
+- Add 'io.spring.dependency-managagement' to control bug in gradle on exclusions not being excluded properly as seen in checkstyle usage.  See https://github.com/checkstyle/checkstyle/issues/14211 for more information. ([#2798](https://github.com/spotbugs/spotbugs/issues/2798))
+
 ## 4.8.3 - 2023-12-12
 ### Fixed
 - Fix FP in CT_CONSTRUCTOR_THROW when the finalizer does not run, since the exception is thrown before java.lang.Object's constructor exits for checked exceptions ([#2710](https://github.com/spotbugs/spotbugs/issues/2710))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ### Build
 - Fix sonar coverage for project ([#2793](https://github.com/spotbugs/spotbugs/issues/2793))
-- Add 'configuratinos.checkstyle resolution starategy' to control bug in gradle on exclusions not being excluded properly as seen in checkstyle usage.  See https://github.com/checkstyle/checkstyle/issues/14211 for more information. ([#2798](https://github.com/spotbugs/spotbugs/issues/2798))
+- Add 'configurations.checkstyle resolution starategy' to control bug in gradle on exclusions not being excluded properly as seen in checkstyle usage.  See https://github.com/checkstyle/checkstyle/issues/14211 for more information. ([#2798](https://github.com/spotbugs/spotbugs/issues/2798))
 
 ## 4.8.3 - 2023-12-12
 ### Fixed

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,6 @@ plugins {
   id "org.gradle.crypto.checksum" version "1.4.0"
   id "com.github.spotbugs" version "6.0.6"
   id "io.github.gradle-nexus.publish-plugin" version "1.3.0"
-  id "io.spring.dependency-management" version "1.1.4"
 }
 
 group = 'com.github.spotbugs'

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
   id "org.gradle.crypto.checksum" version "1.4.0"
   id "com.github.spotbugs" version "6.0.6"
   id "io.github.gradle-nexus.publish-plugin" version "1.3.0"
+  id "io.spring.dependency-management" version "1.1.4"
 }
 
 group = 'com.github.spotbugs'

--- a/gradle/checkstyle.gradle
+++ b/gradle/checkstyle.gradle
@@ -1,8 +1,15 @@
 // Setup checkstyle
 apply plugin: 'checkstyle'
+apply plugin: 'io.spring.dependency-management'
+
+dependencyManagement {
+    dependencies {
+        dependency 'com.puppycrawl.tools:checkstyle:10.12.7'
+    }
+}
 
 checkstyle {
-  toolVersion '10.12.5'
+  toolVersion '10.12.7'
   ignoreFailures false
   configFile file("$rootDir/spotbugs/etc/checkstyle.xml") // TODO : This config file is lame and should be moved out...
 }

--- a/gradle/checkstyle.gradle
+++ b/gradle/checkstyle.gradle
@@ -1,11 +1,10 @@
 // Setup checkstyle
 apply plugin: 'checkstyle'
-apply plugin: 'io.spring.dependency-management'
 
-dependencyManagement {
-    dependencies {
-        dependency 'com.puppycrawl.tools:checkstyle:10.12.7'
-    }
+configurations.checkstyle {
+  resolutionStrategy.capabilitiesResolution.withCapability("com.google.collections:google-collections") {
+    select("com.google.guava:guava:0")
+  }
 }
 
 checkstyle {


### PR DESCRIPTION
As documented with spring here https://github.com/spring-gradle-plugins/dependency-management-plugin/issues/211, there is a long standing defect in exclusion handling within gradle.  With more recent checkstyle, we cannot apply due to exclusion that is not being adhered to.  

See https://github.com/checkstyle/checkstyle/issues/14211 for checkstyle info on situation.

See https://github.com/spotbugs/spotbugs/pull/2752 for our failures trying to pick up latest with the exclusion.