### PR TITLE
Minor cleanup using the ClassName util to convert dotted or slashed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
   - `SING_SINGLETON_GETTER_NOT_SYNCHRONIZED` is reported when the instance-getter method of the singleton class is not synchronized.
     (See [SEI CERT MSC07-J](https://wiki.sei.cmu.edu/confluence/display/java/MSC07-J.+Prevent+multiple+instantiations+of+singleton+objects))
 
+### Changed
+- Minor cleanup in connection with slashed and dotted names ([#2805](https://github.com/spotbugs/spotbugs/pull/2805))
+
 ## 4.8.3 - 2023-12-12
 ### Fixed
 - Fix FP in CT_CONSTRUCTOR_THROW when the finalizer does not run, since the exception is thrown before java.lang.Object's constructor exits for checked exceptions ([#2710](https://github.com/spotbugs/spotbugs/issues/2710))

--- a/eclipsePlugin/src/de/tobject/findbugs/view/BugInfoView.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/view/BugInfoView.java
@@ -515,12 +515,12 @@ public class BugInfoView extends AbstractFindbugsView {
                         return;
                     } else if (theAnnotation instanceof TypeAnnotation) {
                         TypeAnnotation fa = (TypeAnnotation) theAnnotation;
-                        String className = ClassName.fromFieldSignature(fa.getTypeDescriptor());
+                        String className = ClassName.fromFieldSignatureToDottedClassName(fa.getTypeDescriptor());
                         if (className == null) {
                             break findLocation;
                         }
                         IJavaProject project = getIProject();
-                        IType type = project.findType(ClassName.toDottedClassName(className));
+                        IType type = project.findType(className);
                         if (type == null) {
                             break findLocation;
                         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/Analyze.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/Analyze.java
@@ -3,6 +3,7 @@ package edu.umd.cs.findbugs;
 import java.util.HashSet;
 import java.util.Set;
 
+import edu.umd.cs.findbugs.util.ClassName;
 import org.apache.bcel.Repository;
 import org.apache.bcel.classfile.JavaClass;
 
@@ -116,7 +117,7 @@ public class Analyze {
 
         // TODO: This method now returns primitive type signatures, is this ok?
         if (refSig.charAt(0) == 'L') {
-            return refSig.substring(1, refSig.length() - 1).replace('/', '.');
+            return ClassName.fromFieldSignatureToDottedClassName(refSig);
         }
         return refSig;
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/BugInstance.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/BugInstance.java
@@ -1110,7 +1110,7 @@ public class BugInstance implements Comparable<BugInstance>, XMLWriteable, Clone
 
     @Nonnull
     public BugInstance addTypeOfNamedClass(@DottedClassName String typeName) {
-        TypeAnnotation typeAnnotation = new TypeAnnotation("L" + typeName.replace('.', '/') + ";");
+        TypeAnnotation typeAnnotation = new TypeAnnotation("L" + ClassName.toSlashedClassName(typeName) + ";");
         add(typeAnnotation);
         return this;
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/BugInstance.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/BugInstance.java
@@ -2113,11 +2113,11 @@ public class BugInstance implements Comparable<BugInstance>, XMLWriteable, Clone
             ClassContext classContext = analysisCache.getClassAnalysis(ClassContext.class, classDescriptor);
             JavaClass javaClass = classContext.getJavaClass();
             AnnotationEntry[] annotationEntries = javaClass.getAnnotationEntries();
-            List<String> javaAnnotationNames = Arrays.asList(annotationEntries).stream().map((AnnotationEntry ae) -> {
-                // map annotation entry type to dotted class name, for example
-                // Lorg/immutables/value/Generated; -> org.immutables.value.Generated
-                return ClassName.fromFieldSignatureToDottedClassName(ae.getAnnotationType());
-            }).collect(Collectors.toList());
+            // map annotation entry type to dotted class name, for example
+            // Lorg/immutables/value/Generated; -> org.immutables.value.Generated
+            List<String> javaAnnotationNames = Arrays.asList(annotationEntries).stream()
+                    .map((AnnotationEntry ae) -> ClassName.fromFieldSignatureToDottedClassName(ae.getAnnotationType()))
+                    .collect(Collectors.toList());
             pma.setJavaAnnotationNames(javaAnnotationNames);
         } catch (Exception e) {
             LOG.debug(e.getMessage(), e);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/BugInstance.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/BugInstance.java
@@ -2116,7 +2116,7 @@ public class BugInstance implements Comparable<BugInstance>, XMLWriteable, Clone
             List<String> javaAnnotationNames = Arrays.asList(annotationEntries).stream().map((AnnotationEntry ae) -> {
                 // map annotation entry type to dotted class name, for example
                 // Lorg/immutables/value/Generated; -> org.immutables.value.Generated
-                return ae.getAnnotationType().substring(1).replace("/", ".").replace(";", "");
+                return ClassName.fromFieldSignatureToDottedClassName(ae.getAnnotationType());
             }).collect(Collectors.toList());
             pma.setJavaAnnotationNames(javaAnnotationNames);
         } catch (Exception e) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/DeepSubtypeAnalysis.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/DeepSubtypeAnalysis.java
@@ -3,6 +3,7 @@ package edu.umd.cs.findbugs;
 import java.util.List;
 import java.util.Set;
 
+import edu.umd.cs.findbugs.util.ClassName;
 import org.apache.bcel.Repository;
 import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.generic.ArrayType;
@@ -179,7 +180,7 @@ public class DeepSubtypeAnalysis {
 
         // TODO: This method now returns primitive type signatures, is this ok?
         if (refSig.charAt(0) == 'L') {
-            return refSig.substring(1, refSig.length() - 1).replace('/', '.');
+            return ClassName.fromFieldSignatureToDottedClassName(refSig);
         }
         return refSig;
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/DiscoverSourceDirectories.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/DiscoverSourceDirectories.java
@@ -28,6 +28,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
+import edu.umd.cs.findbugs.util.ClassName;
 import org.objectweb.asm.ClassReader;
 
 import edu.umd.cs.findbugs.ba.ClassNotFoundExceptionParser;
@@ -304,7 +305,7 @@ public class DiscoverSourceDirectories {
             String sourceFile = classInfo.getSource();
 
             if (!"".equals(packageName)) {
-                packageName = packageName.replace('.', '/');
+                packageName = ClassName.toSlashedClassName(packageName);
                 packageName += "/";
             }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/EmacsBugReporter.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/EmacsBugReporter.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 
 import javax.annotation.CheckForNull;
 
+import edu.umd.cs.findbugs.util.ClassName;
 import org.apache.bcel.classfile.JavaClass;
 
 import edu.umd.cs.findbugs.ba.AnalysisContext;
@@ -83,7 +84,7 @@ public class EmacsBugReporter extends TextUIBugReporter {
             if ("".equals(pkgName)) {
                 fullPath = line.getSourceFile();
             } else {
-                fullPath = pkgName.replace('.', '/') + "/" + line.getSourceFile();
+                fullPath = ClassName.toSlashedClassName(pkgName) + "/" + line.getSourceFile();
             }
         }
         outputStream.print(fullPath + ":" + lineStart + ":" + lineEnd + " " + bugInstance.getMessage());

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/FieldAnnotation.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/FieldAnnotation.java
@@ -22,6 +22,7 @@ package edu.umd.cs.findbugs;
 import java.io.IOException;
 import java.util.stream.Collectors;
 
+import edu.umd.cs.findbugs.util.ClassName;
 import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Field;
 import org.apache.bcel.classfile.JavaClass;
@@ -91,7 +92,7 @@ public class FieldAnnotation extends PackageMemberAnnotation {
         super(className, DEFAULT_ROLE);
         if (fieldSig.indexOf('.') >= 0) {
             assert false : "signatures should not be dotted: " + fieldSig;
-            fieldSig = fieldSig.replace('.', '/');
+            fieldSig = ClassName.toSlashedClassName(fieldSig);
         }
         this.fieldName = fieldName;
         this.fieldSig = fieldSig;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/FindBugs2.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/FindBugs2.java
@@ -281,7 +281,7 @@ public class FindBugs2 implements IFindBugsEngine, AutoCloseable {
                         @Override
                         public void reportBug(@Nonnull BugInstance bugInstance) {
                             String className = bugInstance.getPrimaryClass().getClassName();
-                            String resourceName = className.replace('.', '/') + ".class";
+                            String resourceName = ClassName.toSlashedClassName(className) + ".class";
                             if (classScreener.matches(resourceName)) {
                                 this.getDelegate().reportBug(bugInstance);
                             }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/MethodAnnotation.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/MethodAnnotation.java
@@ -107,7 +107,7 @@ public class MethodAnnotation extends PackageMemberAnnotation {
         this.methodName = methodName;
         if (methodSig.indexOf('.') >= 0) {
             assert false : "signatures should not be dotted: " + methodSig;
-            methodSig = methodSig.replace('.', '/');
+            methodSig = ClassName.toSlashedClassName(methodSig);
         }
         this.methodSig = methodSig;
         this.isStatic = isStatic;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/MethodAnnotation.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/MethodAnnotation.java
@@ -457,7 +457,7 @@ public class MethodAnnotation extends PackageMemberAnnotation {
     }
 
     private String getUglyMethod() {
-        return className + "." + methodName + " : " + methodSig.replace('/', '.');
+        return className + "." + methodName + " : " + ClassName.toDottedClassName(methodSig);
     }
 
     @Override

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/OpcodeStack.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/OpcodeStack.java
@@ -806,7 +806,7 @@ public class OpcodeStack {
                 return null;
             }
             baseSig = baseSig.substring(1, baseSig.length() - 1);
-            baseSig = baseSig.replace('/', '.');
+            baseSig = ClassName.toDottedClassName(baseSig);
             return Repository.lookupClass(baseSig);
         }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/PackageMemberAnnotation.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/PackageMemberAnnotation.java
@@ -78,7 +78,7 @@ public abstract class PackageMemberAnnotation extends BugAnnotationWithSourceLin
         }
         if (className.indexOf('/') >= 0) {
             assert false : "classname " + className + " should be dotted";
-            className = className.replace('/', '.');
+            className = ClassName.toDottedClassName(className);
         }
         this.className = className;
         this.sourceFileName = sourceFileName;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ProjectPackagePrefixes.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ProjectPackagePrefixes.java
@@ -35,6 +35,7 @@ import java.util.regex.Pattern;
 import edu.umd.cs.findbugs.ba.AnalysisContext;
 import edu.umd.cs.findbugs.charsets.UTF8;
 import edu.umd.cs.findbugs.internalAnnotations.DottedClassName;
+import edu.umd.cs.findbugs.util.ClassName;
 
 /**
  * @author pwilliam
@@ -45,7 +46,7 @@ public class ProjectPackagePrefixes {
         final String[] parts;
 
         PrefixFilter(String prefixes) {
-            prefixes = prefixes.replace('/', '.').trim();
+            prefixes = ClassName.toDottedClassName(prefixes).trim();
             if (prefixes.length() == 0) {
                 parts = new String[0];
             } else {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/TypeAnnotation.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/TypeAnnotation.java
@@ -20,6 +20,7 @@ package edu.umd.cs.findbugs;
 
 import java.io.IOException;
 
+import edu.umd.cs.findbugs.util.ClassName;
 import org.apache.bcel.generic.Type;
 
 import edu.umd.cs.findbugs.ba.AnalysisContext;
@@ -91,7 +92,7 @@ public class TypeAnnotation extends BugAnnotationWithSourceLines {
         if (descriptor.startsWith("L")) {
             AnalysisContext context = AnalysisContext.currentAnalysisContext();
             if (context != null) {
-                String className = typeDescriptor.substring(1, typeDescriptor.length() - 1).replace('/', '.');
+                String className = ClassName.fromFieldSignatureToDottedClassName(typeDescriptor);
                 this.sourceFileName = context.lookupSourceFile(className);
                 this.sourceLines = ClassAnnotation.getSourceLinesForClass(className, sourceFileName);
             } else {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/AbstractClassMember.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/AbstractClassMember.java
@@ -18,6 +18,7 @@
  */
 package edu.umd.cs.findbugs.ba;
 
+import edu.umd.cs.findbugs.util.ClassName;
 import org.apache.bcel.Const;
 
 import edu.umd.cs.findbugs.classfile.ClassDescriptor;
@@ -49,12 +50,12 @@ public abstract class AbstractClassMember implements ClassMember {
         } else if (className.indexOf('/') >= 0) {
             assert false;
             //            slashCountClass++;
-            className = className.replace('/', '.');
+            className = ClassName.toDottedClassName(className);
         }
 
         if (signature.indexOf('.') >= 0) {
             assert false;
-            signature = signature.replace('.', '/');
+            signature = ClassName.toDottedClassName(signature);
             //            dottedCountSignature++;
         }
         // else if (signature.indexOf('/') >= 0) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/AbstractClassMember.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/AbstractClassMember.java
@@ -55,7 +55,7 @@ public abstract class AbstractClassMember implements ClassMember {
 
         if (signature.indexOf('.') >= 0) {
             assert false;
-            signature = ClassName.toDottedClassName(signature);
+            signature = ClassName.toSlashedClassName(signature);
             //            dottedCountSignature++;
         }
         // else if (signature.indexOf('/') >= 0) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/AssertionMethods.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/AssertionMethods.java
@@ -24,6 +24,7 @@ import java.util.BitSet;
 import java.util.List;
 import java.util.StringTokenizer;
 
+import edu.umd.cs.findbugs.util.ClassName;
 import org.apache.bcel.Const;
 import org.apache.bcel.classfile.ClassFormatException;
 import org.apache.bcel.classfile.Constant;
@@ -119,7 +120,7 @@ public class AssertionMethods {
                     ConstantNameAndType cnat = (ConstantNameAndType) cp.getConstant(cmr.getNameAndTypeIndex(),
                             Const.CONSTANT_NameAndType);
                     String methodName = ((ConstantUtf8) cp.getConstant(cnat.getNameIndex(), Const.CONSTANT_Utf8)).getBytes();
-                    String className = cp.getConstantString(cmr.getClassIndex(), Const.CONSTANT_Class).replace('/', '.');
+                    String className = ClassName.toDottedClassName(cp.getConstantString(cmr.getClassIndex(), Const.CONSTANT_Class));
                     String methodSig = ((ConstantUtf8) cp.getConstant(cnat.getSignatureIndex(), Const.CONSTANT_Utf8)).getBytes();
 
                     String classNameLC = className.toLowerCase();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/InnerClassAccessMap.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/InnerClassAccessMap.java
@@ -257,7 +257,7 @@ public class InnerClassAccessMap {
             ConstantFieldref fieldref = (ConstantFieldref) cp.getConstant(cpIndex);
 
             ConstantClass cls = (ConstantClass) cp.getConstant(fieldref.getClassIndex());
-            String className = cls.getBytes(cp).replace('/', '.');
+            String className = ClassName.toDottedClassName(cls.getBytes(cp));
 
             ConstantNameAndType nameAndType = (ConstantNameAndType) cp.getConstant(fieldref.getNameAndTypeIndex());
             String fieldName = nameAndType.getName(cp);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/InnerClassAccessMap.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/InnerClassAccessMap.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import edu.umd.cs.findbugs.util.ClassName;
 import org.apache.bcel.Const;
 import org.apache.bcel.Repository;
 import org.apache.bcel.classfile.Code;
@@ -297,7 +298,7 @@ public class InnerClassAccessMap {
             StringBuilder buf = new StringBuilder();
             buf.append('(');
             if (!field.isStatic()) {
-                String classSig = "L" + javaClass.getClassName().replace('.', '/') + ";";
+                String classSig = "L" + ClassName.toSlashedClassName(javaClass.getClassName()) + ";";
                 buf.append(classSig); // the OuterClass.this reference
             }
             if (!isLoad) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/ObjectTypeFactory.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/ObjectTypeFactory.java
@@ -22,6 +22,7 @@ package edu.umd.cs.findbugs.ba;
 import java.util.HashMap;
 import java.util.Map;
 
+import edu.umd.cs.findbugs.util.ClassName;
 import org.apache.bcel.generic.ObjectType;
 
 import edu.umd.cs.findbugs.FindBugs;
@@ -58,7 +59,7 @@ public class ObjectTypeFactory {
             throw new IllegalArgumentException(s);
         }
         if (s.indexOf('/') >= 0) {
-            s = s.replace('/', '.');
+            s = ClassName.toDottedClassName(s);
         }
 
         Map<String, ObjectType> map = instance.get();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/SignatureConverter.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/SignatureConverter.java
@@ -19,6 +19,7 @@
 
 package edu.umd.cs.findbugs.ba;
 
+import edu.umd.cs.findbugs.util.ClassName;
 import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.classfile.Method;
 import org.apache.bcel.generic.ConstantPoolGen;
@@ -94,7 +95,7 @@ public class SignatureConverter {
             if (semi < 0) {
                 throw new IllegalStateException("missing semicolon in signature " + signature);
             }
-            result.append(signature.substring(1, semi).replace('/', '.'));
+            result.append(ClassName.toDottedClassName(signature.substring(1, semi)));
             signature = signature.substring(semi + 1);
         } else {
             switch (signature.charAt(0)) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/SourceFinder.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/SourceFinder.java
@@ -55,6 +55,7 @@ import edu.umd.cs.findbugs.Project;
 import edu.umd.cs.findbugs.SourceLineAnnotation;
 import edu.umd.cs.findbugs.SystemProperties;
 import edu.umd.cs.findbugs.io.IO;
+import edu.umd.cs.findbugs.util.ClassName;
 import edu.umd.cs.findbugs.util.Util;
 
 /**
@@ -549,7 +550,7 @@ public class SourceFinder implements AutoCloseable {
     }
 
     public static String getCanonicalName(String packageName, String fileName) {
-        String canonicalName = packageName.replace('.', '/') + (packageName.length() > 0 ? "/" : "") + fileName;
+        String canonicalName = ClassName.toSlashedClassName(packageName) + (packageName.length() > 0 ? "/" : "") + fileName;
         return canonicalName;
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/URLClassPath.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/URLClassPath.java
@@ -33,6 +33,7 @@ import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
+import edu.umd.cs.findbugs.util.ClassName;
 import org.apache.bcel.classfile.ClassParser;
 import org.apache.bcel.classfile.JavaClass;
 
@@ -413,7 +414,7 @@ public class URLClassPath implements AutoCloseable, Serializable {
         if (classesThatCantBeFound.contains(className)) {
             throw new ClassNotFoundException("Error while looking for class " + className + ": class not found");
         }
-        String resourceName = className.replace('.', '/') + ".class";
+        String resourceName = ClassName.toSlashedClassName(className) + ".class";
         InputStream in = null;
         boolean parsedClass = false;
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/URLClassPathRepository.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/URLClassPathRepository.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import edu.umd.cs.findbugs.util.ClassName;
 import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.util.ClassPath;
 import org.apache.bcel.util.Repository;
@@ -140,7 +141,7 @@ public class URLClassPathRepository implements Repository {
         // loaded class will appear to be missing (because we're using the
         // wrong name to look it up) and be evicted by some other random
         // version of the class loaded from the classpath.
-        String dottedClassName = className.replace('/', '.');
+        String dottedClassName = ClassName.toDottedClassName(className);
 
         return nameToClassMap.get(dottedClassName);
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/generic/GenericObjectType.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/generic/GenericObjectType.java
@@ -213,13 +213,12 @@ public class GenericObjectType extends ObjectType {
      * @return the underlying ObjectType for this Generic Object
      */
     public ObjectType getObjectType() {
-        String cName = ClassName.fromFieldSignature(getSignature());
+        @DottedClassName
+        String cName = ClassName.fromFieldSignatureToDottedClassName(getSignature());
         if (cName == null) {
             throw new IllegalStateException("Can't provide ObjectType for " + this);
         }
-        @DottedClassName
-        String c = ClassName.toDottedClassName(cName);
-        return ObjectTypeFactory.getInstance(c);
+        return ObjectTypeFactory.getInstance(cName);
     }
 
     /**

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/obl/ObligationFactory.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/obl/ObligationFactory.java
@@ -27,6 +27,7 @@ import java.util.Set;
 
 import javax.annotation.CheckForNull;
 
+import edu.umd.cs.findbugs.util.ClassName;
 import org.apache.bcel.generic.ObjectType;
 import org.apache.bcel.generic.Type;
 
@@ -164,7 +165,7 @@ public class ObligationFactory {
 
     public Obligation addObligation(@DottedClassName String className) {
         int nextId = classNameToObligationMap.size();
-        slashedClassNames.add(className.replace('.', '/'));
+        slashedClassNames.add(ClassName.toSlashedClassName(className));
         Obligation obligation = new Obligation(className, nextId);
         if (classNameToObligationMap.put(className, obligation) != null) {
             throw new IllegalStateException("Obligation " + className + " added multiple times");

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/type/TypeFrameModelingVisitor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/type/TypeFrameModelingVisitor.java
@@ -30,6 +30,7 @@ import java.util.regex.Pattern;
 
 import javax.annotation.CheckForNull;
 
+import edu.umd.cs.findbugs.util.ClassName;
 import org.apache.bcel.Const;
 import org.apache.bcel.classfile.LocalVariable;
 import org.apache.bcel.classfile.LocalVariableTypeTable;
@@ -528,7 +529,7 @@ public class TypeFrameModelingVisitor extends AbstractFrameModelingVisitor<Type,
                             String c = valueNumberDataflow.getClassName(stackValue);
                             if (c != null) {
                                 if (c.charAt(0) != '[' && !c.endsWith(";")) {
-                                    c = "L" + c.replace('.', '/') + ";";
+                                    c = "L" + ClassName.toSlashedClassName(c) + ";";
                                 }
                                 Type type = Type.getType(c);
                                 if (type instanceof ReferenceType) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/vna/ValueNumberFactory.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/vna/ValueNumberFactory.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import javax.annotation.CheckForNull;
 
 import edu.umd.cs.findbugs.internalAnnotations.DottedClassName;
+import edu.umd.cs.findbugs.util.ClassName;
 
 /**
  * Factory for ValueNumbers. A single Factory must be used to create all of the
@@ -96,7 +97,7 @@ public class ValueNumberFactory {
     public ValueNumber getClassObjectValue(@DottedClassName String className) {
         // assert className.indexOf('.') == -1;
         // TODO: Check to see if we need to do this
-        className = className.replace('/', '.');
+        className = ClassName.toDottedClassName(className);
         ValueNumber value = classObjectValueMap.get(className);
         if (value == null) {
             value = createFreshValue(ValueNumber.CONSTANT_CLASS_OBJECT);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/bcel/BCELUtil.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/bcel/BCELUtil.java
@@ -50,7 +50,7 @@ public abstract class BCELUtil {
      * @return a MethodDescriptor identifying the method
      */
     public static MethodDescriptor getMethodDescriptor(JavaClass jclass, Method method) {
-        return DescriptorFactory.instance().getMethodDescriptor(jclass.getClassName().replace('.', '/'), method.getName(),
+        return DescriptorFactory.instance().getMethodDescriptor(ClassName.toSlashedClassName(jclass.getClassName()), method.getName(),
                 method.getSignature(), method.isStatic());
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/DescriptorFactory.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/DescriptorFactory.java
@@ -142,7 +142,7 @@ public class DescriptorFactory {
         assert dottedClassName != null;
         ClassDescriptor classDescriptor = dottedClassDescriptorMap.get(dottedClassName);
         if (classDescriptor == null) {
-            classDescriptor = getClassDescriptor(dottedClassName.replace('.', '/'));
+            classDescriptor = getClassDescriptor(ClassName.toSlashedClassName(dottedClassName));
             dottedClassDescriptorMap.put(dottedClassName, classDescriptor);
         }
         return classDescriptor;
@@ -360,6 +360,6 @@ public class DescriptorFactory {
     }
 
     public static ClassDescriptor createClassDescriptorFromDottedClassName(String dottedClassName) {
-        return createClassDescriptor(dottedClassName.replace('.', '/'));
+        return createClassDescriptor(ClassName.toSlashedClassName(dottedClassName));
     }
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/DescriptorFactory.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/DescriptorFactory.java
@@ -101,7 +101,7 @@ public class DescriptorFactory {
     public void purge(Collection<ClassDescriptor> unusable) {
         for (ClassDescriptor c : unusable) {
             classDescriptorMap.remove(c.getClassName());
-            dottedClassDescriptorMap.remove(c.getClassName().replace('/', '.'));
+            dottedClassDescriptorMap.remove(ClassName.toDottedClassName(c.getClassName()));
         }
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/ClassParserUsingBCEL.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/ClassParserUsingBCEL.java
@@ -58,7 +58,7 @@ public class ClassParserUsingBCEL implements ClassParserInterface {
     public ClassParserUsingBCEL(JavaClass javaClass, @CheckForNull ClassDescriptor expectedClassDescriptor,
             ICodeBaseEntry codeBaseEntry) {
         this.javaClass = javaClass;
-        this.slashedClassName = javaClass.getClassName().replace('.', '/');
+        this.slashedClassName = ClassName.toSlashedClassName(javaClass.getClassName());
         this.expectedClassDescriptor = expectedClassDescriptor;
         this.codeBaseEntry = codeBaseEntry;
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/JrtfsCodeBase.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/JrtfsCodeBase.java
@@ -51,6 +51,7 @@ import edu.umd.cs.findbugs.classfile.ICodeBaseIterator;
 import edu.umd.cs.findbugs.classfile.ICodeBaseLocator;
 import edu.umd.cs.findbugs.classfile.InvalidClassFileFormatException;
 import edu.umd.cs.findbugs.classfile.ResourceNotFoundException;
+import edu.umd.cs.findbugs.util.ClassName;
 
 /**
  *
@@ -97,7 +98,7 @@ public class JrtfsCodeBase extends AbstractScannableCodeBase {
                     Iterator<Path> modIter = pList.iterator();
                     while (modIter.hasNext()) {
                         Path module = modIter.next();
-                        String packageKey = fileName(p).replace('.', '/');
+                        String packageKey = ClassName.toSlashedClassName(fileName(p));
                         String modulePath = fileName(module);
                         if (!modIter.hasNext() && !packageToModule.containsKey(packageKey)) {
                             packageToModule.put(packageKey, modulePath);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/CheckImmutableAnnotation.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/CheckImmutableAnnotation.java
@@ -19,6 +19,7 @@
 
 package edu.umd.cs.findbugs.detect;
 
+import edu.umd.cs.findbugs.util.ClassName;
 import org.apache.bcel.classfile.Field;
 import org.apache.bcel.classfile.JavaClass;
 
@@ -41,7 +42,7 @@ public class CheckImmutableAnnotation extends PreorderVisitor implements Detecto
     @Override
     public void visitJavaClass(JavaClass obj) {
         JCIPAnnotationDatabase jcipAnotationDatabase = AnalysisContext.currentAnalysisContext().getJCIPAnnotationDatabase();
-        if (jcipAnotationDatabase.hasClassAnnotation(obj.getClassName().replace('/', '.'), "Immutable")) {
+        if (jcipAnotationDatabase.hasClassAnnotation(ClassName.toDottedClassName(obj.getClassName()), "Immutable")) {
             super.visitJavaClass(obj);
         }
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DontIgnoreResultOfPutIfAbsent.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DontIgnoreResultOfPutIfAbsent.java
@@ -232,7 +232,7 @@ public class DontIgnoreResultOfPutIfAbsent implements Detector {
                             && !(invoke instanceof INVOKESTATIC)) {
                         TypeFrame typeFrame = typeDataflow.getFactAtLocation(location);
                         Type objType = typeFrame.getStackValue(2);
-                        if (extendsConcurrentMap(ClassName.toDottedClassName(ClassName.fromFieldSignature(objType.getSignature())))) {
+                        if (extendsConcurrentMap(ClassName.fromFieldSignatureToDottedClassName(objType.getSignature()))) {
                             InstructionHandle next = handle.getNext();
                             boolean isIgnored = next != null && next.getInstruction() instanceof POP;
                             //                        boolean isImmediateNullTest = next != null

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DumbMethods.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DumbMethods.java
@@ -1245,7 +1245,7 @@ public class DumbMethods extends OpcodeStackDetector {
                 if (value instanceof String) {
                     String annotationClassName = (String) value;
                     boolean lacksClassfileRetention = AnalysisContext.currentAnalysisContext().getAnnotationRetentionDatabase()
-                            .lacksRuntimeRetention(annotationClassName.replace('/', '.'));
+                            .lacksRuntimeRetention(ClassName.toDottedClassName(annotationClassName));
                     if (lacksClassfileRetention) {
                         ClassDescriptor annotationClass = DescriptorFactory.createClassDescriptor(annotationClassName);
                         accumulator.accumulateBug(

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindBadCast2.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindBadCast2.java
@@ -357,8 +357,8 @@ public class FindBadCast2 implements Detector {
                 // skip; might be due to JSR inlining
                 continue;
             }*/
-            String castName = castSig2.substring(1, castSig2.length() - 1).replace('/', '.');
-            String refName = refSig2.substring(1, refSig2.length() - 1).replace('/', '.');
+            String castName = ClassName.toDottedClassName(castSig2.substring(1, castSig2.length() - 1));
+            String refName = ClassName.toDottedClassName(refSig2.substring(1, refSig2.length() - 1));
 
             if (vnaDataflow == null) {
                 vnaDataflow = classContext.getValueNumberDataflow(method);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindCircularDependencies.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindCircularDependencies.java
@@ -26,6 +26,7 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
+import edu.umd.cs.findbugs.util.ClassName;
 import org.apache.bcel.Const;
 import org.apache.bcel.classfile.JavaClass;
 
@@ -54,7 +55,7 @@ public class FindCircularDependencies extends BytecodeScanningDetector {
     public void sawOpcode(int seen) {
         if ((seen == Const.INVOKESPECIAL) || (seen == Const.INVOKESTATIC) || (seen == Const.INVOKEVIRTUAL)) {
             String refClsName = getClassConstantOperand();
-            refClsName = refClsName.replace('/', '.');
+            refClsName = ClassName.toDottedClassName(refClsName);
             if (refClsName.startsWith("java")) {
                 return;
             }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindHEmismatch.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindHEmismatch.java
@@ -577,16 +577,16 @@ public class FindHEmismatch extends OpcodeStackDetector implements StatelessDete
     String findHashedClassInSignature(String sig) {
         Matcher m = mapPattern.matcher(sig);
         if (m.find()) {
-            return m.group(1).replace('/', '.');
+            return ClassName.toDottedClassName(m.group(1));
         }
         m = hashTablePattern.matcher(sig);
         if (m.find()) {
-            return m.group(1).replace('/', '.');
+            return ClassName.toDottedClassName(m.group(1));
         }
 
         m = setPattern.matcher(sig);
         if (m.find()) {
-            return m.group(1).replace('/', '.');
+            return ClassName.toDottedClassName(m.group(1));
         }
         return null;
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNoSideEffectMethods.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNoSideEffectMethods.java
@@ -914,9 +914,8 @@ public class FindNoSideEffectMethods extends OpcodeStackDetector implements NonR
                         continue;
                     }
                     if (m.isStatic() && getStaticMethods.contains(m) && !m.getSlashedClassName().startsWith("java/")) {
-                        String returnSlashedClassName = ClassName.fromFieldSignature(returnType);
-                        if (returnSlashedClassName != null) {
-                            String returnClass = ClassName.toDottedClassName(returnSlashedClassName);
+                        String returnClass = ClassName.fromFieldSignatureToDottedClassName(returnType);
+                        if (returnClass != null) {
                             if (ClassName.extractPackageName(returnClass).equals(m.getClassDescriptor().getPackageName())) {
                                 /* Skip methods which only retrieve static field from the same package
                                  * As they as often used to trigger class initialization

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindPuzzlers.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindPuzzlers.java
@@ -26,6 +26,7 @@ import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.Map;
 
+import edu.umd.cs.findbugs.util.ClassName;
 import org.apache.bcel.Const;
 import org.apache.bcel.Repository;
 import org.apache.bcel.classfile.Code;
@@ -579,9 +580,9 @@ public class FindPuzzlers extends OpcodeStackDetector {
         if (isTigerOrHigher) {
             if (previousMethodInvocation != null && prevOpCode == Const.INVOKEVIRTUAL && seen == Const.INVOKESTATIC) {
                 String classNameForPreviousMethod = previousMethodInvocation.getClassName();
-                String classNameForThisMethod = getClassConstantOperand();
+                String classNameForThisMethod = ClassName.toDottedClassName(getClassConstantOperand());
                 if (classNameForPreviousMethod.startsWith("java.lang.")
-                        && classNameForPreviousMethod.equals(classNameForThisMethod.replace('/', '.'))
+                        && classNameForPreviousMethod.equals(classNameForThisMethod)
                         && previousMethodInvocation.getName().endsWith("Value")
                         && previousMethodInvocation.getSignature().length() == 3
                         && "valueOf".equals(getNameConstantOperand())
@@ -596,9 +597,9 @@ public class FindPuzzlers extends OpcodeStackDetector {
 
             if (previousMethodInvocation != null && prevOpCode == Const.INVOKESPECIAL && seen == Const.INVOKEVIRTUAL) {
                 String classNameForPreviousMethod = previousMethodInvocation.getClassName();
-                String classNameForThisMethod = getClassConstantOperand();
+                String classNameForThisMethod = ClassName.toDottedClassName(getClassConstantOperand());
                 if (classNameForPreviousMethod.startsWith("java.lang.")
-                        && classNameForPreviousMethod.equals(classNameForThisMethod.replace('/', '.'))
+                        && classNameForPreviousMethod.equals(classNameForThisMethod)
                         && getNameConstantOperand().endsWith("Value") && getSigConstantOperand().length() == 3) {
                     if (getSigConstantOperand().charAt(2) == previousMethodInvocation.getSignature().charAt(1)) {
                         bugAccumulator.accumulateBug(
@@ -649,7 +650,7 @@ public class FindPuzzlers extends OpcodeStackDetector {
                         "java/lang/AssertionFailureError", getPC());
                 int size = Math.min(Math.min(size1, size2), size3);
                 if (size == Integer.MAX_VALUE) {
-                    String dottedClassName = getClassConstantOperand().replace('/', '.');
+                    String dottedClassName = ClassName.toDottedClassName(getClassConstantOperand());
                     if (!dottedClassName.startsWith("junit")) {
                         try {
                             JavaClass targetClass = AnalysisContext.currentAnalysisContext().lookupClass(dottedClassName);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindRefComparison.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindRefComparison.java
@@ -504,9 +504,8 @@ public class FindRefComparison implements Detector, ExtendedTypes {
                     return;
                 }
 
-                String slashedClassName = ClassName.fromFieldSignature(type.getSignature());
-                if (slashedClassName != null) {
-                    String dottedClassName = ClassName.toDottedClassName(slashedClassName);
+                String dottedClassName = ClassName.fromFieldSignatureToDottedClassName(type.getSignature());
+                if (dottedClassName != null) {
                     if (DEFAULT_SUSPICIOUS_SET.contains(dottedClassName)) {
                         type = new FinalConstant(dottedClassName, xf);
                         consumeStack(obj);
@@ -539,9 +538,8 @@ public class FindRefComparison implements Detector, ExtendedTypes {
                         return;
                     }
 
-                    String slashedClassName = ClassName.fromFieldSignature(type.getSignature());
-                    if (slashedClassName != null) {
-                        String dottedClassName = ClassName.toDottedClassName(slashedClassName);
+                    String dottedClassName = ClassName.fromFieldSignatureToDottedClassName(type.getSignature());
+                    if (dottedClassName != null) {
                         if (DEFAULT_SUSPICIOUS_SET.contains(dottedClassName)) {
                             type = new FinalConstant(dottedClassName, xf);
                             consumeStack(obj);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindRefComparison.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindRefComparison.java
@@ -1052,7 +1052,7 @@ public class FindRefComparison implements Detector, ExtendedTypes {
             }
         }
         BugInstance instance = new BugInstance(this, bugPattern, priority).addClassAndMethod(methodGen, sourceFile)
-                .addType("L" + lhs.replace('.', '/') + ";").describe(TypeAnnotation.FOUND_ROLE);
+                .addType("L" + ClassName.toSlashedClassName(lhs) + ";").describe(TypeAnnotation.FOUND_ROLE);
         if (xf != null) {
             instance.addField(xf).describe(FieldAnnotation.LOADED_FROM_ROLE);
         } else {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindUncalledPrivateMethods.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindUncalledPrivateMethods.java
@@ -238,6 +238,6 @@ public class FindUncalledPrivateMethods extends BytecodeScanningDetector impleme
 
     private static String getClassName(JavaClass c, int classIndex) {
         String name = c.getConstantPool().getConstantString(classIndex, Const.CONSTANT_Class);
-        return ClassName.extractClassName(name).replace('/', '.');
+        return ClassName.toDottedClassName(ClassName.extractClassName(name));
     }
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InfiniteRecursiveLoop.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InfiniteRecursiveLoop.java
@@ -19,6 +19,7 @@
 
 package edu.umd.cs.findbugs.detect;
 
+import edu.umd.cs.findbugs.util.ClassName;
 import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Method;
 import org.apache.bcel.generic.Type;
@@ -125,7 +126,7 @@ public class InfiniteRecursiveLoop extends OpcodeStackDetector implements Statel
                 System.out.println("vs. " + getClassName() + "." + getMethodName() + " : " + getMethodSig());
 
             }
-            if (xMethod.getClassName().replace('.', '/').equals(getClassName()) || seen == Const.INVOKEINTERFACE) {
+            if (ClassName.toSlashedClassName(xMethod.getClassName()).equals(getClassName()) || seen == Const.INVOKEINTERFACE) {
                 // Invocation of same method
                 // Now need to see if parameters are the same
                 int firstParameter = 0;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MethodReturnCheck.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MethodReturnCheck.java
@@ -260,9 +260,9 @@ public class MethodReturnCheck extends OpcodeStackDetector implements UseAnnotat
                         String callReturnClass = callSeen.getName().equals(Const.CONSTRUCTOR_NAME) ? callSeen.getClassDescriptor().getClassName()
                                 : ClassName.fromFieldSignature(callReturnType.getSignature());
 
-                        String methodReturnClass = ClassName.fromFieldSignature(methodReturnType.getSignature());
+                        String methodReturnClass = ClassName.fromFieldSignatureToDottedClassName(methodReturnType.getSignature());
                         if (callReturnClass != null && methodReturnClass != null &&
-                                Subtypes2.instanceOf(ClassName.toDottedClassName(callReturnClass), ClassName.toDottedClassName(methodReturnClass))) {
+                                Subtypes2.instanceOf(ClassName.toDottedClassName(callReturnClass), methodReturnClass)) {
                             priority = HIGH_PRIORITY;
                         }
                     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MethodReturnCheck.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MethodReturnCheck.java
@@ -223,7 +223,7 @@ public class MethodReturnCheck extends OpcodeStackDetector implements UseAnnotat
                 if (annotation != null && annotation != CheckReturnValueAnnotation.CHECK_RETURN_VALUE_IGNORE) {
                     int priority = annotation.getPriority();
                     if (!checkReturnAnnotationDatabase.annotationIsDirect(callSeen)
-                            && !callSeen.getSignature().endsWith(callSeen.getClassName().replace('.', '/') + ";")) {
+                            && !callSeen.getSignature().endsWith(ClassName.toSlashedClassName(callSeen.getClassName()) + ";")) {
                         priority++;
                     }
                     bugAccumulator.accumulateBug(new BugInstance(this, annotation.getPattern(), priority).addClassAndMethod(this)
@@ -295,7 +295,7 @@ public class MethodReturnCheck extends OpcodeStackDetector implements UseAnnotat
                     priority += 1;
                 }
                 if (!checkReturnAnnotationDatabase.annotationIsDirect(callSeen)
-                        && !callSeen.getSignature().endsWith(callSeen.getClassName().replace('.', '/') + ";")) {
+                        && !callSeen.getSignature().endsWith(ClassName.toSlashedClassName(callSeen.getClassName()) + ";")) {
                     priority++;
                 }
                 if (callSeen.isPrivate()) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MultithreadedInstanceAccess.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MultithreadedInstanceAccess.java
@@ -22,6 +22,7 @@ package edu.umd.cs.findbugs.detect;
 import java.util.HashSet;
 import java.util.Set;
 
+import edu.umd.cs.findbugs.util.ClassName;
 import org.apache.bcel.Const;
 import org.apache.bcel.Repository;
 import org.apache.bcel.classfile.Code;
@@ -156,7 +157,7 @@ public class MultithreadedInstanceAccess extends OpcodeStackDetector {
         if (c instanceof ConstantFieldref) {
             fieldRef = (ConstantFieldref) c;
 
-            String className = fieldRef.getClass(getConstantPool()).replace('.', '/');
+            String className = ClassName.toSlashedClassName(fieldRef.getClass(getConstantPool()));
             if (className.equals(this.getClassName())) {
                 ConstantPool cp = getConstantPool();
                 int nameAndTypeIdx = fieldRef.getNameAndTypeIndex();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/NoteSuppressedWarnings.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/NoteSuppressedWarnings.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import edu.umd.cs.findbugs.util.ClassName;
 import org.apache.bcel.Repository;
 import org.apache.bcel.classfile.ElementValue;
 import org.apache.bcel.classfile.JavaClass;
@@ -131,7 +132,7 @@ public class NoteSuppressedWarnings extends AnnotationVisitor implements Detecto
         String className = getDottedClassName();
         ClassAnnotation clazz = new ClassAnnotation(className);
         if (className.endsWith(".package-info")) {
-            suppressionMatcher.addPackageSuppressor(new PackageWarningSuppressor(pattern, getPackageName().replace('/', '.')));
+            suppressionMatcher.addPackageSuppressor(new PackageWarningSuppressor(pattern, ClassName.toDottedClassName(getPackageName())));
         } else if (visitingMethod()) {
             suppressionMatcher
                     .addSuppressor(new MethodWarningSuppressor(pattern, clazz, MethodAnnotation.fromVisitedMethod(this)));

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/OverridingEqualsNotSymmetrical.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/OverridingEqualsNotSymmetrical.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 
+import edu.umd.cs.findbugs.util.ClassName;
 import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 
@@ -158,7 +159,7 @@ public class OverridingEqualsNotSymmetrical extends OpcodeStackDetector implemen
 
             }
 
-            String superClassName = getSuperclassName().replace('/', '.');
+            String superClassName = ClassName.toDottedClassName(getSuperclassName());
             if (!Values.DOTTED_JAVA_LANG_OBJECT.equals(superClassName)) {
                 parentMap.put(classAnnotation, new ClassAnnotation(superClassName));
             }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ResolveAllReferences.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ResolveAllReferences.java
@@ -104,7 +104,7 @@ public class ResolveAllReferences extends PreorderVisitor implements Detector {
 
     private String getClassName(JavaClass c, int classIndex) {
         String name = c.getConstantPool().getConstantString(classIndex, Const.CONSTANT_Class);
-        return ClassName.extractClassName(name).replace('/', '.');
+        return ClassName.toDottedClassName(ClassName.extractClassName(name));
     }
 
     private String getMemberName(JavaClass c, String className, int memberNameIndex, int signatureIndex) {
@@ -113,7 +113,7 @@ public class ResolveAllReferences extends PreorderVisitor implements Detector {
     }
 
     private String getMemberName(String className, String memberName, String signature) {
-        return className.replace('/', '.') + "." + memberName + " : " + signature;
+        return ClassName.toDottedClassName(className) + "." + memberName + " : " + signature;
     }
 
     private boolean find(JavaClass target, String name, String signature) throws ClassNotFoundException {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/RuntimeExceptionCapture.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/RuntimeExceptionCapture.java
@@ -226,7 +226,7 @@ public class RuntimeExceptionCapture extends OpcodeStackDetector implements Stat
                     if (signature.startsWith("L")) {
                         signature = SignatureConverter.convert(signature);
                     } else {
-                        signature = signature.replace('/', '.');
+                        signature = ClassName.toDottedClassName(signature);
                     }
                     throwList.add(new ExceptionThrown(signature, getPC()));
                 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SerializableIdiom.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SerializableIdiom.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+import edu.umd.cs.findbugs.util.ClassName;
 import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Attribute;
 import org.apache.bcel.classfile.Code;
@@ -610,7 +611,7 @@ public class SerializableIdiom extends OpcodeStackDetector {
                                 // sig);
                                 // System.out.println("Class stored: " +
                                 // classStored.getClassName());
-                                String genSig = "L" + classStored.getClassName().replace('.', '/') + ";";
+                                String genSig = "L" + ClassName.toSlashedClassName(classStored.getClassName()) + ";";
                                 if (!sig.equals(genSig)) {
                                     double bias = 0.0;
                                     if (!Const.CONSTRUCTOR_NAME.equals(getMethodName())) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SuperfluousInstanceOf.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SuperfluousInstanceOf.java
@@ -20,6 +20,7 @@
 
 package edu.umd.cs.findbugs.detect;
 
+import edu.umd.cs.findbugs.util.ClassName;
 import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.LocalVariable;
@@ -94,7 +95,7 @@ public class SuperfluousInstanceOf extends BytecodeScanningDetector implements S
                     if (lv != null) {
                         String objSignature = lv.getSignature();
                         if (objSignature.charAt(0) == 'L') {
-                            objSignature = objSignature.substring(1, objSignature.length() - 1).replace('/', '.');
+                            objSignature = ClassName.toDottedClassName(objSignature.substring(1, objSignature.length() - 1));
                             String clsSignature = getDottedClassConstantOperand();
 
                             if (clsSignature.charAt(0) != '[') {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SynchronizeOnClassLiteralNotGetClass.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SynchronizeOnClassLiteralNotGetClass.java
@@ -21,6 +21,7 @@ package edu.umd.cs.findbugs.detect;
 
 import java.util.Set;
 
+import edu.umd.cs.findbugs.util.ClassName;
 import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 
@@ -67,13 +68,13 @@ public class SynchronizeOnClassLiteralNotGetClass extends OpcodeStackDetector {
         if (pendingBug != null) {
             if (seen == Const.PUTSTATIC) {
                 String classConstantOperand = getClassConstantOperand();
-                String thisClassName = getThisClass().getClassName().replace('.', '/');
+                String thisClassName = ClassName.toSlashedClassName(getThisClass().getClassName());
                 if (classConstantOperand.equals(thisClassName)) {
                     seenPutStatic = true;
                 }
             } else if (seen == Const.GETSTATIC) {
                 String classConstantOperand = getClassConstantOperand();
-                String thisClassName = getThisClass().getClassName().replace('.', '/');
+                String thisClassName = ClassName.toSlashedClassName(getThisClass().getClassName());
                 if (classConstantOperand.equals(thisClassName)) {
                     seenGetStatic = true;
                 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UnreadFields.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UnreadFields.java
@@ -463,7 +463,7 @@ public class UnreadFields extends OpcodeStackDetector {
             String fieldSignature = (String) stack.getStackItem(1).getConstant();
             String fieldClass = (String) stack.getStackItem(2).getConstant();
             if (fieldName != null && fieldSignature != null && fieldClass != null) {
-                XField f = XFactory.createXField(fieldClass.replace('/', '.'), fieldName, ClassName.toSignature(fieldSignature),
+                XField f = XFactory.createXField(ClassName.toDottedClassName(fieldClass), fieldName, ClassName.toSignature(fieldSignature),
                         false);
                 data.reflectiveFields.add(f);
             }
@@ -474,7 +474,7 @@ public class UnreadFields extends OpcodeStackDetector {
             String fieldName = (String) stack.getStackItem(0).getConstant();
             String fieldClass = (String) stack.getStackItem(1).getConstant();
             if (fieldName != null && fieldClass != null) {
-                XField f = XFactory.createXField(fieldClass.replace('/', '.'), fieldName, "I", false);
+                XField f = XFactory.createXField(ClassName.toDottedClassName(fieldClass), fieldName, "I", false);
                 data.reflectiveFields.add(f);
             }
 
@@ -484,7 +484,7 @@ public class UnreadFields extends OpcodeStackDetector {
             String fieldName = (String) stack.getStackItem(0).getConstant();
             String fieldClass = (String) stack.getStackItem(1).getConstant();
             if (fieldName != null && fieldClass != null) {
-                XField f = XFactory.createXField(fieldClass.replace('/', '.'), fieldName, "J", false);
+                XField f = XFactory.createXField(ClassName.toDottedClassName(fieldClass), fieldName, "J", false);
                 data.reflectiveFields.add(f);
             }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/XMLFactoryBypass.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/XMLFactoryBypass.java
@@ -22,6 +22,7 @@ package edu.umd.cs.findbugs.detect;
 import java.util.HashSet;
 import java.util.Set;
 
+import edu.umd.cs.findbugs.util.ClassName;
 import org.apache.bcel.Const;
 import org.apache.bcel.Repository;
 import org.apache.bcel.classfile.JavaClass;
@@ -97,7 +98,7 @@ public class XMLFactoryBypass extends BytecodeScanningDetector {
                 JavaClass newCls = Repository.lookupClass(getDottedClassConstantOperand());
 
                 JavaClass superCls = curClass.getSuperClass();
-                if (superCls.getClassName().equals(newClsName.replace('/', '.'))) {
+                if (superCls.getClassName().equals(ClassName.toDottedClassName(newClsName))) {
                     return;
                 }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/filter/SignatureUtil.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/filter/SignatureUtil.java
@@ -19,6 +19,8 @@
 
 package edu.umd.cs.findbugs.filter;
 
+import edu.umd.cs.findbugs.util.ClassName;
+
 import java.util.StringTokenizer;
 import java.util.regex.Pattern;
 
@@ -95,7 +97,7 @@ public class SignatureUtil {
         } else if ("void".equals(type)) {
             return "V";
         } else {
-            return "L" + type.replace('.', '/') + ";";
+            return "L" + ClassName.toSlashedClassName(type) + ";";
         }
     }
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/model/ClassFeatureSet.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/model/ClassFeatureSet.java
@@ -24,6 +24,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 
+import edu.umd.cs.findbugs.util.ClassName;
 import org.apache.bcel.Repository;
 import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.Field;
@@ -289,7 +290,7 @@ public class ClassFeatureSet implements XMLWriteable {
         if (signature.startsWith("L")) {
             signature = signature.substring(1, signature.length() - 1).replace('/', '.');
             signature = transformClassName(signature);
-            signature = "L" + signature.replace('.', '/') + ";";
+            signature = "L" + ClassName.toSlashedClassName(signature) + ";";
         }
         buf.append(signature);
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/model/ClassFeatureSet.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/model/ClassFeatureSet.java
@@ -288,7 +288,7 @@ public class ClassFeatureSet implements XMLWriteable {
         }
 
         if (signature.startsWith("L")) {
-            signature = signature.substring(1, signature.length() - 1).replace('/', '.');
+            signature = ClassName.fromFieldSignatureToDottedClassName(signature);
             signature = transformClassName(signature);
             signature = "L" + ClassName.toSlashedClassName(signature) + ";";
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/model/ClassNameRewriterUtil.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/model/ClassNameRewriterUtil.java
@@ -74,7 +74,7 @@ public abstract class ClassNameRewriterUtil {
     public static String rewriteSignature(ClassNameRewriter classNameRewriter, String signature) {
         if (classNameRewriter != IdentityClassNameRewriter.instance() && signature.startsWith("L")) {
 
-            String className = signature.substring(1, signature.length() - 1).replace('/', '.');
+            String className = ClassName.fromFieldSignatureToDottedClassName(signature);
             className = classNameRewriter.rewriteClassName(className);
 
             signature = "L" + ClassName.toSlashedClassName(className) + ";";

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/model/ClassNameRewriterUtil.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/model/ClassNameRewriterUtil.java
@@ -24,6 +24,7 @@ import java.util.Iterator;
 import edu.umd.cs.findbugs.FieldAnnotation;
 import edu.umd.cs.findbugs.MethodAnnotation;
 import edu.umd.cs.findbugs.ba.SignatureParser;
+import edu.umd.cs.findbugs.util.ClassName;
 
 /**
  * Utility methods for using a ClassNameRewriter.
@@ -76,7 +77,7 @@ public abstract class ClassNameRewriterUtil {
             String className = signature.substring(1, signature.length() - 1).replace('/', '.');
             className = classNameRewriter.rewriteClassName(className);
 
-            signature = "L" + className.replace('.', '/') + ";";
+            signature = "L" + ClassName.toSlashedClassName(className) + ";";
         }
 
         return signature;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/ClassName.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/ClassName.java
@@ -147,11 +147,11 @@ public abstract class ClassName {
     @DottedClassName
     public static @CheckForNull String fromFieldSignatureToDottedClassName(String signature) {
         String slashedClassName = ClassName.fromFieldSignature(signature);
-        if (slashedClassName != null) {
-            return toDottedClassName(slashedClassName);
-        } else {
+        if (slashedClassName == null) {
             return null;
         }
+
+        return toDottedClassName(slashedClassName);
     }
 
     /**

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/ClassName.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/ClassName.java
@@ -137,6 +137,24 @@ public abstract class ClassName {
     }
 
     /**
+     * Converts from signature to dotted class name
+     * (e.g., from Ljava/lang/String; to java.lang.String).
+     * Returns null if it is the signature for an array or primitive type.
+     *
+     * @param signature a class signature
+     * @return the class of the signature in dotted format
+     */
+    @DottedClassName
+    public static @CheckForNull String fromFieldSignatureToDottedClassName(String signature) {
+        String slashedClassName = ClassName.fromFieldSignature(signature);
+        if (slashedClassName != null) {
+            return toDottedClassName(slashedClassName);
+        } else {
+            return null;
+        }
+    }
+
+    /**
      * extract the package name from a dotted class name. Package names are
      * always in dotted format.
      *

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/MutableClasses.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/MutableClasses.java
@@ -166,7 +166,7 @@ public class MutableClasses {
         private String getSig() {
             String local = sig;
             if (local == null) {
-                sig = local = "L" + cls.getClassName().replace('.', '/') + ";";
+                sig = local = "L" + ClassName.toSlashedClassName(cls.getClassName()) + ";";
             }
             return local;
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/MutableClasses.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/MutableClasses.java
@@ -72,7 +72,7 @@ public class MutableClasses {
             return false;
         }
 
-        String dottedClassName = sig.substring(1, sig.length() - 1).replace('/', '.');
+        String dottedClassName = ClassName.fromFieldSignatureToDottedClassName(sig);
         int lastDot = dottedClassName.lastIndexOf('.');
 
         if (lastDot >= 0) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/visitclass/AnnotationVisitor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/visitclass/AnnotationVisitor.java
@@ -265,11 +265,10 @@ public class AnnotationVisitor extends PreorderVisitor {
             for (AnnotationEntry ae : e.getAnnotationEntries()) {
                 boolean runtimeVisible = ae.isRuntimeVisible();
 
-                String name = ClassName.fromFieldSignature(ae.getAnnotationType());
+                String name = ClassName.fromFieldSignatureToDottedClassName(ae.getAnnotationType());
                 if (name == null) {
                     continue;
                 }
-                name = ClassName.toDottedClassName(name);
                 Map<String, ElementValue> map = new HashMap<>();
                 for (ElementValuePair ev : ae.getElementValuePairs()) {
                     map.put(ev.getNameString(), ev.getValue());
@@ -291,11 +290,10 @@ public class AnnotationVisitor extends PreorderVisitor {
     public void visitAnnotation(Annotations arg0) {
         for (AnnotationEntry ae : arg0.getAnnotationEntries()) {
             boolean runtimeVisible = ae.isRuntimeVisible();
-            String name = ClassName.fromFieldSignature(ae.getAnnotationType());
+            String name = ClassName.fromFieldSignatureToDottedClassName(ae.getAnnotationType());
             if (name == null) {
                 continue;
             }
-            name = ClassName.toDottedClassName(name);
             Map<String, ElementValue> map = new HashMap<>();
             for (ElementValuePair ev : ae.getElementValuePairs()) {
                 map.put(ev.getNameString(), ev.getValue());

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/visitclass/PreorderVisitor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/visitclass/PreorderVisitor.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import edu.umd.cs.findbugs.util.ClassName;
 import org.apache.bcel.Const;
 import org.apache.bcel.classfile.AnnotationDefault;
 import org.apache.bcel.classfile.AnnotationEntry;
@@ -416,11 +417,11 @@ public class PreorderVisitor extends BetterVisitor {
         thisClass = obj;
         ConstantClass c = (ConstantClass) constantPool.getConstant(obj.getClassNameIndex());
         className = getStringFromIndex(c.getNameIndex());
-        dottedClassName = className.replace('/', '.');
+        dottedClassName = ClassName.toDottedClassName(className);
         packageName = obj.getPackageName();
         sourceFile = obj.getSourceFileName();
         dottedSuperclassName = obj.getSuperclassName();
-        superclassName = dottedSuperclassName.replace('.', '/');
+        superclassName = ClassName.toSlashedClassName(dottedSuperclassName);
 
         ClassDescriptor cDesc = DescriptorFactory.createClassDescriptor(className);
         if (!FindBugs.isNoAnalysis()) {
@@ -694,7 +695,7 @@ public class PreorderVisitor extends BetterVisitor {
             throw new IllegalStateException("getDottedMethodSig called while not visiting method");
         }
         if (dottedMethodSig == null) {
-            dottedMethodSig = getMethodSig().replace('/', '.');
+            dottedMethodSig = ClassName.toDottedClassName(getMethodSig());
         }
         return dottedMethodSig;
     }
@@ -748,7 +749,7 @@ public class PreorderVisitor extends BetterVisitor {
             throw new IllegalStateException("getDottedFieldSig called while not visiting field");
         }
         if (dottedFieldSig == null) {
-            dottedFieldSig = fieldSig.replace('/', '.');
+            dottedFieldSig = ClassName.toDottedClassName(fieldSig);
         }
         return dottedFieldSig;
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/visitclass/PrintClass.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/visitclass/PrintClass.java
@@ -27,6 +27,7 @@ import java.util.TreeSet;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
+import edu.umd.cs.findbugs.util.ClassName;
 import org.apache.bcel.classfile.ClassParser;
 import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.JavaClass;
@@ -103,7 +104,7 @@ public class PrintClass {
             System.err.println("list: No input files specified");
         } else if (zip_file != null) {
             for (int i = 0; i < files; i++) {
-                file_name[i] = file_name[i].replace('.', '/');
+                file_name[i] = ClassName.toSlashedClassName(file_name[i]);
             }
             try (ZipFile z = new ZipFile(zip_file)) {
                 TreeSet<ZipEntry> zipEntries = new TreeSet<>(new ZipEntryComparator());

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/CountClassVersions.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/CountClassVersions.java
@@ -39,6 +39,7 @@ import edu.umd.cs.findbugs.FindBugs;
 import edu.umd.cs.findbugs.charsets.UTF8;
 import edu.umd.cs.findbugs.charsets.UserTextFile;
 import edu.umd.cs.findbugs.config.CommandLine;
+import edu.umd.cs.findbugs.util.ClassName;
 import edu.umd.cs.findbugs.util.DualKeyHashMap;
 import edu.umd.cs.findbugs.util.Util;
 
@@ -139,7 +140,7 @@ public class CountClassVersions {
                     if (!name.endsWith(".class")) {
                         continue;
                     }
-                    if (!name.replace('/', '.').startsWith(commandLine.prefix)) {
+                    if (!ClassName.toDottedClassName(name).startsWith(commandLine.prefix)) {
                         continue;
                     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/FileBugHash.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/FileBugHash.java
@@ -33,6 +33,7 @@ import edu.umd.cs.findbugs.PackageStats.ClassStats;
 import edu.umd.cs.findbugs.SortedBugCollection;
 import edu.umd.cs.findbugs.SourceLineAnnotation;
 import edu.umd.cs.findbugs.charsets.UTF8;
+import edu.umd.cs.findbugs.util.ClassName;
 import edu.umd.cs.findbugs.util.Util;
 
 /**
@@ -60,7 +61,7 @@ public class FileBugHash {
                 if (path.indexOf('.') == -1) {
                     path = cStat.getSourceFile();
                 } else {
-                    path = path.substring(0, path.lastIndexOf('.') + 1).replace('.', '/') + cStat.getSourceFile();
+                    path = ClassName.toSlashedClassName(path.substring(0, path.lastIndexOf('.') + 1)) + cStat.getSourceFile();
                 }
                 counts.put(path, 0);
                 Integer size = sizes.get(path);
@@ -73,7 +74,7 @@ public class FileBugHash {
         for (BugInstance bug : bugs.getCollection()) {
             SourceLineAnnotation source = bug.getPrimarySourceLineAnnotation();
 
-            String packagePath = source.getPackageName().replace('.', '/');
+            String packagePath = ClassName.toSlashedClassName(source.getPackageName());
             String key;
             if (packagePath.length() == 0) {
                 key = source.getSourceFile();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/RejarClassesForAnalysis.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/RejarClassesForAnalysis.java
@@ -359,7 +359,7 @@ public class RejarClassesForAnalysis {
                     }
                     String name = ze.getName();
 
-                    String dottedName = name.replace('/', '.');
+                    String dottedName = ClassName.toDottedClassName(name);
                     if (exclude(dottedName)) {
                         return;
                     }
@@ -416,7 +416,7 @@ public class RejarClassesForAnalysis {
                 }
 
                 String name = ze.getName();
-                String dottedName = name.replace('/', '.');
+                String dottedName = ClassName.toDottedClassName(name);
                 if (!exclude(dottedName)) {
                     classFileFound = true;
                     long timestamp = ze.getTime();
@@ -498,7 +498,7 @@ public class RejarClassesForAnalysis {
 
 
                 String name = ze.getName();
-                String dottedName = name.replace('/', '.');
+                String dottedName = ClassName.toDottedClassName(name);
                 if (exclude(dottedName)) {
                     return;
                 }
@@ -547,7 +547,7 @@ public class RejarClassesForAnalysis {
                 }
 
                 String name = ze.getName();
-                String dottedName = name.replace('/', '.');
+                String dottedName = ClassName.toDottedClassName(name);
 
                 if (exclude(dottedName)) {
                     return;


### PR DESCRIPTION
A lot of the times the conversion from dotted to slashed names and wise versa are done on the spot, without much context and adding the annotations. There are already functions for these in the `ClassName` util class. This PR mainly uses these util functions wherever it's possible, and adds the `fromFieldSignatureToDottedClassName()` method to `ClassName`, since the `fromFieldSignature()` and `toDottedClassName()` methods are used together quite frequently.
I didn't add a changelog entry, since I don't think it's necessary.