### PR TITLE
Update release gha to only run on tags on master

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
         continue-on-error: true
 
       - name: Commit CHANGELOG.md
+        if: (github.ref_type == 'tag') && (github.event.base_ref == 'refs/heads/master')
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           branch: ${{ github.base_ref}}
@@ -53,13 +54,28 @@ jobs:
           curl -L 'https://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops4/R-4.29-202309031000/eclipse-SDK-4.29-linux-gtk-x86_64.tar.gz&r=1' --output eclipse-SDK-4.29-linux-gtk-x86_64.tar.gz
           tar xzvf eclipse-SDK-4.29-linux-gtk-x86_64.tar.gz eclipse
           echo "eclipseRoot.dir=$(pwd)/eclipse" > eclipsePlugin/local.properties
-      - name: Build
+      - name: Build on tag
+        if: (github.ref_type == 'tag') && (github.event.base_ref == 'refs/heads/master')
         run: |
           gpg --quiet --batch --yes --decrypt --passphrase="$GPG_SECRET_PASSPHRASE" --output spotbugs.jks .github/workflows/spotbugs.jks.gpg
           echo sonatypeUsername=eller86 >> gradle.properties
           echo "sonatypePassword=${SONATYPE_PASSWORD}" >> gradle.properties
           echo "keystorepass=${KEYSTORE_PASS}" >> gradle.properties
           ./gradlew assemble publishToSonatype closeAndReleaseSonatypeStagingRepository createReleaseBody --no-daemon
+        env:
+          GPG_SECRET_PASSPHRASE: ${{ secrets.GPG_SECRET_PASSPHRASE }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+          KEYSTORE_PASS: ${{ secrets.KEYSTORE_PASS }}
+      - name: Build otherwise
+        if: (!(github.ref_type == 'tag') && (github.event.base_ref == 'refs/heads/master'))
+        run: |
+          gpg --quiet --batch --yes --decrypt --passphrase="$GPG_SECRET_PASSPHRASE" --output spotbugs.jks .github/workflows/spotbugs.jks.gpg
+          echo sonatypeUsername=eller86 >> gradle.properties
+          echo "sonatypePassword=${SONATYPE_PASSWORD}" >> gradle.properties
+          echo "keystorepass=${KEYSTORE_PASS}" >> gradle.properties
+          ./gradlew assemble publishToSonatype createReleaseBody --no-daemon
         env:
           GPG_SECRET_PASSPHRASE: ${{ secrets.GPG_SECRET_PASSPHRASE }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
@@ -99,7 +115,7 @@ jobs:
         # https://github.com/actions/upload-release-asset/issues/28#issuecomment-617208601
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: startsWith(github.ref, 'refs/tags/')
+        if: (github.ref_type == 'tag') && (github.event.base_ref == 'refs/heads/master')
         run: |
           set -x
           curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.1

--- a/RELEASE_PROCEDURE.md
+++ b/RELEASE_PROCEDURE.md
@@ -8,6 +8,8 @@ When you release fixed version of SpotBugs, please follow these procedures.
 * version number in `CHANGELOG.md`
 * `version`, `full_version`, `maven_plugin_version` and `gradle_plugin_version` in `docs/conf.py`
 
+The PR containing these changes needs to be rebased and merged to master. Since the rebase changes the commit ids, a tag needs to be created on master and pushed there. The push of this tag starts the release CI job.
+
 ## Release to Maven Central
 
 When we push a tag, the build result on GitHub Actions will be deployed to the [SonaType Nexus](https://oss.sonatype.org/), and published to the Maven Central automatically by [Gradle Nexus Publish Plugin](https://github.com/gradle-nexus/publish-plugin). Then we can find [artifacts in the Maven Central](https://repo1.maven.org/maven2/com/github/spotbugs/) after several hours.


### PR DESCRIPTION
This PR updates the release gha to some steps only run on tags pushed to master, and updates the release process documentation.

During the release of 4.8.3 (see https://github.com/spotbugs/spotbugs/pull/2765), I stumbled upon some issues, because the tag created on a separate branch for the release started the release procedure.
The PR containing the release can only be merged by `rebase and merge`, since `create a merge commit` is disabled for the repository, and `squash and merge` would not keep the the commits separate, which needs to be kept separate (and also change the commit ids). The rebase changes the commit ids, which means that the tag, which kicks in the release process, needs to be pushed to the master branch, after the release PR is merged.

I tested this solution on my repository with a simple [test.yml](https://github.com/JuditKnoll/spotbugs/blob/master/.github/workflows/test.yml), which only echoes some values, the `Echo on tag if condition` step has the same condition as this PR.
- when the tag is pushed on to separate branch, which is later merged to master, [the job only runs when pushing the tag, so the relevant step does not run](https://github.com/JuditKnoll/spotbugs/actions/runs/7448441800/job/20263873941),
- when there is no tag, just a commit pushed to master, [the relevant step does not run](https://github.com/JuditKnoll/spotbugs/actions/runs/7448533288/job/20263124283),
- when the tag is only pushed to master, [the relevant step runs](https://github.com/JuditKnoll/spotbugs/actions/runs/7448557603/job/20263201209).