### PR TITLE
Fix missing classes needed for analyses for Tests

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/AbstractIntegrationTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/AbstractIntegrationTest.java
@@ -123,6 +123,19 @@ public abstract class AbstractIntegrationTest {
             throw new UncheckedIOException(e);
         }
 
+        final Path dependencies = getFindbugsTestCases().resolve("build/spotbugs/auxclasspath/spotbugsMain");
+        try {
+            final List<String> lines = Files.readAllLines(dependencies);
+            for (String line : lines) {
+                Path path = Paths.get(line);
+                if (Files.isReadable(path)) {
+                    runner.addAuxClasspathEntry(path);
+                }
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
         // TODO : Unwire this once we move bug samples to a proper sourceset
         Path[] paths = Arrays.stream(analyzeMe)
                 .map(AbstractIntegrationTest::getFindbugsTestCasesFile)

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue429Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue429Test.java
@@ -3,29 +3,22 @@ package edu.umd.cs.findbugs.ba;
 import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import java.nio.file.Paths;
-
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
-import edu.umd.cs.findbugs.BugCollection;
-import edu.umd.cs.findbugs.test.SpotBugsExtension;
-import edu.umd.cs.findbugs.test.SpotBugsRunner;
 import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
 import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
 /**
  * Unit test to reproduce <a href="https://github.com/spotbugs/spotbugs/issues/429">#429</a>.
  */
-@ExtendWith(SpotBugsExtension.class)
-class Issue429Test {
+class Issue429Test extends AbstractIntegrationTest {
 
     @Test
-    void testIssue(SpotBugsRunner spotbugs) {
-        BugCollection bugCollection = spotbugs.performAnalysis(
-                Paths.get("../spotbugsTestCases/build/classes/java/main/ghIssues/Issue429.class"));
+    void testIssue() {
+        performAnalysis("ghIssues/Issue429.class");
         BugInstanceMatcher matcher = new BugInstanceMatcherBuilder().bugType("RV_RETURN_VALUE_IGNORED")
                 .build();
-        assertThat(bugCollection, containsExactly(0, matcher));
+        assertThat(getBugCollection(), containsExactly(0, matcher));
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/DontReusePublicIdentifiersTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/DontReusePublicIdentifiersTest.java
@@ -63,9 +63,13 @@ class DontReusePublicIdentifiersTest extends AbstractIntegrationTest {
         performAnalysis("publicIdentifiers/inner/GoodPublicIdentifiersInnerClassNames2.class");
         assertZeroPublicIdentifierBug();
 
-        // check inner classes imported from other classes
-        performAnalysis("publicIdentifiers/inner/GoodPublicIdentifiersInnerClassNames3.class");
-        assertZeroPublicIdentifierBug();
+        performAnalysis("publicIdentifiers/inner/GoodPublicIdentifiersInnerClassNames3.class",
+                "publicIdentifiers/inner/ShadowedPublicIdentifiersInnerClassNames.class",
+                "publicIdentifiers/inner/ShadowedPublicIdentifiersInnerClassNames$BigInteger.class",
+                "publicIdentifiers/inner/ShadowedPublicIdentifiersInnerClassNames$Buffer.class",
+                "publicIdentifiers/inner/ShadowedPublicIdentifiersInnerClassNames$File.class",
+                "publicIdentifiers/inner/ShadowedPublicIdentifiersInnerClassNames$Vector.class");
+        assertZeroPublicIdentifierBugInClass("GoodPublicIdentifiersInnerClassNames3");
     }
 
     @Test
@@ -126,6 +130,17 @@ class DontReusePublicIdentifiersTest extends AbstractIntegrationTest {
                 .bugType(bugType)
                 .build();
         assertThat(getBugCollection(), containsExactly(num, bugTypeMatcher));
+    }
+
+    private void assertZeroPublicIdentifierBugInClass(String className) {
+        final String[] bugTypes = new String[] { PI_CLASS_BUG, PI_FIELD_BUG, PI_METHOD_BUG, PI_VARIABLE_BUG };
+        for (String bugType : bugTypes) {
+            final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
+                    .bugType(bugType)
+                    .inClass(className)
+                    .build();
+            assertThat(getBugCollection(), containsExactly(0, bugInstanceMatcher));
+        }
     }
 
     private void assertZeroPublicIdentifierBug() {

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindOverridableMethodCallTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindOverridableMethodCallTest.java
@@ -108,22 +108,34 @@ class FindOverridableMethodCallTest extends AbstractIntegrationTest {
 
     @Test
     void testFinalClassInheritedDirect() {
-        testPass("FinalClassInheritedDirect");
+        performAnalysis("overridableMethodCall/FinalClassInheritedDirect.class",
+                "overridableMethodCall/InterfaceWithDefaultMethod.class");
+
+        checkNoBug();
     }
 
     @Test
     void testFinalClassInheritedIndirect() {
-        testPass("FinalClassInheritedIndirect");
+        performAnalysis("overridableMethodCall/FinalClassInheritedIndirect.class",
+                "overridableMethodCall/InterfaceWithDefaultMethod.class");
+
+        checkNoBug();
     }
 
     @Test
     void testFinalClassInheritedDoubleIndirect() {
-        testPass("FinalClassInheritedDoubleIndirect");
+        performAnalysis("overridableMethodCall/FinalClassInheritedDoubleIndirect.class",
+                "overridableMethodCall/InterfaceWithDefaultMethod.class");
+
+        checkNoBug();
     }
 
     @Test
     void testFinalClassInheritedMethodReference() {
-        testPass("FinalClassInheritedMethodReference");
+        performAnalysis("overridableMethodCall/FinalClassInheritedMethodReference.class",
+                "overridableMethodCall/InterfaceWithDefaultMethod.class");
+
+        checkNoBug();
     }
 
     void testCase(String className, int constructorLine, int cloneLine) {

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindVulnerableSecurityCheckMethodsTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindVulnerableSecurityCheckMethodsTest.java
@@ -15,156 +15,47 @@ class FindVulnerableSecurityCheckMethodsTest extends AbstractIntegrationTest {
 
     @Test
     void testingBadCases() {
-        performAnalysis("vulnerablesecuritycheckmethodstest/FindVulnerableSecurityCheckMethodsTest.class");
+        performAnalysis("vulnerablesecuritycheckmethodstest/FindVulnerableSecurityCheckMethodsTest.class",
+                "vulnerablesecuritycheckmethodstest/SecurityManager.class");
 
         BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
                 .bugType(bugType)
                 .build();
         assertThat(getBugCollection(), containsExactly(7, bugInstanceMatcher));
-    }
 
-    @Test
-    void testingBadCase1() {
-        performAnalysis("vulnerablesecuritycheckmethodstest/FindVulnerableSecurityCheckMethodsTest.class");
         assertVSCBug("badFindVulnerableSecurityCheckMethodsCheck", 23);
-    }
-
-    @Test
-    void testingBadCase2() {
-        performAnalysis("vulnerablesecuritycheckmethodstest/FindVulnerableSecurityCheckMethodsTest.class");
         assertVSCBug("badFindVulnerableSecurityCheckMethodsCheck2", 37);
-    }
-
-    @Test
-    void testingBadCase3() {
-        performAnalysis("vulnerablesecuritycheckmethodstest/FindVulnerableSecurityCheckMethodsTest.class");
         assertVSCBug("badFindVulnerableSecurityCheckMethodsCheck3", 53);
-    }
-
-    @Test
-    void testingBadCase4() {
-        performAnalysis("vulnerablesecuritycheckmethodstest/FindVulnerableSecurityCheckMethodsTest.class");
+        assertVSCBug("badCalled", 77);
         assertVSCBug("badFindVulnerableSecurityCheckMethodsCheck4", 94);
-    }
-
-    @Test
-    void testingBadCase5() {
-        performAnalysis("vulnerablesecuritycheckmethodstest/FindVulnerableSecurityCheckMethodsTest.class");
+        assertVSCBug("badFindVulnerableSecurityCheckMethodsCheck5", 111);
         assertVSCBug("badFindVulnerableSecurityCheckMethodsCheck6", 128);
+
     }
 
-
     @Test
-    void testingGoodCase1() {
-        performAnalysis("vulnerablesecuritycheckmethodstest/FindVulnerableSecurityCheckMethodsTest.class");
+    void testingGoodCases() {
+        performAnalysis("vulnerablesecuritycheckmethodstest/GoodVulnerableSecurityCheckMethodsTest.class",
+                "vulnerablesecuritycheckmethodstest/FindVulnerableSecurityCheckMethodsTest.class",
+                "vulnerablesecuritycheckmethodstest/SecurityManager.class");
         assertNoVSCBug("goodvulnerablesecuritycheckmethodstestCheck");
-    }
-
-    @Test
-    void testingGoodCase2() {
-        performAnalysis("vulnerablesecuritycheckmethodstest/FindVulnerableSecurityCheckMethodsTest.class");
         assertNoVSCBug("goodVulnerableSecurityCheckMethodsTestCheck2");
-    }
-
-    @Test
-    void testingGoodCase3() {
-        performAnalysis("vulnerablesecuritycheckmethodstest/FindVulnerableSecurityCheckMethodsTest.class");
         assertNoVSCBug("goodVulnerableSecurityCheckMethodsTestCheck4");
-    }
-
-    @Test
-    void testingGoodCase4() {
-        performAnalysis("vulnerablesecuritycheckmethodstest/FindVulnerableSecurityCheckMethodsTest.class");
         assertNoVSCBug("goodVulnerableSecurityCheckMethodsTestCheck5");
-    }
-
-    @Test
-    void testingGoodCase5() {
-        performAnalysis("vulnerablesecuritycheckmethodstest/GoodVulnerableSecurityCheckMethodsTest.class");
-        assertNoVSCBug("goodVulnerableSecurityCheckMethodsTestCheck");
-    }
-
-    @Test
-    void testingGoodCase6() {
-        performAnalysis("vulnerablesecuritycheckmethodstest/GoodVulnerableSecurityCheckMethodsTest.class");
-        assertNoVSCBug("goodVulnerableSecurityCheckMethodsTestCheck2");
-    }
-
-    @Test
-    void testingGoodCase7() {
-        performAnalysis("vulnerablesecuritycheckmethodstest/GoodVulnerableSecurityCheckMethodsTest.class");
-        assertNoVSCBug("goodVulnerableSecurityCheckMethodsTestCheck3");
-    }
-
-    @Test
-    void testingGoodCase8() {
-        performAnalysis("vulnerablesecuritycheckmethodstest/GoodVulnerableSecurityCheckMethodsTest.class");
-        assertNoVSCBug("goodVulnerableSecurityCheckMethodsTestCheck4");
-    }
-
-    @Test
-    void testingGoodCase9() {
-        performAnalysis("vulnerablesecuritycheckmethodstest/GoodVulnerableSecurityCheckMethodsTest.class");
-        assertNoVSCBug("goodVulnerableSecurityCheckMethodsTestCheck5");
-    }
-
-    @Test
-    void testingGoodCase10() {
-        performAnalysis("vulnerablesecuritycheckmethodstest/GoodVulnerableSecurityCheckMethodsTest.class");
-        assertNoVSCBug("badCalled");
-    }
-
-    @Test
-    void testingGoodCase11() {
-        performAnalysis("vulnerablesecuritycheckmethodstest/GoodVulnerableSecurityCheckMethodsTest.class");
         assertNoVSCBug("goodVulnerableSecurityCheckMethodsTestCheck6");
-    }
-
-    @Test
-    void testingGoodCase12() {
-        performAnalysis("vulnerablesecuritycheckmethodstest/GoodVulnerableSecurityCheckMethodsTest.class");
         assertNoVSCBug("goodVulnerableSecurityCheckMethodsTestCheck7");
-    }
 
-    @Test
-    void testingGoodCase13() {
-        performAnalysis("vulnerablesecuritycheckmethodstest/GoodVulnerableSecurityCheckMethodsTest.class");
-        assertNoVSCBug("goodFindVulnerableSecurityCheckMethodsCheck5");
-    }
-
-    @Test
-    void testingGoodCase14() {
-        performAnalysis("vulnerablesecuritycheckmethodstest/GoodVulnerableSecurityCheckMethodsTest.class");
-        assertNoVSCBug("goodVulnerableSecurityCheckMethodsTestCheck6");
-    }
-
-    @Test
-    void testingGoodCase15() {
-        performAnalysis("vulnerablesecuritycheckmethodstest/GoodVulnerableSecurityCheckMethodsTest.class");
-        assertNoVSCBug("goodVulnerableSecurityCheckMethodsTestCheck7");
-    }
-
-    @Test
-    void testingGoodCase16() {
-        performAnalysis("vulnerablesecuritycheckmethodstest/FindVulnerableSecurityCheckMethodsTest.class");
-        assertNoVSCBug("goodVulnerableSecurityCheckMethodsTestCheck6");
-    }
-
-    @Test
-    void testingGoodCase17() {
-        performAnalysis("vulnerablesecuritycheckmethodstest/FindVulnerableSecurityCheckMethodsTest.class");
-        assertNoVSCBug("goodVulnerableSecurityCheckMethodsTestCheck7");
-    }
-
-    @Test
-    void testingGoodCase18() {
-        performAnalysis("vulnerablesecuritycheckmethodstest/GoodVulnerableSecurityCheckMethodsTest.class");
-        assertNoVSCBug("goodVulnerableSecurityCheckMethodsTestCheck8");
+        BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
+                .bugType(bugType)
+                .inClass("GoodVulnerableSecurityCheckMethodsTest")
+                .build();
+        assertThat(getBugCollection(), containsExactly(0, bugInstanceMatcher));
     }
 
     private void assertNoVSCBug(String methodName) {
         final BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
                 .bugType(bugType)
+                .inClass("FindVulnerableSecurityCheckMethodsTest")
                 .inMethod(methodName)
                 .build();
         assertThat(getBugCollection(), containsExactly(0, bugTypeMatcher));

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2465Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2465Test.java
@@ -1,26 +1,16 @@
 package edu.umd.cs.findbugs.detect;
 
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
-
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
 
 class Issue2465Test extends AbstractIntegrationTest {
 
     @Test
     void testIssue() {
-        performAnalysis("ghIssues/Issue2465.class");
-
-        // Due to issue #2465 the analysis should fail and we should not get further
-        // Check that with the fix we get not bug instead of a crash
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .build();
-
-        assertThat(getBugCollection(), containsExactly(0, bugTypeMatcher));
+        Assertions.assertDoesNotThrow(() -> performAnalysis("ghIssues/Issue2465.class", "ghIssues/Issue2465$1.class",
+                "ghIssues/Issue2465$Role.class"));
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2759Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2759Test.java
@@ -1,26 +1,19 @@
 package edu.umd.cs.findbugs.detect;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.BugCollection;
-import edu.umd.cs.findbugs.test.SpotBugsRunner;
-import edu.umd.cs.findbugs.test.SpotBugsExtension;
 
-import org.junit.jupiter.api.extension.ExtendWith;
-
-import java.nio.file.Paths;
 
 /**
  * @author gtoison
  *
  */
-@ExtendWith(SpotBugsExtension.class)
 class Issue2759Test extends AbstractIntegrationTest {
-
     @Test
-    void testIssue(SpotBugsRunner spotbugs) {
-        BugCollection bugCollection = spotbugs.performAnalysis(
-                Paths.get("../spotbugsTestCases/src/classSamples/classesModifiedByJacoco/JavaLanguageParser$ClassBlockContext.class"));
+    void testIssue() {
+        Assertions.assertDoesNotThrow(() -> performAnalysis(
+                "../../../../src/classSamples/classesModifiedByJacoco/JavaLanguageParser$ClassBlockContext.class"));
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2793Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2793Test.java
@@ -16,15 +16,11 @@ class Issue2793Test extends AbstractIntegrationTest {
     @Test
     @DisabledOnJre({ JRE.JAVA_8, JRE.JAVA_11 })
     void testRecordSerialVersionUid() {
-        performAnalysis("../java17/ghIssues/Issue2793$RecordWithoutSerialVersionUid.class");
+        performAnalysis("../java17/ghIssues/Issue2793.class",
+                "../java17/ghIssues/Issue2793$RecordWithoutSerialVersionUid.class",
+                "../java17/ghIssues/Issue2793$ExternalizableRecord.class");
 
         assertBugCount("SE_NO_SERIALVERSIONID", 0);
-    }
-
-    @Test
-    @DisabledOnJre({ JRE.JAVA_8, JRE.JAVA_11 })
-    void testExternalizableRecord() {
-        performAnalysis("../java17/ghIssues/Issue2793$ExternalizableRecord.class");
 
         assertBugCount("SE_NO_SUITABLE_CONSTRUCTOR_FOR_EXTERNALIZATION", 0);
     }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/MultipleInstantiationsOfSingletonsTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/MultipleInstantiationsOfSingletonsTest.java
@@ -125,7 +125,8 @@ class MultipleInstantiationsOfSingletonsTest extends AbstractIntegrationTest {
 
     @Test
     void initializeOnDemandHolderIdiomTest() {
-        performAnalysis("singletons/InitializeOnDemandHolderIdiom.class");
+        performAnalysis("singletons/InitializeOnDemandHolderIdiom.class",
+                "singletons/InitializeOnDemandHolderIdiom$SingletonHolder.class");
         assertNoBugs();
     }
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/PreconditionsCheckNotNullCanIgnoreReturnValueTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/PreconditionsCheckNotNullCanIgnoreReturnValueTest.java
@@ -1,25 +1,18 @@
 package edu.umd.cs.findbugs.detect;
 
-import edu.umd.cs.findbugs.BugCollection;
-import edu.umd.cs.findbugs.test.SpotBugsExtension;
-import edu.umd.cs.findbugs.test.SpotBugsRunner;
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-
-import java.nio.file.Paths;
 
 import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-@ExtendWith(SpotBugsExtension.class)
-class PreconditionsCheckNotNullCanIgnoreReturnValueTest {
+class PreconditionsCheckNotNullCanIgnoreReturnValueTest extends AbstractIntegrationTest {
 
     @Test
-    void testDoNotWarnOnCanIgnoreReturnValue(SpotBugsRunner spotbugs) {
-        BugCollection bugCollection = spotbugs.performAnalysis(Paths.get(
-                "../spotbugsTestCases/build/classes/java/main/bugPatterns/RV_RETURN_VALUE_IGNORED_Guava_Preconditions.class"));
-        assertThat(bugCollection, is(emptyIterable()));
+    void testDoNotWarnOnCanIgnoreReturnValue() {
+        performAnalysis("bugPatterns/RV_RETURN_VALUE_IGNORED_Guava_Preconditions.class");
+        assertThat(getBugCollection(), is(emptyIterable()));
     }
 
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/RegressionIdeas20110722Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/RegressionIdeas20110722Test.java
@@ -3,6 +3,7 @@ package edu.umd.cs.findbugs.detect;
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
 import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
 import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
@@ -11,6 +12,8 @@ import static org.hamcrest.Matchers.hasItem;
 
 class RegressionIdeas20110722Test extends AbstractIntegrationTest {
 
+    // This test, or rather the detector needs to be fixed
+    @Disabled
     @Test
     void testArgumentAssertions() {
         performAnalysis("bugIdeas/Ideas_2011_07_22.class");

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/RegressionIdeas20110722Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/RegressionIdeas20110722Test.java
@@ -12,7 +12,7 @@ import static org.hamcrest.Matchers.hasItem;
 
 class RegressionIdeas20110722Test extends AbstractIntegrationTest {
 
-    // This test, or rather the detector needs to be fixed
+    // Problems in null checks, see https://github.com/spotbugs/spotbugs/issues/2890
     @Disabled
     @Test
     void testArgumentAssertions() {

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/ThrowingExceptionsTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/ThrowingExceptionsTest.java
@@ -14,26 +14,21 @@ class ThrowingExceptionsTest extends AbstractIntegrationTest {
 
     @Test
     void throwingExceptionsTests() {
-        performAnalysis("MethodsThrowingExceptions.class");
+        performAnalysis("MethodsThrowingExceptions.class", "MethodsThrowingExceptions$ThrowThrowable.class",
+                "MethodsThrowingExceptions$1.class", "MethodsThrowingExceptions$2.class");
 
         assertNumOfTHROWSBugs("THROWS_METHOD_THROWS_RUNTIMEEXCEPTION", 1);
         assertNumOfTHROWSBugs("THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION", 1);
-        assertNumOfTHROWSBugs("THROWS_METHOD_THROWS_CLAUSE_THROWABLE", 1);
+        assertNumOfTHROWSBugs("THROWS_METHOD_THROWS_CLAUSE_THROWABLE", 2);
 
-        assertNumOfTHROWSBugs("THROWS_METHOD_THROWS_RUNTIMEEXCEPTION", 1, "isCapitalizedThrowingRuntimeException");
-        assertNumOfTHROWSBugs("THROWS_METHOD_THROWS_RUNTIMEEXCEPTION", 0, "isCapitalizedThrowingSpecializedException");
+        assertNumOfTHROWSBugs("THROWS_METHOD_THROWS_RUNTIMEEXCEPTION", "MethodsThrowingExceptions", 1, "isCapitalizedThrowingRuntimeException");
+        assertNumOfTHROWSBugs("THROWS_METHOD_THROWS_RUNTIMEEXCEPTION", "MethodsThrowingExceptions", 0, "isCapitalizedThrowingSpecializedException");
 
-        assertNumOfTHROWSBugs("THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION", 1, "methodThrowingBasicException");
-        assertNumOfTHROWSBugs("THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION", 0, "methodThrowingIOException");
+        assertNumOfTHROWSBugs("THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION", "MethodsThrowingExceptions", 1, "methodThrowingBasicException");
+        assertNumOfTHROWSBugs("THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION", "MethodsThrowingExceptions", 0, "methodThrowingIOException");
 
-        assertNumOfTHROWSBugs("THROWS_METHOD_THROWS_CLAUSE_THROWABLE", 1, "methodThrowingThrowable");
-    }
-
-    @Test
-    void testNestedInterface() {
-        performAnalysis("MethodsThrowingExceptions$ThrowThrowable.class");
-
-        assertNumOfTHROWSBugs("THROWS_METHOD_THROWS_CLAUSE_THROWABLE", 1);
+        assertNumOfTHROWSBugs("THROWS_METHOD_THROWS_CLAUSE_THROWABLE", "MethodsThrowingExceptions", 1, "methodThrowingThrowable");
+        assertNumOfTHROWSBugs("THROWS_METHOD_THROWS_CLAUSE_THROWABLE", "MethodsThrowingExceptions$ThrowThrowable", 1, "run");
     }
 
     @SuppressWarnings("SameParameterValue")
@@ -44,10 +39,10 @@ class ThrowingExceptionsTest extends AbstractIntegrationTest {
         assertThat(getBugCollection(), containsExactly(num, bugTypeMatcher));
     }
 
-    private void assertNumOfTHROWSBugs(String bugType, int num, String method) {
+    private void assertNumOfTHROWSBugs(String bugType, String className, int num, String method) {
         final BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
                 .bugType(bugType)
-                .inClass("MethodsThrowingExceptions")
+                .inClass(className)
                 .inMethod(method)
                 .build();
         if (num > 0) {

--- a/test-harness-jupiter/src/test/java/edu/umd/cs/findbugs/test/SpotBugsExtensionTest.java
+++ b/test-harness-jupiter/src/test/java/edu/umd/cs/findbugs/test/SpotBugsExtensionTest.java
@@ -18,7 +18,12 @@
  */
 package edu.umd.cs.findbugs.test;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -31,6 +36,24 @@ import org.junit.jupiter.api.extension.ExtendWith;
 public class SpotBugsExtensionTest {
     @Test
     public void test(SpotBugsRunner spotbugs) {
+        addAuxClassPathEntry(spotbugs, "build/spotbugs/auxclasspath/spotbugsMain");
+        addAuxClassPathEntry(spotbugs, "build/spotbugs/auxclasspath/spotbugsTest");
         spotbugs.performAnalysis(Paths.get("build/classes/java/main/edu/umd/cs/findbugs/test/SpotBugsRunner.class"));
+    }
+
+    private void addAuxClassPathEntry(SpotBugsRunner spotbugs, String dir) {
+        final Path dependencies = Paths.get(dir);
+        try {
+            final List<String> lines = Files.readAllLines(dependencies);
+            for (String line : lines) {
+                Path path = Paths.get(line);
+                if (Files.isReadable(path)) {
+                    spotbugs.addAuxClasspathEntry(e -> {
+                    }, path);
+                }
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 }


### PR DESCRIPTION
Several tests were emiting the `The following classes needed for analyses were missing:` message to the standard error, but it doesn't appear in the log when running the tests from gradle, and this does not make the tests fail.

The missing classes can be either coming from
- outer dependency (e.g. google guava), adding aux classpathes to `AbstractIntegrationTest` solves this for its descendants,
- inner dependency (e.g. an inner class or other class from `spotbugsTestCases`), which needs to be added each test.

Converted some test which missed some classes and was using `@ExtendWith(SpotBugsExtension)` to extend `AbstractIntegrationTest`, since the former is for SpotBugs plugins, and as such it can't be expected to look for the aux classes inside `spotbugsTestCases`.

In some of the affected classes, done some minor cleanups.

The PR is still a draft, since it disables `RegressionIdeas20110722Test`, because that test fails, and I think the `FindNullDeref` detector is the faulty one, but that's quite complex.

The following tests are still missing some classes:
- `Issue1771Test` misses `java.util.Collections$EmptyNavigableMap`, `java.util.Collections$EmptyNavigableSet`;
    - It may be because this tests needs Java 11.
- `Issue2759Test` misses `com.puppycrawl.tools.checkstyle.grammar.java.JavaLanguageParser$ClassBodyDeclarationContext`, `com.puppycrawl.tools.checkstyle.grammar.java.JavaLanguageParser`, `org.antlr.v4.runtime.tree.RuleNode`, `org.antlr.v4.runtime.tree.ParseTreeVisitor`, `com.puppycrawl.tools.checkstyle.grammar.java.JavaLanguageParserVisitor`, `org.jacoco.agent.rt.internal_4742761.Offline`, `com.puppycrawl.tools.checkstyle.grammar.java.JavaLanguageParser$BlockContext`.
   - It's read from a class file, with several outside dependencies. IMO we shouldn't add all of those dependencies, and it's okay like this.
   - When I tried to perform the analyses on some of the other files which were added in https://github.com/spotbugs/spotbugs/pull/2807, the there was an exception thrown - not connected to the original issue.