### PR TITLE
Improve the CountMatcher mismatches description

### DIFF
--- a/test-harness/src/main/java/edu/umd/cs/findbugs/test/CountMatcher.java
+++ b/test-harness/src/main/java/edu/umd/cs/findbugs/test/CountMatcher.java
@@ -53,4 +53,21 @@ public final class CountMatcher<T> extends TypeSafeMatcher<Iterable<T>> {
     public void describeTo(final Description desc) {
         desc.appendText("Iterable containing exactly ").appendValue(count).appendText(" ").appendDescriptionOf(matcher);
     }
+
+    @Override
+    protected void describeMismatchSafely(Iterable<T> items, Description mismatchDescription) {
+        if (!items.iterator().hasNext()) {
+            mismatchDescription.appendText("The collection was empty");
+        } else {
+            for (final Object item : items) {
+                mismatchDescription.appendText("\n");
+                if (matcher.matches(item)) {
+                    mismatchDescription.appendText("Match:   ");
+                } else {
+                    mismatchDescription.appendText("Mismatch:");
+                }
+                matcher.describeMismatch(item, mismatchDescription);
+            }
+        }
+    }
 }

--- a/test-harness/src/main/java/edu/umd/cs/findbugs/test/matcher/BugInstanceMatcher.java
+++ b/test-harness/src/main/java/edu/umd/cs/findbugs/test/matcher/BugInstanceMatcher.java
@@ -223,26 +223,33 @@ public class BugInstanceMatcher extends BaseMatcher<BugInstance> {
 
         if (item instanceof BugInstance) {
             BugInstance bugInstance = (BugInstance) item;
-            if (bugType != null) {
+            boolean hasCriteria = bugType != null
+                    && className != null
+                    && methodName != null
+                    && fieldName != null
+                    && variableName != null
+                    && lineNumber != null;
+
+            if (bugType != null || !hasCriteria) {
                 description.appendText("bugType=").appendValue(bugInstance.getType()).appendText(",");
             }
-            if (className != null) {
+            if (className != null || !hasCriteria) {
                 ClassAnnotation classAnn = extractBugAnnotation(bugInstance, ClassAnnotation.class);
                 description.appendText("className=").appendValue(classAnn).appendText(",");
             }
-            if (methodName != null) {
+            if (methodName != null || !hasCriteria) {
                 MethodAnnotation methodAnn = extractBugAnnotation(bugInstance, MethodAnnotation.class);
                 description.appendText("methodName=").appendValue(methodAnn).appendText(",");
             }
-            if (fieldName != null) {
+            if (fieldName != null || !hasCriteria) {
                 FieldAnnotation fieldAnn = extractBugAnnotation(bugInstance, FieldAnnotation.class);
                 description.appendText("fieldName=").appendValue(fieldAnn).appendText(",");
             }
-            if (variableName != null) {
+            if (variableName != null || !hasCriteria) {
                 LocalVariableAnnotation localVarAnn = extractBugAnnotation(bugInstance, LocalVariableAnnotation.class);
                 description.appendText("variableName=").appendValue(localVarAnn).appendText(",");
             }
-            if (lineNumber != null) {
+            if (lineNumber != null || !hasCriteria) {
                 SourceLineAnnotation srcAnn = extractBugAnnotation(bugInstance, SourceLineAnnotation.class);
                 description.appendText("lineNumber=").appendValue(srcAnn);
             }

--- a/test-harness/src/main/java/edu/umd/cs/findbugs/test/matcher/BugInstanceMatcher.java
+++ b/test-harness/src/main/java/edu/umd/cs/findbugs/test/matcher/BugInstanceMatcher.java
@@ -216,4 +216,38 @@ public class BugInstanceMatcher extends BaseMatcher<BugInstance> {
             description.appendText("lineNumber=").appendValue(lineNumber);
         }
     }
+
+    @Override
+    public void describeMismatch(Object item, Description description) {
+        description.appendText("was ");
+
+        if (item instanceof BugInstance) {
+            BugInstance bugInstance = (BugInstance) item;
+            if (bugType != null) {
+                description.appendText("bugType=").appendValue(bugInstance.getType()).appendText(",");
+            }
+            if (className != null) {
+                ClassAnnotation classAnn = extractBugAnnotation(bugInstance, ClassAnnotation.class);
+                description.appendText("className=").appendValue(classAnn).appendText(",");
+            }
+            if (methodName != null) {
+                MethodAnnotation methodAnn = extractBugAnnotation(bugInstance, MethodAnnotation.class);
+                description.appendText("methodName=").appendValue(methodAnn).appendText(",");
+            }
+            if (fieldName != null) {
+                FieldAnnotation fieldAnn = extractBugAnnotation(bugInstance, FieldAnnotation.class);
+                description.appendText("fieldName=").appendValue(fieldAnn).appendText(",");
+            }
+            if (variableName != null) {
+                LocalVariableAnnotation localVarAnn = extractBugAnnotation(bugInstance, LocalVariableAnnotation.class);
+                description.appendText("variableName=").appendValue(localVarAnn).appendText(",");
+            }
+            if (lineNumber != null) {
+                SourceLineAnnotation srcAnn = extractBugAnnotation(bugInstance, SourceLineAnnotation.class);
+                description.appendText("lineNumber=").appendValue(srcAnn);
+            }
+        } else {
+            description.appendValue(item);
+        }
+    }
 }


### PR DESCRIPTION
Currently when a unit test fails because the `CountMatcher` did not match the description is not very helpful: it shows the list of bugs with their internationalized message while the matcher is setup with (typically) the bug type, source line, method etc.
This is not great when a bug sample contains true positives and false positives because there's no way to tell the bugs appart.

With this change the relevant bug would be shown, for instance:
```
Issue2782Test > testIssue() FAILED
    java.lang.AssertionError: 
    Expected: Iterable containing exactly <1> BugInstance with:
    bugType="BC_UNCONFIRMED_CAST_OF_RETURN_VALUE",lineNumber=<50>
         but:
    Mismatch:was bugType="BC_UNCONFIRMED_CAST",lineNumber=<At Issue2782.java:[line 50]>
    Mismatch:was bugType="BC_UNCONFIRMED_CAST_OF_RETURN_VALUE",lineNumber=<At Issue2782.java:[line 49]>
    Mismatch:was bugType="DLS_DEAD_LOCAL_STORE",lineNumber=<At Issue2782.java:[line 34]>
    Mismatch:was bugType="DLS_DEAD_LOCAL_STORE",lineNumber=<At Issue2782.java:[line 33]>
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:6)
        at edu.umd.cs.findbugs.detect.Issue2782Test.assertBugAtLine(Issue2782Test.java:45)
        at edu.umd.cs.findbugs.detect.Issue2782Test.testIssue(Issue2782Test.java:28)
```