### PR TITLE
Fix for FindFloatEquality same field test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Ignore generic variable types when looking for BC_UNCONFIRMED_CAST_OF_RETURN_VALUE ([#1219](https://github.com/spotbugs/spotbugs/issues/1219))
 - Do not report BC_UNCONFIRMED_CAST for Java 21's type switches ([#2813](https://github.com/spotbugs/spotbugs/pull/2813))
 - Remove AppleExtension library (note: menus slightly changed) ([#2823](https://github.com/spotbugs/spotbugs/pull/2823))
+- Fixed error preventing SpotBugs from reporting FE_FLOATING_POINT_EQUALITY ([#2843](https://github.com/spotbugs/spotbugs/pull/2843))
 
 ### Added
 - New detector `MultipleInstantiationsOfSingletons` and introduced new bug types:

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1097Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1097Test.java
@@ -1,0 +1,29 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
+import org.junit.jupiter.api.Test;
+
+import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class Issue1097Test extends AbstractIntegrationTest {
+
+    @Test
+    void testIssue() {
+        performAnalysis("FloatingPointEquality.class");
+
+        assertBugAtLine("FE_FLOATING_POINT_EQUALITY", 5);
+        assertBugAtLine("FE_FLOATING_POINT_EQUALITY", 13);
+    }
+
+    private void assertBugAtLine(String type, int line) {
+        BugInstanceMatcher bugMatcher = new BugInstanceMatcherBuilder()
+                .bugType(type)
+                .atLine(line)
+                .build();
+
+        assertThat(getBugCollection(), containsExactly(1, bugMatcher));
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindFloatEquality.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindFloatEquality.java
@@ -22,7 +22,6 @@ package edu.umd.cs.findbugs.detect;
 
 import java.util.Collection;
 import java.util.LinkedList;
-import java.util.Objects;
 
 import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
@@ -189,7 +188,13 @@ public class FindFloatEquality extends OpcodeStackDetector implements StatelessD
     }
 
     static boolean sameField(Item i1, Item i2) {
-        return Objects.equals(i1.getXField(), i2.getXField())
-                && i1.getFieldLoadedFromRegister() == i2.getFieldLoadedFromRegister();
+        if (i1.getXField() == null) {
+            return false;
+        }
+        if (!i1.getXField().equals(i2.getXField())) {
+            return false;
+        }
+
+        return i1.getFieldLoadedFromRegister() == i2.getFieldLoadedFromRegister();
     }
 }


### PR DESCRIPTION
The `isSameField()` method was changed in https://github.com/spotbugs/spotbugs/commit/84859d131c1c25346ab8f8ec83d1d674a7eced0f and the case when both arguments aren't fields was changed.
Reverted the change to fix `FE_FLOATING_POINT_EQUALITY`