### PR TITLE
Fix test.gradle to not replace all jvmArgs

### DIFF
--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -6,7 +6,7 @@ tasks.withType(Test) {
     doFirst {
       // https://openjdk.org/jeps/223
       if (System.getProperty("java.specification.version") != "1.8") {
-        jvmArgs = [
+        jvmArgs += [
           '--add-opens', 'java.base/java.lang=ALL-UNNAMED'
         ]
       }


### PR DESCRIPTION
The test gradle tasks currently replaces all jvm args, instead of just adding the necessary ones. This prevents to pass data through the jvm args to the program, thus preventing to debug SpotBugs code from IntelliJ. This PR fixes this problem.