### PR TITLE
[GHA] Use native m1 for macos now and drop flyci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,10 +8,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        include:
-         - os: flyci-macos-large-latest-m1
-           java: 21
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-14]
         java: [17, 21]
       max-parallel: 6
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
See https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/

note: macos-latest is still on version 12.  It won't be on 14 until later this year.  So both for now.