### PR TITLE
`VA_FORMAT_STRING_USES_NEWLINE` handling of text blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Do not report UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR for fields initialized in method annotated with @PostConstruct, @BeforeEach, etc. ([#2872](https://github.com/spotbugs/spotbugs/pull/2872) [#2870](https://github.com/spotbugs/spotbugs/issues/2870) [#453](https://github.com/spotbugs/spotbugs/issues/453))
 - Do not report DLS_DEAD_LOCAL_STORE for Hibernate bytecode enhancements ([#2865](https://github.com/spotbugs/spotbugs/pull/2865))
 - Fixed NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE false positives due to source code formatting ([#2874](https://github.com/spotbugs/spotbugs/pull/2874))
+- Improved the bug description for VA_FORMAT_STRING_USES_NEWLINE when using text blocks, check the usage of String.formatted() ([#2881](https://github.com/spotbugs/spotbugs/pull/2881))
 
 ### Added
 - New detector `MultipleInstantiationsOfSingletons` and introduced new bug types:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Do not report UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR for fields initialized in method annotated with @PostConstruct, @BeforeEach, etc. ([#2872](https://github.com/spotbugs/spotbugs/pull/2872) [#2870](https://github.com/spotbugs/spotbugs/issues/2870) [#453](https://github.com/spotbugs/spotbugs/issues/453))
 - Do not report DLS_DEAD_LOCAL_STORE for Hibernate bytecode enhancements ([#2865](https://github.com/spotbugs/spotbugs/pull/2865))
 - Fixed NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE false positives due to source code formatting ([#2874](https://github.com/spotbugs/spotbugs/pull/2874))
+- Added more nullability annotations in TypeQualifierResolver ([#2558](https://github.com/spotbugs/spotbugs/issues/2558) [#2694](https://github.com/spotbugs/spotbugs/pull/2694))
 - Improved the bug description for VA_FORMAT_STRING_USES_NEWLINE when using text blocks, check the usage of String.formatted() ([#2881](https://github.com/spotbugs/spotbugs/pull/2881))
 
 ### Added

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1877Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1877Test.java
@@ -1,0 +1,43 @@
+package edu.umd.cs.findbugs.detect;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnJre;
+import org.junit.jupiter.api.condition.JRE;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
+
+import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class Issue1877Test extends AbstractIntegrationTest {
+
+    @Test
+    @DisabledOnJre({ JRE.JAVA_8, JRE.JAVA_11 })
+    void testIssue() {
+        performAnalysis("../java17/Issue1877.class");
+
+        assertBugCount("VA_FORMAT_STRING_USES_NEWLINE", 2);
+
+        assertBugAtLine("VA_FORMAT_STRING_USES_NEWLINE", 18);
+        assertBugAtLine("VA_FORMAT_STRING_USES_NEWLINE", 37);
+    }
+
+    private void assertBugCount(String type, int expectedCount) {
+        BugInstanceMatcher bugMatcher = new BugInstanceMatcherBuilder()
+                .bugType(type)
+                .build();
+
+        assertThat(getBugCollection(), containsExactly(expectedCount, bugMatcher));
+    }
+
+    private void assertBugAtLine(String type, int line) {
+        BugInstanceMatcher bugMatcher = new BugInstanceMatcherBuilder()
+                .bugType(type)
+                .atLine(line)
+                .build();
+
+        assertThat(getBugCollection(), containsExactly(1, bugMatcher));
+    }
+}

--- a/spotbugs/etc/messages.xml
+++ b/spotbugs/etc/messages.xml
@@ -7488,6 +7488,13 @@ If the object is, indeed, non-serializable, an error will result.
 <p>
 This format string includes a newline character (\n). In format strings, it is generally
  preferable to use %n, which will produce the platform-specific line separator.
+ 
+ When using text blocks introduced in Java 15, use the <code>\</code> escape sequence:
+	 
+<code>String value = """
+                first line%n\
+                second line%n\
+                """;</code>
 </p>
 ]]>
      </Details>

--- a/spotbugs/etc/messages_fr.xml
+++ b/spotbugs/etc/messages_fr.xml
@@ -3401,6 +3401,25 @@ double value2 =  x / (double) y;
 ]]>
   </Details>
  </BugPattern>
+ <BugPattern type="VA_FORMAT_STRING_USES_NEWLINE">
+    <ShortDescription>Format string should use %n rather than \n</ShortDescription>
+    <LongDescription>Format string should use %n rather than \n in {1}</LongDescription>
+    <Details>
+<![CDATA[
+<p>
+Ce string utilisé dans un format contient le caractère newline (\n). Il est généralement préférable
+ d'utiliser %n qui produira un séparateur de ligne spécifique à la plateforme.
+ 
+ Pour les blocs de texte introduits avec Java 15, utiliser <code>\</code> pour échapper les fins de ligne:
+	 
+<code>String valeur = """
+                premiere ligne%n\
+                seconde ligne%n\
+                """;</code>
+</p>
+]]>
+    </Details>
+ </BugPattern>
  <BugCode abbrev="IL">Boucle infinie</BugCode>
  <BugCode abbrev="VO">Utilisation de volatile</BugCode>
  <BugCode abbrev="UI">Héritage non sûr</BugCode>

--- a/spotbugs/etc/messages_ja.xml
+++ b/spotbugs/etc/messages_ja.xml
@@ -7883,6 +7883,13 @@ double value2 = x / (double) y;
 <p>
 この書式文字列は改行文字 (<code>\n</code>) が含まれています。
 一般的に書式文字列には <code>%n</code> を使用することがより望ましいです。<code>%n</code> は，プラットフォーム特有の行セパレータを作り出します。
+
+Java 15 複数行テキスト ブロック
+
+<code>String value = """
+                first line%n\
+                second line%n\
+                """;</code>
 </p>
 ]]>
   </Details>

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FormatStringChecker.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FormatStringChecker.java
@@ -105,37 +105,20 @@ public class FormatStringChecker extends OpcodeStackDetector {
             String sig = getSigConstantOperand();
             XMethod m = getXMethodOperand();
             if ((m == null || m.isVarArgs())
-                    && sig.indexOf("Ljava/lang/String;[Ljava/lang/Object;)") >= 0
+                    && sig.contains("Ljava/lang/String;[Ljava/lang/Object;)")
                     && ("java/util/Formatter".equals(cl) && "format".equals(nm)
                             || "java/lang/String".equals(cl) && "format".equals(nm)
                             || "java/io/PrintStream".equals(cl) && "format".equals(nm)
                             || "java/io/PrintStream".equals(cl) && "printf".equals(nm)
                             || cl.endsWith("Writer") && "format".equals(nm)
                             || cl.endsWith("Writer") && "printf".equals(nm))
-                    || cl.endsWith("Logger") && nm.endsWith("fmt")) {
+                    || cl.endsWith("Logger") && nm.endsWith("fmt")
+                    || "([Ljava/lang/Object;)Ljava/lang/String;".equals(sig) && "java/lang/String".equals(cl) && "formatted".equals(nm)) {
 
                 if (formatString.indexOf('\n') >= 0) {
                     bugReporter.reportBug(new BugInstance(this, "VA_FORMAT_STRING_USES_NEWLINE", NORMAL_PRIORITY)
                             .addClassAndMethod(this).addCalledMethod(this).addString(formatString)
                             .describe(StringAnnotation.FORMAT_STRING_ROLE).addSourceLine(this));
-                }
-            }
-        }
-
-        // Check for calls to java.lang.String.formatted(), for instance: "xyz".formatted("abc");
-        if (seen == Const.INVOKEVIRTUAL) {
-            String cl = getClassConstantOperand();
-            String nm = getNameConstantOperand();
-
-            if ("java/lang/String".equals(cl) && "formatted".equals(nm)) {
-                Object stackItem = stack.getStackItem(1).getConstant();
-                if (stackItem instanceof String) {
-                    String string = (String) stackItem;
-                    if (string.indexOf('\n') >= 0) {
-                        bugReporter.reportBug(new BugInstance(this, "VA_FORMAT_STRING_USES_NEWLINE", NORMAL_PRIORITY)
-                                .addClassAndMethod(this).addCalledMethod(this).addString(string)
-                                .describe(StringAnnotation.FORMAT_STRING_ROLE).addSourceLine(this));
-                    }
                 }
             }
         }

--- a/spotbugsTestCases/src/java17/Issue1877.java
+++ b/spotbugsTestCases/src/java17/Issue1877.java
@@ -1,0 +1,39 @@
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class Issue1877 {
+	public String truePositive() {
+		String query = """
+				SELECT id,
+				       name
+				FROM   account
+				WHERE  id = '%s'
+				""";
+		return String.format(query, "1");
+	}
+
+	public String trueNegative() {
+		String query = """
+				SELECT id,%n\
+				       name%n\
+				FROM   account%n\
+				WHERE  id = '%s'%n\
+				""";
+		return String.format(query, "1");
+	}
+
+	public String formatted() {
+		return """
+				SELECT id,
+				       name
+				FROM   account
+				WHERE  id = '%s'
+				""".formatted("1");
+	}
+}


### PR DESCRIPTION
The text blocks introduced in Java 15 pose problem when used in a formatter because the line endings are not platform specific and SpotBugs correctly raises a VA_FORMAT_STRING_USES_NEWLINE

Text blocks line endings should be escaped when used in a format (using `%n\`). The bug description should give that solution.

The String.formatted() method (added in Java 15) should also be checked as we are already checking the static version String.format()

This should fix #1877 

