### PR TITLE
Fix for redundant assertion in ValueRangeAnalysisFactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Do not report DLS_DEAD_LOCAL_STORE for Hibernate bytecode enhancements ([#2865](https://github.com/spotbugs/spotbugs/pull/2865))
 - Fixed NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE false positives due to source code formatting ([#2874](https://github.com/spotbugs/spotbugs/pull/2874))
 - Added more nullability annotations in TypeQualifierResolver ([#2558](https://github.com/spotbugs/spotbugs/issues/2558) [#2694](https://github.com/spotbugs/spotbugs/pull/2694))
-
+- Fixed crash in ValueRangeAnalysisFactory when looking for redundant conditions used in assertions [#2887](https://github.com/spotbugs/spotbugs/pull/2887))
 ### Added
 - New detector `MultipleInstantiationsOfSingletons` and introduced new bug types:
   - `SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR` is reported in case of a non-private constructor,

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue608Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue608Test.java
@@ -1,0 +1,15 @@
+package edu.umd.cs.findbugs.detect;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+
+import org.junit.jupiter.api.Test;
+
+class Issue608Test extends AbstractIntegrationTest {
+
+    @Test
+    void testIssue() {
+        assertDoesNotThrow(() -> performAnalysis("ghIssues/Issue608.class"));
+    }
+}

--- a/spotbugsTestCases/src/java/ghIssues/Issue608.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue608.java
@@ -1,0 +1,10 @@
+package ghIssues;
+
+public class Issue608 {
+
+	void methodThatFails(int i) {
+		while (i < 12) {
+			assert (i < 12) : "assertion failure message";
+		}
+	}
+}


### PR DESCRIPTION
When a redundant condition is used in an assertion ValueRangeAnalysisFactory tries to compute the position of the end end for the corresponding instruction block. However it uses `IFNE.getTarget().getPosition()` which returns the position offset (not he position). 
Since the offset is zero, this produces and invalid range (end is before start) and `BitSet.set(start, end)` throws an exception.

Instead compute the end of the block by locating the final `athrow`

Crash reported in issue #608