### PR TITLE
deps: revert to using commons-text 1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Added more nullability annotations in TypeQualifierResolver ([#2558](https://github.com/spotbugs/spotbugs/issues/2558) [#2694](https://github.com/spotbugs/spotbugs/pull/2694))
 - Improved the bug description for VA_FORMAT_STRING_USES_NEWLINE when using text blocks, check the usage of String.formatted() ([#2881](https://github.com/spotbugs/spotbugs/pull/2881))
 - Fixed crash in ValueRangeAnalysisFactory when looking for redundant conditions used in assertions [#2887](https://github.com/spotbugs/spotbugs/pull/2887))
+- Revert again commons-text from 1.11.0 to 1.10.0 to resolve a version conflict ([#2686](https://github.com/spotbugs/spotbugs/issues/2686))
 
 ### Added
 - New detector `MultipleInstantiationsOfSingletons` and introduced new bug types:

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -80,7 +80,7 @@ dependencies {
   }
   implementation 'jaxen:jaxen:2.0.0' // only transitive through org.dom4j:dom4j:2.1.4, which has an *optional* dependency on jaxen:jaxen.
   api 'org.apache.commons:commons-lang3:3.14.0'
-  api 'org.apache.commons:commons-text:1.11.0'
+  api 'org.apache.commons:commons-text:1.10.0'
   api 'org.slf4j:slf4j-api:2.0.12'
   implementation 'net.sf.saxon:Saxon-HE:12.4'
   implementation libs.log4j.core


### PR DESCRIPTION
Upgrading to 1.11.0 caused a version conflict on commons-lang3 which is:
- a direct dependency
- a transitive dependency of commons-text
- a transitive dependency of BCEL

On a Spring/Gradle project the later wins:

     +--- org.apache.bcel:bcel:6.6.1
     |    \--- org.apache.commons:commons-lang3:3.12.0

Revert to commons-text:1.10.0 which is compatible with commons-lang3:3.12.0

Fixes #2686
See #2688 #2880