### PR TITLE
Extend the `FindOverridableMethodCall` detector to handle SER09-J

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
   - `SING_SINGLETON_IMPLEMENTS_SERIALIZABLE` is reported when a class directly or indirectly implements the `Serializable` interface and
   - `SING_SINGLETON_GETTER_NOT_SYNCHRONIZED` is reported when the instance-getter method of the singleton class is not synchronized.
     (See [SEI CERT MSC07-J](https://wiki.sei.cmu.edu/confluence/display/java/MSC07-J.+Prevent+multiple+instantiations+of+singleton+objects))
+- Extend `FindOverridableMethodCall` detector with new bug type: `MC_OVERRIDABLE_METHOD_CALL_IN_READ_OBJECT`. It's reported when an overridable method is called from `readObject()`, according to SEI CERT rule [SER09-J. Do not invoke overridable methods from the readObject() method](https://wiki.sei.cmu.edu/confluence/display/java/SER09-J.+Do+not+invoke+overridable+methods+from+the+readObject%28%29+method).
 
 ### Changed
 - Minor cleanup in connection with slashed and dotted names ([#2805](https://github.com/spotbugs/spotbugs/pull/2805))

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindOverridableMethodCallTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindOverridableMethodCallTest.java
@@ -146,6 +146,66 @@ class FindOverridableMethodCallTest extends AbstractIntegrationTest {
         testReadObject("IndirectReadObject2", 7);
     }
 
+    @Test
+    void DoubleIndirectReadObjectCase1() {
+        testReadObject("DoubleIndirectReadObjectCase1", 18);
+    }
+
+    @Test
+    void DoubleIndirectReadObjectCase2() {
+        testReadObject("DoubleIndirectReadObjectCase2", 18);
+    }
+
+    @Test
+    void DoubleIndirectReadObjectCase3() {
+        testReadObject("DoubleIndirectReadObjectCase3", 13);
+    }
+
+    @Test
+    void DoubleIndirectReadObjectCase4() {
+        testReadObject("DoubleIndirectReadObjectCase4", 12);
+    }
+
+    @Test
+    void DoubleIndirectReadObjectCase5() {
+        testReadObject("DoubleIndirectReadObjectCase5", 7);
+    }
+
+    @Test
+    void DoubleIndirectReadObjectCase6() {
+        testReadObject("DoubleIndirectReadObjectCase6", 7);
+    }
+
+    @Test
+    void MethodReferenceReadObject() {
+        testReadObject("MethodReferenceReadObject", 12);
+    }
+
+    @Test
+    void MethodReferenceReadObjectIndirect1() {
+        testReadObject("MethodReferenceReadObjectIndirect1", 16);
+    }
+
+    @Test
+    void MethodReferenceReadObjectIndirect2() {
+        testReadObject("MethodReferenceReadObjectIndirect2", 24);
+    }
+
+    @Test
+    void MethodReferenceReadObjectIndirect3() {
+        testReadObject("MethodReferenceReadObjectIndirect3", 24);
+    }
+
+    @Test
+    void testFinalClassDirectReadObject() {
+        testPass("FinalClassDirectReadObject");
+    }
+
+    @Test
+    void testFinalClassIndirectReadObject() {
+        testPass("FinalClassIndirectReadObject");
+    }
+
     void testCase(String className, int constructorLine, int cloneLine) {
         performAnalysis("overridableMethodCall/" + className + ".class");
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindOverridableMethodCallTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindOverridableMethodCallTest.java
@@ -152,6 +152,16 @@ class FindOverridableMethodCallTest extends AbstractIntegrationTest {
     }
 
     @Test
+    void testIndirectStreamMethods1() {
+        testPass("IndirectStreamMethods1");
+    }
+
+    @Test
+    void testIndirectStreamMethods2() {
+        testPass("IndirectStreamMethods2");
+    }
+
+    @Test
     void DoubleIndirectReadObjectCase1() {
         testReadObject("DoubleIndirectReadObjectCase1", 18);
     }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindOverridableMethodCallTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindOverridableMethodCallTest.java
@@ -126,12 +126,38 @@ class FindOverridableMethodCallTest extends AbstractIntegrationTest {
         testPass("FinalClassInheritedMethodReference");
     }
 
+    @Test
+    void testDirectReadObject() {
+        testReadObject("DirectReadObject", 8);
+    }
+
+    @Test
+    void testDirectReadObjectStreamMethods() {
+        testPass("DirectReadObjectStreamMethods");
+    }
+
     void testCase(String className, int constructorLine, int cloneLine) {
         performAnalysis("overridableMethodCall/" + className + ".class");
 
         checkOneBug();
         checkOverridableMethodCallInConstructor(className, constructorLine);
         checkOverridableMethodCallInClone(className, cloneLine);
+    }
+
+    void testReadObject(String className, int warningLine) {
+        performAnalysis("overridableMethodCall/" + className + ".class");
+
+        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
+                .bugType("MC_OVERRIDABLE_METHOD_CALL_IN_READ_OBJECT").build();
+        assertThat(getBugCollection(), containsExactly(1, bugTypeMatcher));
+
+        final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
+                .bugType("MC_OVERRIDABLE_METHOD_CALL_IN_READ_OBJECT")
+                .inClass(className)
+                .inMethod("readObject")
+                .atLine(warningLine)
+                .build();
+        assertThat(getBugCollection(), hasItem(bugInstanceMatcher));
     }
 
     void testPass(String className) {
@@ -157,6 +183,10 @@ class FindOverridableMethodCallTest extends AbstractIntegrationTest {
 
         bugTypeMatcher = new BugInstanceMatcherBuilder()
                 .bugType("MC_OVERRIDABLE_METHOD_CALL_IN_CLONE").build();
+        assertThat(getBugCollection(), containsExactly(0, bugTypeMatcher));
+
+        bugTypeMatcher = new BugInstanceMatcherBuilder()
+                .bugType("MC_OVERRIDABLE_METHOD_CALL_IN_READ_OBJECT").build();
         assertThat(getBugCollection(), containsExactly(0, bugTypeMatcher));
     }
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindOverridableMethodCallTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindOverridableMethodCallTest.java
@@ -137,6 +137,11 @@ class FindOverridableMethodCallTest extends AbstractIntegrationTest {
     }
 
     @Test
+    void testDirectReadObjectStreamMethods2() {
+        testReadObject("DirectReadObjectStreamMethods2", 11);
+    }
+
+    @Test
     void testIndirectReadObject1() {
         testReadObject("IndirectReadObject1", 11);
     }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindOverridableMethodCallTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindOverridableMethodCallTest.java
@@ -136,6 +136,16 @@ class FindOverridableMethodCallTest extends AbstractIntegrationTest {
         testPass("DirectReadObjectStreamMethods");
     }
 
+    @Test
+    void testIndirectReadObject1() {
+        testReadObject("IndirectReadObject1", 11);
+    }
+
+    @Test
+    void testIndirectReadObject2() {
+        testReadObject("IndirectReadObject2", 7);
+    }
+
     void testCase(String className, int constructorLine, int cloneLine) {
         performAnalysis("overridableMethodCall/" + className + ".class");
 

--- a/spotbugs/etc/findbugs.xml
+++ b/spotbugs/etc/findbugs.xml
@@ -658,7 +658,7 @@
           <Detector class="edu.umd.cs.findbugs.detect.ReflectionIncreaseAccessibility"
                     reports="REFLC_REFLECTION_MAY_INCREASE_ACCESSIBILITY_OF_CLASS,REFLF_REFLECTION_MAY_INCREASE_ACCESSIBILITY_OF_FIELD"/>
           <Detector class="edu.umd.cs.findbugs.detect.FindOverridableMethodCall"
-                    reports="MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR,MC_OVERRIDABLE_METHOD_CALL_IN_CLONE"/>
+                    reports="MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR,MC_OVERRIDABLE_METHOD_CALL_IN_CLONE,MC_OVERRIDABLE_METHOD_CALL_IN_READ_OBJECT"/>
           <Detector class="edu.umd.cs.findbugs.detect.ConstructorThrow" speed="fast"
                     reports="CT_CONSTRUCTOR_THROW"/>
           <Detector class="edu.umd.cs.findbugs.detect.FindInstanceLockOnSharedStaticData" speed="fast"
@@ -1304,6 +1304,7 @@
           <BugPattern abbrev="REFLF" type="REFLF_REFLECTION_MAY_INCREASE_ACCESSIBILITY_OF_FIELD" category="MALICIOUS_CODE" />
           <BugPattern abbrev="MC" type="MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR" category="MALICIOUS_CODE" />
           <BugPattern abbrev="MC" type="MC_OVERRIDABLE_METHOD_CALL_IN_CLONE" category="MALICIOUS_CODE" />
+          <BugPattern abbrev="MC" type="MC_OVERRIDABLE_METHOD_CALL_IN_READ_OBJECT" category="MALICIOUS_CODE" />
           <BugPattern abbrev="SSD" type="SSD_DO_NOT_USE_INSTANCE_LOCK_ON_SHARED_STATIC_DATA" category="MT_CORRECTNESS" />
           <BugPattern abbrev="FL" type="FL_FLOATS_AS_LOOP_COUNTERS" category="CORRECTNESS" />
           <BugPattern abbrev="THROWS" type="THROWS_METHOD_THROWS_RUNTIMEEXCEPTION" category="BAD_PRACTICE" />

--- a/spotbugs/etc/messages.xml
+++ b/spotbugs/etc/messages.xml
@@ -8796,7 +8796,7 @@ object explicitly.</p>
   </BugPattern>
   <BugPattern type="MC_OVERRIDABLE_METHOD_CALL_IN_READ_OBJECT">
     <ShortDescription>An overridable method is called from the readObject method.</ShortDescription>
-    <LongDescription>Overridable method {1} is called from readObject.</LongDescription>
+    <LongDescription>Overridable method {2} is called from readObject.</LongDescription>
     <Details>
       <![CDATA[<p>
       The readObject() method must not call any overridable methods. Invoking overridable methods from the readObject()
@@ -8805,8 +8805,8 @@ object explicitly.</p>
       therefore object initialization is not complete until readObject exits.</p>
       <p>
       <br/>
-      See SEI CERT rule <a href="https://wiki.sei.cmu.edu/confluence/pages/viewpage.action?pageId=88487921">
-      MET06-J. Do not invoke overridable methods in clone()</a>.
+      See SEI CERT rule <a href="https://wiki.sei.cmu.edu/confluence/display/java/SER09-J.+Do+not+invoke+overridable+methods+from+the+readObject%28%29+method">
+      SER09-J. Do not invoke overridable methods from the readObject() method</a>.
       </p>]]>
     </Details>
   </BugPattern>

--- a/spotbugs/etc/messages.xml
+++ b/spotbugs/etc/messages.xml
@@ -1738,11 +1738,14 @@ factory pattern to create these objects.</p>
   <Detector class="edu.umd.cs.findbugs.detect.FindOverridableMethodCall">
     <Details>
       <![CDATA[
-            <p>Detector for patterns where a constructor or a clone() method calls an overridable
-               method.</p>
+            <p>
+               Detector for patterns where a constructor, a clone(), or a readObject() method
+               calls an overridable method.
+            </p>
             <p>
                Calling an overridable method from a constructor may result in the use of
-               uninitialized data. Calling such method from a clone() method is insecure.
+               uninitialized data. Calling such method from a clone(), or readObject() method
+               is insecure.
             </p>
       ]]>
     </Details>

--- a/spotbugs/etc/messages.xml
+++ b/spotbugs/etc/messages.xml
@@ -8794,6 +8794,22 @@ object explicitly.</p>
       </p>]]>
     </Details>
   </BugPattern>
+  <BugPattern type="MC_OVERRIDABLE_METHOD_CALL_IN_READ_OBJECT">
+    <ShortDescription>An overridable method is called from the readObject method.</ShortDescription>
+    <LongDescription>Overridable method {1} is called from readObject.</LongDescription>
+    <Details>
+      <![CDATA[<p>
+      The readObject() method must not call any overridable methods. Invoking overridable methods from the readObject()
+      method can provide the overriding method with access to the object's state before it is fully initialized. This
+      premature access is possible because, in deserialization, readObject plays the role of object constructor and
+      therefore object initialization is not complete until readObject exits.</p>
+      <p>
+      <br/>
+      See SEI CERT rule <a href="https://wiki.sei.cmu.edu/confluence/pages/viewpage.action?pageId=88487921">
+      MET06-J. Do not invoke overridable methods in clone()</a>.
+      </p>]]>
+    </Details>
+  </BugPattern>
   <BugPattern type="SING_SINGLETON_IMPLEMENTS_CLONEABLE">
     <ShortDescription>Class using singleton design pattern directly implements Cloneable interface.</ShortDescription>
     <LongDescription>Class ({0}) using singleton design pattern directly implements Cloneable interface.</LongDescription>

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindOverridableMethodCall.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindOverridableMethodCall.java
@@ -70,7 +70,6 @@ public class FindOverridableMethodCall extends OpcodeStackDetector {
     private final Map<Integer, CallerInfo> refCallerConstructors = new HashMap<>();
     private final Map<Integer, CallerInfo> refCallerClones = new HashMap<>();
     private final Map<Integer, CallerInfo> refCallerReadObjects = new HashMap<>();
-
     private final MultiMap<Integer, XMethod> refCalleeToCallerMap = new MultiMap<>(ArrayList.class);
 
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindOverridableMethodCall.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindOverridableMethodCall.java
@@ -185,7 +185,7 @@ public class FindOverridableMethodCall extends OpcodeStackDetector {
                             SourceLineAnnotation.fromVisitedInstruction(this));
                 }
             } else if ("readObject".equals(getMethodName())) {
-                checkCallInReadObject(method);
+                checkCallInReadObject(getXMethod(), method);
             } else if (item.getRegisterNumber() == 0
                     && (getXMethod().isPrivate() || getXMethod().isFinal())) {
                 if (method.isPrivate() || method.isFinal()) {
@@ -223,20 +223,19 @@ public class FindOverridableMethodCall extends OpcodeStackDetector {
         return true;
     }
 
-    void checkCallInReadObject(XMethod method) {
+    void checkCallInReadObject(XMethod caller, XMethod method) {
         // SER09-J-EX0: The readObject() method may invoke the overridable methods defaultReadObject() and readFields()
         // in class java.io.ObjectInputStream
         boolean inOis = method.getClassName().equals("java.io.ObjectInputStream");
         String methodName = method.getName();
-        if (inOis && methodName.equals("defaultReadObject") || method.getName().equals("readFields"))
-        {
+        if (inOis && methodName.equals("defaultReadObject") || method.getName().equals("readFields")) {
             return;
         }
 
         if (!method.isPrivate() && !method.isFinal()) {
             bugAccumulator.accumulateBug(
                     new BugInstance(this, "MC_OVERRIDABLE_METHOD_CALL_IN_READ_OBJECT", NORMAL_PRIORITY)
-                            .addClass(this).addString(method.getName()),
+                            .addClass(this).addMethod(caller).addString(method.getName()),
                     SourceLineAnnotation.fromVisitedInstruction(this));
         }
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindOverridableMethodCall.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindOverridableMethodCall.java
@@ -136,6 +136,7 @@ public class FindOverridableMethodCall extends OpcodeStackDetector {
 
     @Override
     public void sawOpcode(int seen) {
+        // FIXME: defaultRead should still be analysed...
         if (getXClass().isFinal()) {
             return;
         }
@@ -183,7 +184,8 @@ public class FindOverridableMethodCall extends OpcodeStackDetector {
                     checkAndRecordCallFromClone(getXMethod(), method,
                             SourceLineAnnotation.fromVisitedInstruction(this));
                 }
-
+            } else if ("readObject".equals(getMethodName())) {
+                checkCallInReadObject(method);
             } else if (item.getRegisterNumber() == 0
                     && (getXMethod().isPrivate() || getXMethod().isFinal())) {
                 if (method.isPrivate() || method.isFinal()) {
@@ -219,6 +221,24 @@ public class FindOverridableMethodCall extends OpcodeStackDetector {
             return false;
         }
         return true;
+    }
+
+    void checkCallInReadObject(XMethod method) {
+        // SER09-J-EX0: The readObject() method may invoke the overridable methods defaultReadObject() and readFields()
+        // in class java.io.ObjectInputStream
+        boolean inOis = method.getClassName().equals("java.io.ObjectInputStream");
+        String methodName = method.getName();
+        if (inOis && methodName.equals("defaultReadObject") || method.getName().equals("readFields"))
+        {
+            return;
+        }
+
+        if (!method.isPrivate() && !method.isFinal()) {
+            bugAccumulator.accumulateBug(
+                    new BugInstance(this, "MC_OVERRIDABLE_METHOD_CALL_IN_READ_OBJECT", NORMAL_PRIORITY)
+                            .addClass(this).addString(method.getName()),
+                    SourceLineAnnotation.fromVisitedInstruction(this));
+        }
     }
 
     private boolean checkAndRecordCallFromConstructor(XMethod constructor, XMethod callee,

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindOverridableMethodCall.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindOverridableMethodCall.java
@@ -196,7 +196,7 @@ public class FindOverridableMethodCall extends OpcodeStackDetector {
                             SourceLineAnnotation.fromVisitedInstruction(this));
                 }
             } else if ("readObject".equals(getMethodName())) {
-                if(checkCallInReadObject(getXMethod(), method,
+                if (checkCallInReadObject(getXMethod(), method,
                         SourceLineAnnotation.fromVisitedInstruction(this))) {
                     checkAndRecordCallFromReadObject(getXMethod(), method,
                             SourceLineAnnotation.fromVisitedInstruction(this));
@@ -252,6 +252,7 @@ public class FindOverridableMethodCall extends OpcodeStackDetector {
         String methodName = method.getName();
         return inOis && methodName.equals("defaultReadObject") || methodName.equals("readFields");
     }
+
     boolean checkCallInReadObject(XMethod caller, XMethod method, SourceLineAnnotation sourceLine) {
         if (!shouldIgnoreCallInReadObject(method) && !method.isPrivate() && !method.isFinal()) {
             bugAccumulator.accumulateBug(
@@ -291,7 +292,7 @@ public class FindOverridableMethodCall extends OpcodeStackDetector {
     }
 
     private boolean checkAndRecordCallFromReadObject(XMethod readObject, XMethod callee,
-                                                SourceLineAnnotation sourceLine) {
+            SourceLineAnnotation sourceLine) {
         XMethod overridable = getIndirectlyCalledOverridable(callee);
         if (overridable != null && !shouldIgnoreCallInReadObject(overridable)) {
             bugAccumulator.accumulateBug(new BugInstance(this,

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindOverridableMethodCall.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindOverridableMethodCall.java
@@ -255,8 +255,7 @@ public class FindOverridableMethodCall extends OpcodeStackDetector {
                     new BugInstance(this, "MC_OVERRIDABLE_METHOD_CALL_IN_READ_OBJECT", NORMAL_PRIORITY)
                             .addClass(this)
                             .addMethod(caller)
-                            .addString(method.getName()),
-                    sourceLine);
+                            .addString(method.getName()), sourceLine);
             return false;
         }
 

--- a/spotbugsTestCases/src/java/overridableMethodCall/DirectReadObject.java
+++ b/spotbugsTestCases/src/java/overridableMethodCall/DirectReadObject.java
@@ -1,0 +1,24 @@
+package overridableMethodCall;
+
+import java.io.ObjectInputStream;
+
+public class DirectReadObject {
+
+    private void readObject(final ObjectInputStream stream) {
+        overridableMethod();
+        privateMethod();
+        finalMethod();
+    }
+
+    void overridableMethod() {
+        System.out.println("I am overridable.");
+    }
+
+    private void privateMethod() {
+        System.out.println("I am private.");
+    }
+
+    final void finalMethod() {
+        System.out.println("I am final.");
+    }
+}

--- a/spotbugsTestCases/src/java/overridableMethodCall/DirectReadObjectStreamMethods.java
+++ b/spotbugsTestCases/src/java/overridableMethodCall/DirectReadObjectStreamMethods.java
@@ -1,0 +1,12 @@
+package overridableMethodCall;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+
+public class DirectReadObjectStreamMethods {
+
+    private void readObject(final ObjectInputStream stream) throws IOException, ClassNotFoundException {
+        stream.defaultReadObject();
+        stream.readFields();
+    }
+}

--- a/spotbugsTestCases/src/java/overridableMethodCall/DirectReadObjectStreamMethods2.java
+++ b/spotbugsTestCases/src/java/overridableMethodCall/DirectReadObjectStreamMethods2.java
@@ -1,0 +1,27 @@
+package overridableMethodCall;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+
+public class DirectReadObjectStreamMethods2 {
+
+    private void readObject(final ObjectInputStream stream) throws IOException, ClassNotFoundException {
+        stream.defaultReadObject();
+        stream.readFields();
+        overridableMethod();
+        privateMethod();
+        finalMethod();
+    }
+
+    void overridableMethod() {
+        System.out.println("I am overridable.");
+    }
+
+    private void privateMethod() {
+        System.out.println("I am private.");
+    }
+
+    final void finalMethod() {
+        System.out.println("I am final.");
+    }
+}

--- a/spotbugsTestCases/src/java/overridableMethodCall/DoubleIndirectReadObjectCase1.java
+++ b/spotbugsTestCases/src/java/overridableMethodCall/DoubleIndirectReadObjectCase1.java
@@ -1,0 +1,34 @@
+package overridableMethodCall;
+
+import java.io.ObjectInputStream;
+
+public class DoubleIndirectReadObjectCase1 {
+    final void indirect1() {
+        finalMethod();
+        indirect2();
+        privateMethod();
+    }
+
+    final void indirect2() {
+        indirect1();
+        overridableMethod();
+    }
+
+    void readObject(final ObjectInputStream stream) {
+        indirect1();
+        privateMethod();
+        finalMethod();
+    }
+
+    void overridableMethod() {
+        System.out.println("I am overridable.");
+    }
+
+    private void privateMethod() {
+        System.out.println("I am private.");
+    }
+
+    final void finalMethod() {
+        System.out.println("I am final.");
+    }
+}

--- a/spotbugsTestCases/src/java/overridableMethodCall/DoubleIndirectReadObjectCase2.java
+++ b/spotbugsTestCases/src/java/overridableMethodCall/DoubleIndirectReadObjectCase2.java
@@ -1,0 +1,34 @@
+package overridableMethodCall;
+
+import java.io.ObjectInputStream;
+
+public class DoubleIndirectReadObjectCase2 {
+    final void indirect2() {
+        indirect1();
+        overridableMethod();
+    }
+
+    final void indirect1() {
+        finalMethod();
+        indirect2();
+        privateMethod();
+    }
+
+    void readObject(final ObjectInputStream stream) {
+        indirect1();
+        privateMethod();
+        finalMethod();
+    }
+
+    void overridableMethod() {
+        System.out.println("I am overridable.");
+    }
+
+    private void privateMethod() {
+        System.out.println("I am private.");
+    }
+
+    final void finalMethod() {
+        System.out.println("I am final.");
+    }
+}

--- a/spotbugsTestCases/src/java/overridableMethodCall/DoubleIndirectReadObjectCase3.java
+++ b/spotbugsTestCases/src/java/overridableMethodCall/DoubleIndirectReadObjectCase3.java
@@ -1,0 +1,34 @@
+package overridableMethodCall;
+
+import java.io.ObjectInputStream;
+
+public class DoubleIndirectReadObjectCase3 {
+    final void indirect1() {
+        finalMethod();
+        indirect2();
+        privateMethod();
+    }
+
+    void readObject(final ObjectInputStream stream) {
+        indirect1();
+        privateMethod();
+        finalMethod();
+    }
+
+    final void indirect2() {
+        indirect1();
+        overridableMethod();
+    }
+
+    void overridableMethod() {
+        System.out.println("I am overridable.");
+    }
+
+    private void privateMethod() {
+        System.out.println("I am private.");
+    }
+
+    final void finalMethod() {
+        System.out.println("I am final.");
+    }
+}

--- a/spotbugsTestCases/src/java/overridableMethodCall/DoubleIndirectReadObjectCase4.java
+++ b/spotbugsTestCases/src/java/overridableMethodCall/DoubleIndirectReadObjectCase4.java
@@ -1,0 +1,34 @@
+package overridableMethodCall;
+
+import java.io.ObjectInputStream;
+
+public class DoubleIndirectReadObjectCase4 {
+    final void indirect2() {
+        indirect1();
+        overridableMethod();
+    }
+
+    void readObject(final ObjectInputStream stream) {
+        indirect1();
+        privateMethod();
+        finalMethod();
+    }
+
+    final void indirect1() {
+        finalMethod();
+        indirect2();
+        privateMethod();
+    }
+
+    void overridableMethod() {
+        System.out.println("I am overridable.");
+    }
+
+    private void privateMethod() {
+        System.out.println("I am private.");
+    }
+
+    final void finalMethod() {
+        System.out.println("I am final.");
+    }
+}

--- a/spotbugsTestCases/src/java/overridableMethodCall/DoubleIndirectReadObjectCase5.java
+++ b/spotbugsTestCases/src/java/overridableMethodCall/DoubleIndirectReadObjectCase5.java
@@ -1,0 +1,34 @@
+package overridableMethodCall;
+
+import java.io.ObjectInputStream;
+
+public class DoubleIndirectReadObjectCase5 {
+    void readObject(final ObjectInputStream stream) {
+        indirect1();
+        privateMethod();
+        finalMethod();
+    }
+
+    final void indirect1() {
+        finalMethod();
+        indirect2();
+        privateMethod();
+    }
+
+    final void indirect2() {
+        indirect1();
+        overridableMethod();
+    }
+
+    void overridableMethod() {
+        System.out.println("I am overridable.");
+    }
+
+    private void privateMethod() {
+        System.out.println("I am private.");
+    }
+
+    final void finalMethod() {
+        System.out.println("I am final.");
+    }
+}

--- a/spotbugsTestCases/src/java/overridableMethodCall/DoubleIndirectReadObjectCase6.java
+++ b/spotbugsTestCases/src/java/overridableMethodCall/DoubleIndirectReadObjectCase6.java
@@ -1,0 +1,34 @@
+package overridableMethodCall;
+
+import java.io.ObjectInputStream;
+
+public class DoubleIndirectReadObjectCase6 {
+    void readObject(final ObjectInputStream stream) {
+        indirect1();
+        privateMethod();
+        finalMethod();
+    }
+
+    final void indirect2() {
+        indirect1();
+        overridableMethod();
+    }
+
+    final void indirect1() {
+        finalMethod();
+        indirect2();
+        privateMethod();
+    }
+
+    void overridableMethod() {
+        System.out.println("I am overridable.");
+    }
+
+    private void privateMethod() {
+        System.out.println("I am private.");
+    }
+
+    final void finalMethod() {
+        System.out.println("I am final.");
+    }
+}

--- a/spotbugsTestCases/src/java/overridableMethodCall/FinalClassDirectReadObject.java
+++ b/spotbugsTestCases/src/java/overridableMethodCall/FinalClassDirectReadObject.java
@@ -1,0 +1,24 @@
+package overridableMethodCall;
+
+import java.io.ObjectInputStream;
+
+public final class FinalClassDirectReadObject {
+
+    private void readObject(final ObjectInputStream stream) {
+        overridableMethod();
+        privateMethod();
+        finalMethod();
+    }
+
+    void overridableMethod() {
+        System.out.println("I am overridable.");
+    }
+
+    private void privateMethod() {
+        System.out.println("I am private.");
+    }
+
+    void finalMethod() {
+        System.out.println("I am final.");
+    }
+}

--- a/spotbugsTestCases/src/java/overridableMethodCall/FinalClassIndirectReadObject.java
+++ b/spotbugsTestCases/src/java/overridableMethodCall/FinalClassIndirectReadObject.java
@@ -1,0 +1,27 @@
+package overridableMethodCall;
+
+import java.io.ObjectInputStream;
+
+public final class FinalClassIndirectReadObject implements Cloneable {
+    void indirect() {
+        overridableMethod();
+    }
+
+    private void readObject(final ObjectInputStream stream) {
+        overridableMethod();
+        privateMethod();
+        finalMethod();
+    }
+
+    void overridableMethod() {
+        System.out.println("I am overridable.");
+    }
+
+    private void privateMethod() {
+        System.out.println("I am private.");
+    }
+
+    void finalMethod() {
+        System.out.println("I am final.");
+    }
+}

--- a/spotbugsTestCases/src/java/overridableMethodCall/IndirectReadObject1.java
+++ b/spotbugsTestCases/src/java/overridableMethodCall/IndirectReadObject1.java
@@ -1,0 +1,27 @@
+package overridableMethodCall;
+
+import java.io.ObjectInputStream;
+
+public class IndirectReadObject1 {
+    final void indirect() {
+        overridableMethod();
+    }
+
+    private void readObject(final ObjectInputStream stream) {
+        indirect();
+        privateMethod();
+        finalMethod();
+    }
+
+    void overridableMethod() {
+        System.out.println("I am overridable.");
+    }
+
+    private void privateMethod() {
+        System.out.println("I am private.");
+    }
+
+    final void finalMethod() {
+        System.out.println("I am final.");
+    }
+}

--- a/spotbugsTestCases/src/java/overridableMethodCall/IndirectReadObject2.java
+++ b/spotbugsTestCases/src/java/overridableMethodCall/IndirectReadObject2.java
@@ -1,0 +1,27 @@
+package overridableMethodCall;
+
+import java.io.ObjectInputStream;
+
+public class IndirectReadObject2 {
+    private void readObject(final ObjectInputStream stream) {
+        indirect();
+        privateMethod();
+        finalMethod();
+    }
+
+    final void indirect() {
+        overridableMethod();
+    }
+
+    void overridableMethod() {
+        System.out.println("I am overridable.");
+    }
+
+    private void privateMethod() {
+        System.out.println("I am private.");
+    }
+
+    final void finalMethod() {
+        System.out.println("I am final.");
+    }
+}

--- a/spotbugsTestCases/src/java/overridableMethodCall/IndirectStreamMethods1.java
+++ b/spotbugsTestCases/src/java/overridableMethodCall/IndirectStreamMethods1.java
@@ -1,0 +1,15 @@
+package overridableMethodCall;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+
+public class IndirectStreamMethods1 {
+    final void indirect(final ObjectInputStream stream) throws IOException, ClassNotFoundException {
+        stream.defaultReadObject();
+        stream.readFields();
+    }
+
+    private void readObject(final ObjectInputStream stream) throws IOException, ClassNotFoundException {
+        indirect(stream);
+    }
+}

--- a/spotbugsTestCases/src/java/overridableMethodCall/IndirectStreamMethods2.java
+++ b/spotbugsTestCases/src/java/overridableMethodCall/IndirectStreamMethods2.java
@@ -1,0 +1,15 @@
+package overridableMethodCall;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+
+public class IndirectStreamMethods2 {
+    private void readObject(final ObjectInputStream stream) throws IOException, ClassNotFoundException {
+        indirect(stream);
+    }
+
+    final void indirect(final ObjectInputStream stream) throws IOException, ClassNotFoundException {
+        stream.defaultReadObject();
+        stream.readFields();
+    }
+}

--- a/spotbugsTestCases/src/java/overridableMethodCall/MethodReferenceReadObject.java
+++ b/spotbugsTestCases/src/java/overridableMethodCall/MethodReferenceReadObject.java
@@ -1,0 +1,28 @@
+package overridableMethodCall;
+
+import java.io.ObjectInputStream;
+import java.util.concurrent.Callable;
+
+public class MethodReferenceReadObject {
+    private void wrapper(Callable f) throws Exception {
+        f.call();
+    }
+
+    void readObject(final ObjectInputStream stream) throws Exception {
+        wrapper(this::overridableMethod);
+        wrapper(this::privateMethod);
+        wrapper(this::finalMethod);
+    }
+
+    int overridableMethod() {
+        return 1;
+    }
+
+    private int privateMethod() {
+        return 2;
+    }
+
+    final int finalMethod() {
+        return 3;
+    }
+}

--- a/spotbugsTestCases/src/java/overridableMethodCall/MethodReferenceReadObjectIndirect1.java
+++ b/spotbugsTestCases/src/java/overridableMethodCall/MethodReferenceReadObjectIndirect1.java
@@ -1,0 +1,32 @@
+package overridableMethodCall;
+
+import java.io.ObjectInputStream;
+import java.util.concurrent.Callable;
+
+public class MethodReferenceReadObjectIndirect1 {
+    private void wrapper(Callable f) throws Exception {
+        f.call();
+    }
+
+    final int indirect() {
+        return overridableMethod();
+    }
+
+    void readObject(final ObjectInputStream stream) throws Exception {
+        wrapper(this::indirect);
+        wrapper(this::privateMethod);
+        wrapper(this::finalMethod);
+    }
+
+    int overridableMethod() {
+        return 1;
+    }
+
+    private int privateMethod() {
+        return 2;
+    }
+
+    final int finalMethod() {
+        return 3;
+    }
+}

--- a/spotbugsTestCases/src/java/overridableMethodCall/MethodReferenceReadObjectIndirect2.java
+++ b/spotbugsTestCases/src/java/overridableMethodCall/MethodReferenceReadObjectIndirect2.java
@@ -1,0 +1,40 @@
+package overridableMethodCall;
+
+import java.io.ObjectInputStream;
+import java.util.concurrent.Callable;
+
+public class MethodReferenceReadObjectIndirect2 {
+    private int wrapper(Callable f) throws Exception {
+        return (int) f.call();
+    }
+
+    final int indirectOverridable() throws Exception {
+        return wrapper(this::overridableMethod);
+    }
+
+    final int indirectPrivate() throws Exception {
+        return wrapper(this::privateMethod);
+    }
+
+    final int indirectFinal() throws Exception {
+        return wrapper(this::finalMethod);
+    }
+
+    void readObject(final ObjectInputStream stream) throws Exception {
+        indirectOverridable();
+        indirectPrivate();
+        indirectFinal();
+    }
+
+    int overridableMethod() {
+        return 1;
+    }
+
+    private int privateMethod() {
+        return 2;
+    }
+
+    final int finalMethod() {
+        return 3;
+    }
+}

--- a/spotbugsTestCases/src/java/overridableMethodCall/MethodReferenceReadObjectIndirect3.java
+++ b/spotbugsTestCases/src/java/overridableMethodCall/MethodReferenceReadObjectIndirect3.java
@@ -1,0 +1,40 @@
+package overridableMethodCall;
+
+import java.io.ObjectInputStream;
+import java.util.concurrent.Callable;
+
+public class MethodReferenceReadObjectIndirect3 {
+    private int wrapper(Callable f) throws Exception {
+        return (int) f.call();
+    }
+
+    final int indirectOverridable() throws Exception {
+        return wrapper(this::overridableMethod);
+    }
+
+    final int indirectPrivate() throws Exception {
+        return wrapper(this::privateMethod);
+    }
+
+    final int indirectFinal() throws Exception {
+        return wrapper(this::finalMethod);
+    }
+
+    void readObject(final ObjectInputStream stream) throws Exception {
+        wrapper(this::indirectOverridable);
+        wrapper(this::indirectPrivate);
+        wrapper(this::indirectFinal);
+    }
+
+    int overridableMethod() {
+        return 1;
+    }
+
+    private int privateMethod() {
+        return 2;
+    }
+
+    final int finalMethod() {
+        return 3;
+    }
+}


### PR DESCRIPTION
The readObject() method must not call any overridable methods. Invoking overridable methods from the readObject() method can provide the overriding method with access to the object's state before it is fully initialized. This premature access is possible because, in deserialization, readObject plays the role of object constructor and therefore object initialization is not complete until readObject exits.

Please read the [SEI CERT rule SER09-J](https://wiki.sei.cmu.edu/confluence/display/java/SER09-J.+Do+not+invoke+overridable+methods+from+the+readObject%28%29+method) for details.

The rule is similar to [MET06-J. Do not invoke overridable methods in clone()](https://wiki.sei.cmu.edu/confluence/pages/viewpage.action?pageId=88487921)), which is detected by the `FindOverridableMethodCall`, hence the extension of the existing detector instead of introducing a new one with the same functionality.