### PR TITLE
[checkstyle] Bump to 10.14.2, remove dependency management to exclude guava

### DIFF
--- a/gradle/checkstyle.gradle
+++ b/gradle/checkstyle.gradle
@@ -1,14 +1,8 @@
 // Setup checkstyle
 apply plugin: 'checkstyle'
 
-configurations.checkstyle {
-  resolutionStrategy.capabilitiesResolution.withCapability("com.google.collections:google-collections") {
-    select("com.google.guava:guava:33.1.0-jre")
-  }
-}
-
 checkstyle {
-  toolVersion '10.14.1'
+  toolVersion '10.14.2'
   ignoreFailures false
   configFile file("$rootDir/spotbugs/etc/checkstyle.xml") // TODO : This config file is lame and should be moved out...
 }


### PR DESCRIPTION
https://github.com/checkstyle/checkstyle/issues/14211

tested at https://github.com/checkstyle/checkstyle/issues/14211#issuecomment-2002201042