### PR TITLE
Update the filter XSD namespace and location for the upcoming 4.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Fixed crash in ValueRangeAnalysisFactory when looking for redundant conditions used in assertions [#2887](https://github.com/spotbugs/spotbugs/pull/2887))
 - Revert again commons-text from 1.11.0 to 1.10.0 to resolve a version conflict ([#2686](https://github.com/spotbugs/spotbugs/issues/2686))
 - Fixed false positive MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR when referencing but not calling an overridable method [#2837](https://github.com/spotbugs/spotbugs/pull/2837))
+- Update the filter XSD namespace and location for the upcoming 4.8.4 release [#2909](https://github.com/spotbugs/spotbugs/issues/2909))
 
 ### Added
 - New detector `MultipleInstantiationsOfSingletons` and introduced new bug types:

--- a/docs/filter.rst
+++ b/docs/filter.rst
@@ -309,9 +309,9 @@ Complete Example
 
     <?xml version="1.0" encoding="UTF-8"?>
     <FindBugsFilter
-		xmlns="https://github.com/spotbugs/filter/3.0.0"
+		xmlns="https://github.com/spotbugs/filter/4.8.4"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
+		xsi:schemaLocation="https://github.com/spotbugs/filter/4.8.4 https://raw.githubusercontent.com/spotbugs/spotbugs/4.8.4/spotbugs/etc/findbugsfilter.xsd">
     <Match>
       <Class name="com.foobar.ClassNotToBeAnalyzed" />
     </Match>

--- a/spotbugs/etc/findbugsfilter.xsd
+++ b/spotbugs/etc/findbugsfilter.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<schema targetNamespace="https://github.com/spotbugs/filter/3.0.0" elementFormDefault="unqualified"
-    xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/master/spotbugs/etc/findbugsfilter.xsd"
-    xmlns="http://www.w3.org/2001/XMLSchema" xmlns:fb="https://github.com/spotbugs/filter/3.0.0">
+<schema targetNamespace="https://github.com/spotbugs/filter/4.8.4" elementFormDefault="unqualified"
+    xsi:schemaLocation="https://github.com/spotbugs/filter/4.8.4 https://raw.githubusercontent.com/spotbugs/spotbugs/4.8.4/spotbugs/etc/findbugsfilter.xsd"
+    xmlns="http://www.w3.org/2001/XMLSchema" xmlns:fb="https://github.com/spotbugs/filter/4.8.4">
 
     <element name="FindBugsFilter" type="fb:FindBugsFilterType"></element>
 


### PR DESCRIPTION
The XSD was modified but the namespace and location remained on 3.0.0
Update them to the upcoming 4.8.4 version (instead of using the ever moving master branch), the location will be available once the 4.8.4 Git tag is created
