### PR TITLE
Fetch Git history when performing a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
+        with:
+          fetch-depth: 0
       - name: Get previous tag for the change log
         id: previousTag
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         uses: requarks/changelog-action@v1
         with:
           token: ${{ github.token }}
-          toTag: ${{ github.ref }}
+          toTag: ${{ github.ref_name }}
           fromTag: ${{ env.previousTag }}
           writeToFile: true
         continue-on-error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,8 @@ jobs:
         uses: requarks/changelog-action@v1
         with:
           token: ${{ github.token }}
-          toTag: ${{ github.ref_name }}
-          fromTag: ${{ env.previousTag }}
+          toTag: ${{ env.previousTag }}
+          fromTag: ${{ github.ref_name }}
           writeToFile: true
         continue-on-error: true
 


### PR DESCRIPTION
The release workflow does not fetch the Git history so looking for the previous tag only gets the latest tag and `requarks/changelog-action` says that it cannot update the Changelog (because from/to tags are the same)