### PR TITLE
GHA - Nver close stale items / Move release to use Java 21

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,10 +42,10 @@ jobs:
           commit_message: 'docs: update CHANGELOG.md for ${{ github.ref_name }}'
           file_pattern: CHANGELOG.md
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: temurin
           cache: gradle
       - uses: gradle/wrapper-validation-action@v2

--- a/.github/workflows/ticket-management.yml
+++ b/.github/workflows/ticket-management.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/stale@v9
         with:
           days-before-stale: 30
-          days-before-close: 30
+          days-before-close: -1
           stale-pr-label: 'Stale'
           stale-issue-label: 'need info'
           only-issue-labels: 'need info'


### PR DESCRIPTION
Before opening a 'pull request'

* Search existing issues and pull requests to see if the issue was already discussed.
* Check our discussions to see if the issue was already discussed.
* Check for specific project we support to raise the issue on, under [spotbugs](https://github.com/spotbugs)
* Do not open intellij plugin issues here, open them at [intellij-plugin](https://github.com/JetBrains/spotbugs-intellij-plugin) *
