### PR TITLE
Fix `SING_SINGLETON_GETTER_NOT_SYNCHRONIZED` FP with eager instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased - 2024-??-??
+### Fixed
+- Fix FP `SING_SINGLETON_GETTER_NOT_SYNCHRONIZED` with eager instances ([#2932]https://github.com/spotbugs/spotbugs/issues/2932)
 
 ## 4.8.4 - 2024-04-07
 ### Fixed

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/MultipleInstantiationsOfSingletonsTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/MultipleInstantiationsOfSingletonsTest.java
@@ -12,6 +12,12 @@ import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
 class MultipleInstantiationsOfSingletonsTest extends AbstractIntegrationTest {
     @Test
+    void notLazyInitSingletonTest() {
+        performAnalysis("singletons/NotLazyInitSingleton.class");
+        assertNoBugs();
+    }
+
+    @Test
     void cloneableSingletonTest() {
         performAnalysis("singletons/CloneableSingleton.class");
         assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_CLONEABLE", 1);

--- a/spotbugsTestCases/src/java/singletons/NotLazyInitSingleton.java
+++ b/spotbugsTestCases/src/java/singletons/NotLazyInitSingleton.java
@@ -1,0 +1,17 @@
+package singletons;
+
+/**
+ * See https://github.com/spotbugs/spotbugs/issues/2932
+ */
+public class NotLazyInitSingleton {
+    private static final NotLazyInitSingleton INSTANCE = new NotLazyInitSingleton();
+
+    private NotLazyInitSingleton() {
+        // hidden on purpose
+    }
+
+    // the singleton is not initialized lazily,
+    public static NotLazyInitSingleton instance() {
+        return INSTANCE;
+    }
+}


### PR DESCRIPTION
This PR fixes #2932 : with eager instances the getter method of a Singleton class doesn't need to synchronize.