### PR TITLE
Change Gradle Enterprise (deprecated) to Develocity

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("com.gradle.enterprise") version "3.17.1"
+  id("com.gradle.develocity") version "3.17.1"
 }
 
 include(":eclipsePlugin")
@@ -16,9 +16,9 @@ include(":test-harness-jupiter")
 
 rootProject.name = "spotbugs"
 
-gradleEnterprise {
+develocity {
   buildScan {
-    termsOfServiceUrl = "https://gradle.com/terms-of-service"
-    termsOfServiceAgree = "yes"
+    termsOfUseUrl = "https://gradle.com/terms-of-service"
+    termsOfUseAgree = "yes"
   }
 }


### PR DESCRIPTION
Gradle deprecated it some plugin ids, the build (see [gha run](https://github.com/spotbugs/spotbugs/actions/runs/8680606093/job/23801545703)) emitting the following warnings:

```
WARNING: The following functionality has been deprecated and will be removed in the next major release of the Develocity Gradle plugin. For assistance with migration, see https://gradle.com/help/gradle-plugin-develocity-migration.
- The deprecated "gradleEnterprise.buildScan.termsOfServiceUrl" API has been replaced by "develocity.buildScan.termsOfUseUrl"
- The deprecated "gradleEnterprise.buildScan.termsOfServiceAgree" API has been replaced by "develocity.buildScan.termsOfUseAgree"
- The "com.gradle.enterprise" plugin has been replaced by "com.gradle.develocity"
```
This PR solves this.