### PR TITLE
Fix FPs with multiple initialization of Singletons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ## Unreleased - 2024-??-??
 ### Fixed
-- Fix FP `SING_SINGLETON_GETTER_NOT_SYNCHRONIZED` with eager instances ([#2932]https://github.com/spotbugs/spotbugs/issues/2932)
+- Fix FP `SING_SINGLETON_GETTER_NOT_SYNCHRONIZED` with eager instances ([#2932](https://github.com/spotbugs/spotbugs/issues/2932))
+- Fix FPs when looking for multiple initialization of Singletons ([#2934](https://github.com/spotbugs/spotbugs/issues/2934))
 - Do not report DLS_DEAD_LOCAL_STORE for Java 21's type switches when switch instruction is TABLESWITCH([#2736](https://github.com/spotbugs/spotbugs/issues/2736))
 - Fix FP `SE_BAD_FIELD` for record fields ([#2935]https://github.com/spotbugs/spotbugs/issues/2935)
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/MultipleInstantiationsOfSingletonsTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/MultipleInstantiationsOfSingletonsTest.java
@@ -65,6 +65,12 @@ class MultipleInstantiationsOfSingletonsTest extends AbstractIntegrationTest {
     }
 
     @Test
+    void notSingletonWithFactoryMethodTest() {
+        performAnalysis("singletons/NotSingletonWithFactoryMethod.class");
+        assertNoBugs();
+    }
+
+    @Test
     void notLazyInitSingletonTest() {
         performAnalysis("singletons/NotLazyInitSingleton.class");
         assertNoBugs();

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/MultipleInstantiationsOfSingletonsTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/MultipleInstantiationsOfSingletonsTest.java
@@ -12,6 +12,59 @@ import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
 class MultipleInstantiationsOfSingletonsTest extends AbstractIntegrationTest {
     @Test
+    void abstractClassTest() {
+        performAnalysis("singletons/AbstractClass.class",
+                "singletons/AbstractClass$Nested.class");
+        assertNoBugs();
+    }
+
+    @Test
+    void innerChildInstanceTest() {
+        performAnalysis("singletons/InnerChildInstance.class",
+                "singletons/InnerChildInstance$Unknown.class",
+                "singletons/InnerChildInstance$1.class");
+        assertNoBugs();
+    }
+
+    @Test
+    void innerChildAndMoreInstanceTest() {
+        performAnalysis("singletons/InnerChildAndMoreInstance.class",
+                "singletons/InnerChildAndMoreInstance$1.class",
+                "singletons/InnerChildAndMoreInstance$Unknown.class");
+        assertNumOfSINGBugs("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR", 1);
+        assertSINGBug("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR", "InnerChildAndMoreInstance");
+
+        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_CLONEABLE", 0);
+        assertNumOfSINGBugs("SING_SINGLETON_INDIRECTLY_IMPLEMENTS_CLONEABLE", 0);
+        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_CLONE_METHOD", 0);
+        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_SERIALIZABLE", 0);
+        assertNumOfSINGBugs("SING_SINGLETON_GETTER_NOT_SYNCHRONIZED", 0);
+    }
+
+    @Test
+    void InnerChildAndMoreInstanceReorderedTest() {
+        performAnalysis("singletons/InnerChildAndMoreInstanceReordered.class",
+                "singletons/InnerChildAndMoreInstanceReordered$1.class",
+                "singletons/InnerChildAndMoreInstanceReordered$Unknown.class");
+        assertNumOfSINGBugs("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR", 1);
+        assertSINGBug("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR", "InnerChildAndMoreInstanceReordered");
+
+        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_CLONEABLE", 0);
+        assertNumOfSINGBugs("SING_SINGLETON_INDIRECTLY_IMPLEMENTS_CLONEABLE", 0);
+        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_CLONE_METHOD", 0);
+        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_SERIALIZABLE", 0);
+        assertNumOfSINGBugs("SING_SINGLETON_GETTER_NOT_SYNCHRONIZED", 0);
+    }
+
+    @Test
+    void InnerChildAndMoreInstanceNoGetterTest() {
+        performAnalysis("singletons/InnerChildAndMoreInstanceNoGetter.class",
+                "singletons/InnerChildAndMoreInstanceNoGetter$1.class",
+                "singletons/InnerChildAndMoreInstanceNoGetter$Unknown.class");
+        assertNoBugs();
+    }
+
+    @Test
     void notLazyInitSingletonTest() {
         performAnalysis("singletons/NotLazyInitSingleton.class");
         assertNoBugs();
@@ -61,6 +114,32 @@ class MultipleInstantiationsOfSingletonsTest extends AbstractIntegrationTest {
         performAnalysis("singletons/ProtectedConstructor.class");
         assertNumOfSINGBugs("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR", 1);
         assertSINGBug("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR", "ProtectedConstructor");
+
+        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_CLONEABLE", 0);
+        assertNumOfSINGBugs("SING_SINGLETON_INDIRECTLY_IMPLEMENTS_CLONEABLE", 0);
+        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_CLONE_METHOD", 0);
+        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_SERIALIZABLE", 0);
+        assertNumOfSINGBugs("SING_SINGLETON_GETTER_NOT_SYNCHRONIZED", 0);
+    }
+
+    @Test
+    void protectedConstructorStaticInitTest() {
+        performAnalysis("singletons/ProtectedConstructorStaticInit.class");
+        assertNumOfSINGBugs("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR", 1);
+        assertSINGBug("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR", "ProtectedConstructorStaticInit");
+
+        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_CLONEABLE", 0);
+        assertNumOfSINGBugs("SING_SINGLETON_INDIRECTLY_IMPLEMENTS_CLONEABLE", 0);
+        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_CLONE_METHOD", 0);
+        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_SERIALIZABLE", 0);
+        assertNumOfSINGBugs("SING_SINGLETON_GETTER_NOT_SYNCHRONIZED", 0);
+    }
+
+    @Test
+    void protectedConstructorStaticInitReorderedTest() {
+        performAnalysis("singletons/ProtectedConstructorStaticInitReordered.class");
+        assertNumOfSINGBugs("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR", 1);
+        assertSINGBug("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR", "ProtectedConstructorStaticInitReordered");
 
         assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_CLONEABLE", 0);
         assertNumOfSINGBugs("SING_SINGLETON_INDIRECTLY_IMPLEMENTS_CLONEABLE", 0);
@@ -139,6 +218,12 @@ class MultipleInstantiationsOfSingletonsTest extends AbstractIntegrationTest {
     @Test
     void enumSingletonTest() {
         performAnalysis("singletons/EnumSingleton.class");
+        assertNoBugs();
+    }
+
+    @Test
+    void oneEnumSingletonTest() {
+        performAnalysis("singletons/OneEnumSingleton.class");
         assertNoBugs();
     }
 

--- a/spotbugsTestCases/src/java/singletons/AbstractClass.java
+++ b/spotbugsTestCases/src/java/singletons/AbstractClass.java
@@ -1,0 +1,46 @@
+package singletons;
+
+import java.io.Serializable;
+import java.util.Objects;
+/**
+ * See <a href="https://github.com/spotbugs/spotbugs/issues/2934">#2934</a>
+ */
+public abstract class AbstractClass implements Serializable {
+    public static class Nested extends AbstractClass {
+        private static final long serialVersionUID = 1L;
+
+        private final String appTag;
+
+        Nested(final String appTag) {
+            this.appTag = appTag;
+        }
+
+        @Override
+        String abstractMethod() {
+            return appTag;
+        }
+    }
+
+    private static final AbstractClass NESTED = new Nested(null);
+    private static final long serialVersionUID = 1L;
+
+    public static AbstractClass nested() {
+        return NESTED;
+    }
+
+    abstract String abstractMethod();
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(abstractMethod());
+    }
+
+    @Override
+    public final boolean equals(final Object obj) {
+        if (this == obj || obj instanceof AbstractClass) {
+            AbstractClass other = (AbstractClass) obj;
+            return Objects.equals(abstractMethod(), other.abstractMethod());
+        }
+        return false;
+    }
+}

--- a/spotbugsTestCases/src/java/singletons/InnerChildAndMoreInstance.java
+++ b/spotbugsTestCases/src/java/singletons/InnerChildAndMoreInstance.java
@@ -1,0 +1,17 @@
+package singletons;
+
+public class InnerChildAndMoreInstance {
+    private static class Unknown extends InnerChildAndMoreInstance {
+    }
+
+    private static final InnerChildAndMoreInstance UNKNOWN = new Unknown();
+
+    private static final InnerChildAndMoreInstance INSTANCE = new InnerChildAndMoreInstance();
+
+    public static InnerChildAndMoreInstance getUnknown() {
+        return UNKNOWN;
+    }
+    public static InnerChildAndMoreInstance instance() {
+        return INSTANCE;
+    }
+}

--- a/spotbugsTestCases/src/java/singletons/InnerChildAndMoreInstanceNoGetter.java
+++ b/spotbugsTestCases/src/java/singletons/InnerChildAndMoreInstanceNoGetter.java
@@ -1,0 +1,14 @@
+package singletons;
+
+public class InnerChildAndMoreInstanceNoGetter {
+    private static class Unknown extends InnerChildAndMoreInstanceNoGetter {
+    }
+
+    private static final InnerChildAndMoreInstanceNoGetter INSTANCE = new InnerChildAndMoreInstanceNoGetter();
+
+    private static final InnerChildAndMoreInstanceNoGetter UNKNOWN = new Unknown();
+
+    public static InnerChildAndMoreInstanceNoGetter getUnknown() {
+        return UNKNOWN;
+    }
+}

--- a/spotbugsTestCases/src/java/singletons/InnerChildAndMoreInstanceReordered.java
+++ b/spotbugsTestCases/src/java/singletons/InnerChildAndMoreInstanceReordered.java
@@ -1,0 +1,17 @@
+package singletons;
+
+public class InnerChildAndMoreInstanceReordered {
+    private static class Unknown extends InnerChildAndMoreInstanceReordered {
+    }
+
+    private static final InnerChildAndMoreInstanceReordered INSTANCE = new InnerChildAndMoreInstanceReordered();
+
+    private static final InnerChildAndMoreInstanceReordered UNKNOWN = new Unknown();
+
+    public static InnerChildAndMoreInstanceReordered instance() {
+        return INSTANCE;
+    }
+    public static InnerChildAndMoreInstanceReordered getUnknown() {
+        return UNKNOWN;
+    }
+}

--- a/spotbugsTestCases/src/java/singletons/InnerChildInstance.java
+++ b/spotbugsTestCases/src/java/singletons/InnerChildInstance.java
@@ -1,0 +1,15 @@
+package singletons;
+
+/**
+ * See <a href="https://github.com/spotbugs/spotbugs/issues/2934">#2934</a>
+ */
+public class InnerChildInstance {
+    private static class Unknown extends InnerChildInstance {
+    }
+
+    private static final InnerChildInstance UNKNOWN = new Unknown();
+
+    public static InnerChildInstance getUnknown() {
+        return UNKNOWN;
+    }
+}

--- a/spotbugsTestCases/src/java/singletons/NotSingletonWithFactoryMethod.java
+++ b/spotbugsTestCases/src/java/singletons/NotSingletonWithFactoryMethod.java
@@ -1,7 +1,7 @@
 package singletons;
 
 /**
- * See https://github.com/spotbugs/spotbugs/issues/2934
+ * See <a href="https://github.com/spotbugs/spotbugs/issues/2934">#2934</a>
  */
 public class NotSingletonWithFactoryMethod {
 
@@ -11,6 +11,10 @@ public class NotSingletonWithFactoryMethod {
 
     private NotSingletonWithFactoryMethod(String text) {
         this.text = text;
+    }
+
+    public NotSingletonWithFactoryMethod() {
+        this.text = "default";
     }
 
     public static NotSingletonWithFactoryMethod instance1() {

--- a/spotbugsTestCases/src/java/singletons/NotSingletonWithFactoryMethod.java
+++ b/spotbugsTestCases/src/java/singletons/NotSingletonWithFactoryMethod.java
@@ -1,0 +1,27 @@
+package singletons;
+
+/**
+ * See https://github.com/spotbugs/spotbugs/issues/2934
+ */
+public class NotSingletonWithFactoryMethod {
+
+    private static final NotSingletonWithFactoryMethod INSTANCE = new NotSingletonWithFactoryMethod("1");
+
+    private final String text;
+
+    private NotSingletonWithFactoryMethod(String text) {
+        this.text = text;
+    }
+
+    public static NotSingletonWithFactoryMethod instance1() {
+        return INSTANCE;
+    }
+
+    public static NotSingletonWithFactoryMethod create(String text) {
+        return new NotSingletonWithFactoryMethod("text");
+    }
+
+    public String getText() {
+        return text;
+    }
+}

--- a/spotbugsTestCases/src/java/singletons/OneEnumSingleton.java
+++ b/spotbugsTestCases/src/java/singletons/OneEnumSingleton.java
@@ -1,0 +1,16 @@
+package singletons;
+
+public enum OneEnumSingleton {
+    INSTANCE; // Only one element
+
+    // Nontransient field
+    int value;
+
+    public int getValue() {
+        return value;
+    }
+
+    public void setValue(int value) {
+        this.value = value;
+    }
+}

--- a/spotbugsTestCases/src/java/singletons/ProtectedConstructorStaticInit.java
+++ b/spotbugsTestCases/src/java/singletons/ProtectedConstructorStaticInit.java
@@ -1,0 +1,17 @@
+package singletons;
+
+class ProtectedConstructorStaticInit {
+    protected ProtectedConstructorStaticInit() {
+        
+    }
+   
+    public static synchronized ProtectedConstructorStaticInit getInstance() {
+      return instance;
+    }
+    
+    private static ProtectedConstructorStaticInit instance;
+
+    static {
+        instance = new ProtectedConstructorStaticInit();
+    }
+}

--- a/spotbugsTestCases/src/java/singletons/ProtectedConstructorStaticInitReordered.java
+++ b/spotbugsTestCases/src/java/singletons/ProtectedConstructorStaticInitReordered.java
@@ -1,0 +1,18 @@
+package singletons;
+
+class ProtectedConstructorStaticInitReordered {
+    protected ProtectedConstructorStaticInitReordered() {
+        
+    }
+
+    static {
+        instance = new ProtectedConstructorStaticInitReordered();
+    }
+
+    public static synchronized ProtectedConstructorStaticInitReordered getInstance() {
+      return instance;
+    }
+    
+    private static ProtectedConstructorStaticInitReordered instance;
+
+}


### PR DESCRIPTION
This PR fixes https://github.com/spotbugs/spotbugs/issues/2934.
The `MultipleInstantiationsOfSingletons` detector is a bit eagerly considers classes as singletons. With this change, the detector
- accepts enums with 1 elements as well, not only those with 0 elements,
- recognizes if instance field is assigned a specific inner child instance, not the containing class itself, and does not consider these classes as singletons,
- does not consider singletons abstract classes or interfaces,
- can find the instance getter method more accurately.