### PR TITLE
Fix test-harness-jupiter test dependency

### DIFF
--- a/test-harness-jupiter/build.gradle
+++ b/test-harness-jupiter/build.gradle
@@ -24,6 +24,8 @@ java {
 }
 
 test {
+  dependsOn(":test-harness-jupiter:spotbugsMain")
+  dependsOn(":test-harness-jupiter:spotbugsTest")
   useJUnitPlatform()
 }
 


### PR DESCRIPTION
Fixing `gradlew test` fail after `gradlew clean` because of build dependencies introduced in https://github.com/spotbugs/spotbugs/pull/2840.
Thank you, @gtoison for letting me know at https://github.com/spotbugs/spotbugs/pull/2840#issuecomment-2095290651.

It looks like the two files in [SpotBugsExtensionTest](https://github.com/spotbugs/spotbugs/blob/master/test-harness-jupiter/src/test/java/edu/umd/cs/findbugs/test/SpotBugsExtensionTest.java), `build/spotbugs/auxclasspath/spotbugsMain` and `build/spotbugs/auxclasspath/spotbugsTest` are added respectively during the `:test-harness-jupiter:spotbugsMain` and `:test-harness-jupiter:spotbugsTest` build phases. Tried removing this dependencies first, but in that case same classes needed for the analyses were missing.

Since it's only an small internal test fix, I did not add a changelog entry.