### PR TITLE
Avoid exception when inspecting empty switch statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 ## Unreleased - 2024-??-??
 ### Fixed
 - Do not report BC_UNCONFIRMED_CAST for Java 21's type switches when the switch instruction is TABLESWITCH ([#2782](https://github.com/spotbugs/spotbugs/issues/2782))
-
+- Do not throw exception when inspecting empty switch statements ([#2995](https://github.com/spotbugs/spotbugs/issues/2995))
 ## 4.8.5 - 2024-05-03
 ### Fixed
 - Fix FP `SING_SINGLETON_GETTER_NOT_SYNCHRONIZED` with eager instances ([#2932](https://github.com/spotbugs/spotbugs/issues/2932))
@@ -39,8 +39,8 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Improved the bug description for VA_FORMAT_STRING_USES_NEWLINE when using text blocks, check the usage of String.formatted() ([#2881](https://github.com/spotbugs/spotbugs/pull/2881))
 - Fixed crash in ValueRangeAnalysisFactory when looking for redundant conditions used in assertions [#2887](https://github.com/spotbugs/spotbugs/pull/2887))
 - Revert again commons-text from 1.11.0 to 1.10.0 to resolve a version conflict ([#2686](https://github.com/spotbugs/spotbugs/issues/2686))
-- Fixed false positive MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR when referencing but not calling an overridable method [#2837](https://github.com/spotbugs/spotbugs/pull/2837))
-- Update the filter XSD namespace and location for the upcoming 4.8.4 release [#2909](https://github.com/spotbugs/spotbugs/issues/2909))
+- Fixed false positive MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR when referencing but not calling an overridable method ([#2837](https://github.com/spotbugs/spotbugs/pull/2837))
+- Update the filter XSD namespace and location for the upcoming 4.8.4 release ([#2909](https://github.com/spotbugs/spotbugs/issues/2909))
 
 ### Added
 - New detector `MultipleInstantiationsOfSingletons` and introduced new bug types:

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue2995Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue2995Test.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-public class Issue2995Test  extends AbstractIntegrationTest {
+public class Issue2995Test extends AbstractIntegrationTest {
 
     @Test
     void testIssue() {

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue2995Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue2995Test.java
@@ -1,0 +1,25 @@
+package edu.umd.cs.findbugs.ba;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import edu.umd.cs.findbugs.SortedBugCollection;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
+import org.junit.jupiter.api.Test;
+
+import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class Issue2995Test  extends AbstractIntegrationTest {
+
+    @Test
+    void testIssue() {
+        performAnalysis("ghIssues/Issue2995.class");
+
+        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
+                .bugType("SF_DEAD_STORE_DUE_TO_SWITCH_FALLTHROUGH").build();
+
+        SortedBugCollection bugCollection = (SortedBugCollection) getBugCollection();
+        assertThat(bugCollection, containsExactly(0, bugTypeMatcher));
+
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/SwitchHandler.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/SwitchHandler.java
@@ -87,7 +87,7 @@ public class SwitchHandler {
         int size = switchOffsetStack.size();
         while (--size >= 0) {
             SwitchDetails existingDetail = switchOffsetStack.get(size);
-            if (details.switchPC > (existingDetail.switchPC + existingDetail.swOffsets[existingDetail.swOffsets.length - 1])) {
+            if (details.switchPC > (existingDetail.switchPC + existingDetail.getLastOffset())) {
                 switchOffsetStack.remove(size);
             }
         }
@@ -289,6 +289,10 @@ public class SwitchHandler {
                 return Short.MIN_VALUE;
             }
             return switchPC + defaultOffset;
+        }
+
+        public int getLastOffset() {
+            return swOffsets.length > 0 ? swOffsets[swOffsets.length - 1] : 0;
         }
     }
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/SwitchHandler.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/SwitchHandler.java
@@ -291,7 +291,7 @@ public class SwitchHandler {
             return switchPC + defaultOffset;
         }
 
-        public int getLastOffset() {
+        private int getLastOffset() {
             return swOffsets.length > 0 ? swOffsets[swOffsets.length - 1] : 0;
         }
     }

--- a/spotbugsTestCases/src/java/ghIssues/Issue2995.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue2995.java
@@ -1,0 +1,16 @@
+package ghIssues;
+
+public class Issue2995 {
+
+    public void emptySwitch() {
+        int foo = (int) (Math.random() * 5);
+
+        switch ((int) (Math.random() * 5)) {
+            default: break;
+        }
+
+        switch (foo++) {
+            default: break;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2995 

The testcase reproduces the issue, at least with Java 11. For the fix itself I'm not 100% sure it's the right approach