### PR TITLE
Adjust priority since relaxed mode reports even `IGNORED_PRIORITY`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,14 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 ### Fixed
 - Do not report BC_UNCONFIRMED_CAST for Java 21's type switches when the switch instruction is TABLESWITCH ([#2782](https://github.com/spotbugs/spotbugs/issues/2782))
 - Do not throw exception when inspecting empty switch statements ([#2995](https://github.com/spotbugs/spotbugs/issues/2995))
+- Adjust priority since relaxed mode reports even `IGNORED_PRIORITY` ([#2994]https://github.com/spotbugs/spotbugs/issues/2994)
+
 ## 4.8.5 - 2024-05-03
 ### Fixed
 - Fix FP `SING_SINGLETON_GETTER_NOT_SYNCHRONIZED` with eager instances ([#2932](https://github.com/spotbugs/spotbugs/issues/2932))
 - Fix FPs when looking for multiple initialization of Singletons ([#2934](https://github.com/spotbugs/spotbugs/issues/2934))
 - Do not report DLS_DEAD_LOCAL_STORE for Java 21's type switches when switch instruction is TABLESWITCH([#2736](https://github.com/spotbugs/spotbugs/issues/2736))
 - Fix FP `SE_BAD_FIELD` for record fields ([#2935]https://github.com/spotbugs/spotbugs/issues/2935)
-- Adjust priority since relaxed mode reports even `IGNORED_PRIORITY` ([#2994]https://github.com/spotbugs/spotbugs/issues/2994)
 
 ## 4.8.4 - 2024-04-07
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Fix FPs when looking for multiple initialization of Singletons ([#2934](https://github.com/spotbugs/spotbugs/issues/2934))
 - Do not report DLS_DEAD_LOCAL_STORE for Java 21's type switches when switch instruction is TABLESWITCH([#2736](https://github.com/spotbugs/spotbugs/issues/2736))
 - Fix FP `SE_BAD_FIELD` for record fields ([#2935]https://github.com/spotbugs/spotbugs/issues/2935)
+- Adjust priority since relaxed mode reports even `IGNORED_PRIORITY` ([#2994]https://github.com/spotbugs/spotbugs/issues/2994)
 
 ## 4.8.4 - 2024-04-07
 ### Fixed

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/PackageStats.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/PackageStats.java
@@ -47,7 +47,10 @@ class BugCounts {
     @OverridingMethodsMustInvokeSuper
     public void addError(BugInstance bug) {
         ensureNonnullBugCounts();
-        ++nBugs[bug.getPriority()];
+        // in 'relaxed' mode we might get bug with priority 5 = IGNORE_PRIORITY
+        int adjustedPriority = Math.min(bug.getPriority(), Priorities.IGNORE_PRIORITY - 1);
+
+        ++nBugs[adjustedPriority];
         ++nBugs[0];
     }
 


### PR DESCRIPTION
Adjust the priority in case is was `>= IGNORED_PRIORITY` as it might be the case in "relaxed" mode.
I understand that this is expected because there's a similar adjustment at: https://github.com/spotbugs/spotbugs/blob/861f4324c1c62c99b87f5d63b9e636f8df990261/spotbugs/src/main/java/edu/umd/cs/findbugs/ProjectStats.java#L277

Not sure how to reproduce the problem and this seem fairly straightforward so I did not add a tautological test, let me know if you think this is required