### PR TITLE
Removed log4j2 prefer() dependency constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Fix FPs when looking for multiple initialization of Singletons ([#2934](https://github.com/spotbugs/spotbugs/issues/2934))
 - Do not report DLS_DEAD_LOCAL_STORE for Java 21's type switches when switch instruction is TABLESWITCH([#2736](https://github.com/spotbugs/spotbugs/issues/2736))
 - Fix FP `SE_BAD_FIELD` for record fields ([#2935]https://github.com/spotbugs/spotbugs/issues/2935)
+- Fix duplicated log4j2 jar in distribution ([#3001]https://github.com/spotbugs/spotbugs/issues/3001)
 
 ## 4.8.4 - 2024-04-07
 ### Fixed

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -352,7 +352,6 @@ dependencies {
     logBinding("org.apache.logging.log4j:log4j-core") {
       version {
         strictly("[2.17.1, 3[")
-        prefer("2.22.0")
       }
       because("CVE-2021-44228, CVE-2021-45046, CVE-2021-45105, CVE-2021-44832: Log4j vulnerable to remote code execution and other critical security vulnerabilities")
     }


### PR DESCRIPTION
The constraint causes gradle to add log4j-core-2.22.0.jar and log4j-core-2.23.1.jar to the distribution.
Removed the constraint so only the latter version is included.
