### PR TITLE
GHA Matrix Update (drop macos-14 as now default / Add jdk 22)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest, macos-14]
-        java: [11, 17, 21]
+        java: [11, 17, 21, 22]
       max-parallel: 6
     runs-on: ${{ matrix.os }}
     continue-on-error: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-14]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         java: [11, 17, 21, 22]
       max-parallel: 6
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
I did not add a change log here since just minor build adjustments to our build on github (no code changes to our project).