### PR TITLE
Update spotbugs plugin to 6.0.16

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id "org.sonarqube" version "5.0.0.4638"
   id "org.gradle.crypto.checksum" version "1.4.0"
-  id "com.github.spotbugs" version "6.0.15"
+  id "com.github.spotbugs" version "6.0.16"
   id "io.github.gradle-nexus.publish-plugin" version "2.0.0"
 }
 

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -186,6 +186,14 @@ def jar = tasks.named('jar', Jar) {
 }
 tasks.spotbugsMain.dependsOn(jar)
 tasks.spotbugsGui.dependsOn(jar)
+tasks.withType(com.github.spotbugs.snom.SpotBugsTask).configureEach {
+  reports {
+    html {
+      // we use local spotbugs.jar, we cannot reference stylesheet from the published jar
+      stylesheet = resources.text.fromFile('src/xsl/fancy-hist.xsl')
+    }
+  }
+}
 
 // Populate bin folder with scripts
 def scripts = tasks.register('scripts', Copy) {


### PR DESCRIPTION
Replacement for https://github.com/spotbugs/spotbugs/pull/3009 fixing a build failure.
The latest Gradle plugin fails to find the stylesheet if the `spotbugs` gradle configuration was changed to include a *project* instead of an *external jar* file.

While this could be also fixed in the Gradle plugin, I don't think it makes sense to add complexity to the plugin for a very unique use-case of running SpotBugs on self.