### PR TITLE
[GHA] Do not run ticket management on forks

### DIFF
--- a/.github/workflows/ticket-management.yml
+++ b/.github/workflows/ticket-management.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   stale-pr-and-issue:
     # Mark stale issues and PRs, then close them 30 days later.
+    if: github.repository_owner == 'spotbugs'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v9


### PR DESCRIPTION
This may take a day to become effective but should stop this from running on forks.  Will not merge until I've seen that actually happen.