### PR TITLE
Check that JEP 456's unnamed variables do not cause false positive

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2736Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2736Test.java
@@ -20,7 +20,7 @@ class Issue2736Test extends AbstractIntegrationTest {
         assertBugCount(0);
     }
 
-    private void assertBugCount(String type, int expectedCount) {
+    private void assertBugCount(int expectedCount) {
         BugInstanceMatcher bugMatcher = new BugInstanceMatcherBuilder()
                 .build();
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2736Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2736Test.java
@@ -1,0 +1,29 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnJre;
+import org.junit.jupiter.api.condition.JRE;
+
+import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
+import static org.hamcrest.MatcherAssert.*;
+
+class Issue2736Test extends AbstractIntegrationTest {
+
+    @Test
+    @DisabledOnJre({ JRE.JAVA_8, JRE.JAVA_11, JRE.JAVA_17, JRE.JAVA_21 })
+    void testIssue() {
+        performAnalysis("../java22/Issue2736.class");
+
+        assertBugCount(0);
+    }
+
+    private void assertBugCount(String type, int expectedCount) {
+        BugInstanceMatcher bugMatcher = new BugInstanceMatcherBuilder()
+                .build();
+
+        assertThat(getBugCollection(), containsExactly(expectedCount, bugMatcher));
+    }
+}

--- a/spotbugsTestCases/build.gradle
+++ b/spotbugsTestCases/build.gradle
@@ -42,7 +42,9 @@ dependencies {
 tasks.withType(JavaCompile).configureEach {
   options.compilerArgs << '-Xlint:none'
   options.encoding = 'UTF-8'
-  if (it.name == 'classesJava21') {
+  if (it.name == 'classesJava22') {
+    options.release = 22
+  } else if (it.name == 'classesJava21') {
     options.release = 21
   } else if (it.name == 'classesJava17') {
     options.release = 17
@@ -90,6 +92,12 @@ def classesJava21 = tasks.register('classesJava21', JavaCompile) {
   source = file('src/java21')
 }
 
+def classesJava22 = tasks.register('classesJava22', JavaCompile) {
+  destinationDirectory.set(layout.buildDirectory.dir("classes/java/java22"))
+  classpath = sourceSets.main.compileClasspath
+  source = file('src/java22')
+}
+
 def jvmVersion = JavaVersion.current()
 tasks.named('classes').configure {
   dependsOn classesJava8
@@ -103,6 +111,11 @@ tasks.named('classes').configure {
     dependsOn classesJava21
   } else {
     println "skip tests for Java 21 features"
+  }
+  if (jvmVersion.isCompatibleWith(JavaVersion.VERSION_22)) {
+    dependsOn classesJava22
+  } else {
+    println "skip tests for Java 22 features"
   }
 }
 

--- a/spotbugsTestCases/src/java22/Issue2736.java
+++ b/spotbugsTestCases/src/java22/Issue2736.java
@@ -1,0 +1,36 @@
+import java.util.List;
+
+public class Issue2736 {
+	public void catchBlock(String s) {
+		try {
+			int i = Integer.parseInt(s);
+		} catch (NumberFormatException _) { // Unnamed variable
+			System.out.println("Bad number: " + s);
+		}
+	}
+
+	public int typeSwitch(List<String> values) {
+		int i = 0;
+		for (String _ : values) { // Unnamed variable
+			i++;
+		}
+		return i;
+	}
+
+	public int variable(List<String> values) {
+		var _ = values.remove(0); // Unnamed variable
+		var _ = values.remove(0); // Unnamed variable
+		var x = values.remove(0);
+
+		return x.length();
+	}
+
+	public int typeSwitch(Object x) {
+		return switch (x) {
+			case String _ -> 1; // Unnamed variable
+			case Integer _ -> 2; // Unnamed variable
+			case Long abc -> 3;
+			default -> 42;
+		};
+	}
+}


### PR DESCRIPTION
[JEP 456](https://openjdk.org/jeps/456) introduced unnamed variables in Java 22
As discussed in #2736 check that these unnamed variables do not cause false positives (or errors)

Since this is the first test case using Java 22 features this PR modifies the build to compile Java 22 samples when running on JDK >= 22

I've not updated the changelog since this PR only adds some tests.