### PR TITLE
Remove reliance on some deprecated Gradle features

### DIFF
--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -15,8 +15,12 @@ tasks.named('compileJava', JavaCompile).configure {
 tasks.withType(AbstractArchiveTask).configureEach {
   preserveFileTimestamps = false
   reproducibleFileOrder = true
-  dirMode = 0775
-  fileMode = 0664
+  dirPermissions{
+    unix (775)
+  }
+  filePermissions{
+    unix (664)
+  }
 }
 
 def classLoader = plugins['com.github.spotbugs'].class.classLoader

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -16,10 +16,10 @@ tasks.withType(AbstractArchiveTask).configureEach {
   preserveFileTimestamps = false
   reproducibleFileOrder = true
   dirPermissions{
-    unix (775)
+    unix (0775)
   }
   filePermissions{
-    unix (664)
+    unix (0664)
   }
 }
 

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -225,7 +225,9 @@ def scripts = tasks.register('scripts', Copy) {
 
   into(layout.buildDirectory.dir("bin"))
   duplicatesStrategy DuplicatesStrategy.FAIL
-  fileMode 0755
+  filePermissions{
+    unix (755)
+  }
 }
 
 // This disables hundreds of javadoc warnings on missing tags etc, see #340
@@ -285,7 +287,9 @@ tasks.named('distTar', Tar) {
 }
 def distZip = tasks.named('distZip', Zip) {
   duplicatesStrategy = DuplicatesStrategy.FAIL
-  fileMode 0755
+  filePermissions{
+    unix (755)
+  }
 }
 tasks.named('jar') {
   dependsOn tasks.named('updateManifest')

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -226,7 +226,7 @@ def scripts = tasks.register('scripts', Copy) {
   into(layout.buildDirectory.dir("bin"))
   duplicatesStrategy DuplicatesStrategy.FAIL
   filePermissions{
-    unix (755)
+    unix (0755)
   }
 }
 
@@ -288,7 +288,7 @@ tasks.named('distTar', Tar) {
 def distZip = tasks.named('distZip', Zip) {
   duplicatesStrategy = DuplicatesStrategy.FAIL
   filePermissions{
-    unix (755)
+    unix (0755)
   }
 }
 tasks.named('jar') {

--- a/test-harness-jupiter/build.gradle
+++ b/test-harness-jupiter/build.gradle
@@ -10,6 +10,8 @@ dependencies {
   testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
   testImplementation project(':spotbugs')
   testImplementation 'org.junit.jupiter:junit-jupiter-api'
+  testImplementation 'org.junit.jupiter:junit-jupiter'
+  testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('javadoc', Javadoc).configure {


### PR DESCRIPTION
The `fileMode` / `dirMode` and automatic loading of test framework implementations are deprecated in Gradle and will be removed from Gradle 9.0.
See these warnings when running `gradlew build smokeTest --warning-mode all`:
```
Script '\gradle\java.gradle': line 18
The CopyProcessingSpec.setDirMode(Integer) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Please use the dirPermissions(Action) method instead. Consult the upgrading guide for further information: 
https://docs.gradle.org/8.8/userguide/upgrading_version_8.html#unix_file_permissions_deprecated
        at java_c0o32gdeqv4fv0fvfgauj6rbx$_run_closure4.doCall$original(\gradle\java.gradle:18)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
        at build_clx9mxa6a1y9bu2thcsex5m14$_run_closure6.doCall$original(\eclipsePlugin-test\build.gradle:53)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
Script '\gradle\java.gradle': line 19
The CopyProcessingSpec.setFileMode(Integer) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Please use the filePermissions(Action) method instead. Consult the upgrading guide for further information: 
https://docs.gradle.org/8.8/userguide/upgrading_version_8.html#unix_file_permissions_deprecated
        at java_c0o32gdeqv4fv0fvfgauj6rbx$_run_closure4.doCall$original(\gradle\java.gradle:19)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
        at build_clx9mxa6a1y9bu2thcsex5m14$_run_closure6.doCall$original(\eclipsePlugin-test\build.gradle:53)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)

[...]

> Configure project :
Build file '\spotbugs\build.gradle': line 288
The CopyProcessingSpec.setFileMode(Integer) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Please use the filePermissions(Action) method instead. Consult the upgrading guide for further information: 
https://docs.gradle.org/8.8/userguide/upgrading_version_8.html#unix_file_permissions_deprecated
        at build_cfmhszmmki1xgz698lem82p3x$_run_closure19.doCall$original(\spotbugs\build.gradle:288)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
        at build_1v287rufs3f8gbd7o8eyme64y$_run_closure5.doCall$original(\spotbugs\build.gradle:72)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
Build file '\spotbugs\build.gradle': line 228
The CopyProcessingSpec.setFileMode(Integer) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Please use the filePermissions(Action) method instead. Consult the upgrading guide for further information: 
https://docs.gradle.org/8.8/userguide/upgrading_version_8.html#unix_file_permissions_deprecated
        at build_cfmhszmmki1xgz698lem82p3x$_run_closure14.doCall$original(\spotbugs\build.gradle:228)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
Relying on the convention for Test.classpath in custom Test tasks has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: 
https://docs.gradle.org/8.8/userguide/upgrading_version_8.html#test_task_default_classpath

[...]

> Task :test-harness-jupiter:test
The automatic loading of test framework implementation dependencies has been deprecated. This is scheduled to be removed in Gradle 9.0. Declare the desired test framework directly on the test suite or explicitly declare the test framework implementation dependencies on the test's runtime classpath. Consult the upgrading guide for further information: 
https://docs.gradle.org/8.8/userguide/upgrading_version_8.html#test_framework_implementation_dependencies

```

I haven't added a changelog entry, since this is only a small config change.