### PR TITLE
Keep a maximum of 10000 cached analysis entries by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 ## Unreleased - 2024-??-??
 ### Fixed
 - Do not consider Records as Singletons ([#2981](https://github.com/spotbugs/spotbugs/issues/2981))
+- Keep a maximum of 10000 cached analysis entries for plugin's analysis engines ([#3025](https://github.com/spotbugs/spotbugs/pull/3025))
 
 ## 4.8.6 - 2024-06-17
 ### Fixed

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/AnalysisCache.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/AnalysisCache.java
@@ -72,6 +72,11 @@ public class AnalysisCache implements IAnalysisCache {
      */
     private static final int MAX_CLASS_RESULTS_TO_CACHE = 5000;
 
+    /**
+     * Maximum number of results to cache. Plugins such as FindSecBugs are using the cache and using an unbounded map can lead to OOM errors on large projects
+     */
+    private static final int DEFAULT_RESULTS_TO_CACHE = 10000;
+
     //    private static final boolean ASSERTIONS_ENABLED = SystemProperties.ASSERTIONS_ENABLED;
 
     // Fields
@@ -442,7 +447,7 @@ public class AnalysisCache implements IAnalysisCache {
         } else if (engine instanceof IClassAnalysisEngine && ((IClassAnalysisEngine<?>) engine).canRecompute()) {
             descriptorMap = new MapCache<>(MAX_CLASS_RESULTS_TO_CACHE);
         } else {
-            descriptorMap = new HashMap<>();
+            descriptorMap = new MapCache<>(DEFAULT_RESULTS_TO_CACHE);
         }
         return descriptorMap;
     }


### PR DESCRIPTION
There are some outstanding issues in the https://github.com/spotbugs/sonar-findbugs project where the analysis seems to take forevever: 
https://github.com/spotbugs/sonar-findbugs/issues/254
https://github.com/spotbugs/sonar-findbugs/issues/361
https://github.com/spotbugs/sonar-findbugs/issues/291
https://github.com/spotbugs/sonar-findbugs/issues/317
https://github.com/spotbugs/sonar-findbugs/issues/318
https://github.com/spotbugs/sonar-findbugs/issues/367
https://github.com/spotbugs/sonar-findbugs/issues/1022

None of these error reports provide tractable information (a memory dump, a thread dump, etc.) which would help troubleshooting the problem, except for the last one where the user was kind enough to provide a thread dump.

My observartions are that:
- This only seems to happen for large projects
- This only seems to happen for the sonar project which coincidentally bundles the FindSecBugs plugin
- The thread dump indicates that FindSecBugs was trying to make a taint analysis, which are cached in the global analysis cache.

Although this is not a hard proof, it does seem to me that storing analysis results in an unbounded map _is_ a memory leak.

This PR should hopefully fix the problem by storing at most 10000 cache entries for unspecified analysis engines.