### PR TITLE
Only report `MC_OVERRIDABLE_METHOD_CALL_IN_READ_OBJECT` when calling own methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 ### Fixed
 - Do not consider Records as Singletons ([#2981](https://github.com/spotbugs/spotbugs/issues/2981))
 - Keep a maximum of 10000 cached analysis entries for plugin's analysis engines ([#3025](https://github.com/spotbugs/spotbugs/pull/3025))
+- Only report `MC_OVERRIDABLE_METHOD_CALL_IN_READ_OBJECT` when calling own methods ([#2957](https://github.com/spotbugs/spotbugs/issues/2957))
 
 ## 4.8.6 - 2024-06-17
 ### Fixed

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindOverridableMethodCallTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindOverridableMethodCallTest.java
@@ -238,6 +238,11 @@ class FindOverridableMethodCallTest extends AbstractIntegrationTest {
         testPass("OverridableMethodCallsInReadObjectCase1");
     }
 
+    @Test
+    void testOverridableMethodCallsInReadObjectCase2() {
+        testReadObject("OverridableMethodCallsInReadObjectCase1", 10);
+    }
+
     void testCase(String className, int constructorLine, int cloneLine) {
         performAnalysis("overridableMethodCall/" + className + ".class");
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindOverridableMethodCallTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindOverridableMethodCallTest.java
@@ -233,6 +233,11 @@ class FindOverridableMethodCallTest extends AbstractIntegrationTest {
         testPass("FinalClassIndirectReadObject");
     }
 
+    @Test
+    void testOverridableMethodCallsInReadObjectCase1() {
+        testPass("OverridableMethodCallsInReadObjectCase1");
+    }
+
     void testCase(String className, int constructorLine, int cloneLine) {
         performAnalysis("overridableMethodCall/" + className + ".class");
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindOverridableMethodCallTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindOverridableMethodCallTest.java
@@ -240,7 +240,7 @@ class FindOverridableMethodCallTest extends AbstractIntegrationTest {
 
     @Test
     void testOverridableMethodCallsInReadObjectCase2() {
-        testReadObject("OverridableMethodCallsInReadObjectCase1", 10);
+        testReadObject("OverridableMethodCallsInReadObjectCase2", 11);
     }
 
     void testCase(String className, int constructorLine, int cloneLine) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindOverridableMethodCall.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindOverridableMethodCall.java
@@ -248,11 +248,9 @@ public class FindOverridableMethodCall extends OpcodeStackDetector {
     }
 
     private boolean shouldIgnoreCallInReadObject(XMethod method) {
-        // SER09-J-EX0: The readObject() method may invoke the overridable methods defaultReadObject() and readFields()
-        // in class java.io.ObjectInputStream
-        boolean inOIS = "java.io.ObjectInputStream".equals(method.getClassName());
-        String methodName = method.getName();
-        return inOIS && ("defaultReadObject".equals(methodName) || "readFields".equals(methodName));
+        // We're only interested in method calls on the object itself
+        // Calling ObjectInputStream.readInt() is not considered risky here because the object stream is potentially under the control of the attacker.
+        return !getClassContext().getClassDescriptor().getDottedClassName().equals(method.getClassName());
     }
 
     private boolean reportIfOverridableCallInReadObject(XMethod caller, XMethod method, SourceLineAnnotation sourceLine) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindOverridableMethodCall.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindOverridableMethodCall.java
@@ -253,16 +253,18 @@ public class FindOverridableMethodCall extends OpcodeStackDetector {
         // We're only interested in method calls on the object itself
         // Calling ObjectInputStream.readInt() is not considered risky here because we assume that the object stream is not under the control of the attacker.
         // Checking for vulnerabilities when the object stream IS under control of the attacker is beyond the scope of this detector.
-    	@DottedClassName String className = getClassContext().getClassDescriptor().getDottedClassName();
-    	@DottedClassName String methodClassName = method.getClassName();
-		
-		try {
-			return !className.equals(methodClassName) && !Hierarchy.isSubtype(className, methodClassName);
-		} catch (ClassNotFoundException e) {
-			AnalysisContext.reportMissingClass(e);
-			
-			return true;
-		}
+        @DottedClassName
+        String className = getClassContext().getClassDescriptor().getDottedClassName();
+        @DottedClassName
+        String methodClassName = method.getClassName();
+
+        try {
+            return !className.equals(methodClassName) && !Hierarchy.isSubtype(className, methodClassName);
+        } catch (ClassNotFoundException e) {
+            AnalysisContext.reportMissingClass(e);
+
+            return true;
+        }
     }
 
     private boolean reportIfOverridableCallInReadObject(XMethod caller, XMethod method, SourceLineAnnotation sourceLine) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindOverridableMethodCall.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindOverridableMethodCall.java
@@ -249,7 +249,8 @@ public class FindOverridableMethodCall extends OpcodeStackDetector {
 
     private boolean shouldIgnoreCallInReadObject(XMethod method) {
         // We're only interested in method calls on the object itself
-        // Calling ObjectInputStream.readInt() is not considered risky here because the object stream is potentially under the control of the attacker.
+        // Calling ObjectInputStream.readInt() is not considered risky here because we assume that the object stream is not under the control of the attacker.
+        // Checking for vulnerabilities when the object stream IS under control of the attacker is beyond the scope of this detector.
         return !getClassContext().getClassDescriptor().getDottedClassName().equals(method.getClassName());
     }
 

--- a/spotbugsTestCases/src/java/overridableMethodCall/OverridableMethodCallsInReadObjectCase1.java
+++ b/spotbugsTestCases/src/java/overridableMethodCall/OverridableMethodCallsInReadObjectCase1.java
@@ -1,0 +1,14 @@
+package overridableMethodCall;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+
+public class OverridableMethodCallsInReadObjectCase1 {
+
+    void readObject(final ObjectInputStream in) throws IOException {
+        String af = in.readUTF();
+        if ("undefined".equals(af)) {
+            in.readInt();
+        }
+    }
+}

--- a/spotbugsTestCases/src/java/overridableMethodCall/OverridableMethodCallsInReadObjectCase2.java
+++ b/spotbugsTestCases/src/java/overridableMethodCall/OverridableMethodCallsInReadObjectCase2.java
@@ -1,0 +1,14 @@
+package overridableMethodCall;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.util.ArrayList;
+
+public class OverridableMethodCallsInReadObjectCase2 extends ArrayList<String> {
+
+	void readObject(final ObjectInputStream in) throws IOException {
+        if (isEmpty()) { // isEmpty() is overridable, expecting MC_OVERRIDABLE_METHOD_CALL_IN_READ_OBJECT here
+            in.readInt();
+        }
+    }
+}

--- a/spotbugsTestCases/src/java/overridableMethodCall/OverridableMethodCallsInReadObjectCase2.java
+++ b/spotbugsTestCases/src/java/overridableMethodCall/OverridableMethodCallsInReadObjectCase2.java
@@ -5,8 +5,9 @@ import java.io.ObjectInputStream;
 import java.util.ArrayList;
 
 public class OverridableMethodCallsInReadObjectCase2 extends ArrayList<String> {
+	private static final long serialVersionUID = -8492406703622812582L;
 
-	void readObject(final ObjectInputStream in) throws IOException {
+	private void readObject(final ObjectInputStream in) throws IOException {
         if (isEmpty()) { // isEmpty() is overridable, expecting MC_OVERRIDABLE_METHOD_CALL_IN_READ_OBJECT here
             in.readInt();
         }


### PR DESCRIPTION
As discussed in #2957 calling overridable methods from `readObject` on the `ObjectOutputStream` (such as `readInt`) should be fine in most cases.

This PR changes the `shouldIgnoreCallInReadObject()` logic to ignore all methods, except for these on the class under analysis.
In other words, `"test".equals(x)` and `stream.readInt()` are fine but `this.isAdmin()` is not