### PR TITLE
Multi catch type analysis fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 ### Fixed
 - Do not consider Records as Singletons ([#2981](https://github.com/spotbugs/spotbugs/issues/2981))
 - Keep a maximum of 10000 cached analysis entries for plugin's analysis engines ([#3025](https://github.com/spotbugs/spotbugs/pull/3025))
+- Check the actual caught exceptions (instead of the their common type) when analyzing multi-catch blocks ([#2968](https://github.com/spotbugs/spotbugs/issues/2968))
 
 ## 4.8.6 - 2024-06-17
 ### Fixed

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2968Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2968Test.java
@@ -1,0 +1,28 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
+import org.junit.jupiter.api.Test;
+
+import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class Issue2968Test extends AbstractIntegrationTest {
+
+    @Test
+    void testIssue() {
+        performAnalysis(
+                "ghIssues/Issue2968.class",
+                "ghIssues/Issue2968$1.class",
+                "ghIssues/Issue2968$TestIf.class",
+                "ghIssues/Issue2968$CommonException.class",
+                "ghIssues/Issue2968$ActualException.class",
+                "ghIssues/Issue2968$RedHerring1Exception.class",
+                "ghIssues/Issue2968$RedHerring2Exception.class");
+        BugInstanceMatcher bugMatcher = new BugInstanceMatcherBuilder()
+                .bugType("BC_IMPOSSIBLE_INSTANCEOF")
+                .build();
+        assertThat(getBugCollection(), containsExactly(0, bugMatcher));
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/type/TypeAnalysis.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/type/TypeAnalysis.java
@@ -825,26 +825,26 @@ public class TypeAnalysis extends FrameDataflowAnalysis<Type, TypeFrame> impleme
         return result;
     }
 
-	/**
-	 * @return <code>true</code> if the block catching <code>catchType</code> (which might be a multi-catch block) is catching exceptions of type <code>thrownType</code>
-	 */
-	private boolean handlerBlockCatches(ObjectType catchType, ObjectType thrownType) throws ClassNotFoundException {
-		if (catchType instanceof ExceptionObjectType) {
-			ExceptionObjectType exceptionType = (ExceptionObjectType) catchType;
-			ThrownExceptionIterator exceptionTypesIterator = exceptionType.getExceptionSet().iterator();
-			
-			while (exceptionTypesIterator.hasNext()) {
-				ObjectType caughtExceptionType = exceptionTypesIterator.next();
-				if (Hierarchy.isSubtype(thrownType, caughtExceptionType)) {
-					return true;
-				}
-			}
-			
-			return false;
-		} else {
-			return Hierarchy.isSubtype(thrownType, catchType);
-		}		
-	}
+    /**
+     * @return <code>true</code> if the block catching <code>catchType</code> (which might be a multi-catch block) is catching exceptions of type <code>thrownType</code>
+     */
+    private boolean handlerBlockCatches(ObjectType catchType, ObjectType thrownType) throws ClassNotFoundException {
+        if (catchType instanceof ExceptionObjectType) {
+            ExceptionObjectType exceptionType = (ExceptionObjectType) catchType;
+            ThrownExceptionIterator exceptionTypesIterator = exceptionType.getExceptionSet().iterator();
+
+            while (exceptionTypesIterator.hasNext()) {
+                ObjectType caughtExceptionType = exceptionTypesIterator.next();
+                if (Hierarchy.isSubtype(thrownType, caughtExceptionType)) {
+                    return true;
+                }
+            }
+
+            return false;
+        } else {
+            return Hierarchy.isSubtype(thrownType, catchType);
+        }
+    }
 
     /**
      * Compute the set of exception types that can be thrown by given basic

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/type/TypeAnalysis.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/type/TypeAnalysis.java
@@ -63,6 +63,7 @@ import edu.umd.cs.findbugs.ba.RepositoryLookupFailureCallback;
 import edu.umd.cs.findbugs.ba.SignatureConverter;
 import edu.umd.cs.findbugs.ba.generic.GenericSignatureParser;
 import edu.umd.cs.findbugs.ba.generic.GenericUtilities;
+import edu.umd.cs.findbugs.ba.type.ExceptionSet.ThrownExceptionIterator;
 import edu.umd.cs.findbugs.ba.vna.ValueNumber;
 import edu.umd.cs.findbugs.ba.vna.ValueNumberDataflow;
 import edu.umd.cs.findbugs.ba.vna.ValueNumberFrame;
@@ -792,7 +793,7 @@ public class TypeAnalysis extends FrameDataflowAnalysis<Type, TypeFrame> impleme
                 }
 
                 try {
-                    if (Hierarchy.isSubtype(thrownType, catchType)) {
+                    if (handlerBlockCatches(catchType, thrownType)) {
                         // Exception can be thrown along this edge
                         result.add(thrownType, explicit);
 
@@ -823,6 +824,27 @@ public class TypeAnalysis extends FrameDataflowAnalysis<Type, TypeFrame> impleme
 
         return result;
     }
+
+	/**
+	 * @return <code>true</code> if the block catching <code>catchType</code> (which might be a multi-catch block) is catching exceptions of type <code>thrownType</code>
+	 */
+	private boolean handlerBlockCatches(ObjectType catchType, ObjectType thrownType) throws ClassNotFoundException {
+		if (catchType instanceof ExceptionObjectType) {
+			ExceptionObjectType exceptionType = (ExceptionObjectType) catchType;
+			ThrownExceptionIterator exceptionTypesIterator = exceptionType.getExceptionSet().iterator();
+			
+			while (exceptionTypesIterator.hasNext()) {
+				ObjectType caughtExceptionType = exceptionTypesIterator.next();
+				if (Hierarchy.isSubtype(thrownType, caughtExceptionType)) {
+					return true;
+				}
+			}
+			
+			return false;
+		} else {
+			return Hierarchy.isSubtype(thrownType, catchType);
+		}		
+	}
 
     /**
      * Compute the set of exception types that can be thrown by given basic

--- a/spotbugsTestCases/src/java/ghIssues/Issue2968.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue2968.java
@@ -1,0 +1,40 @@
+package ghIssues;
+
+public class Issue2968 {
+    public static void main(String[] args) {
+        TestIf testIf = () -> { throw new ActualException(); };
+        try {
+            testIf.test();
+        } catch (RedHerring1Exception | RedHerring2Exception exc)  {
+            // special exception handling, no need for the "large" `catch(Exception)` block
+        } catch (Exception exc) {
+            // some code that needs to be done with with any kind of exception, like general reporting
+            exc.printStackTrace();
+
+            // false positive SpotBug report:
+
+            // instanceof will always return false in spotbugs.SpotBugsReproducerDemo.main(String[]), since
+            // a RuntimeException cannot be a spotbugs.SpotBugsReproducerDemo$CommonException
+            if (exc instanceof CommonException) {
+                // report the additional information from CommonException
+                System.out.println("this gets printed!");   // just for demo
+            }
+
+            // additional code for every subclass of Exception
+        }
+    }
+
+    private interface TestIf {
+        void test() throws ActualException, RedHerring1Exception, RedHerring2Exception;
+    }
+
+    private static class CommonException extends Exception {
+        // contains project-specific information extending a general Exception
+    }
+
+    private static class ActualException extends CommonException { }
+
+    private static class RedHerring1Exception extends CommonException { }
+
+    private static class RedHerring2Exception extends CommonException { }
+}


### PR DESCRIPTION
Thanks for the reproducer @ghernadi !
The issue is that when building the CFG of the method SpotBugs was incorrectly analyzing the caught type (singular) when it actually was the types (plural) corresponding to a multi-catch block.
This should fix #2968 and supersede #2999