### PR TITLE
Increase Version class log level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Only report `MC_OVERRIDABLE_METHOD_CALL_IN_READ_OBJECT` when calling own methods ([#2957](https://github.com/spotbugs/spotbugs/issues/2957))
 - Check the actual caught exceptions (instead of the their common type) when analyzing multi-catch blocks ([#2968](https://github.com/spotbugs/spotbugs/issues/2968))
 - System property `findbugs.refcomp.reportAll` is now being used. For some new conditions, it will emit an experimental warning ([#2988](https://github.com/spotbugs/spotbugs/pull/2988))
+- `-version` flag prints the version to the standard output ([#2797](https://github.com/spotbugs/spotbugs/issues/2797))
 
 ## 4.8.6 - 2024-06-17
 ### Fixed

--- a/spotbugs/log4j2.xml
+++ b/spotbugs/log4j2.xml
@@ -1,13 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="WARN">
   <Appenders>
-    <Console name="Console" target="SYSTEM_OUT">
+    <Console name="ConsoleLog" target="SYSTEM_OUT">
       <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+    </Console>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%msg%n"/>
     </Console>
   </Appenders>
   <Loggers>
-    <Root level="error">
+    <Logger name="edu.umd.cs.findbugs.Version" level="info" additivity="false">
       <AppenderRef ref="Console"/>
+    </Logger>
+    <Root level="error">
+      <AppenderRef ref="ConsoleLog"/>
     </Root>
   </Loggers>
 </Configuration>


### PR DESCRIPTION
In the 0894023 commit, console print lines were replaced in the `Version` class with info log lines, because of the #635 task, however, in the `log4j2.xml`, the log level is configured to log only at error level, as mentioned here: https://github.com/spotbugs/spotbugs/issues/2797#issuecomment-1925306938

Console:
```
$ ./spotbugs -version
4.9.0-SNAPSHOT
```

fixes #2797 