### PR TITLE
Generics enhancements

### DIFF
--- a/classfile-backport/build.gradle
+++ b/classfile-backport/build.gradle
@@ -1,0 +1,33 @@
+apply from: "$rootDir/gradle/checkstyle.gradle"
+apply from: "$rootDir/gradle/javadoc.gradle"
+apply from: "$rootDir/gradle/maven.gradle"
+
+tasks.named('javadoc', Javadoc).configure {
+  options.with {
+    memberLevel = JavadocMemberLevel.PUBLIC
+    docTitle = 'SpotBugs Classfile API Backport Documentation'
+  }
+  doFirst {
+    // This is supposed to enable everything except "missing" but doesn't work with gradle
+    // See http://docs.oracle.com/javase/8/docs/technotes/tools/unix/javadoc.html
+    options.addBooleanOption('Xdoclint:all,-missing', true)
+  }
+  doLast {
+    logger.warn('Javadoc: "missing" warnings are disabled, see #340!')
+  }
+}
+
+java {
+  withJavadocJar()
+  withSourcesJar()
+}
+
+publishing.publications.maven {
+  pom {
+    name = 'SpotBugs Classfile API Backport'
+    description = 'Backport of Java classfile API'
+  }
+}
+
+ext.moduleName = 'com.github.spotbugs.classfile-backport'
+apply from: "$rootDir/gradle/jigsaw.gradle"

--- a/classfile-backport/src/main/java/com/github/spotbugs/java/lang/classfile/ClassSignature.java
+++ b/classfile-backport/src/main/java/com/github/spotbugs/java/lang/classfile/ClassSignature.java
@@ -31,7 +31,7 @@ import com.github.spotbugs.jdk.internal.classfile.impl.SignaturesImpl;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Models the generic signature of a class file, as defined by {@jvms 4.7.9}.
+ * Models the generic signature of a class file, as defined by @jvms 4.7.9.
  *
  * @since 22
  */

--- a/classfile-backport/src/main/java/com/github/spotbugs/java/lang/classfile/ClassSignature.java
+++ b/classfile-backport/src/main/java/com/github/spotbugs/java/lang/classfile/ClassSignature.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.github.spotbugs.java.lang.classfile;
+
+import java.util.List;
+
+import com.github.spotbugs.jdk.internal.classfile.impl.SignaturesImpl;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Models the generic signature of a class file, as defined by {@jvms 4.7.9}.
+ *
+ * @since 22
+ */
+public interface ClassSignature {
+
+    /** {@return the type parameters of this class} */
+    List<Signature.TypeParam> typeParameters();
+
+    /** {@return the instantiation of the superclass in this signature} */
+    Signature.RefTypeSig superclassSignature();
+
+    /** {@return the instantiation of the interfaces in this signature} */
+    List<Signature.RefTypeSig> superinterfaceSignatures();
+
+    /** {@return the raw signature string} */
+    String signatureString();
+
+    /**
+     * Parses a raw class signature string into a {@linkplain Signature}
+     * @param classSignature the raw class signature string
+     * @return class signature
+     */
+    public static ClassSignature parseFrom(String classSignature) {
+        return new SignaturesImpl().parseClassSignature(requireNonNull(classSignature));
+    }
+}

--- a/classfile-backport/src/main/java/com/github/spotbugs/java/lang/classfile/ClassSignature.java
+++ b/classfile-backport/src/main/java/com/github/spotbugs/java/lang/classfile/ClassSignature.java
@@ -37,16 +37,16 @@ import static java.util.Objects.requireNonNull;
  */
 public interface ClassSignature {
 
-    /** {@return the type parameters of this class} */
+    /** @return the type parameters of this class */
     List<Signature.TypeParam> typeParameters();
 
-    /** {@return the instantiation of the superclass in this signature} */
+    /** @return the instantiation of the superclass in this signature */
     Signature.RefTypeSig superclassSignature();
 
-    /** {@return the instantiation of the interfaces in this signature} */
+    /** @return the instantiation of the interfaces in this signature */
     List<Signature.RefTypeSig> superinterfaceSignatures();
 
-    /** {@return the raw signature string} */
+    /** @return the raw signature string */
     String signatureString();
 
     /**

--- a/classfile-backport/src/main/java/com/github/spotbugs/java/lang/classfile/MethodSignature.java
+++ b/classfile-backport/src/main/java/com/github/spotbugs/java/lang/classfile/MethodSignature.java
@@ -37,19 +37,19 @@ import com.github.spotbugs.jdk.internal.classfile.impl.SignaturesImpl;
  */
 public interface MethodSignature {
 
-    /** {@return the type parameters of this method} */
+    /** @return the type parameters of this method */
     List<Signature.TypeParam> typeParameters();
 
-    /** {@return the signatures of the parameters of this method} */
+    /** @return the signatures of the parameters of this method */
     List<Signature> arguments();
 
-    /** {@return the signatures of the return value of this method} */
+    /** @return the signatures of the return value of this method */
     Signature result();
 
-    /** {@return the signatures of the exceptions thrown by this method} */
+    /** @return the signatures of the exceptions thrown by this method */
     List<Signature.ThrowableSig> throwableSignatures();
 
-    /** {@return the raw signature string} */
+    /** @return the raw signature string */
     String signatureString();
 
     /**

--- a/classfile-backport/src/main/java/com/github/spotbugs/java/lang/classfile/MethodSignature.java
+++ b/classfile-backport/src/main/java/com/github/spotbugs/java/lang/classfile/MethodSignature.java
@@ -31,7 +31,7 @@ import java.util.List;
 import com.github.spotbugs.jdk.internal.classfile.impl.SignaturesImpl;
 
 /**
- * Models the generic signature of a method, as defined by {@jvms 4.7.9}.
+ * Models the generic signature of a method, as defined by @jvms 4.7.9.
  *
  * @since 22
  */

--- a/classfile-backport/src/main/java/com/github/spotbugs/java/lang/classfile/MethodSignature.java
+++ b/classfile-backport/src/main/java/com/github/spotbugs/java/lang/classfile/MethodSignature.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.github.spotbugs.java.lang.classfile;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import com.github.spotbugs.jdk.internal.classfile.impl.SignaturesImpl;
+
+/**
+ * Models the generic signature of a method, as defined by {@jvms 4.7.9}.
+ *
+ * @since 22
+ */
+public interface MethodSignature {
+
+    /** {@return the type parameters of this method} */
+    List<Signature.TypeParam> typeParameters();
+
+    /** {@return the signatures of the parameters of this method} */
+    List<Signature> arguments();
+
+    /** {@return the signatures of the return value of this method} */
+    Signature result();
+
+    /** {@return the signatures of the exceptions thrown by this method} */
+    List<Signature.ThrowableSig> throwableSignatures();
+
+    /** {@return the raw signature string} */
+    String signatureString();
+
+    /**
+     * Parses a raw method signature string into a {@linkplain MethodSignature}
+     * @param methodSignature the raw method signature string
+     * @return method signature
+     */
+    public static MethodSignature parseFrom(String methodSignature) {
+
+        return new SignaturesImpl().parseMethodSignature(requireNonNull(methodSignature));
+    }
+}

--- a/classfile-backport/src/main/java/com/github/spotbugs/java/lang/classfile/Signature.java
+++ b/classfile-backport/src/main/java/com/github/spotbugs/java/lang/classfile/Signature.java
@@ -32,9 +32,8 @@ import java.util.Optional;
 import com.github.spotbugs.jdk.internal.classfile.impl.SignaturesImpl;
 
 /**
- * Models generic Java type signatures, as defined in {@jvms 4.7.9.1}.
+ * Models generic Java type signatures, as defined in @jvms 4.7.9.1.
  *
- * @sealedGraph
  * @since 22
  */
 public interface Signature {
@@ -76,7 +75,6 @@ public interface Signature {
      * Models the signature of a reference type, which may be a class, interface,
      * type variable, or array type.
      *
-     * @sealedGraph
      * @since 22
      */
     public interface RefTypeSig
@@ -263,7 +261,6 @@ public interface Signature {
     /**
      * Models a signature for a throwable type.
      *
-     * @sealedGraph
      * @since 22
      */
     public interface ThrowableSig extends Signature {

--- a/classfile-backport/src/main/java/com/github/spotbugs/java/lang/classfile/Signature.java
+++ b/classfile-backport/src/main/java/com/github/spotbugs/java/lang/classfile/Signature.java
@@ -38,7 +38,7 @@ import com.github.spotbugs.jdk.internal.classfile.impl.SignaturesImpl;
  */
 public interface Signature {
 
-    /** {@return the raw signature string} */
+    /** @return the raw signature string */
     String signatureString();
 
     /**
@@ -57,11 +57,11 @@ public interface Signature {
      */
     public interface BaseTypeSig extends Signature {
 
-        /** {@return the single-letter descriptor for the base type} */
+        /** @return the single-letter descriptor for the base type */
         char baseType();
 
         /**
-         * {@return the signature of a primitive type or void}
+         * @return the signature of a primitive type or void
          * @param baseType the single-letter descriptor for the base type
          */
         public static BaseTypeSig of(char baseType) {
@@ -89,13 +89,13 @@ public interface Signature {
     public interface ClassTypeSig
             extends RefTypeSig, ThrowableSig {
 
-        /** {@return the signature of the outer type, if any} */
+        /** @return the signature of the outer type, if any */
         Optional<ClassTypeSig> outerType();
 
-        /** {@return the class name} */
+        /** @return the class name */
         String className();
 
-        /** {@return the type arguments of the class} */
+        /** @return the type arguments of the class */
         List<TypeArg> typeArgs();
     }
 
@@ -135,14 +135,14 @@ public interface Signature {
             SUPER;
         }
 
-        /** {@return the wildcard indicator} */
+        /** @return the wildcard indicator */
         WildcardIndicator wildcardIndicator();
 
-        /** {@return the signature of the type bound, if any} */
+        /** @return the signature of the type bound, if any */
         Optional<RefTypeSig> boundType();
 
         /**
-         * {@return a bounded type arg}
+         * @return a bounded type arg
          * @param boundType the bound
          */
         public static TypeArg of(RefTypeSig boundType) {
@@ -151,14 +151,14 @@ public interface Signature {
         }
 
         /**
-         * {@return an unbounded type arg}
+         * @return an unbounded type arg
          */
         public static TypeArg unbounded() {
             return of(WildcardIndicator.UNBOUNDED, Optional.empty());
         }
 
         /**
-         * {@return an upper-bounded type arg}
+         * @return an upper-bounded type arg
          * @param boundType the upper bound
          */
         public static TypeArg extendsOf(RefTypeSig boundType) {
@@ -167,7 +167,7 @@ public interface Signature {
         }
 
         /**
-         * {@return a lower-bounded type arg}
+         * @return a lower-bounded type arg
          * @param boundType the lower bound
          */
         public static TypeArg superOf(RefTypeSig boundType) {
@@ -176,7 +176,7 @@ public interface Signature {
         }
 
         /**
-         * {@return a bounded type arg}
+         * @return a bounded type arg
          * @param wildcard the wild card
          * @param boundType optional bound type
          */
@@ -193,11 +193,11 @@ public interface Signature {
     public interface TypeVarSig
             extends RefTypeSig, ThrowableSig {
 
-        /** {@return the name of the type variable} */
+        /** @return the name of the type variable */
         String identifier();
 
         /**
-         * {@return a signature for a type variable}
+         * @return a signature for a type variable
          * @param identifier the name of the type variable
          */
         public static TypeVarSig of(String identifier) {
@@ -213,11 +213,11 @@ public interface Signature {
     public interface ArrayTypeSig
             extends RefTypeSig {
 
-        /** {@return the signature of the component type} */
+        /** @return the signature of the component type */
         Signature componentSignature();
 
         /**
-         * {@return a signature for an array type}
+         * @return a signature for an array type
          * @param componentSignature the component type
          */
         public static ArrayTypeSig of(Signature componentSignature) {
@@ -225,7 +225,7 @@ public interface Signature {
         }
 
         /**
-         * {@return a signature for an array type}
+         * @return a signature for an array type
          * @param dims the dimension of the array
          * @param componentSignature the component type
          */
@@ -248,13 +248,13 @@ public interface Signature {
      */
     public interface TypeParam {
 
-        /** {@return the name of the type parameter} */
+        /** @return the name of the type parameter */
         String identifier();
 
-        /** {@return the class bound of the type parameter} */
+        /** @return the class bound of the type parameter */
         Optional<RefTypeSig> classBound();
 
-        /** {@return the interface bounds of the type parameter} */
+        /** @return the interface bounds of the type parameter */
         List<RefTypeSig> interfaceBounds();
     }
 

--- a/classfile-backport/src/main/java/com/github/spotbugs/java/lang/classfile/Signature.java
+++ b/classfile-backport/src/main/java/com/github/spotbugs/java/lang/classfile/Signature.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.github.spotbugs.java.lang.classfile;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+import java.util.Optional;
+
+import com.github.spotbugs.jdk.internal.classfile.impl.SignaturesImpl;
+
+/**
+ * Models generic Java type signatures, as defined in {@jvms 4.7.9.1}.
+ *
+ * @sealedGraph
+ * @since 22
+ */
+public interface Signature {
+
+    /** {@return the raw signature string} */
+    String signatureString();
+
+    /**
+     * Parses generic Java type signature from raw string
+     * @param javaTypeSignature raw Java type signature string
+     * @return Java type signature
+     */
+    public static Signature parseFrom(String javaTypeSignature) {
+        return new SignaturesImpl().parseSignature(requireNonNull(javaTypeSignature));
+    }
+
+    /**
+     * Models the signature of a primitive type or void
+     *
+     * @since 22
+     */
+    public interface BaseTypeSig extends Signature {
+
+        /** {@return the single-letter descriptor for the base type} */
+        char baseType();
+
+        /**
+         * {@return the signature of a primitive type or void}
+         * @param baseType the single-letter descriptor for the base type
+         */
+        public static BaseTypeSig of(char baseType) {
+            if ("VIJCSBFDZ".indexOf(baseType) < 0)
+                throw new IllegalArgumentException("invalid base type signature");
+            return new SignaturesImpl.BaseTypeSigImpl(baseType);
+        }
+    }
+
+    /**
+     * Models the signature of a reference type, which may be a class, interface,
+     * type variable, or array type.
+     *
+     * @sealedGraph
+     * @since 22
+     */
+    public interface RefTypeSig
+            extends Signature {
+    }
+
+    /**
+     * Models the signature of a possibly-parameterized class or interface type.
+     *
+     * @since 22
+     */
+    public interface ClassTypeSig
+            extends RefTypeSig, ThrowableSig {
+
+        /** {@return the signature of the outer type, if any} */
+        Optional<ClassTypeSig> outerType();
+
+        /** {@return the class name} */
+        String className();
+
+        /** {@return the type arguments of the class} */
+        List<TypeArg> typeArgs();
+    }
+
+    /**
+     * Models the type argument.
+     *
+     * @since 22
+     */
+    public interface TypeArg {
+
+        /**
+         * Indicator for whether a wildcard has default bound, no bound,
+         * an upper bound, or a lower bound
+         *
+         * @since 22
+         */
+        public enum WildcardIndicator {
+
+            /**
+             * default bound wildcard (empty)
+             */
+            DEFAULT,
+
+            /**
+             * unbounded indicator {@code *}
+             */
+            UNBOUNDED,
+
+            /**
+             * upper-bounded indicator {@code +}
+             */
+            EXTENDS,
+
+            /**
+             * lower-bounded indicator {@code -}
+             */
+            SUPER;
+        }
+
+        /** {@return the wildcard indicator} */
+        WildcardIndicator wildcardIndicator();
+
+        /** {@return the signature of the type bound, if any} */
+        Optional<RefTypeSig> boundType();
+
+        /**
+         * {@return a bounded type arg}
+         * @param boundType the bound
+         */
+        public static TypeArg of(RefTypeSig boundType) {
+            requireNonNull(boundType);
+            return of(WildcardIndicator.DEFAULT, Optional.of(boundType));
+        }
+
+        /**
+         * {@return an unbounded type arg}
+         */
+        public static TypeArg unbounded() {
+            return of(WildcardIndicator.UNBOUNDED, Optional.empty());
+        }
+
+        /**
+         * {@return an upper-bounded type arg}
+         * @param boundType the upper bound
+         */
+        public static TypeArg extendsOf(RefTypeSig boundType) {
+            requireNonNull(boundType);
+            return of(WildcardIndicator.EXTENDS, Optional.of(boundType));
+        }
+
+        /**
+         * {@return a lower-bounded type arg}
+         * @param boundType the lower bound
+         */
+        public static TypeArg superOf(RefTypeSig boundType) {
+            requireNonNull(boundType);
+            return of(WildcardIndicator.SUPER, Optional.of(boundType));
+        }
+
+        /**
+         * {@return a bounded type arg}
+         * @param wildcard the wild card
+         * @param boundType optional bound type
+         */
+        public static TypeArg of(WildcardIndicator wildcard, Optional<RefTypeSig> boundType) {
+            return new SignaturesImpl.TypeArgImpl(wildcard, boundType);
+        }
+    }
+
+    /**
+     * Models the signature of a type variable.
+     *
+     * @since 22
+     */
+    public interface TypeVarSig
+            extends RefTypeSig, ThrowableSig {
+
+        /** {@return the name of the type variable} */
+        String identifier();
+
+        /**
+         * {@return a signature for a type variable}
+         * @param identifier the name of the type variable
+         */
+        public static TypeVarSig of(String identifier) {
+            return new SignaturesImpl.TypeVarSigImpl(requireNonNull(identifier));
+        }
+    }
+
+    /**
+     * Models the signature of an array type.
+     *
+     * @since 22
+     */
+    public interface ArrayTypeSig
+            extends RefTypeSig {
+
+        /** {@return the signature of the component type} */
+        Signature componentSignature();
+
+        /**
+         * {@return a signature for an array type}
+         * @param componentSignature the component type
+         */
+        public static ArrayTypeSig of(Signature componentSignature) {
+            return of(1, requireNonNull(componentSignature));
+        }
+
+        /**
+         * {@return a signature for an array type}
+         * @param dims the dimension of the array
+         * @param componentSignature the component type
+         */
+        public static ArrayTypeSig of(int dims, Signature componentSignature) {
+            requireNonNull(componentSignature);
+            if (dims < 1 || dims > 255)
+                throw new IllegalArgumentException("illegal array depth value");
+            if (componentSignature instanceof SignaturesImpl.ArrayTypeSigImpl) {
+                SignaturesImpl.ArrayTypeSigImpl arr = (SignaturesImpl.ArrayTypeSigImpl) componentSignature;
+                return new SignaturesImpl.ArrayTypeSigImpl(dims + arr.arrayDepth(), arr.elemType());
+            }
+            return new SignaturesImpl.ArrayTypeSigImpl(dims, componentSignature);
+        }
+    }
+
+    /**
+     * Models a signature for a type parameter of a generic class or method.
+     *
+     * @since 22
+     */
+    public interface TypeParam {
+
+        /** {@return the name of the type parameter} */
+        String identifier();
+
+        /** {@return the class bound of the type parameter} */
+        Optional<RefTypeSig> classBound();
+
+        /** {@return the interface bounds of the type parameter} */
+        List<RefTypeSig> interfaceBounds();
+    }
+
+    /**
+     * Models a signature for a throwable type.
+     *
+     * @sealedGraph
+     * @since 22
+     */
+    public interface ThrowableSig extends Signature {
+    }
+}

--- a/classfile-backport/src/main/java/com/github/spotbugs/jdk/internal/classfile/impl/SignaturesImpl.java
+++ b/classfile-backport/src/main/java/com/github/spotbugs/jdk/internal/classfile/impl/SignaturesImpl.java
@@ -1,0 +1,485 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.github.spotbugs.jdk.internal.classfile.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import com.github.spotbugs.java.lang.classfile.ClassSignature;
+import com.github.spotbugs.java.lang.classfile.MethodSignature;
+import com.github.spotbugs.java.lang.classfile.Signature;
+import com.github.spotbugs.java.lang.classfile.Signature.*;
+
+import java.util.Collections;
+
+public final class SignaturesImpl {
+
+    public SignaturesImpl() {
+    }
+
+    private String sig;
+    private int sigp;
+
+    public ClassSignature parseClassSignature(String signature) {
+        this.sig = signature;
+        sigp = 0;
+        List<TypeParam> typeParamTypes = parseParamTypes();
+        RefTypeSig superclass = referenceTypeSig();
+        ArrayList<RefTypeSig> superinterfaces = null;
+        while (sigp < sig.length()) {
+            if (superinterfaces == null)
+                superinterfaces = new ArrayList<>();
+            superinterfaces.add(referenceTypeSig());
+        }
+        return new ClassSignatureImpl(typeParamTypes, superclass, null2Empty(superinterfaces));
+    }
+
+    public MethodSignature parseMethodSignature(String signature) {
+        this.sig = signature;
+        sigp = 0;
+        List<TypeParam> typeParamTypes = parseParamTypes();
+        assert sig.charAt(sigp) == '(';
+        sigp++;
+        ArrayList<Signature> paramTypes = null;
+        while (sig.charAt(sigp) != ')') {
+            if (paramTypes == null)
+                paramTypes = new ArrayList<>();
+            paramTypes.add(typeSig());
+        }
+        sigp++;
+        Signature returnType = typeSig();
+        ArrayList<ThrowableSig> throwsTypes = null;
+        while (sigp < sig.length() && sig.charAt(sigp) == '^') {
+            sigp++;
+            if (throwsTypes == null)
+                throwsTypes = new ArrayList<>();
+            Signature t = typeSig();
+            if (t instanceof ThrowableSig) {
+                ThrowableSig ts = (ThrowableSig) t;
+                throwsTypes.add(ts);
+            } else
+                throw new IllegalArgumentException("not a valid type signature: " + sig);
+        }
+        return new MethodSignatureImpl(typeParamTypes, null2Empty(throwsTypes), returnType, null2Empty(paramTypes));
+    }
+
+    public Signature parseSignature(String signature) {
+        this.sig = signature;
+        sigp = 0;
+        return typeSig();
+    }
+
+    private List<TypeParam> parseParamTypes() {
+        ArrayList<TypeParam> typeParamTypes = null;
+        if (sig.charAt(sigp) == '<') {
+            sigp++;
+            typeParamTypes = new ArrayList<>();
+            while (sig.charAt(sigp) != '>') {
+                int sep = sig.indexOf(":", sigp);
+                String name = sig.substring(sigp, sep);
+                RefTypeSig classBound = null;
+                ArrayList<RefTypeSig> interfaceBounds = null;
+                sigp = sep + 1;
+                if (sig.charAt(sigp) != ':')
+                    classBound = referenceTypeSig();
+                while (sig.charAt(sigp) == ':') {
+                    sigp++;
+                    if (interfaceBounds == null)
+                        interfaceBounds = new ArrayList<>();
+                    interfaceBounds.add(referenceTypeSig());
+                }
+                typeParamTypes.add(new TypeParamImpl(name, Optional.ofNullable(classBound), null2Empty(interfaceBounds)));
+            }
+            sigp++;
+        }
+        return null2Empty(typeParamTypes);
+    }
+
+    private Signature typeSig() {
+        char c = sig.charAt(sigp++);
+        switch (c) {
+        case 'B':
+        case 'C':
+        case 'D':
+        case 'F':
+        case 'I':
+        case 'J':
+        case 'V':
+        case 'S':
+        case 'Z':
+            return Signature.BaseTypeSig.of(c);
+        default:
+            sigp--;
+            return referenceTypeSig();
+        }
+    }
+
+    private RefTypeSig referenceTypeSig() {
+        char c = sig.charAt(sigp++);
+        switch (c) {
+        case 'L':
+            StringBuilder sb = new StringBuilder();
+            ArrayList<TypeArg> argTypes = null;
+            Signature.ClassTypeSig t = null;
+            char sigch;
+            do {
+                switch (sigch = sig.charAt(sigp++)) {
+                case '<': {
+                    argTypes = new ArrayList<>();
+                    while (sig.charAt(sigp) != '>')
+                        argTypes.add(typeArg());
+                    sigp++;
+                    break;
+                }
+                case '.':
+                case ';': {
+                    t = new ClassTypeSigImpl(Optional.ofNullable(t), sb.toString(), null2Empty(argTypes));
+                    sb.setLength(0);
+                    argTypes = null;
+                    break;
+                }
+                default: {
+                    sb.append(sigch);
+                    break;
+                }
+                }
+            } while (sigch != ';');
+            return t;
+        case 'T':
+            int sep = sig.indexOf(';', sigp);
+            TypeVarSig ty = Signature.TypeVarSig.of(sig.substring(sigp, sep));
+            sigp = sep + 1;
+            return ty;
+        case '[':
+            return ArrayTypeSig.of(typeSig());
+        }
+        throw new IllegalArgumentException("not a valid type signature: " + sig);
+    }
+
+    private TypeArg typeArg() {
+        char c = sig.charAt(sigp++);
+        switch (c) {
+        case '*':
+            return TypeArg.unbounded();
+        case '+':
+            return TypeArg.extendsOf(referenceTypeSig());
+        case '-':
+            return TypeArg.superOf(referenceTypeSig());
+        default:
+            sigp--;
+            return TypeArg.of(referenceTypeSig());
+        }
+    }
+
+    public static class BaseTypeSigImpl implements Signature.BaseTypeSig {
+        private char baseType;
+
+        public BaseTypeSigImpl(char baseType) {
+            this.baseType = baseType;
+        }
+
+        @Override
+        public String signatureString() {
+            return "" + baseType;
+        }
+
+        @Override
+        public char baseType() {
+            return baseType;
+        }
+    }
+
+    public static class TypeVarSigImpl implements Signature.TypeVarSig {
+        private String identifier;
+
+        public TypeVarSigImpl(String identifier) {
+            this.identifier = identifier;
+        }
+
+        @Override
+        public String signatureString() {
+            return "T" + identifier + ';';
+        }
+
+        @Override
+        public String identifier() {
+            return identifier;
+        }
+    }
+
+    public static class ArrayTypeSigImpl implements Signature.ArrayTypeSig {
+        private int arrayDepth;
+        private Signature elemType;
+
+        public ArrayTypeSigImpl(int arrayDepth, Signature elemType) {
+            this.arrayDepth = arrayDepth;
+            this.elemType = elemType;
+        }
+
+        @Override
+        public Signature componentSignature() {
+            return arrayDepth > 1 ? new ArrayTypeSigImpl(arrayDepth - 1, elemType) : elemType;
+        }
+
+        @Override
+        public String signatureString() {
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < arrayDepth; i++) {
+                sb.append("[");
+            }
+            sb.append(elemType.signatureString());
+            return sb.toString();
+        }
+
+        public int arrayDepth() {
+            return arrayDepth;
+        }
+
+        public Signature elemType() {
+            return elemType;
+        }
+    }
+
+    public static class ClassTypeSigImpl
+            implements Signature.ClassTypeSig {
+        private Optional<ClassTypeSig> outerType;
+        private String className;
+        private List<Signature.TypeArg> typeArgs;
+
+        public ClassTypeSigImpl(Optional<ClassTypeSig> outerType, String className, List<Signature.TypeArg> typeArgs) {
+            this.outerType = outerType;
+            this.className = className;
+            this.typeArgs = typeArgs;
+        }
+
+        @Override
+        public String signatureString() {
+            String prefix = "L";
+            if (outerType.isPresent()) {
+                prefix = outerType.get().signatureString();
+                assert prefix.charAt(prefix.length() - 1) == ';';
+                prefix = prefix.substring(0, prefix.length() - 1) + '.';
+            }
+            String suffix = ";";
+            if (!typeArgs.isEmpty()) {
+                StringBuilder sb = new StringBuilder();
+                sb.append('<');
+                for (TypeArg ta : typeArgs)
+                    sb.append(((TypeArgImpl) ta).signatureString());
+                suffix = sb.append(">;").toString();
+            }
+            return prefix + className + suffix;
+        }
+
+        @Override
+        public String className() {
+            return className;
+        }
+
+        @Override
+        public Optional<ClassTypeSig> outerType() {
+            return outerType;
+        }
+
+        @Override
+        public List<TypeArg> typeArgs() {
+            return typeArgs;
+        }
+    }
+
+    public static class TypeArgImpl implements Signature.TypeArg {
+        private WildcardIndicator wildcardIndicator;
+        private Optional<RefTypeSig> boundType;
+
+        public TypeArgImpl(WildcardIndicator wildcardIndicator, Optional<RefTypeSig> boundType) {
+            this.wildcardIndicator = wildcardIndicator;
+            this.boundType = boundType;
+        }
+
+        public String signatureString() {
+            switch (wildcardIndicator) {
+            case DEFAULT:
+                return boundType.get().signatureString();
+            case EXTENDS:
+                return "+" + boundType.get().signatureString();
+            case SUPER:
+                return "-" + boundType.get().signatureString();
+            case UNBOUNDED:
+                return "*";
+            default:
+                throw new IllegalArgumentException("Unexpected wildcard indicator: " + wildcardIndicator);
+            }
+        }
+
+        @Override
+        public WildcardIndicator wildcardIndicator() {
+            return wildcardIndicator;
+        }
+
+        @Override
+        public Optional<RefTypeSig> boundType() {
+            return boundType;
+        }
+    }
+
+    public static class TypeParamImpl
+            implements TypeParam {
+        private String identifier;
+        private Optional<RefTypeSig> classBound;
+        private List<RefTypeSig> interfaceBounds;
+
+        public TypeParamImpl(String identifier, Optional<RefTypeSig> classBound, List<RefTypeSig> interfaceBounds) {
+            this.identifier = identifier;
+            this.classBound = classBound;
+            this.interfaceBounds = interfaceBounds;
+        }
+
+        @Override
+        public String identifier() {
+            return identifier;
+        }
+
+        @Override
+        public Optional<RefTypeSig> classBound() {
+            return classBound;
+        }
+
+        @Override
+        public List<RefTypeSig> interfaceBounds() {
+            return interfaceBounds;
+        }
+    }
+
+    private static StringBuilder printTypeParameters(List<TypeParam> typeParameters) {
+        StringBuilder sb = new StringBuilder();
+        if (typeParameters != null && !typeParameters.isEmpty()) {
+            sb.append('<');
+            for (TypeParam tp : typeParameters) {
+                sb.append(tp.identifier()).append(':');
+                if (tp.classBound().isPresent())
+                    sb.append(tp.classBound().get().signatureString());
+                if (tp.interfaceBounds() != null)
+                    for (RefTypeSig is : tp.interfaceBounds())
+                        sb.append(':').append(is.signatureString());
+            }
+            sb.append('>');
+        }
+        return sb;
+    }
+
+    public static class ClassSignatureImpl implements ClassSignature {
+        private List<TypeParam> typeParameters;
+        private RefTypeSig superclassSignature;
+        private List<RefTypeSig> superinterfaceSignatures;
+
+        public ClassSignatureImpl(List<TypeParam> typeParameters, RefTypeSig superclassSignature,
+                List<RefTypeSig> superinterfaceSignatures) {
+            this.typeParameters = typeParameters;
+            this.superclassSignature = superclassSignature;
+            this.superinterfaceSignatures = superinterfaceSignatures;
+        }
+
+        @Override
+        public String signatureString() {
+            StringBuilder sb = printTypeParameters(typeParameters);
+            sb.append(superclassSignature.signatureString());
+            if (superinterfaceSignatures != null)
+                for (RefTypeSig in : superinterfaceSignatures)
+                    sb.append(in.signatureString());
+            return sb.toString();
+        }
+
+        @Override
+        public List<TypeParam> typeParameters() {
+            return typeParameters;
+        }
+
+        @Override
+        public RefTypeSig superclassSignature() {
+            return superclassSignature;
+        }
+
+        @Override
+        public List<RefTypeSig> superinterfaceSignatures() {
+            return superinterfaceSignatures;
+        }
+    }
+
+    public static class MethodSignatureImpl implements MethodSignature {
+        private List<TypeParam> typeParameters;
+        private List<ThrowableSig> throwableSignatures;
+        private Signature result;
+        private List<Signature> arguments;
+
+        public MethodSignatureImpl(
+                List<TypeParam> typeParameters,
+                List<ThrowableSig> throwableSignatures,
+                Signature result,
+                List<Signature> arguments) {
+            this.typeParameters = typeParameters;
+            this.throwableSignatures = throwableSignatures;
+            this.result = result;
+            this.arguments = arguments;
+        }
+
+        @Override
+        public String signatureString() {
+            StringBuilder sb = printTypeParameters(typeParameters);
+            sb.append('(');
+            for (Signature a : arguments)
+                sb.append(a.signatureString());
+            sb.append(')').append(result.signatureString());
+            if (!throwableSignatures.isEmpty())
+                for (ThrowableSig t : throwableSignatures)
+                    sb.append('^').append(t.signatureString());
+            return sb.toString();
+        }
+
+        @Override
+        public List<TypeParam> typeParameters() {
+            return typeParameters;
+        }
+
+        @Override
+        public List<Signature> arguments() {
+            return arguments;
+        }
+
+        @Override
+        public Signature result() {
+            return result;
+        }
+
+        @Override
+        public List<ThrowableSig> throwableSignatures() {
+            return throwableSignatures;
+        }
+    }
+
+    private static <T> List<T> null2Empty(ArrayList<T> l) {
+        return l == null ? Collections.emptyList() : Collections.unmodifiableList(l);
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,6 +13,7 @@ include(":spotbugsTestCases")
 include(":test-harness")
 include(":test-harness-core")
 include(":test-harness-jupiter")
+include(":classfile-backport")
 
 rootProject.name = "spotbugs"
 

--- a/spotbugs-tests/build.gradle
+++ b/spotbugs-tests/build.gradle
@@ -11,6 +11,7 @@ dependencies {
   implementation project(':spotbugsTestCases')
   implementation project(':test-harness')
   implementation project(':test-harness-jupiter')
+  implementation project(':classfile-backport')
 
   implementation 'org.junit.jupiter:junit-jupiter-engine:5.10.3'
   implementation 'org.junit.jupiter:junit-jupiter-params:5.10.3'

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/generic/GenericUtilitiesTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/generic/GenericUtilitiesTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 
 import org.apache.bcel.generic.ReferenceType;
 import org.apache.bcel.generic.Type;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -82,6 +83,7 @@ class GenericUtilitiesTest {
     }
 
     @Test
+    @Disabled("Invalid signature fixed in Eclipse JDT: https://bugs.eclipse.org/bugs/show_bug.cgi?id=494198")
     void testEclipseJDTInvalidUpperBoundSignature() {
         final Type type = GenericUtilities.getType("!+LHasUniqueKey<Ljava/lang/Integer;>;");
         assertThat(type, instanceOf(GenericObjectType.class));
@@ -90,6 +92,7 @@ class GenericUtilitiesTest {
     }
 
     @Test
+    @Disabled("Invalid signature fixed in Eclipse JDT: https://bugs.eclipse.org/bugs/show_bug.cgi?id=494198")
     void testEclipseJDTInvalidLowerBoundSignature() {
         final Type type = GenericUtilities.getType("!-LHasUniqueKey<Ljava/lang/Integer;>;");
         assertThat(type, instanceOf(GenericObjectType.class));
@@ -98,6 +101,7 @@ class GenericUtilitiesTest {
     }
 
     @Test
+    @Disabled("Invalid signature fixed in Eclipse JDT: https://bugs.eclipse.org/bugs/show_bug.cgi?id=494198")
     void testEclipseJDTInvalidWildcardSignature() {
         final Type type = GenericUtilities.getType("!*");
         assertThat(type, instanceOf(GenericObjectType.class));

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue608GenericObjectTypeTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue608GenericObjectTypeTest.java
@@ -8,6 +8,6 @@ class Issue608GenericObjectTypeTest extends AbstractIntegrationTest {
 
     @Test
     void testIssue() {
-    	performAnalysis("ghIssues/Issue608GenericObjectType.class");
+        performAnalysis("ghIssues/Issue608GenericObjectType.class");
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue608GenericObjectTypeTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue608GenericObjectTypeTest.java
@@ -1,0 +1,13 @@
+package edu.umd.cs.findbugs.detect;
+
+import org.junit.jupiter.api.Test;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+
+class Issue608GenericObjectTypeTest extends AbstractIntegrationTest {
+
+    @Test
+    void testIssue() {
+    	performAnalysis("ghIssues/Issue608GenericObjectType.class");
+    }
+}

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -96,6 +96,8 @@ dependencies {
 
   guiImplementation sourceSets.main.runtimeClasspath
   guiCompileOnly project(':spotbugs-annotations')
+  
+  implementation project(":classfile-backport")
 }
 
 clean {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/generic/GenericObjectType.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/generic/GenericObjectType.java
@@ -88,7 +88,7 @@ public class GenericObjectType extends ObjectType {
         // Self referencing generics will cause a stack overflow when calling Objects.equals(parameters, that.parameters)
         // For instance: <C extends Map<X, C>, X extends Number>
         // Instead we compare the generic signature when we know it
-        if (genericSignature != null && genericSignature.endsWith(that.genericSignature)) {
+        if (genericSignature != null && genericSignature.equals(that.genericSignature)) {
             return true;
         }
         return Objects.equals(parameters, that.parameters)

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/generic/GenericUtilities.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/generic/GenericUtilities.java
@@ -364,14 +364,10 @@ public class GenericUtilities {
      * This method is analogous to <code>Type.getType(String)</code>, except
      * that it also accepts signatures with generic information. e.g.
      * <code>Ljava/util/ArrayList&lt;TT;&gt;;</code>
-     * <p>
      *
-     * The signature should only contain one type. Use GenericSignatureParser to
-     * break up a signature with many types or call createTypes(String) to
-     * return a list of types
-     * @param wildcardIndicator
-     * @param resolvedTypes
-     * @param resolvedTypeVariables
+     * @param signature The signature of the type
+     * @param methodSignature The signature of the enclosing method
+     * @param classSignature The signature of the enclosing class
      */
     public static @CheckForNull Type getType(Signature signature, MethodSignature methodSignature, ClassSignature classSignature) {
         return getType(signature, methodSignature, classSignature, new HashMap<>(), new HashMap<>(), null);
@@ -624,14 +620,7 @@ public class GenericUtilities {
         return types;
     }
 
-    /**
-     * Parse a bytecode signature that has 1 or more (possibly generic) types
-     * and return a list of the Types.
-     * @param signature
-     *            bytecode signature e.g. e.g.
-     *            <code>Ljava/util/ArrayList&lt;Ljava/lang/String;&gt;;Ljava/util/ArrayList&lt;TT;&gt;;Ljava/util/ArrayList&lt;*&gt;;</code>
-     */
-    public static final @CheckForNull List<ReferenceType> getTypeParameters(List<TypeArg> parameters,
+    private static final @CheckForNull List<ReferenceType> getTypeParameters(List<TypeArg> parameters,
             MethodSignature methodSignature,
             ClassSignature classSignature,
             Map<String, Type> resolvedTypeVariables,

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/type/TypeFrameModelingVisitor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/type/TypeFrameModelingVisitor.java
@@ -30,11 +30,14 @@ import java.util.regex.Pattern;
 
 import javax.annotation.CheckForNull;
 
-import edu.umd.cs.findbugs.util.ClassName;
 import org.apache.bcel.Const;
+import org.apache.bcel.Repository;
 import org.apache.bcel.classfile.LocalVariable;
 import org.apache.bcel.classfile.LocalVariableTypeTable;
 import org.apache.bcel.generic.*;
+
+import com.github.spotbugs.java.lang.classfile.ClassSignature;
+import com.github.spotbugs.java.lang.classfile.MethodSignature;
 
 import edu.umd.cs.findbugs.OpcodeStack.Item;
 import edu.umd.cs.findbugs.SystemProperties;
@@ -60,6 +63,7 @@ import edu.umd.cs.findbugs.ba.vna.ValueNumberFrame;
 import edu.umd.cs.findbugs.classfile.CheckedAnalysisException;
 import edu.umd.cs.findbugs.classfile.ClassDescriptor;
 import edu.umd.cs.findbugs.classfile.DescriptorFactory;
+import edu.umd.cs.findbugs.util.ClassName;
 
 /**
  * Visitor to model the effects of bytecode instructions on the types of the
@@ -681,11 +685,12 @@ public class TypeFrameModelingVisitor extends AbstractFrameModelingVisitor<Type,
                     m = m2;
                 }
                 if (sourceSignature != null && !sourceSignature.equals(m.getSignature())) {
-                    GenericSignatureParser p = new GenericSignatureParser(sourceSignature);
-                    String rv = p.getReturnTypeSignature();
+                    ClassSignature classSignature = GenericSignatureParser.getSignature(Repository.lookupClass(m.getClassName()));
+                    MethodSignature p = MethodSignature.parseFrom(sourceSignature);
+                    String rv = p.result().signatureString();
                     if (rv.charAt(0) != 'T') {
                         try {
-                            Type t = GenericUtilities.getType(rv);
+                            Type t = GenericUtilities.getType(p.result(), p, classSignature);
                             if (t != null) {
                                 assert t.getType() != Const.T_VOID;
                                 result = merge(result, t);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindBadCast2.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindBadCast2.java
@@ -29,6 +29,8 @@ import org.apache.bcel.generic.Select;
 import org.apache.bcel.generic.Type;
 import org.apache.bcel.generic.TypedInstruction;
 
+import com.github.spotbugs.java.lang.classfile.MethodSignature;
+
 import edu.umd.cs.findbugs.Analyze;
 import edu.umd.cs.findbugs.BugAccumulator;
 import edu.umd.cs.findbugs.BugAnnotation;
@@ -49,7 +51,6 @@ import edu.umd.cs.findbugs.ba.Location;
 import edu.umd.cs.findbugs.ba.MethodUnprofitableException;
 import edu.umd.cs.findbugs.ba.XFactory;
 import edu.umd.cs.findbugs.ba.XMethod;
-import edu.umd.cs.findbugs.ba.generic.GenericSignatureParser;
 import edu.umd.cs.findbugs.ba.npe.IsNullValue;
 import edu.umd.cs.findbugs.ba.npe.IsNullValueDataflow;
 import edu.umd.cs.findbugs.ba.npe.IsNullValueFrame;
@@ -238,8 +239,8 @@ public class FindBadCast2 implements Detector {
                             && (sourceSignature.startsWith("<") || sourceSignature.indexOf("java/lang/Class") >= 0);
 
                     if (sourceSignature != null) {
-                        GenericSignatureParser signatureParser = new GenericSignatureParser(sourceSignature);
-                        String returnTypeSignature = signatureParser.getReturnTypeSignature();
+                        MethodSignature signature = MethodSignature.parseFrom(sourceSignature);
+                        String returnTypeSignature = signature.result().signatureString();
 
                         if (returnTypeSignature != null && returnTypeSignature.startsWith("T")) {
                             // The signature for variable types starts by a T (so <X> would have signature TX)

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FunctionsThatMightBeMistakenForProcedures.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FunctionsThatMightBeMistakenForProcedures.java
@@ -29,6 +29,9 @@ import org.apache.bcel.classfile.Field;
 import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.generic.Type;
 
+import com.github.spotbugs.java.lang.classfile.ClassSignature;
+import com.github.spotbugs.java.lang.classfile.MethodSignature;
+
 import edu.umd.cs.findbugs.BugInstance;
 import edu.umd.cs.findbugs.BugReporter;
 import edu.umd.cs.findbugs.FirstPassDetector;
@@ -130,9 +133,9 @@ public class FunctionsThatMightBeMistakenForProcedures extends OpcodeStackDetect
         XMethod m = getXMethod();
         String sourceSig = m.getSourceSignature();
         if (sourceSig != null) {
-            GenericSignatureParser sig = new GenericSignatureParser(sourceSig);
-            String genericReturnValue = sig.getReturnTypeSignature();
-            Type t = GenericUtilities.getType(genericReturnValue);
+            ClassSignature classSignature = GenericSignatureParser.getSignature(getThisClass());
+            MethodSignature sig = MethodSignature.parseFrom(sourceSig);
+            Type t = GenericUtilities.getType(sig.result(), sig, classSignature);
             if (t instanceof GenericObjectType) {
                 funky = true;
             }

--- a/spotbugsTestCases/src/java/ghIssues/Issue608GenericObjectType.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue608GenericObjectType.java
@@ -1,0 +1,28 @@
+package ghIssues;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+
+public class Issue608GenericObjectType {
+	protected <C extends Collection<String>> C validateMBeansNamesList(C namesList, String name) {
+		namesList.remove(name);
+		
+		Collection<String> availableNames = new ArrayList<>();
+		availableNames.containsAll(namesList);
+		
+		return namesList;
+	}
+
+
+	protected <C extends Map<X, C>, X extends Number> C validateMBeansNamesList(C namesList, X number) {
+		namesList.remove(number);
+
+		Collection<X> availableNames = new ArrayList<>();
+		if (availableNames.containsAll(namesList.values())) {
+			throw new IllegalStateException();
+		}
+
+		return namesList;
+	}
+}


### PR DESCRIPTION
Variable types such as `<C extends Collection<String>>` are not analyzed correctly because they are not parsed from the method signature as noted in #608 