### PR TITLE
Extends `@SuppressFBWarnings` to allow regex and exact matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased - 2024-??-??
+### Added
+- Updated the `SuppressFBWarnings` annotation to support finer grained bug suppressions ([#3102](https://github.com/spotbugs/spotbugs/pull/3102))
+
 ### Fixed
 - Do not consider Records as Singletons ([#2981](https://github.com/spotbugs/spotbugs/issues/2981))
 - Keep a maximum of 10000 cached analysis entries for plugin's analysis engines ([#3025](https://github.com/spotbugs/spotbugs/pull/3025))

--- a/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/SuppressFBWarnings.java
+++ b/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/SuppressFBWarnings.java
@@ -48,12 +48,12 @@ public @interface SuppressFBWarnings {
      * <p>By default <code>SuppressFBWarnings</code> annotations suppress bugs by prefix,
      * for instance <code> @SuppressFBWarnings(value = "EI_EXPO", justification = "It's OK")</code>
      * will suppress bugs of type <code>EI_EXPOSE_REP</code> and <code>EI_EXPOSE_REP2</code>.
-     * 
+     *
      * <p>You might use <code>@SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "It's OK" matchType=EXACT)</code>
      * to suppress <code>EI_EXPOSE_REP</code> but not EI_EXPOSE_REP2</code>
-     * 
+     *
      * <p>Regular expressions are also supported with <code>matchType=REGEX</code>
-     * 
+     *
      * @see SuppressMatchType
      */
     SuppressMatchType matchType() default SuppressMatchType.DEFAULT;

--- a/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/SuppressFBWarnings.java
+++ b/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/SuppressFBWarnings.java
@@ -49,7 +49,7 @@ public @interface SuppressFBWarnings {
      * for instance <code> @SuppressFBWarnings(value = "EI_EXPO", justification = "It's OK")</code>
      * will suppress bugs of type <code>EI_EXPOSE_REP</code> and <code>EI_EXPOSE_REP2</code>.
      *
-     * <p>You might use <code>@SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "It's OK" matchType=EXACT)</code>
+     * <p>You might use <code>@SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "It's OK", matchType=EXACT)</code>
      * to suppress <code>EI_EXPOSE_REP</code> but not EI_EXPOSE_REP2</code>
      *
      * <p>Regular expressions are also supported with <code>matchType=REGEX</code>

--- a/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/SuppressFBWarnings.java
+++ b/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/SuppressFBWarnings.java
@@ -43,4 +43,18 @@ public @interface SuppressFBWarnings {
      * Optional documentation of the reason why the warning is suppressed
      */
     String justification() default "";
+
+    /**
+     * <p>By default <code>SuppressFBWarnings</code> annotations suppress bugs by prefix,
+     * for instance <code> @SuppressFBWarnings(value = "EI_EXPO", justification = "It's OK")</code>
+     * will suppress bugs of type <code>EI_EXPOSE_REP</code> and <code>EI_EXPOSE_REP2</code>.
+     * 
+     * <p>You might use <code>@SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "It's OK" matchType=EXACT)</code>
+     * to suppress <code>EI_EXPOSE_REP</code> but not EI_EXPOSE_REP2</code>
+     * 
+     * <p>Regular expressions are also supported with <code>matchType=REGEX</code>
+     * 
+     * @see SuppressMatchType
+     */
+    SuppressMatchType matchType() default SuppressMatchType.DEFAULT;
 }

--- a/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/SuppressFBWarnings.java
+++ b/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/SuppressFBWarnings.java
@@ -50,7 +50,7 @@ public @interface SuppressFBWarnings {
      * will suppress bugs of type <code>EI_EXPOSE_REP</code> and <code>EI_EXPOSE_REP2</code>.
      *
      * <p>You might use <code>@SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "It's OK", matchType=EXACT)</code>
-     * to suppress <code>EI_EXPOSE_REP</code> but not EI_EXPOSE_REP2</code>
+     * to suppress <code>EI_EXPOSE_REP</code> but not <code>EI_EXPOSE_REP2</code>
      *
      * <p>Regular expressions are also supported with <code>matchType=REGEX</code>
      *

--- a/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/SuppressFBWarnings.java
+++ b/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/SuppressFBWarnings.java
@@ -50,9 +50,9 @@ public @interface SuppressFBWarnings {
      * will suppress bugs of type <code>EI_EXPOSE_REP</code> and <code>EI_EXPOSE_REP2</code>.
      *
      * <p>You might use <code>@SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "It's OK", matchType=EXACT)</code>
-     * to suppress <code>EI_EXPOSE_REP</code> but not <code>EI_EXPOSE_REP2</code>
+     * to suppress <code>EI_EXPOSE_REP</code>, but not <code>EI_EXPOSE_REP2</code>.
      *
-     * <p>Regular expressions are also supported with <code>matchType=REGEX</code>
+     * <p>Regular expressions are also supported with <code>matchType=REGEX</code>.
      *
      * @see SuppressMatchType
      */

--- a/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/SuppressMatchType.java
+++ b/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/SuppressMatchType.java
@@ -3,20 +3,25 @@ package edu.umd.cs.findbugs.annotations;
 public enum SuppressMatchType {
 
     /**
+     * Default bug suppression using a mixed prefixed / case insensitive match depending on the criterion.
      * Suppress bugs matching any of:
-     * <li/> the given bug type {@link String#startsWith(String)}
-     * <li/> the given bug category {@link String#equalsIgnoreCase(String)}
-     * <li/> the given bug abbreviation {@link String#equalsIgnoreCase(String)}
+     * <li> the given bug type with: {@link String#startsWith(String)}
+     * <li> the given bug category with: {@link String#equalsIgnoreCase(String)}
+     * <li> the given bug abbreviation with: {@link String#equalsIgnoreCase(String)}
      */
     DEFAULT,
 
     /**
-     * Suppress bugs matching the exact (case sensitive) given type.
+     * Exact (case sensitive match).
+     * Suppress bugs matching any of:
+     * <li> the given bug type with: {@link String#equals(Object)}
+     * <li> the given bug category with: {@link String#equals(Object)}
+     * <li> the given bug abbreviation with: {@link String#equals(Object)}
      */
     EXACT,
 
     /**
-     * Suppress bugs whose type match the given regular expression.
+     * Suppress bugs whose type, category or abbreviation match the given regular expression.
      */
     REGEX;
 }

--- a/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/SuppressMatchType.java
+++ b/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/SuppressMatchType.java
@@ -1,0 +1,22 @@
+package edu.umd.cs.findbugs.annotations;
+
+public enum SuppressMatchType {
+
+    /**
+     * Suppress bugs matching any of:
+     * <li/> the given bug type {@link String#startsWith(String)}
+     * <li/> the given bug category {@link String#equalsIgnoreCase(String)}
+     * <li/> the given bug abbreviation {@link String#equalsIgnoreCase(String)}
+     */
+    DEFAULT,
+
+    /**
+     * Suppress bugs matching the exact (case sensitive) given type.
+     */
+    EXACT,
+
+    /**
+     * Suppress bug whose type match the given regular expression.
+     */
+    REGEX;
+}

--- a/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/SuppressMatchType.java
+++ b/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/SuppressMatchType.java
@@ -16,7 +16,7 @@ public enum SuppressMatchType {
     EXACT,
 
     /**
-     * Suppress bug whose type match the given regular expression.
+     * Suppress bugs whose type match the given regular expression.
      */
     REGEX;
 }

--- a/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/SuppressMatchType.java
+++ b/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/SuppressMatchType.java
@@ -5,18 +5,22 @@ public enum SuppressMatchType {
     /**
      * Default bug suppression using a mixed prefixed / case insensitive match depending on the criterion.
      * Suppress bugs matching any of:
+     * <ul>
      * <li> the given bug type with: {@link String#startsWith(String)}
      * <li> the given bug category with: {@link String#equalsIgnoreCase(String)}
      * <li> the given bug abbreviation with: {@link String#equalsIgnoreCase(String)}
+     * </ul>
      */
     DEFAULT,
 
     /**
      * Exact (case sensitive match).
      * Suppress bugs matching any of:
+     * <ul>
      * <li> the given bug type with: {@link String#equals(Object)}
      * <li> the given bug category with: {@link String#equals(Object)}
      * <li> the given bug abbreviation with: {@link String#equals(Object)}
+     * </ul>
      */
     EXACT,
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/WarningSuppressorTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/WarningSuppressorTest.java
@@ -1,0 +1,31 @@
+package edu.umd.cs.findbugs;
+
+import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
+
+public class WarningSuppressorTest extends AbstractIntegrationTest {
+
+    @Test
+    void testIssue() {
+        performAnalysis("suppress/SuppressedBugs.class");
+
+        assertMethodBugsCount("suppressedNpePrefix", 0);
+        assertMethodBugsCount("nonSuppressedNpePrefix", 2);
+
+        assertMethodBugsCount("suppressedNpeExact", 0);
+        assertMethodBugsCount("nonSuppressedNpeExact", 2);
+
+        assertMethodBugsCount("suppressedNpeRegex", 0);
+        assertMethodBugsCount("nonSuppressedNpeRegex", 2);
+    }
+
+    private void assertMethodBugsCount(String methodName, int expectedCount) {
+        BugInstanceMatcher matcher = new BugInstanceMatcherBuilder().inMethod(methodName).build();
+        assertThat(getBugCollection(), containsExactly(expectedCount, matcher));
+    }
+}

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/WarningSuppressorTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/WarningSuppressorTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
 import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
-public class WarningSuppressorTest extends AbstractIntegrationTest {
+class WarningSuppressorTest extends AbstractIntegrationTest {
 
     @Test
     void testIssue() {
@@ -19,6 +19,7 @@ public class WarningSuppressorTest extends AbstractIntegrationTest {
 
         assertMethodBugsCount("suppressedNpeExact", 0);
         assertMethodBugsCount("nonSuppressedNpeExact", 2);
+        assertMethodBugsCount("nonSuppressedNpeExactDifferentCase", 2);
 
         assertMethodBugsCount("suppressedNpeRegex", 0);
         assertMethodBugsCount("nonSuppressedNpeRegex", 2);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ClassWarningSuppressor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ClassWarningSuppressor.java
@@ -1,11 +1,13 @@
 package edu.umd.cs.findbugs;
 
+import edu.umd.cs.findbugs.annotations.SuppressMatchType;
+
 public class ClassWarningSuppressor extends WarningSuppressor {
 
     ClassAnnotation clazz;
 
-    public ClassWarningSuppressor(String bugPattern, ClassAnnotation clazz) {
-        super(bugPattern);
+    public ClassWarningSuppressor(String bugPattern, SuppressMatchType matchType, ClassAnnotation clazz) {
+        super(bugPattern, matchType);
         this.clazz = clazz;
         if (DEBUG) {
             System.out.println("Suppressing " + bugPattern + " in " + clazz);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/FieldWarningSuppressor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/FieldWarningSuppressor.java
@@ -1,11 +1,13 @@
 package edu.umd.cs.findbugs;
 
+import edu.umd.cs.findbugs.annotations.SuppressMatchType;
+
 public class FieldWarningSuppressor extends ClassWarningSuppressor {
 
     FieldAnnotation field;
 
-    public FieldWarningSuppressor(String bugPattern, ClassAnnotation clazz, FieldAnnotation field) {
-        super(bugPattern, clazz);
+    public FieldWarningSuppressor(String bugPattern, SuppressMatchType matchType, ClassAnnotation clazz, FieldAnnotation field) {
+        super(bugPattern, matchType, clazz);
         this.field = field;
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/MethodWarningSuppressor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/MethodWarningSuppressor.java
@@ -1,11 +1,13 @@
 package edu.umd.cs.findbugs;
 
+import edu.umd.cs.findbugs.annotations.SuppressMatchType;
+
 public class MethodWarningSuppressor extends ClassWarningSuppressor {
 
     MethodAnnotation method;
 
-    public MethodWarningSuppressor(String bugPattern, ClassAnnotation clazz, MethodAnnotation method) {
-        super(bugPattern, clazz);
+    public MethodWarningSuppressor(String bugPattern, SuppressMatchType matchType, ClassAnnotation clazz, MethodAnnotation method) {
+        super(bugPattern, matchType, clazz);
         this.method = method;
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/PackageWarningSuppressor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/PackageWarningSuppressor.java
@@ -1,11 +1,13 @@
 package edu.umd.cs.findbugs;
 
+import edu.umd.cs.findbugs.annotations.SuppressMatchType;
+
 public class PackageWarningSuppressor extends WarningSuppressor {
 
     String packageName;
 
-    public PackageWarningSuppressor(String bugPattern, String packageName) {
-        super(bugPattern);
+    public PackageWarningSuppressor(String bugPattern, SuppressMatchType matchType, String packageName) {
+        super(bugPattern, matchType);
         this.packageName = packageName;
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ParameterWarningSuppressor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ParameterWarningSuppressor.java
@@ -1,13 +1,15 @@
 package edu.umd.cs.findbugs;
 
+import edu.umd.cs.findbugs.annotations.SuppressMatchType;
+
 public class ParameterWarningSuppressor extends ClassWarningSuppressor {
 
     final MethodAnnotation method;
 
     final int register;
 
-    public ParameterWarningSuppressor(String bugPattern, ClassAnnotation clazz, MethodAnnotation method, int register) {
-        super(bugPattern, clazz);
+    public ParameterWarningSuppressor(String bugPattern, SuppressMatchType matchType, ClassAnnotation clazz, MethodAnnotation method, int register) {
+        super(bugPattern, matchType, clazz);
         this.method = method;
         this.register = register;
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/WarningSuppressor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/WarningSuppressor.java
@@ -48,12 +48,17 @@ abstract public class WarningSuppressor implements Matcher {
                 }
                 break;
             case EXACT:
-                if (!bugInstance.getType().equals(bugPattern)) {
+                if (!bugInstance.getType().equals(bugPattern)
+                        && !bugInstance.getBugPattern().getCategory().equals(bugPattern)
+                        && !bugInstance.getBugPattern().getAbbrev().equals(bugPattern)) {
                     return false;
                 }
                 break;
             case REGEX:
-                if (!Pattern.matches(bugPattern, bugInstance.getType())) {
+                Pattern pattern = Pattern.compile(bugPattern);
+                if (!pattern.matcher(bugInstance.getType()).matches()
+                        && !pattern.matcher(bugInstance.getBugPattern().getCategory()).matches()
+                        && !pattern.matcher(bugInstance.getBugPattern().getAbbrev()).matches()) {
                     return false;
                 }
                 break;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/NoteSuppressedWarnings.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/NoteSuppressedWarnings.java
@@ -40,6 +40,7 @@ import edu.umd.cs.findbugs.NonReportingDetector;
 import edu.umd.cs.findbugs.PackageWarningSuppressor;
 import edu.umd.cs.findbugs.ParameterWarningSuppressor;
 import edu.umd.cs.findbugs.SuppressionMatcher;
+import edu.umd.cs.findbugs.annotations.SuppressMatchType;
 import edu.umd.cs.findbugs.ba.AnalysisContext;
 import edu.umd.cs.findbugs.ba.ClassContext;
 import edu.umd.cs.findbugs.bcel.BCELUtil;
@@ -87,11 +88,13 @@ public class NoteSuppressedWarnings extends AnnotationVisitor implements Detecto
             return;
         }
         String[] suppressed = getAnnotationParameterAsStringArray(map, "value");
+        SuppressMatchType matchType = getAnnotationParameterAsEnum(map, "matchType", SuppressMatchType.class);
+
         if (suppressed == null || suppressed.length == 0) {
-            suppressWarning(null);
+            suppressWarning(null, matchType);
         } else {
             for (String s : suppressed) {
-                suppressWarning(s);
+                suppressWarning(s, matchType);
             }
         }
     }
@@ -111,35 +114,37 @@ public class NoteSuppressedWarnings extends AnnotationVisitor implements Detecto
         }
 
         String[] suppressed = getAnnotationParameterAsStringArray(map, "value");
+        SuppressMatchType matchType = getAnnotationParameterAsEnum(map, "matchType", SuppressMatchType.class);
+
         if (suppressed == null || suppressed.length == 0) {
-            suppressWarning(p, null);
+            suppressWarning(p, null, matchType);
         } else {
             for (String s : suppressed) {
-                suppressWarning(p, s);
+                suppressWarning(p, s, matchType);
             }
         }
     }
 
-    private void suppressWarning(int parameter, String pattern) {
+    private void suppressWarning(int parameter, String pattern, SuppressMatchType matchType) {
         String className = getDottedClassName();
         ClassAnnotation clazz = new ClassAnnotation(className);
-        suppressionMatcher.addSuppressor(new ParameterWarningSuppressor(pattern, clazz, MethodAnnotation.fromVisitedMethod(this),
+        suppressionMatcher.addSuppressor(new ParameterWarningSuppressor(pattern, matchType, clazz, MethodAnnotation.fromVisitedMethod(this),
                 parameter));
 
     }
 
-    private void suppressWarning(String pattern) {
+    private void suppressWarning(String pattern, SuppressMatchType matchType) {
         String className = getDottedClassName();
         ClassAnnotation clazz = new ClassAnnotation(className);
         if (className.endsWith(".package-info")) {
-            suppressionMatcher.addPackageSuppressor(new PackageWarningSuppressor(pattern, ClassName.toDottedClassName(getPackageName())));
+            suppressionMatcher.addPackageSuppressor(new PackageWarningSuppressor(pattern, matchType, ClassName.toDottedClassName(getPackageName())));
         } else if (visitingMethod()) {
             suppressionMatcher
-                    .addSuppressor(new MethodWarningSuppressor(pattern, clazz, MethodAnnotation.fromVisitedMethod(this)));
+                    .addSuppressor(new MethodWarningSuppressor(pattern, matchType, clazz, MethodAnnotation.fromVisitedMethod(this)));
         } else if (visitingField()) {
-            suppressionMatcher.addSuppressor(new FieldWarningSuppressor(pattern, clazz, FieldAnnotation.fromVisitedField(this)));
+            suppressionMatcher.addSuppressor(new FieldWarningSuppressor(pattern, matchType, clazz, FieldAnnotation.fromVisitedField(this)));
         } else {
-            suppressionMatcher.addSuppressor(new ClassWarningSuppressor(pattern, clazz));
+            suppressionMatcher.addSuppressor(new ClassWarningSuppressor(pattern, matchType, clazz));
         }
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/visitclass/AnnotationVisitor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/visitclass/AnnotationVisitor.java
@@ -28,6 +28,7 @@ import org.apache.bcel.classfile.Annotations;
 import org.apache.bcel.classfile.ArrayElementValue;
 import org.apache.bcel.classfile.ElementValue;
 import org.apache.bcel.classfile.ElementValuePair;
+import org.apache.bcel.classfile.EnumElementValue;
 import org.apache.bcel.classfile.ParameterAnnotationEntry;
 import org.apache.bcel.classfile.ParameterAnnotations;
 import org.apache.bcel.classfile.SimpleElementValue;
@@ -97,6 +98,19 @@ public class AnnotationVisitor extends PreorderVisitor {
         } catch (Exception e) {
             return null;
         }
+    }
+
+    @CheckForNull
+    protected static <E extends Enum<E>> E getAnnotationParameterAsEnum(Map<String, ElementValue> map, String parameter, Class<E> type) {
+        ElementValue ev = map.get(parameter);
+
+        if (ev instanceof EnumElementValue) {
+            String enumValueString = ((EnumElementValue) ev).getEnumValueString();
+
+            return Enum.valueOf(null, enumValueString);
+        }
+
+        return null;
     }
 
     /**

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/visitclass/AnnotationVisitor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/visitclass/AnnotationVisitor.java
@@ -107,7 +107,7 @@ public class AnnotationVisitor extends PreorderVisitor {
         if (ev instanceof EnumElementValue) {
             String enumValueString = ((EnumElementValue) ev).getEnumValueString();
 
-            return Enum.valueOf(null, enumValueString);
+            return Enum.valueOf(type, enumValueString);
         }
 
         return null;

--- a/spotbugsTestCases/src/java/suppress/SuppressedBugs.java
+++ b/spotbugsTestCases/src/java/suppress/SuppressedBugs.java
@@ -1,0 +1,49 @@
+package suppress;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import edu.umd.cs.findbugs.annotations.SuppressMatchType;
+
+public class SuppressedBugs {
+
+	@SuppressFBWarnings(value = "NP")
+	public int suppressedNpePrefix() {
+		// NP_ALWAYS_NULL and NP_LOAD_OF_KNOWN_NULL_VALUE
+		String x = null;
+		return x.length();
+	}
+
+	@SuppressFBWarnings(value = "XYZ")
+	public int nonSuppressedNpePrefix() {
+		// NP_ALWAYS_NULL and NP_LOAD_OF_KNOWN_NULL_VALUE
+		String x = null;
+		return x.length();
+	}
+
+	@SuppressFBWarnings(value = {"NP_ALWAYS_NULL", "NP_LOAD_OF_KNOWN_NULL_VALUE"}, matchType = SuppressMatchType.EXACT)
+	public int suppressedNpeExact() {
+		// NP_ALWAYS_NULL and NP_LOAD_OF_KNOWN_NULL_VALUE
+		String x = null;
+		return x.length();
+	}
+
+	@SuppressFBWarnings(value = "XYZ", matchType = SuppressMatchType.EXACT)
+	public int nonSuppressedNpeExact() {
+		// NP_ALWAYS_NULL and NP_LOAD_OF_KNOWN_NULL_VALUE
+		String x = null;
+		return x.length();
+	}
+
+	@SuppressFBWarnings(value = "NP.*", matchType = SuppressMatchType.REGEX)
+	public int suppressedNpeRegex() {
+		// NP_ALWAYS_NULL and NP_LOAD_OF_KNOWN_NULL_VALUE
+		String x = null;
+		return x.length();
+	}
+
+	@SuppressFBWarnings(value = "XYZ.*", matchType = SuppressMatchType.REGEX)
+	public int nonSuppressedNpeRegex() {
+		// NP_ALWAYS_NULL and NP_LOAD_OF_KNOWN_NULL_VALUE
+		String x = null;
+		return x.length();
+	}
+}

--- a/spotbugsTestCases/src/java/suppress/SuppressedBugs.java
+++ b/spotbugsTestCases/src/java/suppress/SuppressedBugs.java
@@ -33,6 +33,14 @@ public class SuppressedBugs {
 		return x.length();
 	}
 
+	// Exact match is case sensitive, this won't suppress anything
+	@SuppressFBWarnings(value = {"np_always_null", "np_load_of_known_null_value"}, matchType = SuppressMatchType.EXACT)
+	public int nonSuppressedNpeExactDifferentCase() {
+		// NP_ALWAYS_NULL and NP_LOAD_OF_KNOWN_NULL_VALUE
+		String x = null;
+		return x.length();
+	}
+
 	@SuppressFBWarnings(value = "NP.*", matchType = SuppressMatchType.REGEX)
 	public int suppressedNpeRegex() {
 		// NP_ALWAYS_NULL and NP_LOAD_OF_KNOWN_NULL_VALUE


### PR DESCRIPTION
Extend the bug suppression, allowing exact (not prefix) bug type match, and regex bug type match