### PR TITLE
Perform Bug-Reporter deduplication based on target files

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/TextUICommandLineTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/TextUICommandLineTest.java
@@ -114,8 +114,8 @@ class TextUICommandLineTest {
         Path altFile = tmpdir.resolve("sibling2").resolve("..").resolve(file.getFileName());
         TextUICommandLine commandLine = new TextUICommandLine();
         try (FindBugs2 findbugs = new FindBugs2()) {
-            commandLine.handleOption("-xml", "=" + file.toString());
-            commandLine.handleOption("-xml", "=" + altFile.toString());
+            commandLine.handleOption("-xml", "=" + file);
+            commandLine.handleOption("-xml", "=" + altFile);
 
             commandLine.configureEngine(findbugs);
             var configuredReporter = findbugs.getBugReporter();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/TextUIBugReporter.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/TextUIBugReporter.java
@@ -47,7 +47,7 @@ public abstract class TextUIBugReporter extends AbstractBugReporter implements C
 
     private boolean applySuppressions = false;
 
-    private String deduplicationKey = null;
+    private String outputTarget = null;
 
     static final String OTHER_CATEGORY_ABBREV = "X";
 
@@ -242,18 +242,18 @@ public abstract class TextUIBugReporter extends AbstractBugReporter implements C
         }
     }
 
-    public String getDeduplicationKey() {
-        return this.deduplicationKey;
+    public String getOutputTarget() {
+        return this.outputTarget;
     }
 
-    public void setDeduplicationKey(String key) {
-        this.deduplicationKey = key;
+    public void setOutputTarget(String key) {
+        this.outputTarget = key;
     }
 
     public boolean isDuplicateOf(TextUIBugReporter other) {
-        return this.deduplicationKey != null
-                && other.deduplicationKey != null
-                && this.deduplicationKey.equals(other.deduplicationKey);
+        return this.outputTarget != null
+                && other.outputTarget != null
+                && this.outputTarget.equals(other.outputTarget);
     }
 
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/TextUIBugReporter.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/TextUIBugReporter.java
@@ -47,6 +47,8 @@ public abstract class TextUIBugReporter extends AbstractBugReporter implements C
 
     private boolean applySuppressions = false;
 
+    private String deduplicationKey = null;
+
     static final String OTHER_CATEGORY_ABBREV = "X";
 
     protected PrintWriter outputStream = UTF8.printWriter(System.out, true);
@@ -239,6 +241,21 @@ public abstract class TextUIBugReporter extends AbstractBugReporter implements C
             }
         }
     }
+
+    public String getDeduplicationKey() {
+        return this.deduplicationKey;
+    }
+
+    public void setDeduplicationKey(String key) {
+        this.deduplicationKey = key;
+    }
+
+    public boolean isDuplicateOf(TextUIBugReporter other) {
+        return this.deduplicationKey != null
+                && other.deduplicationKey != null
+                && this.deduplicationKey.equals(other.deduplicationKey);
+    }
+
 
     public boolean isApplySuppressions() {
         return applySuppressions;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/TextUIBugReporter.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/TextUIBugReporter.java
@@ -47,7 +47,7 @@ public abstract class TextUIBugReporter extends AbstractBugReporter implements C
 
     private boolean applySuppressions = false;
 
-    private String outputTarget = null;
+    private String outputTarget;
 
     static final String OTHER_CATEGORY_ABBREV = "X";
 
@@ -251,9 +251,7 @@ public abstract class TextUIBugReporter extends AbstractBugReporter implements C
     }
 
     public boolean isDuplicateOf(TextUIBugReporter other) {
-        return this.outputTarget != null
-                && other.outputTarget != null
-                && this.outputTarget.equals(other.outputTarget);
+        return outputTarget != null && outputTarget.equals(other.outputTarget);
     }
 
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/TextUICommandLine.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/TextUICommandLine.java
@@ -276,7 +276,9 @@ public class TextUICommandLine extends FindBugsCommandLine {
     /* visible for testing */ String handleOutputFilePath(TextUIBugReporter reporter, String optionExtraPart) {
         int index = optionExtraPart.indexOf('=');
         if (index >= 0) {
-            Path path = Paths.get(optionExtraPart.substring(index + 1));
+            String reportTarget = optionExtraPart.substring(index + 1);
+            reporter.setDeduplicationKey(reportTarget);
+            Path path = Paths.get(reportTarget);
             try {
                 OutputStream oStream = Files.newOutputStream(path, StandardOpenOption.CREATE, StandardOpenOption.WRITE,
                         StandardOpenOption.TRUNCATE_EXISTING);
@@ -345,7 +347,7 @@ public class TextUICommandLine extends FindBugsCommandLine {
             bugReporterType = SORTING_REPORTER;
             SortingBugReporter sortingBugReporter = new SortingBugReporter();
             handleOutputFilePath(sortingBugReporter, optionExtraPart);
-            reporters.add(sortingBugReporter);
+            addDistinctBugReporter(sortingBugReporter);
         } else if ("-xml".equals(option)) {
             bugReporterType = XML_REPORTER;
             XMLBugReporter xmlBugReporter = new XMLBugReporter(project);
@@ -366,11 +368,11 @@ public class TextUICommandLine extends FindBugsCommandLine {
             }
             xmlBugReporter.setAddMessages(xmlWithMessages);
             xmlBugReporter.setMinimalXML(xmlMinimal);
-            reporters.add(xmlBugReporter);
+            addDistinctBugReporter(xmlBugReporter);
         } else if ("-emacs".equals(option)) {
             EmacsBugReporter emacsBugReporter = new EmacsBugReporter();
             handleOutputFilePath(emacsBugReporter, optionExtraPart);
-            reporters.add(emacsBugReporter);
+            addDistinctBugReporter(emacsBugReporter);
             bugReporterType = EMACS_REPORTER;
         } else if ("-relaxed".equals(option)) {
             relaxedReportingMode = true;
@@ -385,17 +387,17 @@ public class TextUICommandLine extends FindBugsCommandLine {
             if (!"".equals(optionExtraPart)) {
                 htmlBugReporter.setStylesheet(optionExtraPart);
             }
-            reporters.add(htmlBugReporter);
+            addDistinctBugReporter(htmlBugReporter);
         } else if ("-xdocs".equals(option)) {
             bugReporterType = XDOCS_REPORTER;
             XDocsBugReporter xDocsBugReporter = new XDocsBugReporter(project);
             handleOutputFilePath(xDocsBugReporter, optionExtraPart);
-            reporters.add(xDocsBugReporter);
+            addDistinctBugReporter(xDocsBugReporter);
         } else if ("-sarif".equals(option)) {
             bugReporterType = SARIF_REPORTER;
             SarifBugReporter sarifBugReporter = new SarifBugReporter(project);
             handleOutputFilePath(sarifBugReporter, optionExtraPart);
-            reporters.add(sarifBugReporter);
+            addDistinctBugReporter(sarifBugReporter);
         } else if ("-applySuppression".equals(option)) {
             applySuppression = true;
         } else if ("-quiet".equals(option)) {
@@ -675,7 +677,7 @@ public class TextUICommandLine extends FindBugsCommandLine {
         }
         switch (bugReporterType) {
         case PRINTING_REPORTER:
-            reporters.add(new PrintingBugReporter());
+            addDistinctBugReporter(new PrintingBugReporter());
             break;
         case SORTING_REPORTER:
         case XML_REPORTER:
@@ -815,5 +817,20 @@ public class TextUICommandLine extends FindBugsCommandLine {
      */
     private UserPreferences getUserPreferences() {
         return project.getConfiguration();
+    }
+
+    /**
+     * Adds a reporter to the aggregating list of reporters, assuming it does not duplicate a known reporter.
+     *
+     * @param reporter The reporter to add to the list of known reporters.
+     */
+    private void addDistinctBugReporter(TextUIBugReporter reporter) {
+        for (TextUIBugReporter known : reporters) {
+            if (known.isDuplicateOf(reporter)) {
+                logger.warn("Attempted to add multiple reporters writing to the same file at {}. First reporter wins.", known.getDeduplicationKey());
+                return;
+            }
+        }
+        reporters.add(reporter);
     }
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/TextUICommandLine.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/TextUICommandLine.java
@@ -30,7 +30,6 @@ import java.io.PrintStream;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Iterator;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/TextUICommandLine.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/TextUICommandLine.java
@@ -276,9 +276,8 @@ public class TextUICommandLine extends FindBugsCommandLine {
     /* visible for testing */ String handleOutputFilePath(TextUIBugReporter reporter, String optionExtraPart) {
         int index = optionExtraPart.indexOf('=');
         if (index >= 0) {
-            String reportTarget = optionExtraPart.substring(index + 1);
-            reporter.setDeduplicationKey(reportTarget);
-            Path path = Paths.get(reportTarget);
+            Path path = Paths.get(optionExtraPart.substring(index + 1)).normalize().toAbsolutePath();
+            reporter.setOutputTarget(path.toString());
             try {
                 OutputStream oStream = Files.newOutputStream(path, StandardOpenOption.CREATE, StandardOpenOption.WRITE,
                         StandardOpenOption.TRUNCATE_EXISTING);
@@ -820,14 +819,14 @@ public class TextUICommandLine extends FindBugsCommandLine {
     }
 
     /**
-     * Adds a reporter to the aggregating list of reporters, assuming it does not duplicate a known reporter.
+     * Adds a reporter to the aggregating list of reporters, skipping the operation if a duplicate reporter is already present.
      *
      * @param reporter The reporter to add to the list of known reporters.
      */
     private void addDistinctBugReporter(TextUIBugReporter reporter) {
         for (TextUIBugReporter known : reporters) {
             if (known.isDuplicateOf(reporter)) {
-                logger.warn("Attempted to add multiple reporters writing to the same file at {}. First reporter wins.", known.getDeduplicationKey());
+                logger.warn("Attempted to add multiple reporters writing to the same file at {}. First reporter wins.", known.getOutputTarget());
                 return;
             }
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/TextUICommandLine.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/TextUICommandLine.java
@@ -276,7 +276,7 @@ public class TextUICommandLine extends FindBugsCommandLine {
     /* visible for testing */ String handleOutputFilePath(TextUIBugReporter reporter, String optionExtraPart) {
         int index = optionExtraPart.indexOf('=');
         if (index >= 0) {
-            Path path = Paths.get(optionExtraPart.substring(index + 1)).normalize().toAbsolutePath();
+            Path path = Path.of(optionExtraPart.substring(index + 1)).normalize().toAbsolutePath();
             reporter.setOutputTarget(path.toString());
             try {
                 OutputStream oStream = Files.newOutputStream(path, StandardOpenOption.CREATE, StandardOpenOption.WRITE,


### PR DESCRIPTION
This is attempt number two to fix #2047, after the initial attempt broke stylesheet behavior and was reverted.

The first attempt at this was in PR #2894, subsequently reverted in #3038 to fix issue #2969 