### PR TITLE
Run the build against JDK 23

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        java: [11, 17, 21, 22]
+        java: [11, 17, 21, 23]
       max-parallel: 6
     runs-on: ${{ matrix.os }}
     continue-on-error: true


### PR DESCRIPTION
A small update to the build to run against the latest JDK version (23) instead of the previous one (22)