### PR TITLE
Add bug checking assert functions to `AbstractIntegrationTest`

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/AbstractIntegrationTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/AbstractIntegrationTest.java
@@ -148,10 +148,23 @@ public abstract class AbstractIntegrationTest {
         bugReporter = runner.run(paths);
     }
 
+    /**
+     * Asserts that there are exactly zero bug instances with the given bug type.
+     * The match is checked according to {@link BugInstanceMatcher}.
+     *
+     * @param bugType the expected bug type
+     */
     final protected void assertNoBugType(String bugType) {
         assertBugTypeCount(bugType, 0);
     }
 
+    /**
+     * Asserts that there are exactly the given number of bug instances with the given bug type.
+     * The match is checked according to {@link BugInstanceMatcher}.
+     *
+     * @param bugType the expected bug type
+     * @param count the expected number of matches
+     */
     final protected void assertBugTypeCount(String bugType, int count) {
         final BugInstanceMatcher matcher = new BugInstanceMatcherBuilder()
                 .bugType(bugType)
@@ -159,10 +172,25 @@ public abstract class AbstractIntegrationTest {
         assertThat(getBugCollection(), containsExactly(count, matcher));
     }
 
+    /**
+     * Asserts that there are exactly zero bug instances with the given bug type in the given class.
+     * The match is checked according to {@link BugInstanceMatcher}.
+     *
+     * @param bugType the expected bug type
+     * @param className the expected class name. See {@link BugInstanceMatcher#BugInstanceMatcher(String, String, String, String, String, Integer, Integer, Confidence, String, List) BugInstanceMatcher's constructor} for details.
+     */
     final protected void assertNoBugInClass(String bugType, String className) {
         assertBugInClassCount(bugType, className, 0);
     }
 
+    /**
+     * Asserts that there are exactly the given number of bug instances with the given bug type in the given class.
+     * The match is checked according to {@link BugInstanceMatcher}.
+     *
+     * @param bugType the expected bug type
+     * @param className the expected class name. See {@link BugInstanceMatcher#BugInstanceMatcher(String, String, String, String, String, Integer, Integer, Confidence, String, List) BugInstanceMatcher's constructor} for details.
+     * @param count the expected number of matches
+     */
     final protected void assertBugInClassCount(String bugType, String className, int count) {
         final BugInstanceMatcher matcher = new BugInstanceMatcherBuilder()
                 .bugType(bugType)
@@ -171,6 +199,13 @@ public abstract class AbstractIntegrationTest {
         assertThat(getBugCollection(), containsExactly(count, matcher));
     }
 
+    /**
+     * Asserts that there is a bug instance with the given bug type in the given class.
+     * The match is checked according to {@link BugInstanceMatcher}.
+     *
+     * @param bugType the expected bug type
+     * @param className the expected class name. See {@link BugInstanceMatcher#BugInstanceMatcher(String, String, String, String, String, Integer, Integer, Confidence, String, List) BugInstanceMatcher's constructor} for details.
+     */
     final protected void assertBugInClass(String bugType, String className) {
         final BugInstanceMatcher matcher = new BugInstanceMatcherBuilder()
                 .bugType(bugType)
@@ -179,6 +214,14 @@ public abstract class AbstractIntegrationTest {
         assertThat(getBugCollection(), hasItem(matcher));
     }
 
+    /**
+     * Asserts that there are exactly zero bug instances with the given bug type in the given class in the given method.
+     * The match is checked according to {@link BugInstanceMatcher}.
+     *
+     * @param bugType the expected bug type
+     * @param className the expected class name. See {@link BugInstanceMatcher#BugInstanceMatcher(String, String, String, String, String, Integer, Integer, Confidence, String, List) BugInstanceMatcher's constructor} for details.
+     * @param method the expected method's name
+     */
     final protected void assertNoBugInMethod(String bugType, String className, String method) {
         final BugInstanceMatcher matcher = new BugInstanceMatcherBuilder()
                 .bugType(bugType)
@@ -189,6 +232,14 @@ public abstract class AbstractIntegrationTest {
         assertThat(getBugCollection(), containsExactly(0, matcher));
     }
 
+    /**
+     * Asserts that there is a bug instance with the given bug type in the given class in the given method.
+     * The match is checked according to {@link BugInstanceMatcher}.
+     *
+     * @param bugType the expected bug type
+     * @param className the expected class name. See {@link BugInstanceMatcher#BugInstanceMatcher(String, String, String, String, String, Integer, Integer, Confidence, String, List) BugInstanceMatcher's constructor} for details.
+     * @param method the expected method's name
+     */
     final protected void assertBugInMethod(String bugType, String className, String method) {
         final BugInstanceMatcher matcher = new BugInstanceMatcherBuilder()
                 .bugType(bugType)
@@ -198,6 +249,15 @@ public abstract class AbstractIntegrationTest {
         assertThat(getBugCollection(), hasItem(matcher));
     }
 
+    /**
+     * Asserts that there is a bug instance with the given bug type in the given class in the given method at the given line.
+     * The match is checked according to {@link BugInstanceMatcher}.
+     *
+     * @param bugType the expected bug type
+     * @param className the expected class name. See {@link BugInstanceMatcher#BugInstanceMatcher(String, String, String, String, String, Integer, Integer, Confidence, String, List) BugInstanceMatcher's constructor} for details.
+     * @param method the expected method's name
+     * @param line the expected line
+     */
     final protected void assertBugInMethodAtLine(String bugType, String className, String method, int line) {
         final BugInstanceMatcher matcher = new BugInstanceMatcherBuilder()
                 .bugType(bugType)
@@ -208,6 +268,16 @@ public abstract class AbstractIntegrationTest {
         assertThat(getBugCollection(), hasItem(matcher));
     }
 
+    /**
+     * Asserts that there is a bug instance with the given bug type in the given class in the given method at the given line with the given confidence.
+     * The match is checked according to {@link BugInstanceMatcher}.
+     *
+     * @param bugType the expected bug type
+     * @param className the expected class name. See {@link BugInstanceMatcher#BugInstanceMatcher(String, String, String, String, String, Integer, Integer, Confidence, String, List) BugInstanceMatcher's constructor} for details.
+     * @param method the expected method's name
+     * @param line the expected line
+     * @param confidence the expected confidence
+     */
     final protected void assertBugInMethodAtLineWithConfidence(String bugType, String className, String method, int line, Confidence confidence) {
         final BugInstanceMatcher matcher = new BugInstanceMatcherBuilder()
                 .bugType(bugType)
@@ -219,6 +289,15 @@ public abstract class AbstractIntegrationTest {
         assertThat(getBugCollection(), hasItem(matcher));
     }
 
+    /**
+     * Asserts that there is a bug instance with the given bug type in the given class in the given method at the given field.
+     * The match is checked according to {@link BugInstanceMatcher}.
+     *
+     * @param bugType the expected bug type
+     * @param className the expected class name. See {@link BugInstanceMatcher#BugInstanceMatcher(String, String, String, String, String, Integer, Integer, Confidence, String, List) BugInstanceMatcher's constructor} for details.
+     * @param method the expected method's name
+     * @param fieldName the expected field's name
+     */
     final protected void assertBugInMethodAtField(String bugType, String className, String method, String fieldName) {
         final BugInstanceMatcher matcher = new BugInstanceMatcherBuilder()
                 .bugType(bugType)
@@ -229,6 +308,14 @@ public abstract class AbstractIntegrationTest {
         assertThat(getBugCollection(), hasItem(matcher));
     }
 
+    /**
+     * Asserts that there is a bug instance with the given bug type in the given class at the given field.
+     * The match is checked according to {@link BugInstanceMatcher}.
+     *
+     * @param bugType the expected bug type
+     * @param className the expected class name. See {@link BugInstanceMatcher#BugInstanceMatcher(String, String, String, String, String, Integer, Integer, Confidence, String, List) BugInstanceMatcher's constructor} for details.
+     * @param fieldName the expected field's name
+     */
     final protected void assertBugAtField(String bugType, String className, String fieldName) {
         final BugInstanceMatcher matcher = new BugInstanceMatcherBuilder()
                 .bugType(bugType)
@@ -238,6 +325,15 @@ public abstract class AbstractIntegrationTest {
         assertThat(getBugCollection(), hasItem(matcher));
     }
 
+    /**
+     * Asserts that there is a bug instance with the given bug type in the given class at the given field at the given line.
+     * The match is checked according to {@link BugInstanceMatcher}.
+     *
+     * @param bugType the expected bug type
+     * @param className the expected class name. See {@link BugInstanceMatcher#BugInstanceMatcher(String, String, String, String, String, Integer, Integer, Confidence, String, List) BugInstanceMatcher's constructor} for details.
+     * @param fieldName the expected field's name
+     * @param line the expected line
+     */
     final protected void assertBugAtFieldAtLine(String bugType, String className, String fieldName, int line) {
         final BugInstanceMatcher matcher = new BugInstanceMatcherBuilder()
                 .bugType(bugType)
@@ -248,6 +344,16 @@ public abstract class AbstractIntegrationTest {
         assertThat(getBugCollection(), hasItem(matcher));
     }
 
+    /**
+     * Asserts that there is a bug instance with the given bug type in the given class in the given method at the given variable at the given line.
+     * The match is checked according to {@link BugInstanceMatcher}.
+     *
+     * @param bugType the expected bug type
+     * @param className the expected class name. See {@link BugInstanceMatcher#BugInstanceMatcher(String, String, String, String, String, Integer, Integer, Confidence, String, List) BugInstanceMatcher's constructor} for details.
+     * @param method the expected method's name
+     * @param variableName the expected variable name
+     * @param line the expected line
+     */
     final protected void assertBugAtVar(String bugType, String className, String method, String variableName, int line) {
         final BugInstanceMatcher matcher = new BugInstanceMatcherBuilder()
                 .bugType(bugType)
@@ -259,16 +365,32 @@ public abstract class AbstractIntegrationTest {
         assertThat(getBugCollection(), hasItem(matcher));
     }
 
-    final protected void assertBugInMethodAtVariable(String bugType, String className, String methodName, String variableName) {
+    /**
+     * Asserts that there is a bug instance with the given bug type in the given class in the given method at the given variable.
+     * The match is checked according to {@link BugInstanceMatcher}.
+     *
+     * @param bugType the expected bug type
+     * @param className the expected class name. See {@link BugInstanceMatcher#BugInstanceMatcher(String, String, String, String, String, Integer, Integer, Confidence, String, List) BugInstanceMatcher's constructor} for details.
+     * @param method the expected method's name
+     * @param variableName the expected variable name
+     */
+    final protected void assertBugInMethodAtVariable(String bugType, String className, String method, String variableName) {
         final BugInstanceMatcher matcher = new BugInstanceMatcherBuilder()
                 .bugType(bugType)
                 .inClass(className)
-                .inMethod(methodName)
+                .inMethod(method)
                 .atVariable(variableName)
                 .build();
         assertThat(getBugCollection(), hasItem(matcher));
     }
 
+    /**
+     * Asserts that there is a bug instance with the given bug type at the given line.
+     * The match is checked according to {@link BugInstanceMatcher}.
+     *
+     * @param bugType the expected bug type
+     * @param line the expected line
+     */
     final protected void assertBugAtLine(String bugType, int line) {
         final BugInstanceMatcher matcher = new BugInstanceMatcherBuilder()
                 .bugType(bugType)

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/AbstractIntegrationTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/AbstractIntegrationTest.java
@@ -19,6 +19,9 @@
 
 package edu.umd.cs.findbugs;
 
+import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -30,8 +33,10 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 
+import edu.umd.cs.findbugs.annotations.Confidence;
 import edu.umd.cs.findbugs.internalAnnotations.SlashedClassName;
 import edu.umd.cs.findbugs.test.AnalysisRunner;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
 import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
 /**
@@ -141,5 +146,134 @@ public abstract class AbstractIntegrationTest {
                 .map(AbstractIntegrationTest::getFindbugsTestCasesFile)
                 .toArray(Path[]::new);
         bugReporter = runner.run(paths);
+    }
+
+    final protected void assertNoBugType(String bugType) {
+        assertBugTypeCount(bugType, 0);
+    }
+
+    final protected void assertBugTypeCount(String bugType, int count) {
+        final BugInstanceMatcher matcher = new BugInstanceMatcherBuilder()
+                .bugType(bugType)
+                .build();
+        assertThat(getBugCollection(), containsExactly(count, matcher));
+    }
+
+    final protected void assertNoBugInClass(String bugType, String className) {
+        assertBugInClassCount(bugType, className, 0);
+    }
+
+    final protected void assertBugInClassCount(String bugType, String className, int count) {
+        final BugInstanceMatcher matcher = new BugInstanceMatcherBuilder()
+                .bugType(bugType)
+                .inClass(className)
+                .build();
+        assertThat(getBugCollection(), containsExactly(count, matcher));
+    }
+
+    final protected void assertBugInClass(String bugType, String className) {
+        final BugInstanceMatcher matcher = new BugInstanceMatcherBuilder()
+                .bugType(bugType)
+                .inClass(className)
+                .build();
+        assertThat(getBugCollection(), hasItem(matcher));
+    }
+
+    final protected void assertNoBugInMethod(String bugType, String className, String method) {
+        final BugInstanceMatcher matcher = new BugInstanceMatcherBuilder()
+                .bugType(bugType)
+                .inClass(className)
+                .inMethod(method)
+                .build();
+
+        assertThat(getBugCollection(), containsExactly(0, matcher));
+    }
+
+    final protected void assertBugInMethod(String bugType, String className, String method) {
+        final BugInstanceMatcher matcher = new BugInstanceMatcherBuilder()
+                .bugType(bugType)
+                .inClass(className)
+                .inMethod(method)
+                .build();
+        assertThat(getBugCollection(), hasItem(matcher));
+    }
+
+    final protected void assertBugInMethodAtLine(String bugType, String className, String method, int line) {
+        final BugInstanceMatcher matcher = new BugInstanceMatcherBuilder()
+                .bugType(bugType)
+                .inClass(className)
+                .inMethod(method)
+                .atLine(line)
+                .build();
+        assertThat(getBugCollection(), hasItem(matcher));
+    }
+
+    final protected void assertBugInMethodAtLineWithConfidence(String bugType, String className, String method, int line, Confidence confidence) {
+        final BugInstanceMatcher matcher = new BugInstanceMatcherBuilder()
+                .bugType(bugType)
+                .inClass(className)
+                .inMethod(method)
+                .atLine(line)
+                .withConfidence(confidence)
+                .build();
+        assertThat(getBugCollection(), hasItem(matcher));
+    }
+
+    final protected void assertBugInMethodAtField(String bugType, String className, String method, String fieldName) {
+        final BugInstanceMatcher matcher = new BugInstanceMatcherBuilder()
+                .bugType(bugType)
+                .inClass(className)
+                .inMethod(method)
+                .atField(fieldName)
+                .build();
+        assertThat(getBugCollection(), hasItem(matcher));
+    }
+
+    final protected void assertBugAtField(String bugType, String className, String fieldName) {
+        final BugInstanceMatcher matcher = new BugInstanceMatcherBuilder()
+                .bugType(bugType)
+                .inClass(className)
+                .atField(fieldName)
+                .build();
+        assertThat(getBugCollection(), hasItem(matcher));
+    }
+
+    final protected void assertBugAtFieldAtLine(String bugType, String className, String fieldName, int line) {
+        final BugInstanceMatcher matcher = new BugInstanceMatcherBuilder()
+                .bugType(bugType)
+                .inClass(className)
+                .atField(fieldName)
+                .atLine(line)
+                .build();
+        assertThat(getBugCollection(), hasItem(matcher));
+    }
+
+    final protected void assertBugAtVar(String bugType, String className, String method, String variableName, int line) {
+        final BugInstanceMatcher matcher = new BugInstanceMatcherBuilder()
+                .bugType(bugType)
+                .inClass(className)
+                .inMethod(method)
+                .atVariable(variableName)
+                .atLine(line)
+                .build();
+        assertThat(getBugCollection(), hasItem(matcher));
+    }
+
+    final protected void assertBugInMethodAtVariable(String bugType, String className, String methodName, String variableName) {
+        final BugInstanceMatcher matcher = new BugInstanceMatcherBuilder()
+                .bugType(bugType)
+                .inClass(className)
+                .inMethod(methodName)
+                .atVariable(variableName)
+                .build();
+        assertThat(getBugCollection(), hasItem(matcher));
+    }
+
+    final protected void assertBugAtLine(String bugType, int line) {
+        final BugInstanceMatcher matcher = new BugInstanceMatcherBuilder()
+                .bugType(bugType)
+                .atLine(line)
+                .build();
+        assertThat(getBugCollection(), hasItem(matcher));
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue1254Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue1254Test.java
@@ -1,16 +1,10 @@
 package edu.umd.cs.findbugs.ba;
 
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnJre;
 import org.junit.jupiter.api.condition.JRE;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.BugCollection;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
 /**
  * @see <a href="https://github.com/spotbugs/spotbugs/issues/1254">GitHub issue</a>
@@ -27,9 +21,7 @@ class Issue1254Test extends AbstractIntegrationTest {
     @Test
     void testUnresolvableReference() {
         performAnalysis(CLASS_LIST);
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder().bugType("VR_UNRESOLVABLE_REFERENCE")
-                .build();
-        assertThat(getBugCollection(), containsExactly(0, bugTypeMatcher));
+        assertNoBugType("VR_UNRESOLVABLE_REFERENCE");
     }
 
     /**
@@ -39,11 +31,8 @@ class Issue1254Test extends AbstractIntegrationTest {
     @DisabledOnJre(JRE.JAVA_8)
     void testUncalledPrivateMethod() {
         performAnalysis(CLASS_LIST);
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder().bugType("UPM_UNCALLED_PRIVATE_METHOD")
-                .build();
-        assertThat(getBugCollection(), containsExactly(2, bugTypeMatcher));
-        BugCollection bugCollection = getBugCollection();
-        bugCollection.findBug(null, "UPM_UNCALLED_PRIVATE_METHOD", 25);
-        bugCollection.findBug(null, "UPM_UNCALLED_PRIVATE_METHOD", 36);
+        assertBugTypeCount("UPM_UNCALLED_PRIVATE_METHOD", 2);
+        assertBugInMethod("UPM_UNCALLED_PRIVATE_METHOD", "Issue1254", "uncalledOuterMethod");
+        assertBugInMethod("UPM_UNCALLED_PRIVATE_METHOD", "Issue1254$Inner", "uncalledInnerMethod");
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue1338Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue1338Test.java
@@ -1,15 +1,10 @@
 package edu.umd.cs.findbugs.ba;
 
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnJre;
 import org.junit.jupiter.api.condition.JRE;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
 /**
  * @see <a href="https://github.com/spotbugs/spotbugs/issues/1338">GitHub issue</a>
@@ -26,8 +21,6 @@ class Issue1338Test extends AbstractIntegrationTest {
     @DisabledOnJre(JRE.JAVA_8)
     void testMethodCallInTryWithResource() {
         performAnalysis(CLASS_LIST);
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder().bugType("RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE")
-                .build();
-        assertThat(getBugCollection(), containsExactly(0, bugTypeMatcher));
+        assertNoBugType("RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE");
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue1464Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue1464Test.java
@@ -1,13 +1,8 @@
 package edu.umd.cs.findbugs.ba;
 
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 import org.junit.jupiter.api.Test;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
 /**
  * @see <a href="https://github.com/spotbugs/spotbugs/issues/1464">GitHub issue #1464</a>
@@ -18,8 +13,6 @@ class Issue1464Test extends AbstractIntegrationTest {
     @Test
     void testIssue() {
         performAnalysis("ghIssues/Issue1464.class");
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder().bugType("DMI_RANDOM_USED_ONLY_ONCE").build();
-        assertThat(getBugCollection(), containsExactly(2, bugTypeMatcher));
+        assertBugTypeCount("DMI_RANDOM_USED_ONLY_ONCE", 2);
     }
-
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue2145Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue2145Test.java
@@ -1,19 +1,14 @@
 package edu.umd.cs.findbugs.ba;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasSize;
-
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.SortedBugCollection;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class Issue2145Test extends AbstractIntegrationTest {
 
     @Test
     void testIssue() {
-        performAnalysis("ghIssues/Issue2145.class");
-        SortedBugCollection bugCollection = (SortedBugCollection) getBugCollection();
-        assertThat(bugCollection.getErrors(), hasSize(0));
+        Assertions.assertDoesNotThrow(() -> performAnalysis("ghIssues/Issue2145.class"));
     }
 
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue2402Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue2402Test.java
@@ -1,14 +1,8 @@
 package edu.umd.cs.findbugs.ba;
 
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 import org.junit.jupiter.api.Test;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
-import edu.umd.cs.findbugs.SortedBugCollection;
 
 class Issue2402Test extends AbstractIntegrationTest {
 
@@ -23,10 +17,6 @@ class Issue2402Test extends AbstractIntegrationTest {
                 "ghIssues/issue2402/TestD.class",
                 "ghIssues/issue2402/TestD$UMap.class");
 
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder().bugType("HE_SIGNATURE_DECLARES_HASHING_OF_UNHASHABLE_CLASS").build();
-
-        SortedBugCollection bugCollection = (SortedBugCollection) getBugCollection();
-        assertThat(bugCollection, containsExactly(4, bugTypeMatcher));
+        assertBugTypeCount("HE_SIGNATURE_DECLARES_HASHING_OF_UNHASHABLE_CLASS", 4);
     }
-
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue2995Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue2995Test.java
@@ -1,13 +1,7 @@
 package edu.umd.cs.findbugs.ba;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.SortedBugCollection;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 import org.junit.jupiter.api.Test;
-
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 class Issue2995Test extends AbstractIntegrationTest {
 
@@ -15,11 +9,6 @@ class Issue2995Test extends AbstractIntegrationTest {
     void testIssue() {
         performAnalysis("ghIssues/Issue2995.class");
 
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType("SF_DEAD_STORE_DUE_TO_SWITCH_FALLTHROUGH").build();
-
-        SortedBugCollection bugCollection = (SortedBugCollection) getBugCollection();
-        assertThat(bugCollection, containsExactly(0, bugTypeMatcher));
-
+        assertNoBugType("SF_DEAD_STORE_DUE_TO_SWITCH_FALLTHROUGH");
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue3069Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue3069Test.java
@@ -1,13 +1,7 @@
 package edu.umd.cs.findbugs.ba;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 import org.junit.jupiter.api.Test;
-
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItem;
 
 class Issue3069Test extends AbstractIntegrationTest {
 
@@ -19,23 +13,7 @@ class Issue3069Test extends AbstractIntegrationTest {
                 "org/rocksdb/ReadOptions.class",
                 "org/rocksdb/RocksObject.class");
 
-        assertBug("readOptionsNotClosed", 8);
-        assertBug(1);
-    }
-
-    private void assertBug(int num) {
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType("OBL_UNSATISFIED_OBLIGATION")
-                .build();
-        assertThat(getBugCollection(), containsExactly(num, bugTypeMatcher));
-    }
-
-    private void assertBug(String method, int line) {
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType("OBL_UNSATISFIED_OBLIGATION")
-                .inMethod(method)
-                .atLine(line)
-                .build();
-        assertThat(getBugCollection(), hasItem(bugTypeMatcher));
+        assertBugInMethodAtLine("OBL_UNSATISFIED_OBLIGATION", "Issue3069", "readOptionsNotClosed", 8);
+        assertBugTypeCount("OBL_UNSATISFIED_OBLIGATION", 1);
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue371Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue371Test.java
@@ -1,22 +1,13 @@
 package edu.umd.cs.findbugs.ba;
 
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 import org.junit.jupiter.api.Test;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
 class Issue371Test extends AbstractIntegrationTest {
-
     @Test
     void testIssue() {
         performAnalysis("lambdas/Issue371.class");
-        final BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE").build();
-        assertThat(getBugCollection(), containsExactly(1, bugTypeMatcher));
+        assertBugTypeCount("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", 1);
     }
-
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue389Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue389Test.java
@@ -1,23 +1,15 @@
 package edu.umd.cs.findbugs.ba;
 
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 import org.junit.jupiter.api.Test;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
 class Issue389Test extends AbstractIntegrationTest {
 
     @Test
     void testIssue() {
         performAnalysis("ghIssues/Issue389.class");
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder().bugType("UC_USELESS_VOID_METHOD").build();
-        assertThat(getBugCollection(), containsExactly(3, bugTypeMatcher));
-        bugTypeMatcher = new BugInstanceMatcherBuilder().bugType("DLS_DEAD_LOCAL_STORE").build();
-        assertThat(getBugCollection(), containsExactly(3, bugTypeMatcher));
+        assertBugTypeCount("UC_USELESS_VOID_METHOD", 3);
+        assertBugTypeCount("DLS_DEAD_LOCAL_STORE", 3);
     }
-
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue390Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue390Test.java
@@ -1,16 +1,12 @@
 package edu.umd.cs.findbugs.ba;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
-import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.StringWriter;
 
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -19,8 +15,7 @@ class Issue390Test extends AbstractIntegrationTest {
     @Test
     void testIssue() {
         performAnalysis("ghIssues/Issue390.class");
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder().bugType("JUA_DONT_ASSERT_INSTANCEOF_IN_TESTS").build();
-        MatcherAssert.assertThat(getBugCollection(), containsExactly(1, bugTypeMatcher));
+        assertBugTypeCount("JUA_DONT_ASSERT_INSTANCEOF_IN_TESTS", 1);
     }
 
     /**

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue408Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue408Test.java
@@ -1,6 +1,5 @@
 package edu.umd.cs.findbugs.ba;
 
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -13,8 +12,6 @@ import org.junit.jupiter.api.condition.DisabledOnJre;
 import org.junit.jupiter.api.condition.JRE;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
 /**
  * @see <a href="https://github.com/spotbugs/spotbugs/issues/408">#408</a>
@@ -25,9 +22,7 @@ class Issue408Test extends AbstractIntegrationTest {
     @Test
     @DisabledOnJre(JRE.JAVA_8)
     void testSingleClass() {
-        Throwable throwable = Assertions.assertThrows(AssertionError.class, () -> {
-            performAnalysis("../java11/module-info.class");
-        });
+        Throwable throwable = Assertions.assertThrows(AssertionError.class, () -> performAnalysis("../java11/module-info.class"));
         Assertions.assertEquals("Analysis failed with exception", throwable.getMessage());
         assertThat(throwable.getCause(), is(instanceOf(IOException.class)));
     }
@@ -35,9 +30,7 @@ class Issue408Test extends AbstractIntegrationTest {
     @Test
     @DisabledOnJre(JRE.JAVA_8)
     void testFewClasses() {
-        performAnalysis("../java11/module-info.class", "../java11/Issue408.class");
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder().build();
-        assertThat(getBugCollection(), containsExactly(0, bugTypeMatcher));
+        Assertions.assertDoesNotThrow(() -> performAnalysis("../java11/module-info.class", "../java11/Issue408.class"));
     }
 
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue413Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue413Test.java
@@ -1,21 +1,15 @@
 package edu.umd.cs.findbugs.ba;
 
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
 class Issue413Test extends AbstractIntegrationTest {
 
     @Test
     void testIssue() {
-        performAnalysis("ghIssues/Issue413.class");
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder().build();
-        assertThat(getBugCollection(), containsExactly(0, bugTypeMatcher));
+        Assertions.assertDoesNotThrow(() -> performAnalysis("ghIssues/Issue413.class"));
     }
-
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue429Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue429Test.java
@@ -1,13 +1,7 @@
 package edu.umd.cs.findbugs.ba;
 
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
 import org.junit.jupiter.api.Test;
-
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
 /**
  * Unit test to reproduce <a href="https://github.com/spotbugs/spotbugs/issues/429">#429</a>.
@@ -17,8 +11,6 @@ class Issue429Test extends AbstractIntegrationTest {
     @Test
     void testIssue() {
         performAnalysis("ghIssues/Issue429.class");
-        BugInstanceMatcher matcher = new BugInstanceMatcherBuilder().bugType("RV_RETURN_VALUE_IGNORED")
-                .build();
-        assertThat(getBugCollection(), containsExactly(0, matcher));
+        assertNoBugType("RV_RETURN_VALUE_IGNORED");
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue516Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue516Test.java
@@ -1,14 +1,9 @@
 package edu.umd.cs.findbugs.ba;
 
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 import org.junit.jupiter.api.Test;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
 import edu.umd.cs.findbugs.LocalVariableAnnotation;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
 class Issue516Test extends AbstractIntegrationTest {
 
@@ -20,10 +15,6 @@ class Issue516Test extends AbstractIntegrationTest {
         // In this case the test will fail and would need to be adopted.
         // Note that in case the bug will be fixed for some compilers, the assumption will vary for different
         // compiler and different compiler versions.
-        String variableName = LocalVariableAnnotation.UNKNOWN_NAME;
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder().bugType("DLS_DEAD_LOCAL_STORE")
-                .atVariable(variableName).build();
-        assertThat(getBugCollection(), containsExactly(1, bugTypeMatcher));
+        assertBugAtVar("DLS_DEAD_LOCAL_STORE", "Issue516", "missingLvtEntry", LocalVariableAnnotation.UNKNOWN_NAME, 10);
     }
-
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue527Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue527Test.java
@@ -1,8 +1,6 @@
 package edu.umd.cs.findbugs.ba;
 
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -13,22 +11,17 @@ import org.junit.jupiter.api.Test;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
 import edu.umd.cs.findbugs.SortedBugCollection;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
 class Issue527Test extends AbstractIntegrationTest {
 
     @Test
     void testSimpleLambdas() {
         performAnalysis("lambdas/Issue527.class");
-        final BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType("NP_NULL_ON_SOME_PATH").build();
+        assertBugTypeCount("NP_NULL_ON_SOME_PATH", 2);
         SortedBugCollection bugCollection = (SortedBugCollection) getBugCollection();
-        assertThat(bugCollection, containsExactly(2, bugTypeMatcher));
         Iterator<String> missingIter = bugCollection.missingClassIterator();
         List<String> strings = new ArrayList<>();
         missingIter.forEachRemaining(x -> strings.add(x));
         assertEquals(Collections.EMPTY_LIST, strings);
     }
-
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue547Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue547Test.java
@@ -1,29 +1,24 @@
 package edu.umd.cs.findbugs.ba;
 
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
 import edu.umd.cs.findbugs.SortedBugCollection;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
 class Issue547Test extends AbstractIntegrationTest {
 
     @Test
     void testLambdas() {
-        performAnalysis("lambdas/Issue547.class");
-        final BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder().build();
+        Assertions.assertDoesNotThrow(() -> performAnalysis("lambdas/Issue547.class"));
         SortedBugCollection bugCollection = (SortedBugCollection) getBugCollection();
-        assertThat(bugCollection, containsExactly(0, bugTypeMatcher));
         Iterator<String> missingIter = bugCollection.missingClassIterator();
         List<String> strings = new ArrayList<>();
         missingIter.forEachRemaining(x -> strings.add(x));

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue688Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue688Test.java
@@ -18,24 +18,17 @@
  */
 package edu.umd.cs.findbugs.ba;
 
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.SortedBugCollection;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
 class Issue688Test extends AbstractIntegrationTest {
 
     @Test
     void testIssue() {
-        performAnalysis("ghIssues/Issue688.class");
-        final BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder().build();
-        SortedBugCollection bugCollection = (SortedBugCollection) getBugCollection();
-        assertThat(bugCollection, containsExactly(0, bugTypeMatcher));
+        Assertions.assertDoesNotThrow(() -> performAnalysis("ghIssues/Issue688.class"));
     }
 
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue758Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue758Test.java
@@ -18,21 +18,15 @@
  */
 package edu.umd.cs.findbugs.ba;
 
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.MatcherAssert.assertThat;
-
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.SortedBugCollection;
 
 class Issue758Test extends AbstractIntegrationTest {
 
     @Test
     void testIssue() {
-        performAnalysis("ghIssues/Issue758.class");
-        SortedBugCollection bugCollection = (SortedBugCollection) getBugCollection();
-        assertThat(bugCollection.getErrors(), hasSize(0));
+        Assertions.assertDoesNotThrow(() -> performAnalysis("ghIssues/Issue758.class"));
     }
 
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue893Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue893Test.java
@@ -1,21 +1,14 @@
 package edu.umd.cs.findbugs.ba;
 
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
-
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
 class Issue893Test extends AbstractIntegrationTest {
 
     @Test
     void testIssue() {
-        performAnalysis("ghIssues/Issue893.class");
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder().build();
-        assertThat(getBugCollection(), containsExactly(0, bugTypeMatcher));
+        Assertions.assertDoesNotThrow(() -> performAnalysis("ghIssues/Issue893.class"));
     }
 
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Bug3107916Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Bug3107916Test.java
@@ -1,20 +1,14 @@
 package edu.umd.cs.findbugs.detect;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 import org.junit.jupiter.api.Test;
-
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItem;
 
 class Bug3107916Test extends AbstractIntegrationTest {
     @Test
     void test() {
         performAnalysis("sfBugs/Bug3107916.class");
 
-        assertNpBugInMethod("doCompare", 20);
+        assertBugInMethodAtLine("NP_NULL_ON_SOME_PATH_MIGHT_BE_INFEASIBLE", "Bug3107916", "doCompare", 20);
         assertNoNpBugInMethod("doCompare2");
     }
 
@@ -35,22 +29,7 @@ class Bug3107916Test extends AbstractIntegrationTest {
             "NP_METHOD_PARAMETER_RELAXING_ANNOTATION",
         };
         for (String bugtype : bugtypes) {
-            final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
-                    .bugType(bugtype)
-                    .inClass("Bug3107916")
-                    .inMethod(method)
-                    .build();
-            assertThat(getBugCollection(), containsExactly(0, bugInstanceMatcher));
+            assertNoBugInMethod(bugtype, "Bug3107916", method);
         }
-    }
-
-    private void assertNpBugInMethod(String method, int line) {
-        final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
-                .bugType("NP_NULL_ON_SOME_PATH_MIGHT_BE_INFEASIBLE")
-                .inClass("Bug3107916")
-                .inMethod(method)
-                .atLine(line)
-                .build();
-        assertThat(getBugCollection(), hasItem(bugInstanceMatcher));
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Bug3277814Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Bug3277814Test.java
@@ -1,13 +1,7 @@
 package edu.umd.cs.findbugs.detect;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 import org.junit.jupiter.api.Test;
-
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItem;
 
 class Bug3277814Test extends AbstractIntegrationTest {
     @Test
@@ -15,7 +9,7 @@ class Bug3277814Test extends AbstractIntegrationTest {
         performAnalysis("sfBugs/Bug3277814.class");
 
         assertNoNpBugInMethod("test");
-        assertNpBugInMethod("test2", 44);
+        assertBugInMethodAtLine("NP_NULL_ON_SOME_PATH", "Bug3277814", "test2", 44);
     }
 
     private void assertNoNpBugInMethod(String method) {
@@ -35,22 +29,7 @@ class Bug3277814Test extends AbstractIntegrationTest {
             "NP_METHOD_PARAMETER_RELAXING_ANNOTATION",
         };
         for (String bugtype : bugtypes) {
-            final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
-                    .bugType(bugtype)
-                    .inClass("Bug3277814")
-                    .inMethod(method)
-                    .build();
-            assertThat(getBugCollection(), containsExactly(0, bugInstanceMatcher));
+            assertNoBugInMethod(bugtype, "Bug3277814", method);
         }
-    }
-
-    private void assertNpBugInMethod(String method, int line) {
-        final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
-                .bugType("NP_NULL_ON_SOME_PATH")
-                .inClass("Bug3277814")
-                .inMethod(method)
-                .atLine(line)
-                .build();
-        assertThat(getBugCollection(), hasItem(bugInstanceMatcher));
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/ConstructorThrowTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/ConstructorThrowTest.java
@@ -1,307 +1,289 @@
 package edu.umd.cs.findbugs.detect;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 import org.junit.jupiter.api.Test;
 
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItem;
-
 class ConstructorThrowTest extends AbstractIntegrationTest {
+
+    private final String CT_THROW = "CT_CONSTRUCTOR_THROW";
 
     @Test
     void testConstructorThrowCheck1() {
         performAnalysis("constructorthrow/ConstructorThrowTest1.class");
-        assertNumOfCTBugs(1);
-        assertCTBugInLine(9);
+        assertBugTypeCount(CT_THROW, 1);
+        assertBugAtLine(CT_THROW, 9);
     }
 
     @Test
     void testConstructorThrowCheck2() {
         performAnalysis("constructorthrow/ConstructorThrowTest2.class");
-        assertNumOfCTBugs(1);
-        assertCTBugInLine(11);
+        assertBugTypeCount(CT_THROW, 1);
+        assertBugAtLine(CT_THROW, 11);
     }
 
     @Test
     void testConstructorThrowCheck3() {
         performAnalysis("constructorthrow/ConstructorThrowTest3.class");
-        assertNumOfCTBugs(1);
-        assertCTBugInLine(9);
+        assertBugTypeCount(CT_THROW, 1);
+        assertBugAtLine(CT_THROW, 9);
     }
 
     @Test
     void testConstructorThrowCheck4() {
         performAnalysis("constructorthrow/ConstructorThrowTest4.class");
-        assertNumOfCTBugs(1);
-        assertCTBugInLine(20);
+        assertBugTypeCount(CT_THROW, 1);
+        assertBugAtLine(CT_THROW, 20);
     }
 
     @Test
     void testConstructorThrowCheck5() {
         performAnalysis("constructorthrow/ConstructorThrowTest5.class");
-        assertNumOfCTBugs(2);
-        assertCTBugInLine(11);
-        assertCTBugInLine(16);
+        assertBugTypeCount(CT_THROW, 2);
+        assertBugAtLine(CT_THROW, 11);
+        assertBugAtLine(CT_THROW, 16);
     }
 
     @Test
     void testConstructorThrowCheck6() {
         performAnalysis("constructorthrow/ConstructorThrowTest6.class");
-        assertNumOfCTBugs(1);
-        assertCTBugInLine(11);
+        assertBugTypeCount(CT_THROW, 1);
+        assertBugAtLine(CT_THROW, 11);
     }
 
     @Test
     void testConstructorThrowCheck7() {
         performAnalysis("constructorthrow/ConstructorThrowTest7.class");
-        assertNumOfCTBugs(0); // It doesn't work for lambdas
+        assertNoBugType(CT_THROW); // It doesn't work for lambdas
     }
 
     @Test
     void testConstructorThrowCheck8() {
         performAnalysis("constructorthrow/ConstructorThrowTest8.class");
-        assertNumOfCTBugs(0); // It doesn't work for lambdas
+        assertNoBugType(CT_THROW); // It doesn't work for lambdas
     }
 
     @Test
     void testConstructorThrowCheck9() {
         performAnalysis("constructorthrow/ConstructorThrowTest9.class");
-        assertNumOfCTBugs(0); // It doesn't work for lambdas
+        assertNoBugType(CT_THROW); // It doesn't work for lambdas
     }
 
     @Test
     void testConstructorThrowCheck10() {
         performAnalysis("constructorthrow/ConstructorThrowTest10.class");
-        assertNumOfCTBugs(1);
-        assertCTBugInLine(9);
+        assertBugTypeCount(CT_THROW, 1);
+        assertBugAtLine(CT_THROW, 9);
     }
 
     @Test
     void testConstructorThrowCheck11() {
         performAnalysis("constructorthrow/ConstructorThrowTest11.class");
-        assertNumOfCTBugs(1);
-        assertCTBugInLine(15);
+        assertBugTypeCount(CT_THROW, 1);
+        assertBugAtLine(CT_THROW, 15);
     }
 
     @Test
     void testConstructorThrowCheck12() {
         performAnalysis("constructorthrow/ConstructorThrowTest12.class");
-        assertNumOfCTBugs(1);
-        assertCTBugInLine(15);
+        assertBugTypeCount(CT_THROW, 1);
+        assertBugAtLine(CT_THROW, 15);
     }
 
     @Test
     void testConstructorThrowCheck13() {
         performAnalysis("constructorthrow/ConstructorThrowTest13.class");
-        assertNumOfCTBugs(1);
-        assertCTBugInLine(19);
+        assertBugTypeCount(CT_THROW, 1);
+        assertBugAtLine(CT_THROW, 19);
     }
 
     @Test
     void testConstructorThrowCheck14() {
         performAnalysis("constructorthrow/ConstructorThrowTest14.class");
-        assertNumOfCTBugs(1);
-        assertCTBugInLine(24);
+        assertBugTypeCount(CT_THROW, 1);
+        assertBugAtLine(CT_THROW, 24);
     }
 
     @Test
     void testConstructorThrowCheck15() {
         performAnalysis("constructorthrow/ConstructorThrowTest15.class");
-        assertNumOfCTBugs(1);
-        assertCTBugInLine(15);
+        assertBugTypeCount(CT_THROW, 1);
+        assertBugAtLine(CT_THROW, 15);
     }
 
     @Test
     void testConstructorThrowCheck16() {
         performAnalysis("constructorthrow/ConstructorThrowTest16.class");
-        assertNumOfCTBugs(1);
-        assertCTBugInLine(10);
+        assertBugTypeCount(CT_THROW, 1);
+        assertBugAtLine(CT_THROW, 10);
     }
 
     @Test
     void testConstructorThrowCheck17() {
         performAnalysis("constructorthrow/ConstructorThrowTest17.class");
-        assertNumOfCTBugs(1);
-        assertCTBugInLine(9);
+        assertBugTypeCount(CT_THROW, 1);
+        assertBugAtLine(CT_THROW, 9);
     }
 
     @Test
     void testConstructorThrowCheck18() {
         performAnalysis("constructorthrow/ConstructorThrowTest18.class");
-        assertNumOfCTBugs(1);
-        assertCTBugInLine(11);
+        assertBugTypeCount(CT_THROW, 1);
+        assertBugAtLine(CT_THROW, 11);
     }
 
     @Test
     void testConstructorThrowCheck19() {
         performAnalysis("constructorthrow/ConstructorThrowTest19.class");
-        assertNumOfCTBugs(1);
-        assertCTBugInLine(11);
+        assertBugTypeCount(CT_THROW, 1);
+        assertBugAtLine(CT_THROW, 11);
     }
 
     @Test
     void testConstructorThrowCheck20() {
         performAnalysis("constructorthrow/ConstructorThrowTest20.class");
-        assertNumOfCTBugs(1);
-        assertCTBugInLine(13);
+        assertBugTypeCount(CT_THROW, 1);
+        assertBugAtLine(CT_THROW, 13);
     }
 
     @Test
     void testConstructorThrowCheck21() {
         performAnalysis("constructorthrow/ConstructorThrowTest21.class");
-        assertNumOfCTBugs(1);
-        assertCTBugInLine(9);
+        assertBugTypeCount(CT_THROW, 1);
+        assertBugAtLine(CT_THROW, 9);
     }
 
     @Test
     void testConstructorThrowCheck22() {
         performAnalysis("constructorthrow/ConstructorThrowTest22.class");
-        assertNumOfCTBugs(1);
-        assertCTBugInLine(11);
+        assertBugTypeCount(CT_THROW, 1);
+        assertBugAtLine(CT_THROW, 11);
     }
 
     @Test
     void testConstructorThrowCheck23() {
         performAnalysis("constructorthrow/ConstructorThrowTest23.class");
-        assertNumOfCTBugs(0); // It doesn't work for lambdas
+        assertNoBugType(CT_THROW); // It doesn't work for lambdas
     }
 
     @Test
     void testConstructorThrowCheck24() {
         performAnalysis("constructorthrow/ConstructorThrowTest24.class");
-        assertNumOfCTBugs(1);
-        assertCTBugInLine(11);
+        assertBugTypeCount(CT_THROW, 1);
+        assertBugAtLine(CT_THROW, 11);
     }
 
     @Test
     void testGoodConstructorThrowCheck1() {
         performAnalysis("constructorthrow/ConstructorThrowNegativeTest1.class");
-        assertNumOfCTBugs(0);
+        assertNoBugType(CT_THROW);
     }
 
     @Test
     void testGoodConstructorThrowCheck2() {
         performAnalysis("constructorthrow/ConstructorThrowNegativeTest2.class");
-        assertNumOfCTBugs(0);
+        assertNoBugType(CT_THROW);
     }
 
     @Test
     void testGoodConstructorThrowCheck3() {
         performAnalysis("constructorthrow/ConstructorThrowNegativeTest3.class");
-        assertNumOfCTBugs(0);
+        assertNoBugType(CT_THROW);
     }
 
     @Test
     void testGoodConstructorThrowCheck4() {
         performAnalysis("constructorthrow/ConstructorThrowNegativeTest4.class");
-        assertNumOfCTBugs(0);
+        assertNoBugType(CT_THROW);
     }
 
     @Test
     void testGoodConstructorThrowCheck5() {
         performAnalysis("constructorthrow/ConstructorThrowNegativeTest5.class");
-        assertNumOfCTBugs(0);
+        assertNoBugType(CT_THROW);
     }
 
     @Test
     void testGoodConstructorThrowCheck6() {
         performAnalysis("constructorthrow/ConstructorThrowNegativeTest6.class");
-        assertNumOfCTBugs(0);
+        assertNoBugType(CT_THROW);
     }
 
     @Test
     void testGoodConstructorThrowCheck7() {
         performAnalysis("constructorthrow/ConstructorThrowNegativeTest7.class");
-        assertNumOfCTBugs(0);
+        assertNoBugType(CT_THROW);
     }
 
     @Test
     void testGoodConstructorThrowCheck8() {
         performAnalysis("constructorthrow/ConstructorThrowNegativeTest8.class");
-        assertNumOfCTBugs(0);
+        assertNoBugType(CT_THROW);
     }
 
     @Test
     void testGoodConstructorThrowCheck9() {
         performAnalysis("constructorthrow/ConstructorThrowNegativeTest9.class");
-        assertNumOfCTBugs(0);
+        assertNoBugType(CT_THROW);
     }
 
     @Test
     void testGoodConstructorThrowCheck10() {
         performAnalysis("constructorthrow/ConstructorThrowNegativeTest10.class");
-        assertNumOfCTBugs(0);
+        assertNoBugType(CT_THROW);
     }
 
     @Test
     void testGoodConstructorThrowCheck11() {
         performAnalysis("constructorthrow/ConstructorThrowNegativeTest11.class");
-        assertNumOfCTBugs(0);
+        assertNoBugType(CT_THROW);
     }
 
     @Test
     void testGoodConstructorThrowCheck12() {
         performAnalysis("constructorthrow/ConstructorThrowNegativeTest12.class");
-        assertNumOfCTBugs(0);
+        assertNoBugType(CT_THROW);
     }
 
     @Test
     void testGoodConstructorThrowCheck13() {
         performAnalysis("constructorthrow/ConstructorThrowNegativeTest12.class",
                 "constructorthrow/ConstructorThrowNegativeTest13.class");
-        assertNumOfCTBugs(0);
+        assertNoBugType(CT_THROW);
     }
 
     @Test
     void testGoodConstructorThrowCheck14() {
         performAnalysis("constructorthrow/ConstructorThrowNegativeTest14.class");
-        assertNumOfCTBugs(0);
+        assertNoBugType(CT_THROW);
     }
 
     @Test
     void testGoodConstructorThrowCheck15() {
         performAnalysis("constructorthrow/ConstructorThrowNegativeTest15.class");
-        assertNumOfCTBugs(0);
+        assertNoBugType(CT_THROW);
     }
 
     @Test
     void testGoodConstructorThrowCheck16() {
         performAnalysis("constructorthrow/ConstructorThrowNegativeTest16.class");
-        assertNumOfCTBugs(0);
+        assertNoBugType(CT_THROW);
     }
 
     @Test
     void testGoodConstructorThrowCheck17() {
         performAnalysis("constructorthrow/ConstructorThrowNegativeTest17.class");
-        assertNumOfCTBugs(0);
+        assertNoBugType(CT_THROW);
     }
 
     @Test
     void testGoodConstructorThrowCheck18() {
         performAnalysis("constructorthrow/ConstructorThrowNegativeTest18.class");
-        assertNumOfCTBugs(0);
+        assertNoBugType(CT_THROW);
     }
 
     @Test
     void testGoodConstructorThrowCheck19() {
         performAnalysis("constructorthrow/ConstructorThrowNegativeTest19.class");
-        assertNumOfCTBugs(0);
-    }
-
-    private void assertNumOfCTBugs(int num) {
-        final BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType("CT_CONSTRUCTOR_THROW").build();
-        assertThat(getBugCollection(), containsExactly(num, bugTypeMatcher));
-    }
-
-    private void assertCTBugInLine(int line) {
-        final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
-                .bugType("CT_CONSTRUCTOR_THROW")
-                .atLine(line)
-                .build();
-        assertThat(getBugCollection(), hasItem(bugInstanceMatcher));
+        assertNoBugType(CT_THROW);
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/DontReusePublicIdentifiersTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/DontReusePublicIdentifiersTest.java
@@ -1,14 +1,7 @@
 package edu.umd.cs.findbugs.detect;
 
-import edu.umd.cs.findbugs.*;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
 import org.junit.jupiter.api.Test;
-
-
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItem;
 
 class DontReusePublicIdentifiersTest extends AbstractIntegrationTest {
 
@@ -21,8 +14,8 @@ class DontReusePublicIdentifiersTest extends AbstractIntegrationTest {
     void testShadowedPublicIdentifiersClassNames() {
         // check shadowed public identifiers as standalone classes
         performAnalysis("publicIdentifiers/standalone/InputStream.class");
-        assertNumOfShadowedPublicIdentifierBugs(PI_CLASS_BUG, 1);
-        assertShadowedPublicIdentifierClassBug("InputStream");
+        assertBugTypeCount(PI_CLASS_BUG, 1);
+        assertBugInClass(PI_CLASS_BUG, "InputStream");
 
         // check shadowed public identifiers as inner classes
         performAnalysis("publicIdentifiers/inner/ShadowedPublicIdentifiersInnerClassNames.class",
@@ -30,19 +23,19 @@ class DontReusePublicIdentifiersTest extends AbstractIntegrationTest {
                 "publicIdentifiers/inner/ShadowedPublicIdentifiersInnerClassNames$Buffer.class",
                 "publicIdentifiers/inner/ShadowedPublicIdentifiersInnerClassNames$File.class",
                 "publicIdentifiers/inner/ShadowedPublicIdentifiersInnerClassNames$BigInteger.class");
-        assertNumOfShadowedPublicIdentifierBugs(PI_CLASS_BUG, 4);
-        assertShadowedPublicIdentifierClassBug("ShadowedPublicIdentifiersInnerClassNames$Vector");
-        assertShadowedPublicIdentifierClassBug("ShadowedPublicIdentifiersInnerClassNames$Buffer");
-        assertShadowedPublicIdentifierClassBug("ShadowedPublicIdentifiersInnerClassNames$File");
-        assertShadowedPublicIdentifierClassBug("ShadowedPublicIdentifiersInnerClassNames$BigInteger");
+        assertBugTypeCount(PI_CLASS_BUG, 4);
+        assertBugInClass(PI_CLASS_BUG, "ShadowedPublicIdentifiersInnerClassNames$Vector");
+        assertBugInClass(PI_CLASS_BUG, "ShadowedPublicIdentifiersInnerClassNames$Buffer");
+        assertBugInClass(PI_CLASS_BUG, "ShadowedPublicIdentifiersInnerClassNames$File");
+        assertBugInClass(PI_CLASS_BUG, "ShadowedPublicIdentifiersInnerClassNames$BigInteger");
 
         // check shadowed public identifiers as repeatedly nested classes
         performAnalysis("publicIdentifiers/inner/ShadowedPublicIdentifiersInnerClassNames2.class",
                 "publicIdentifiers/inner/ShadowedPublicIdentifiersInnerClassNames2$List.class",
                 "publicIdentifiers/inner/ShadowedPublicIdentifiersInnerClassNames2$List$Node.class");
-        assertNumOfShadowedPublicIdentifierBugs(PI_CLASS_BUG, 2);
-        assertShadowedPublicIdentifierClassBug("ShadowedPublicIdentifiersInnerClassNames2$List");
-        assertShadowedPublicIdentifierClassBug("ShadowedPublicIdentifiersInnerClassNames2$List$Node");
+        assertBugTypeCount(PI_CLASS_BUG, 2);
+        assertBugInClass(PI_CLASS_BUG, "ShadowedPublicIdentifiersInnerClassNames2$List");
+        assertBugInClass(PI_CLASS_BUG, "ShadowedPublicIdentifiersInnerClassNames2$List$Node");
     }
 
     @Test
@@ -75,9 +68,9 @@ class DontReusePublicIdentifiersTest extends AbstractIntegrationTest {
     @Test
     void testShadowedPublicIdentifiersFieldNames() {
         performAnalysis("publicIdentifiers/ShadowedPublicIdentifiersFieldNames.class");
-        assertNumOfShadowedPublicIdentifierBugs(PI_FIELD_BUG, 2);
-        assertShadowedPublicIdentifierFieldBug("String");
-        assertShadowedPublicIdentifierFieldBug("Integer");
+        assertBugTypeCount(PI_FIELD_BUG, 2);
+        assertBugAtField(PI_FIELD_BUG, "ShadowedPublicIdentifiersFieldNames", "String");
+        assertBugAtField(PI_FIELD_BUG, "ShadowedPublicIdentifiersFieldNames", "Integer");
     }
 
     @Test
@@ -89,11 +82,11 @@ class DontReusePublicIdentifiersTest extends AbstractIntegrationTest {
     @Test
     void testShadowedPublicIdentifiersMethodNames() {
         performAnalysis("publicIdentifiers/ShadowedPublicIdentifiersMethodNames.class");
-        assertNumOfShadowedPublicIdentifierBugs(PI_METHOD_BUG, 3);
+        assertBugTypeCount(PI_METHOD_BUG, 3);
 
-        assertShadowedPublicIdentifierMethodBug("ShadowedPublicIdentifiersMethodNames", "InputStream", 5);
-        assertShadowedPublicIdentifierMethodBug("ShadowedPublicIdentifiersMethodNames", "Integer", 9);
-        assertShadowedPublicIdentifierMethodBug("ShadowedPublicIdentifiersMethodNames", "ArrayList", 14);
+        assertBugInMethodAtLine(PI_METHOD_BUG, "ShadowedPublicIdentifiersMethodNames", "InputStream", 5);
+        assertBugInMethodAtLine(PI_METHOD_BUG, "ShadowedPublicIdentifiersMethodNames", "Integer", 9);
+        assertBugInMethodAtLine(PI_METHOD_BUG, "ShadowedPublicIdentifiersMethodNames", "ArrayList", 14);
     }
 
     @Test
@@ -105,18 +98,18 @@ class DontReusePublicIdentifiersTest extends AbstractIntegrationTest {
         performAnalysis("publicIdentifiers/ShadowedPublicIdentifiersOverriddenMethods.class",
                 "publicIdentifiers/ShadowedPublicIdentifiersOverridableMethods.class");
 
-        assertNumOfShadowedPublicIdentifierBugs(PI_METHOD_BUG, 1);
-        assertShadowedPublicIdentifierMethodBug("ShadowedPublicIdentifiersOverridableMethods", "ArrayList", 5);
+        assertBugTypeCount(PI_METHOD_BUG, 1);
+        assertBugInMethodAtLine(PI_METHOD_BUG, "ShadowedPublicIdentifiersOverridableMethods", "ArrayList", 5);
     }
 
     @Test
     void testShadowedPublicIdentifiersVariableNames() {
         performAnalysis("publicIdentifiers/ShadowedPublicIdentifiersVariableNames.class");
-        assertNumOfShadowedPublicIdentifierBugs(PI_VARIABLE_BUG, 3);
+        assertBugTypeCount(PI_VARIABLE_BUG, 3);
 
-        assertShadowedPublicIdentifierVariableBug("containsShadowedLocalVariable1", "ArrayList");
-        assertShadowedPublicIdentifierVariableBug("containsShadowedLocalVariable2", "Integer");
-        assertShadowedPublicIdentifierVariableBug("containsShadowedLocalVariable3", "File");
+        assertBugInMethodAtVariable(PI_VARIABLE_BUG, "ShadowedPublicIdentifiersVariableNames", "containsShadowedLocalVariable1", "ArrayList");
+        assertBugInMethodAtVariable(PI_VARIABLE_BUG, "ShadowedPublicIdentifiersVariableNames", "containsShadowedLocalVariable2", "Integer");
+        assertBugInMethodAtVariable(PI_VARIABLE_BUG, "ShadowedPublicIdentifiersVariableNames", "containsShadowedLocalVariable3", "File");
     }
 
     @Test
@@ -125,66 +118,17 @@ class DontReusePublicIdentifiersTest extends AbstractIntegrationTest {
         assertZeroPublicIdentifierBug();
     }
 
-    private void assertNumOfShadowedPublicIdentifierBugs(String bugType, int num) {
-        final BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType(bugType)
-                .build();
-        assertThat(getBugCollection(), containsExactly(num, bugTypeMatcher));
-    }
-
     private void assertZeroPublicIdentifierBugInClass(String className) {
         final String[] bugTypes = new String[] { PI_CLASS_BUG, PI_FIELD_BUG, PI_METHOD_BUG, PI_VARIABLE_BUG };
         for (String bugType : bugTypes) {
-            final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
-                    .bugType(bugType)
-                    .inClass(className)
-                    .build();
-            assertThat(getBugCollection(), containsExactly(0, bugInstanceMatcher));
+            assertNoBugInClass(bugType, className);
         }
     }
 
     private void assertZeroPublicIdentifierBug() {
-        assertNumOfShadowedPublicIdentifierBugs(PI_CLASS_BUG, 0);
-        assertNumOfShadowedPublicIdentifierBugs(PI_METHOD_BUG, 0);
-        assertNumOfShadowedPublicIdentifierBugs(PI_FIELD_BUG, 0);
-        assertNumOfShadowedPublicIdentifierBugs(PI_VARIABLE_BUG, 0);
+        assertNoBugType(PI_CLASS_BUG);
+        assertNoBugType(PI_METHOD_BUG);
+        assertNoBugType(PI_FIELD_BUG);
+        assertNoBugType(PI_VARIABLE_BUG);
     }
-
-    private void assertShadowedPublicIdentifierClassBug(String className) {
-        final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
-                .bugType(PI_CLASS_BUG)
-                .inClass(className)
-                .build();
-        assertThat(getBugCollection(), hasItem(bugInstanceMatcher));
-    }
-
-    private void assertShadowedPublicIdentifierFieldBug(String fieldName) {
-        final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
-                .bugType(PI_FIELD_BUG)
-                .inClass("ShadowedPublicIdentifiersFieldNames")
-                .atField(fieldName)
-                .build();
-        assertThat(getBugCollection(), hasItem(bugInstanceMatcher));
-    }
-
-    private void assertShadowedPublicIdentifierMethodBug(String className, String methodName, int sourceLine) {
-        final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
-                .bugType(PI_METHOD_BUG)
-                .inClass(className)
-                .inMethod(methodName)
-                .atLine(sourceLine)
-                .build();
-        assertThat(getBugCollection(), hasItem(bugInstanceMatcher));
-    }
-
-    private void assertShadowedPublicIdentifierVariableBug(String methodName, String variableName) {
-        final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
-                .bugType(PI_VARIABLE_BUG)
-                .inClass("ShadowedPublicIdentifiersVariableNames")
-                .inMethod(methodName)
-                .atVariable(variableName)
-                .build();
-        assertThat(getBugCollection(), hasItem(bugInstanceMatcher));
-    }
-
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/DontUseFloatsAsLoopCountersTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/DontUseFloatsAsLoopCountersTest.java
@@ -3,37 +3,16 @@ package edu.umd.cs.findbugs.detect;
 import org.junit.jupiter.api.Test;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
-
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 class DontUseFloatsAsLoopCountersTest extends AbstractIntegrationTest {
 
     @Test
     void testChecks() {
         performAnalysis("DontUseFloatsAsLoopCounters.class");
-        assertNumOfEOSBugs(3);
-        assertBug("test1", 8);
-        assertBug("test2", 15);
-        assertBug("test3", 21);
-    }
+        assertBugTypeCount("FL_FLOATS_AS_LOOP_COUNTERS", 3);
 
-    private void assertBug(String method, int line) {
-        final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
-                .bugType("FL_FLOATS_AS_LOOP_COUNTERS")
-                .inClass("DontUseFloatsAsLoopCounters")
-                .inMethod(method)
-                .atLine(line)
-                .build();
-        assertThat(getBugCollection(), hasItem(bugInstanceMatcher));
-    }
-
-    private void assertNumOfEOSBugs(int num) {
-        final BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType("FL_FLOATS_AS_LOOP_COUNTERS").build();
-        assertThat(getBugCollection(), containsExactly(num, bugTypeMatcher));
+        assertBugInMethodAtLine("FL_FLOATS_AS_LOOP_COUNTERS", "DontUseFloatsAsLoopCounters", "test1", 8);
+        assertBugInMethodAtLine("FL_FLOATS_AS_LOOP_COUNTERS", "DontUseFloatsAsLoopCounters", "test2", 15);
+        assertBugInMethodAtLine("FL_FLOATS_AS_LOOP_COUNTERS", "DontUseFloatsAsLoopCounters", "test3", 21);
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindArgumentAssertionsTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindArgumentAssertionsTest.java
@@ -1,23 +1,19 @@
 package edu.umd.cs.findbugs.detect;
 
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 import org.junit.jupiter.api.Test;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
 import edu.umd.cs.findbugs.annotations.Confidence;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
 class FindArgumentAssertionsTest extends AbstractIntegrationTest {
+
+    private static final String BUG_TYPE = "AA_ASSERTION_OF_ARGUMENTS";
 
     @Test
     void testArgumentAssertions() {
         performAnalysis("ArgumentAssertions.class");
 
-        assertNumOfDABugs(23);
+        assertBugTypeCount(BUG_TYPE, 23);
 
         assertDABug("getAbsAdd", 4);
         assertDABug("getAbsAdd", 5);
@@ -42,40 +38,18 @@ class FindArgumentAssertionsTest extends AbstractIntegrationTest {
         assertDABug("compDouble", 129);
         assertDABug("indirect", 136);
         // assertDABug("indirect2", 143); -- indirect assertions of arguments are not supported yet (except copies)
-        assertNoDABug("literal");
-        assertNoDABug("literalAndMessage");
-        assertNoDABug("literalAndMessageStr");
-        assertNoDABug("conditionallyInMessage");
-        assertNoDABug("privateMethod");
-        assertNoDABug("privateFinalMethod");
-        assertNoDABug("privateStaticMethod");
+        assertNoBugInMethod(BUG_TYPE, "ArgumentAssertions", "literal");
+        assertNoBugInMethod(BUG_TYPE, "ArgumentAssertions", "literalAndMessage");
+        assertNoBugInMethod(BUG_TYPE, "ArgumentAssertions", "literalAndMessageStr");
+        assertNoBugInMethod(BUG_TYPE, "ArgumentAssertions", "conditionallyInMessage");
+        assertNoBugInMethod(BUG_TYPE, "ArgumentAssertions", "privateMethod");
+        assertNoBugInMethod(BUG_TYPE, "ArgumentAssertions", "privateFinalMethod");
+        assertNoBugInMethod(BUG_TYPE, "ArgumentAssertions", "privateStaticMethod");
         assertDABug("assertingArgInFor", 198);
         // assertDABug("lambda$assertingArgInStream$0", 206); // assertations inside streams are not supported yet
     }
 
-    private void assertNumOfDABugs(int num) {
-        final BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType("AA_ASSERTION_OF_ARGUMENTS").build();
-        assertThat(getBugCollection(), containsExactly(num, bugTypeMatcher));
-    }
-
-    private void assertNoDABug(String method) {
-        final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
-                .bugType("AA_ASSERTION_OF_ARGUMENTS")
-                .inClass("ArgumentAssertions")
-                .inMethod(method)
-                .build();
-        assertThat(getBugCollection(), containsExactly(0, bugInstanceMatcher));
-    }
-
     private void assertDABug(String method, int line) {
-        final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
-                .bugType("AA_ASSERTION_OF_ARGUMENTS")
-                .inClass("ArgumentAssertions")
-                .inMethod(method)
-                .atLine(line)
-                .withConfidence(Confidence.LOW)
-                .build();
-        assertThat(getBugCollection(), hasItem(bugInstanceMatcher));
+        assertBugInMethodAtLineWithConfidence(BUG_TYPE, "ArgumentAssertions", method, line, Confidence.LOW);
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindAssertionsWithSideEffectsTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindAssertionsWithSideEffectsTest.java
@@ -1,15 +1,8 @@
 package edu.umd.cs.findbugs.detect;
 
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 import org.junit.jupiter.api.Test;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.annotations.Confidence;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
 class FindAssertionsWithSideEffectsTest extends AbstractIntegrationTest {
 
@@ -18,29 +11,12 @@ class FindAssertionsWithSideEffectsTest extends AbstractIntegrationTest {
         performAnalysis("AssertionsWithSideEffects.class",
                 "AssertionsWithSideEffects$ImmutableList.class");
 
-        assertNumOfBugs("ASE_ASSERTION_WITH_SIDE_EFFECT", 3);
-        assertNumOfBugs("ASE_ASSERTION_WITH_SIDE_EFFECT_METHOD", 1);
+        assertBugTypeCount("ASE_ASSERTION_WITH_SIDE_EFFECT", 3);
+        assertBugTypeCount("ASE_ASSERTION_WITH_SIDE_EFFECT_METHOD", 1);
 
-        assertBug("ASE_ASSERTION_WITH_SIDE_EFFECT", "iinc", 6);
-        assertBug("ASE_ASSERTION_WITH_SIDE_EFFECT", "storeBoolean", 12);
-        assertBug("ASE_ASSERTION_WITH_SIDE_EFFECT", "storeInt", 18);
-        assertBug("ASE_ASSERTION_WITH_SIDE_EFFECT_METHOD", "addAndRemove", 26);
-    }
-
-    private void assertNumOfBugs(String error, int num) {
-        final BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType(error).build();
-        assertThat(getBugCollection(), containsExactly(num, bugTypeMatcher));
-    }
-
-    private void assertBug(String error, String method, int line) {
-        final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
-                .bugType(error)
-                .inClass("AssertionsWithSideEffects")
-                .inMethod(method)
-                .atLine(line)
-                .withConfidence(Confidence.LOW)
-                .build();
-        assertThat(getBugCollection(), hasItem(bugInstanceMatcher));
+        assertBugInMethodAtLine("ASE_ASSERTION_WITH_SIDE_EFFECT", "AssertionsWithSideEffects", "iinc", 6);
+        assertBugInMethodAtLine("ASE_ASSERTION_WITH_SIDE_EFFECT", "AssertionsWithSideEffects", "storeBoolean", 12);
+        assertBugInMethodAtLine("ASE_ASSERTION_WITH_SIDE_EFFECT", "AssertionsWithSideEffects", "storeInt", 18);
+        assertBugInMethodAtLine("ASE_ASSERTION_WITH_SIDE_EFFECT_METHOD", "AssertionsWithSideEffects", "addAndRemove", 26);
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindBadEndOfStreamCheckTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindBadEndOfStreamCheckTest.java
@@ -1,61 +1,42 @@
 package edu.umd.cs.findbugs.detect;
 
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 import org.junit.jupiter.api.Test;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
 class FindBadEndOfStreamCheckTest extends AbstractIntegrationTest {
+    private final static String EOS_BUG_TYPE = "EOS_BAD_END_OF_STREAM_CHECK";
+
 
     @Test
     void testBadEndOfFileChecks() {
         performAnalysis("endOfStreamCheck/BadEndOfStreamCheck.class");
 
-        assertNumOfEOSBugs(16);
+        assertBugTypeCount(EOS_BUG_TYPE, 16);
 
-        assertEOSBug("badFileInputStream1", 12);
-        assertEOSBug("badFileInputStream2", 25);
-        assertEOSBug("badFileInputStream3", 39);
-        assertEOSBug("badFileInputStream4", 55);
-        assertEOSBug("badFileInputStream5", 70);
-        assertEOSBug("badFileInputStream6", 83);
-        assertEOSBug("badFileInputStream7", 97);
-        assertEOSBug("badFileInputStream8", 113);
-        assertEOSBug("badFileReader1", 128);
-        assertEOSBug("badFileReader2", 141);
-        assertEOSBug("badFileReader3", 155);
-        assertEOSBug("badFileReader4", 171);
-        assertEOSBug("badFileReader5", 186);
-        assertEOSBug("badFileReader6", 199);
-        assertEOSBug("badFileReader7", 213);
-        assertEOSBug("badFileReader8", 229);
+        final String className = "BadEndOfStreamCheck";
+        assertBugInMethodAtLine(EOS_BUG_TYPE, className, "badFileInputStream1", 12);
+        assertBugInMethodAtLine(EOS_BUG_TYPE, className, "badFileInputStream2", 25);
+        assertBugInMethodAtLine(EOS_BUG_TYPE, className, "badFileInputStream3", 39);
+        assertBugInMethodAtLine(EOS_BUG_TYPE, className, "badFileInputStream4", 55);
+        assertBugInMethodAtLine(EOS_BUG_TYPE, className, "badFileInputStream5", 70);
+        assertBugInMethodAtLine(EOS_BUG_TYPE, className, "badFileInputStream6", 83);
+        assertBugInMethodAtLine(EOS_BUG_TYPE, className, "badFileInputStream7", 97);
+        assertBugInMethodAtLine(EOS_BUG_TYPE, className, "badFileInputStream8", 113);
+        assertBugInMethodAtLine(EOS_BUG_TYPE, className, "badFileReader1", 128);
+        assertBugInMethodAtLine(EOS_BUG_TYPE, className, "badFileReader2", 141);
+        assertBugInMethodAtLine(EOS_BUG_TYPE, className, "badFileReader3", 155);
+        assertBugInMethodAtLine(EOS_BUG_TYPE, className, "badFileReader4", 171);
+        assertBugInMethodAtLine(EOS_BUG_TYPE, className, "badFileReader5", 186);
+        assertBugInMethodAtLine(EOS_BUG_TYPE, className, "badFileReader6", 199);
+        assertBugInMethodAtLine(EOS_BUG_TYPE, className, "badFileReader7", 213);
+        assertBugInMethodAtLine(EOS_BUG_TYPE, className, "badFileReader8", 229);
     }
 
     @Test
     void testGoodEndOfFileChecks() {
         performAnalysis("endOfStreamCheck/GoodEndOfStreamCheck.class");
 
-        assertNumOfEOSBugs(0);
-    }
-
-    private void assertNumOfEOSBugs(int num) {
-        final BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType("EOS_BAD_END_OF_STREAM_CHECK").build();
-        assertThat(getBugCollection(), containsExactly(num, bugTypeMatcher));
-    }
-
-    private void assertEOSBug(String method, int line) {
-        final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
-                .bugType("EOS_BAD_END_OF_STREAM_CHECK")
-                .inClass("BadEndOfStreamCheck")
-                .inMethod(method)
-                .atLine(line)
-                .build();
-        assertThat(getBugCollection(), hasItem(bugInstanceMatcher));
+        assertNoBugType(EOS_BUG_TYPE);
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindInstanceLockOnSharedStaticDataCheckTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindInstanceLockOnSharedStaticDataCheckTest.java
@@ -1,68 +1,46 @@
 package edu.umd.cs.findbugs.detect;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 import org.junit.jupiter.api.Test;
 
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItem;
-
 class FindInstanceLockOnSharedStaticDataCheckTest extends AbstractIntegrationTest {
+    private static final String BUG_TYPE = "SSD_DO_NOT_USE_INSTANCE_LOCK_ON_SHARED_STATIC_DATA";
 
     @Test
     void findSSDBugInClass_InstanceLevelLockOnSharedStaticData() {
         performAnalysis("instanceLockOnSharedStaticData/InstanceLevelLockObject.class");
+        assertBugTypeCount(BUG_TYPE, 1);
 
-        assertNumOfSSDBugs(1);
-
-        assertSSDBug("InstanceLevelLockObject", "methodWithBug", 12);
+        assertBugInMethodAtLine(BUG_TYPE, "InstanceLevelLockObject", "methodWithBug", 12);
     }
 
     @Test
     void findSSDBugInClass_InstanceLevelSynchronizedMethod() {
         performAnalysis("instanceLockOnSharedStaticData/InstanceLevelSynchronizedMethod.class");
 
-        assertNumOfSSDBugs(1);
+        assertBugTypeCount(BUG_TYPE, 1);
 
-        assertSSDBug("InstanceLevelSynchronizedMethod", "methodWithBug", 10);
+        assertBugInMethodAtLine(BUG_TYPE, "InstanceLevelSynchronizedMethod", "methodWithBug", 10);
     }
 
     @Test
     void findNoSSDBugInClass_StaticLockInsideNotStaticSynchronizedMethod() {
         performAnalysis("instanceLockOnSharedStaticData/StaticLockInsideNotStaticSynchronizedMethod.class");
 
-        assertNumOfSSDBugs(0);
+        assertNoBugType(BUG_TYPE);
     }
 
     @Test
     void findNoSSDBugInClass_LockingOnJavaLangClassObject() {
         performAnalysis("instanceLockOnSharedStaticData/LockingOnJavaLangClassObject.class");
 
-        assertNumOfSSDBugs(0);
+        assertNoBugType(BUG_TYPE);
     }
 
     @Test
     void findNoSSDBugInClass_StaticLockObjectOnStaticSharedData() {
         performAnalysis("instanceLockOnSharedStaticData/StaticLockObjectOnStaticSharedData.class");
 
-        assertNumOfSSDBugs(0);
-    }
-
-    private void assertNumOfSSDBugs(int num) {
-        final BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType("SSD_DO_NOT_USE_INSTANCE_LOCK_ON_SHARED_STATIC_DATA").build();
-        assertThat(getBugCollection(), containsExactly(num, bugTypeMatcher));
-    }
-
-    private void assertSSDBug(String className, String methodName, int line) {
-        final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
-                .bugType("SSD_DO_NOT_USE_INSTANCE_LOCK_ON_SHARED_STATIC_DATA")
-                .inClass(className)
-                .inMethod(methodName)
-                .atLine(line)
-                .build();
-        assertThat(getBugCollection(), hasItem(bugInstanceMatcher));
+        assertNoBugType(BUG_TYPE);
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindOverridableMethodCallTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindOverridableMethodCallTest.java
@@ -1,18 +1,11 @@
 package edu.umd.cs.findbugs.detect;
 
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.Matchers.hasItem;
-
+import edu.umd.cs.findbugs.annotations.Confidence;
 import org.apache.bcel.Const;
-
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.jupiter.api.Test;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.annotations.Confidence;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
 class FindOverridableMethodCallTest extends AbstractIntegrationTest {
 
@@ -247,24 +240,17 @@ class FindOverridableMethodCallTest extends AbstractIntegrationTest {
         performAnalysis("overridableMethodCall/" + className + ".class");
 
         checkOneBug();
-        checkOverridableMethodCallInConstructor(className, constructorLine);
-        checkOverridableMethodCallInClone(className, cloneLine);
+
+        assertBugInMethodAtLineWithConfidence("MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR", className, Const.CONSTRUCTOR_NAME, constructorLine,
+                Confidence.LOW);
+        assertBugInMethodAtLine("MC_OVERRIDABLE_METHOD_CALL_IN_CLONE", className, "clone", cloneLine);
     }
 
     void testReadObject(String className, int warningLine) {
         performAnalysis("overridableMethodCall/" + className + ".class");
 
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType("MC_OVERRIDABLE_METHOD_CALL_IN_READ_OBJECT").build();
-        assertThat(getBugCollection(), containsExactly(1, bugTypeMatcher));
-
-        final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
-                .bugType("MC_OVERRIDABLE_METHOD_CALL_IN_READ_OBJECT")
-                .inClass(className)
-                .inMethod("readObject")
-                .atLine(warningLine)
-                .build();
-        assertThat(getBugCollection(), hasItem(bugInstanceMatcher));
+        assertBugTypeCount("MC_OVERRIDABLE_METHOD_CALL_IN_READ_OBJECT", 1);
+        assertBugInMethodAtLine("MC_OVERRIDABLE_METHOD_CALL_IN_READ_OBJECT", className, "readObject", warningLine);
     }
 
     void testPass(String className) {
@@ -274,47 +260,13 @@ class FindOverridableMethodCallTest extends AbstractIntegrationTest {
     }
 
     void checkOneBug() {
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType("MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR").build();
-        assertThat(getBugCollection(), containsExactly(1, bugTypeMatcher));
-
-        bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType("MC_OVERRIDABLE_METHOD_CALL_IN_CLONE").build();
-        assertThat(getBugCollection(), containsExactly(1, bugTypeMatcher));
+        assertBugTypeCount("MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR", 1);
+        assertBugTypeCount("MC_OVERRIDABLE_METHOD_CALL_IN_CLONE", 1);
     }
 
     void checkNoBug() {
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType("MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR").build();
-        assertThat(getBugCollection(), containsExactly(0, bugTypeMatcher));
-
-        bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType("MC_OVERRIDABLE_METHOD_CALL_IN_CLONE").build();
-        assertThat(getBugCollection(), containsExactly(0, bugTypeMatcher));
-
-        bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType("MC_OVERRIDABLE_METHOD_CALL_IN_READ_OBJECT").build();
-        assertThat(getBugCollection(), containsExactly(0, bugTypeMatcher));
-    }
-
-    void checkOverridableMethodCallInConstructor(String className, int line) {
-        final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
-                .bugType("MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR")
-                .inClass(className)
-                .inMethod(Const.CONSTRUCTOR_NAME)
-                .withConfidence(Confidence.LOW)
-                .atLine(line)
-                .build();
-        assertThat(getBugCollection(), hasItem(bugInstanceMatcher));
-    }
-
-    void checkOverridableMethodCallInClone(String className, int line) {
-        final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
-                .bugType("MC_OVERRIDABLE_METHOD_CALL_IN_CLONE")
-                .inClass(className)
-                .inMethod("clone")
-                .atLine(line)
-                .build();
-        assertThat(getBugCollection(), hasItem(bugInstanceMatcher));
+        assertNoBugType("MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR");
+        assertNoBugType("MC_OVERRIDABLE_METHOD_CALL_IN_CLONE");
+        assertNoBugType("MC_OVERRIDABLE_METHOD_CALL_IN_READ_OBJECT");
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindPotentialSecurityCheckBasedOnUntrustedSourceTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindPotentialSecurityCheckBasedOnUntrustedSourceTest.java
@@ -1,42 +1,21 @@
 package edu.umd.cs.findbugs.detect;
 
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 import org.junit.jupiter.api.Test;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
 class FindPotentialSecurityCheckBasedOnUntrustedSourceTest extends AbstractIntegrationTest {
 
     @Test
-    void testUntrustedSources() throws Exception {
+    void testUntrustedSources() {
         performAnalysis("PotentialSecurityCheckBasedOnUntrustedSource.class",
                 "PotentialSecurityCheckBasedOnUntrustedSource$1.class",
                 "PotentialSecurityCheckBasedOnUntrustedSource$2.class");
 
-        assertNumOfUSCBugs(2);
-        assertUSCBug("badOpenFile", 11);
-        assertUSCBug("badOpenFileLambda", 40);
-    }
+        final String bugType = "USC_POTENTIAL_SECURITY_CHECK_BASED_ON_UNTRUSTED_SOURCE";
 
-    private void assertNumOfUSCBugs(int num) throws Exception {
-        final BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType("USC_POTENTIAL_SECURITY_CHECK_BASED_ON_UNTRUSTED_SOURCE").build();
-        assertThat(getBugCollection(), containsExactly(num, bugTypeMatcher));
-    }
-
-    private void assertUSCBug(String methodName, int line) throws Exception {
-        final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
-                .bugType("USC_POTENTIAL_SECURITY_CHECK_BASED_ON_UNTRUSTED_SOURCE")
-                .inClass("PotentialSecurityCheckBasedOnUntrustedSource")
-                .inMethod(methodName)
-                .atLine(line)
-                .build();
-
-        assertThat(getBugCollection(), hasItem(bugInstanceMatcher));
+        assertBugTypeCount(bugType, 2);
+        assertBugInMethodAtLine(bugType, "PotentialSecurityCheckBasedOnUntrustedSource", "badOpenFile", 11);
+        assertBugInMethodAtLine(bugType, "PotentialSecurityCheckBasedOnUntrustedSource", "badOpenFileLambda", 40);
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindPublicAttributesTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindPublicAttributesTest.java
@@ -1,13 +1,7 @@
 package edu.umd.cs.findbugs.detect;
 
-import edu.umd.cs.findbugs.*;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
 import org.junit.jupiter.api.Test;
-
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItem;
 
 class FindPublicAttributesTest extends AbstractIntegrationTest {
 
@@ -19,41 +13,25 @@ class FindPublicAttributesTest extends AbstractIntegrationTest {
     void testPublicAttributesChecks() {
         performAnalysis("PublicAttributesTest.class");
 
-        assertNumOfBugs(PRIMITIVE_PUBLIC, 3);
-        assertNumOfBugs(ARRAY_PUBLIC, 4);
-        assertNumOfBugs(MUTABLE_PUBLIC, 1);
+        assertBugTypeCount(PRIMITIVE_PUBLIC, 3);
+        assertBugTypeCount(ARRAY_PUBLIC, 4);
+        assertBugTypeCount(MUTABLE_PUBLIC, 1);
 
-        assertBugTypeAtField(PRIMITIVE_PUBLIC, "attr1", 11);
-        assertBugTypeAtField(PRIMITIVE_PUBLIC, "attr2", 42);
-        assertBugTypeAtField(PRIMITIVE_PUBLIC, "sattr1", 15);
-        assertBugTypeAtField(MUTABLE_PUBLIC, "hm", 20);
-        assertBugTypeAtField(ARRAY_PUBLIC, "items", 28);
-        assertBugTypeAtField(ARRAY_PUBLIC, "nitems", 48);
-        assertBugTypeAtField(ARRAY_PUBLIC, "sitems", 32);
-        assertBugTypeAtField(ARRAY_PUBLIC, "SFITEMS", 34);
+        assertBugAtFieldAtLine(PRIMITIVE_PUBLIC, "PublicAttributesTest", "attr1", 11);
+        assertBugAtFieldAtLine(PRIMITIVE_PUBLIC, "PublicAttributesTest", "attr2", 42);
+        assertBugAtFieldAtLine(PRIMITIVE_PUBLIC, "PublicAttributesTest", "sattr1", 15);
+        assertBugAtFieldAtLine(MUTABLE_PUBLIC, "PublicAttributesTest", "hm", 20);
+        assertBugAtFieldAtLine(ARRAY_PUBLIC, "PublicAttributesTest", "items", 28);
+        assertBugAtFieldAtLine(ARRAY_PUBLIC, "PublicAttributesTest", "nitems", 48);
+        assertBugAtFieldAtLine(ARRAY_PUBLIC, "PublicAttributesTest", "sitems", 32);
+        assertBugAtFieldAtLine(ARRAY_PUBLIC, "PublicAttributesTest", "SFITEMS", 34);
     }
 
     @Test
     void testGoodPublicAttributesChecks() {
         performAnalysis("PublicAttributesNegativeTest.class");
-        assertNumOfBugs(PRIMITIVE_PUBLIC, 0);
-        assertNumOfBugs(ARRAY_PUBLIC, 0);
-        assertNumOfBugs(MUTABLE_PUBLIC, 0);
-    }
-
-    private void assertNumOfBugs(String bugtype, int num) {
-        final BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType(bugtype).build();
-        assertThat(getBugCollection(), containsExactly(num, bugTypeMatcher));
-    }
-
-    private void assertBugTypeAtField(String bugtype, String field, int line) {
-        final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
-                .bugType(bugtype)
-                .inClass("PublicAttributesTest")
-                .atField(field)
-                .atLine(line)
-                .build();
-        assertThat(getBugCollection(), hasItem(bugInstanceMatcher));
+        assertBugTypeCount(PRIMITIVE_PUBLIC, 0);
+        assertBugTypeCount(ARRAY_PUBLIC, 0);
+        assertBugTypeCount(MUTABLE_PUBLIC, 0);
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindRefComparisonTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindRefComparisonTest.java
@@ -1,9 +1,5 @@
 package edu.umd.cs.findbugs.detect;
 
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItem;
-
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 
@@ -12,8 +8,6 @@ import edu.umd.cs.findbugs.DetectorFactory;
 import edu.umd.cs.findbugs.DetectorFactoryCollection;
 import edu.umd.cs.findbugs.SystemProperties;
 import edu.umd.cs.findbugs.annotations.Confidence;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
 class FindRefComparisonTest extends AbstractIntegrationTest {
 
@@ -36,8 +30,8 @@ class FindRefComparisonTest extends AbstractIntegrationTest {
         SystemProperties.setProperty("findbugs.refcomp.reportAll", "true"); // enable ref comparison
 
         performAnalysisForRefComp();
-        assertNumOfRefCompBugs(1);
-        assertRefCompBug("RefComparisons", "integerBadComparison", 5, Confidence.HIGH);
+        assertBugTypeCount("RC_REF_COMPARISON", 1);
+        assertBugInMethodAtLineWithConfidence("RC_REF_COMPARISON", "RefComparisons", "integerBadComparison", 5, Confidence.HIGH);
     }
 
     @Test
@@ -47,10 +41,10 @@ class FindRefComparisonTest extends AbstractIntegrationTest {
 
         SystemProperties.removeProperty("findbugs.refcomp.reportAll");
         performAnalysisForRefComp();
-        assertNumOfRefCompBugs(3);
-        assertRefCompBug("RefComparisons", "integerBadComparison", 5, Confidence.HIGH);
-        assertRefCompBug("RefComparisons", "myClass1BadComparison", 13, Confidence.LOW);
-        assertRefCompBug("RefComparisons", "myClass2BadComparison", 21, Confidence.LOW);
+        assertBugTypeCount("RC_REF_COMPARISON", 3);
+        assertBugInMethodAtLineWithConfidence("RC_REF_COMPARISON", "RefComparisons", "integerBadComparison", 5, Confidence.HIGH);
+        assertBugInMethodAtLineWithConfidence("RC_REF_COMPARISON", "RefComparisons", "myClass1BadComparison", 13, Confidence.LOW);
+        assertBugInMethodAtLineWithConfidence("RC_REF_COMPARISON", "RefComparisons", "myClass2BadComparison", 21, Confidence.LOW);
     }
 
     @Test
@@ -59,8 +53,8 @@ class FindRefComparisonTest extends AbstractIntegrationTest {
         SystemProperties.setProperty("findbugs.refcomp.reportAll", "false");
 
         performAnalysis("RefComparisons.class");
-        assertNumOfRefCompBugs(1);
-        assertRefCompBug("RefComparisons", "integerBadComparison", 5, Confidence.HIGH);
+        assertBugTypeCount("RC_REF_COMPARISON", 1);
+        assertBugInMethodAtLineWithConfidence("RC_REF_COMPARISON", "RefComparisons", "integerBadComparison", 5, Confidence.HIGH);
     }
 
     @Test
@@ -69,27 +63,10 @@ class FindRefComparisonTest extends AbstractIntegrationTest {
         SystemProperties.setProperty("findbugs.refcomp.reportAll", "true");
 
         performAnalysisForRefComp();
-        assertNumOfRefCompBugs(3);
-        assertRefCompBug("RefComparisons", "integerBadComparison", 5, Confidence.HIGH);
-        assertRefCompBug("RefComparisons", "myClass1BadComparison", 13, Confidence.LOW);
-        assertRefCompBug("RefComparisons", "myClass2BadComparison", 21, Confidence.LOW);
-    }
-
-    private void assertNumOfRefCompBugs(int num) {
-        final BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType("RC_REF_COMPARISON").build();
-        assertThat(getBugCollection(), containsExactly(num, bugTypeMatcher));
-    }
-
-    private void assertRefCompBug(String className, String method, int line, Confidence confidence) {
-        final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
-                .bugType("RC_REF_COMPARISON")
-                .inClass(className)
-                .inMethod(method)
-                .atLine(line)
-                .withConfidence(confidence)
-                .build();
-        assertThat(getBugCollection(), hasItem(bugInstanceMatcher));
+        assertBugTypeCount("RC_REF_COMPARISON", 3);
+        assertBugInMethodAtLineWithConfidence("RC_REF_COMPARISON", "RefComparisons", "integerBadComparison", 5, Confidence.HIGH);
+        assertBugInMethodAtLineWithConfidence("RC_REF_COMPARISON", "RefComparisons", "myClass1BadComparison", 13, Confidence.LOW);
+        assertBugInMethodAtLineWithConfidence("RC_REF_COMPARISON", "RefComparisons", "myClass2BadComparison", 21, Confidence.LOW);
     }
 
     private static void setPriorityAdjustment(int adjustment) {

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindReturnRefTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindReturnRefTest.java
@@ -1,16 +1,10 @@
 package edu.umd.cs.findbugs.detect;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnJre;
 import org.junit.jupiter.api.condition.JRE;
-
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItem;
 
 class FindReturnRefTest extends AbstractIntegrationTest {
     @Test
@@ -25,54 +19,54 @@ class FindReturnRefTest extends AbstractIntegrationTest {
     void testFindReturnRefTestChecks() {
         performAnalysis("FindReturnRefTest.class");
 
-        assertNumOfBugs("EI_EXPOSE_BUF", 2);
-        assertNumOfBugs("EI_EXPOSE_BUF2", 2);
-        assertNumOfBugs("EI_EXPOSE_REP", 6);
-        assertNumOfBugs("EI_EXPOSE_REP2", 6);
-        assertNumOfBugs("EI_EXPOSE_STATIC_BUF2", 2);
-        assertNumOfBugs("EI_EXPOSE_STATIC_REP2", 6);
-        assertNumOfBugs("MS_EXPOSE_BUF", 2);
-        assertNumOfBugs("MS_EXPOSE_REP", 6);
+        assertBugTypeCount("EI_EXPOSE_BUF", 2);
+        assertBugTypeCount("EI_EXPOSE_BUF2", 2);
+        assertBugTypeCount("EI_EXPOSE_REP", 6);
+        assertBugTypeCount("EI_EXPOSE_REP2", 6);
+        assertBugTypeCount("EI_EXPOSE_STATIC_BUF2", 2);
+        assertBugTypeCount("EI_EXPOSE_STATIC_REP2", 6);
+        assertBugTypeCount("MS_EXPOSE_BUF", 2);
+        assertBugTypeCount("MS_EXPOSE_REP", 6);
 
-        assertBug("EI_EXPOSE_BUF", "FindReturnRefTest", "getBufferWrap", "charArray");
-        assertBug("EI_EXPOSE_BUF", "FindReturnRefTest", "getBufferDuplicate", "charBuf");
+        assertBugInMethodAtField("EI_EXPOSE_BUF", "FindReturnRefTest", "getBufferWrap", "charArray");
+        assertBugInMethodAtField("EI_EXPOSE_BUF", "FindReturnRefTest", "getBufferDuplicate", "charBuf");
 
-        assertBug("EI_EXPOSE_BUF2", "FindReturnRefTest", "setBufferDuplicate", "charBuf");
-        assertBug("EI_EXPOSE_BUF2", "FindReturnRefTest", "setBufferWrap", "charBuf");
+        assertBugInMethodAtField("EI_EXPOSE_BUF2", "FindReturnRefTest", "setBufferDuplicate", "charBuf");
+        assertBugInMethodAtField("EI_EXPOSE_BUF2", "FindReturnRefTest", "setBufferWrap", "charBuf");
 
-        assertBug("EI_EXPOSE_REP", "FindReturnRefTest", "getBuffer", "charBuf");
-        assertBug("EI_EXPOSE_REP", "FindReturnRefTest", "getDate", "date");
-        assertBug("EI_EXPOSE_REP", "FindReturnRefTest", "getDate2", "date");
-        assertBug("EI_EXPOSE_REP", "FindReturnRefTest", "getDateArray", "dateArray");
-        assertBug("EI_EXPOSE_REP", "FindReturnRefTest", "getValues", "hm");
-        assertBug("EI_EXPOSE_REP", "FindReturnRefTest", "getDateArray2", "dateArray");
+        assertBugInMethodAtField("EI_EXPOSE_REP", "FindReturnRefTest", "getBuffer", "charBuf");
+        assertBugInMethodAtField("EI_EXPOSE_REP", "FindReturnRefTest", "getDate", "date");
+        assertBugInMethodAtField("EI_EXPOSE_REP", "FindReturnRefTest", "getDate2", "date");
+        assertBugInMethodAtField("EI_EXPOSE_REP", "FindReturnRefTest", "getDateArray", "dateArray");
+        assertBugInMethodAtField("EI_EXPOSE_REP", "FindReturnRefTest", "getValues", "hm");
+        assertBugInMethodAtField("EI_EXPOSE_REP", "FindReturnRefTest", "getDateArray2", "dateArray");
 
-        assertBug("EI_EXPOSE_REP2", "FindReturnRefTest", "setBuffer", "charBuf");
-        assertBug("EI_EXPOSE_REP2", "FindReturnRefTest", "setDate", "date");
-        assertBug("EI_EXPOSE_REP2", "FindReturnRefTest", "setDate2", "date");
-        assertBug("EI_EXPOSE_REP2", "FindReturnRefTest", "setDateArray", "dateArray");
-        assertBug("EI_EXPOSE_REP2", "FindReturnRefTest", "setValues", "hm");
-        assertBug("EI_EXPOSE_REP2", "FindReturnRefTest", "setDateArray2", "dateArray");
+        assertBugInMethodAtField("EI_EXPOSE_REP2", "FindReturnRefTest", "setBuffer", "charBuf");
+        assertBugInMethodAtField("EI_EXPOSE_REP2", "FindReturnRefTest", "setDate", "date");
+        assertBugInMethodAtField("EI_EXPOSE_REP2", "FindReturnRefTest", "setDate2", "date");
+        assertBugInMethodAtField("EI_EXPOSE_REP2", "FindReturnRefTest", "setDateArray", "dateArray");
+        assertBugInMethodAtField("EI_EXPOSE_REP2", "FindReturnRefTest", "setValues", "hm");
+        assertBugInMethodAtField("EI_EXPOSE_REP2", "FindReturnRefTest", "setDateArray2", "dateArray");
 
-        assertBug("EI_EXPOSE_STATIC_BUF2", "FindReturnRefTest", "setStaticBufferDuplicate", "sCharBuf");
-        assertBug("EI_EXPOSE_STATIC_BUF2", "FindReturnRefTest", "setStaticBufferWrap", "sCharBuf");
+        assertBugInMethodAtField("EI_EXPOSE_STATIC_BUF2", "FindReturnRefTest", "setStaticBufferDuplicate", "sCharBuf");
+        assertBugInMethodAtField("EI_EXPOSE_STATIC_BUF2", "FindReturnRefTest", "setStaticBufferWrap", "sCharBuf");
 
-        assertBug("EI_EXPOSE_STATIC_REP2", "FindReturnRefTest", "getStaticValues2", "shm");
-        assertBug("EI_EXPOSE_STATIC_REP2", "FindReturnRefTest", "setStaticBuffer", "sCharBuf");
-        assertBug("EI_EXPOSE_STATIC_REP2", "FindReturnRefTest", "setStaticDate", "sDate");
-        assertBug("EI_EXPOSE_STATIC_REP2", "FindReturnRefTest", "setStaticDate2", "sDate");
-        assertBug("EI_EXPOSE_STATIC_REP2", "FindReturnRefTest", "setStaticDateArray", "sDateArray");
-        assertBug("EI_EXPOSE_STATIC_REP2", "FindReturnRefTest", "setStaticDateArray2", "sDateArray");
+        assertBugInMethodAtField("EI_EXPOSE_STATIC_REP2", "FindReturnRefTest", "getStaticValues2", "shm");
+        assertBugInMethodAtField("EI_EXPOSE_STATIC_REP2", "FindReturnRefTest", "setStaticBuffer", "sCharBuf");
+        assertBugInMethodAtField("EI_EXPOSE_STATIC_REP2", "FindReturnRefTest", "setStaticDate", "sDate");
+        assertBugInMethodAtField("EI_EXPOSE_STATIC_REP2", "FindReturnRefTest", "setStaticDate2", "sDate");
+        assertBugInMethodAtField("EI_EXPOSE_STATIC_REP2", "FindReturnRefTest", "setStaticDateArray", "sDateArray");
+        assertBugInMethodAtField("EI_EXPOSE_STATIC_REP2", "FindReturnRefTest", "setStaticDateArray2", "sDateArray");
 
-        assertBug("MS_EXPOSE_BUF", "FindReturnRefTest", "getStaticBufferWrap", "sCharArray");
-        assertBug("MS_EXPOSE_BUF", "FindReturnRefTest", "getStaticBufferDuplicate", "sCharBuf");
+        assertBugInMethodAtField("MS_EXPOSE_BUF", "FindReturnRefTest", "getStaticBufferWrap", "sCharArray");
+        assertBugInMethodAtField("MS_EXPOSE_BUF", "FindReturnRefTest", "getStaticBufferDuplicate", "sCharBuf");
 
-        assertBug("MS_EXPOSE_REP", "FindReturnRefTest", "getStaticBuffer", "sCharBuf");
-        assertBug("MS_EXPOSE_REP", "FindReturnRefTest", "getStaticDate", "sDate");
-        assertBug("MS_EXPOSE_REP", "FindReturnRefTest", "getStaticDate2", "sDate");
-        assertBug("MS_EXPOSE_REP", "FindReturnRefTest", "getStaticDateArray", "sDateArray");
-        assertBug("MS_EXPOSE_REP", "FindReturnRefTest", "getStaticValues", "shm");
-        assertBug("MS_EXPOSE_REP", "FindReturnRefTest", "getStaticDateArray2", "sDateArray");
+        assertBugInMethodAtField("MS_EXPOSE_REP", "FindReturnRefTest", "getStaticBuffer", "sCharBuf");
+        assertBugInMethodAtField("MS_EXPOSE_REP", "FindReturnRefTest", "getStaticDate", "sDate");
+        assertBugInMethodAtField("MS_EXPOSE_REP", "FindReturnRefTest", "getStaticDate2", "sDate");
+        assertBugInMethodAtField("MS_EXPOSE_REP", "FindReturnRefTest", "getStaticDateArray", "sDateArray");
+        assertBugInMethodAtField("MS_EXPOSE_REP", "FindReturnRefTest", "getStaticValues", "shm");
+        assertBugInMethodAtField("MS_EXPOSE_REP", "FindReturnRefTest", "getStaticDateArray2", "sDateArray");
     }
 
     @Test
@@ -80,28 +74,28 @@ class FindReturnRefTest extends AbstractIntegrationTest {
     void testUnmodifiableClass() {
         performAnalysis("../java17/exposemutable/UnmodifiableClass.class");
 
-        assertBug("EI_EXPOSE_REP", "UnmodifiableClass", "getListWithTernary2", "listWithTernary2");
-        assertBug("EI_EXPOSE_REP", "UnmodifiableClass", "getSetWithTernary2", "setWithTernary2");
-        assertBug("EI_EXPOSE_REP", "UnmodifiableClass", "getMapWithTernary2", "mapWithTernary2");
-        assertBug("EI_EXPOSE_REP", "UnmodifiableClass", "getListWithTernary3", "listWithTernary3");
-        assertBug("EI_EXPOSE_REP", "UnmodifiableClass", "getSetWithTernary3", "setWithTernary3");
-        assertBug("EI_EXPOSE_REP", "UnmodifiableClass", "getMapWithTernary3", "mapWithTernary3");
+        assertBugInMethodAtField("EI_EXPOSE_REP", "UnmodifiableClass", "getListWithTernary2", "listWithTernary2");
+        assertBugInMethodAtField("EI_EXPOSE_REP", "UnmodifiableClass", "getSetWithTernary2", "setWithTernary2");
+        assertBugInMethodAtField("EI_EXPOSE_REP", "UnmodifiableClass", "getMapWithTernary2", "mapWithTernary2");
+        assertBugInMethodAtField("EI_EXPOSE_REP", "UnmodifiableClass", "getListWithTernary3", "listWithTernary3");
+        assertBugInMethodAtField("EI_EXPOSE_REP", "UnmodifiableClass", "getSetWithTernary3", "setWithTernary3");
+        assertBugInMethodAtField("EI_EXPOSE_REP", "UnmodifiableClass", "getMapWithTernary3", "mapWithTernary3");
 
-        assertBug("EI_EXPOSE_REP", "UnmodifiableClass", "getListWithIf2", "listWithIf2");
-        assertBug("EI_EXPOSE_REP", "UnmodifiableClass", "getSetWithIf2", "setWithIf2");
-        assertBug("EI_EXPOSE_REP", "UnmodifiableClass", "getMapWithIf2", "mapWithIf2");
-        assertBug("EI_EXPOSE_REP", "UnmodifiableClass", "getListWithIf3", "listWithIf3");
-        assertBug("EI_EXPOSE_REP", "UnmodifiableClass", "getSetWithIf3", "setWithIf3");
-        assertBug("EI_EXPOSE_REP", "UnmodifiableClass", "getMapWithIf3", "mapWithIf3");
+        assertBugInMethodAtField("EI_EXPOSE_REP", "UnmodifiableClass", "getListWithIf2", "listWithIf2");
+        assertBugInMethodAtField("EI_EXPOSE_REP", "UnmodifiableClass", "getSetWithIf2", "setWithIf2");
+        assertBugInMethodAtField("EI_EXPOSE_REP", "UnmodifiableClass", "getMapWithIf2", "mapWithIf2");
+        assertBugInMethodAtField("EI_EXPOSE_REP", "UnmodifiableClass", "getListWithIf3", "listWithIf3");
+        assertBugInMethodAtField("EI_EXPOSE_REP", "UnmodifiableClass", "getSetWithIf3", "setWithIf3");
+        assertBugInMethodAtField("EI_EXPOSE_REP", "UnmodifiableClass", "getMapWithIf3", "mapWithIf3");
 
-        assertNumOfBugs("EI_EXPOSE_REP", 12);
-        assertNumOfBugs("EI_EXPOSE_BUF", 0);
-        assertNumOfBugs("EI_EXPOSE_BUF2", 0);
-        assertNumOfBugs("EI_EXPOSE_REP2", 0);
-        assertNumOfBugs("EI_EXPOSE_STATIC_BUF2", 0);
-        assertNumOfBugs("EI_EXPOSE_STATIC_REP2", 0);
-        assertNumOfBugs("MS_EXPOSE_BUF", 0);
-        assertNumOfBugs("MS_EXPOSE_REP", 0);
+        assertBugTypeCount("EI_EXPOSE_REP", 12);
+        assertBugTypeCount("EI_EXPOSE_BUF", 0);
+        assertBugTypeCount("EI_EXPOSE_BUF2", 0);
+        assertBugTypeCount("EI_EXPOSE_REP2", 0);
+        assertBugTypeCount("EI_EXPOSE_STATIC_BUF2", 0);
+        assertBugTypeCount("EI_EXPOSE_STATIC_REP2", 0);
+        assertBugTypeCount("MS_EXPOSE_BUF", 0);
+        assertBugTypeCount("MS_EXPOSE_REP", 0);
     }
 
     @Test
@@ -120,29 +114,13 @@ class FindReturnRefTest extends AbstractIntegrationTest {
     }
 
     private void assertNoExposeBug() {
-        assertNumOfBugs("EI_EXPOSE_BUF", 0);
-        assertNumOfBugs("EI_EXPOSE_BUF2", 0);
-        assertNumOfBugs("EI_EXPOSE_REP", 0);
-        assertNumOfBugs("EI_EXPOSE_REP2", 0);
-        assertNumOfBugs("EI_EXPOSE_STATIC_BUF2", 0);
-        assertNumOfBugs("EI_EXPOSE_STATIC_REP2", 0);
-        assertNumOfBugs("MS_EXPOSE_BUF", 0);
-        assertNumOfBugs("MS_EXPOSE_REP", 0);
-    }
-
-    private void assertNumOfBugs(String bugtype, int num) {
-        final BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType(bugtype).build();
-        assertThat(getBugCollection(), containsExactly(num, bugTypeMatcher));
-    }
-
-    private void assertBug(String bugtype, String className, String method, String field) {
-        final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
-                .bugType(bugtype)
-                .inClass(className)
-                .inMethod(method)
-                .atField(field)
-                .build();
-        assertThat(getBugCollection(), hasItem(bugInstanceMatcher));
+        assertBugTypeCount("EI_EXPOSE_BUF", 0);
+        assertBugTypeCount("EI_EXPOSE_BUF2", 0);
+        assertBugTypeCount("EI_EXPOSE_REP", 0);
+        assertBugTypeCount("EI_EXPOSE_REP2", 0);
+        assertBugTypeCount("EI_EXPOSE_STATIC_BUF2", 0);
+        assertBugTypeCount("EI_EXPOSE_STATIC_REP2", 0);
+        assertBugTypeCount("MS_EXPOSE_BUF", 0);
+        assertBugTypeCount("MS_EXPOSE_REP", 0);
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindVulnerableSecurityCheckMethodsTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindVulnerableSecurityCheckMethodsTest.java
@@ -1,35 +1,27 @@
 package edu.umd.cs.findbugs.detect;
 
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItem;
-
 import org.junit.jupiter.api.Test;
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
 class FindVulnerableSecurityCheckMethodsTest extends AbstractIntegrationTest {
 
-    static String bugType = "VSC_VULNERABLE_SECURITY_CHECK_METHODS";
+    private static final String BUG_TYPE = "VSC_VULNERABLE_SECURITY_CHECK_METHODS";
 
     @Test
     void testingBadCases() {
         performAnalysis("vulnerablesecuritycheckmethodstest/FindVulnerableSecurityCheckMethodsTest.class",
                 "vulnerablesecuritycheckmethodstest/SecurityManager.class");
 
-        BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
-                .bugType(bugType)
-                .build();
-        assertThat(getBugCollection(), containsExactly(7, bugInstanceMatcher));
+        assertBugTypeCount(BUG_TYPE, 7);
+        String className = "FindVulnerableSecurityCheckMethodsTest";
 
-        assertVSCBug("badFindVulnerableSecurityCheckMethodsCheck", 23);
-        assertVSCBug("badFindVulnerableSecurityCheckMethodsCheck2", 37);
-        assertVSCBug("badFindVulnerableSecurityCheckMethodsCheck3", 53);
-        assertVSCBug("badCalled", 77);
-        assertVSCBug("badFindVulnerableSecurityCheckMethodsCheck4", 94);
-        assertVSCBug("badFindVulnerableSecurityCheckMethodsCheck5", 111);
-        assertVSCBug("badFindVulnerableSecurityCheckMethodsCheck6", 128);
+        assertBugInMethodAtLine(BUG_TYPE, className, "badFindVulnerableSecurityCheckMethodsCheck", 23);
+        assertBugInMethodAtLine(BUG_TYPE, className, "badFindVulnerableSecurityCheckMethodsCheck2", 37);
+        assertBugInMethodAtLine(BUG_TYPE, className, "badFindVulnerableSecurityCheckMethodsCheck3", 53);
+        assertBugInMethodAtLine(BUG_TYPE, className, "badCalled", 77);
+        assertBugInMethodAtLine(BUG_TYPE, className, "badFindVulnerableSecurityCheckMethodsCheck4", 94);
+        assertBugInMethodAtLine(BUG_TYPE, className, "badFindVulnerableSecurityCheckMethodsCheck5", 111);
+        assertBugInMethodAtLine(BUG_TYPE, className, "badFindVulnerableSecurityCheckMethodsCheck6", 128);
 
     }
 
@@ -38,35 +30,13 @@ class FindVulnerableSecurityCheckMethodsTest extends AbstractIntegrationTest {
         performAnalysis("vulnerablesecuritycheckmethodstest/GoodVulnerableSecurityCheckMethodsTest.class",
                 "vulnerablesecuritycheckmethodstest/FindVulnerableSecurityCheckMethodsTest.class",
                 "vulnerablesecuritycheckmethodstest/SecurityManager.class");
-        assertNoVSCBug("goodvulnerablesecuritycheckmethodstestCheck");
-        assertNoVSCBug("goodVulnerableSecurityCheckMethodsTestCheck2");
-        assertNoVSCBug("goodVulnerableSecurityCheckMethodsTestCheck4");
-        assertNoVSCBug("goodVulnerableSecurityCheckMethodsTestCheck5");
-        assertNoVSCBug("goodVulnerableSecurityCheckMethodsTestCheck6");
-        assertNoVSCBug("goodVulnerableSecurityCheckMethodsTestCheck7");
+        assertNoBugInMethod(BUG_TYPE, "FindVulnerableSecurityCheckMethodsTest", "goodvulnerablesecuritycheckmethodstestCheck");
+        assertNoBugInMethod(BUG_TYPE, "FindVulnerableSecurityCheckMethodsTest", "goodVulnerableSecurityCheckMethodsTestCheck2");
+        assertNoBugInMethod(BUG_TYPE, "FindVulnerableSecurityCheckMethodsTest", "goodVulnerableSecurityCheckMethodsTestCheck4");
+        assertNoBugInMethod(BUG_TYPE, "FindVulnerableSecurityCheckMethodsTest", "goodVulnerableSecurityCheckMethodsTestCheck5");
+        assertNoBugInMethod(BUG_TYPE, "FindVulnerableSecurityCheckMethodsTest", "goodVulnerableSecurityCheckMethodsTestCheck6");
+        assertNoBugInMethod(BUG_TYPE, "FindVulnerableSecurityCheckMethodsTest", "goodVulnerableSecurityCheckMethodsTestCheck7");
 
-        BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
-                .bugType(bugType)
-                .inClass("GoodVulnerableSecurityCheckMethodsTest")
-                .build();
-        assertThat(getBugCollection(), containsExactly(0, bugInstanceMatcher));
-    }
-
-    private void assertNoVSCBug(String methodName) {
-        final BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType(bugType)
-                .inClass("FindVulnerableSecurityCheckMethodsTest")
-                .inMethod(methodName)
-                .build();
-        assertThat(getBugCollection(), containsExactly(0, bugTypeMatcher));
-    }
-
-    private void assertVSCBug(String methodName, int lineNumber) {
-        final BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType(bugType)
-                .inMethod(methodName)
-                .atLine(lineNumber)
-                .build();
-        assertThat(getBugCollection(), hasItem(bugTypeMatcher));
+        assertNoBugInClass(BUG_TYPE, "GoodVulnerableSecurityCheckMethodsTest");
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1097Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1097Test.java
@@ -1,12 +1,7 @@
 package edu.umd.cs.findbugs.detect;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 import org.junit.jupiter.api.Test;
-
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 class Issue1097Test extends AbstractIntegrationTest {
 
@@ -16,14 +11,5 @@ class Issue1097Test extends AbstractIntegrationTest {
 
         assertBugAtLine("FE_FLOATING_POINT_EQUALITY", 5);
         assertBugAtLine("FE_FLOATING_POINT_EQUALITY", 13);
-    }
-
-    private void assertBugAtLine(String type, int line) {
-        BugInstanceMatcher bugMatcher = new BugInstanceMatcherBuilder()
-                .bugType(type)
-                .atLine(line)
-                .build();
-
-        assertThat(getBugCollection(), containsExactly(1, bugMatcher));
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1219Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1219Test.java
@@ -1,13 +1,8 @@
 package edu.umd.cs.findbugs.detect;
 
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 import org.junit.jupiter.api.Test;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
 class Issue1219Test extends AbstractIntegrationTest {
 
@@ -19,22 +14,7 @@ class Issue1219Test extends AbstractIntegrationTest {
                 "ghIssues/Issue1219$Factory.class",
                 "ghIssues/Issue1219$Test.class");
 
-        assertBugCount("BC_UNCONFIRMED_CAST_OF_RETURN_VALUE", 1);
+        assertBugTypeCount("BC_UNCONFIRMED_CAST_OF_RETURN_VALUE", 1);
         assertBugAtLine("BC_UNCONFIRMED_CAST_OF_RETURN_VALUE", 36);
-    }
-
-    private void assertBugCount(String type, int expectedCount) {
-        BugInstanceMatcher bugMatcher = new BugInstanceMatcherBuilder()
-                .bugType(type).build();
-
-        assertThat(getBugCollection(),
-                containsExactly(expectedCount, bugMatcher));
-    }
-
-    private void assertBugAtLine(String type, int line) {
-        BugInstanceMatcher bugMatcher = new BugInstanceMatcherBuilder()
-                .bugType(type).atLine(line).build();
-
-        assertThat(getBugCollection(), containsExactly(1, bugMatcher));
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1472Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1472Test.java
@@ -1,13 +1,7 @@
 package edu.umd.cs.findbugs.detect;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 import org.junit.jupiter.api.Test;
-
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 
 /**
  * @see <a href="https://github.com/spotbugs/spotbugs/issues/1472">GitHub issue #1472</a>
@@ -17,9 +11,6 @@ class Issue1472Test extends AbstractIntegrationTest {
     @Test
     void testIssue() {
         performAnalysis("ghIssues/Issue1472.class");
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType("SA_LOCAL_SELF_COMPUTATION")
-                .build();
-        assertThat(getBugCollection(), containsExactly(4, bugTypeMatcher));
+        assertBugTypeCount("SA_LOCAL_SELF_COMPUTATION", 4);
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1498Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1498Test.java
@@ -1,12 +1,8 @@
 package edu.umd.cs.findbugs.detect;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
 import org.junit.jupiter.api.Test;
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 class Issue1498Test extends AbstractIntegrationTest {
 
@@ -14,7 +10,6 @@ class Issue1498Test extends AbstractIntegrationTest {
     void testIssue() {
         System.setProperty("frc.debug", "true");
         performAnalysis("ghIssues/Issue1498.class");
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder().bugType("IM_MULTIPLYING_RESULT_OF_IREM").build();
-        assertThat(getBugCollection(), containsExactly(3, bugTypeMatcher));
+        assertBugTypeCount("IM_MULTIPLYING_RESULT_OF_IREM", 3);
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1518Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1518Test.java
@@ -1,12 +1,7 @@
 package edu.umd.cs.findbugs.detect;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 import org.junit.jupiter.api.Test;
-
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @see <a href="https://github.com/spotbugs/spotbugs/issues/1518">GitHub issue #1518</a>
@@ -16,9 +11,6 @@ class Issue1518Test extends AbstractIntegrationTest {
     @Test
     void testIssue() {
         performAnalysis("ghIssues/Issue1518.class");
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType("RV_01_TO_INT")
-                .build();
-        assertThat(getBugCollection(), containsExactly(3, bugTypeMatcher));
+        assertBugTypeCount("RV_01_TO_INT", 3);
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1539Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1539Test.java
@@ -1,14 +1,9 @@
 package edu.umd.cs.findbugs.detect;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.ParameterizedTest;
-
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.stream.Stream;
 
@@ -33,9 +28,6 @@ class Issue1539Test extends AbstractIntegrationTest {
     @MethodSource("classes")
     void testInstance(String className) {
         performAnalysis(classLocation(className));
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType("DMI_RANDOM_USED_ONLY_ONCE")
-                .build();
-        assertThat(getBugCollection(), containsExactly(0, bugTypeMatcher));
+        assertNoBugType("DMI_RANDOM_USED_ONLY_ONCE");
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1642Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1642Test.java
@@ -16,19 +16,16 @@ class Issue1642Test extends AbstractIntegrationTest {
     @Test
     void testIssue() {
         performAnalysis("ghIssues/Issue1642.class");
-        BugInstanceMatcherBuilder builder = new BugInstanceMatcherBuilder()
-                .bugType("NP_NONNULL_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR");
+        assertBugTypeCount("NP_NONNULL_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR", 6);
 
-        BugInstanceMatcher fieldBMatcher = builder.atField("b").build();
-        BugInstanceMatcher fieldCMatcher = builder.atField("c").build();
-        BugInstanceMatcher fieldDMatcher = builder.atField("d").build();
-        BugInstanceMatcher fieldXMatcher = builder.atField("x").build();
-        BugInstanceMatcher fieldYMatcher = builder.atField("y").build();
+        assertBugAtField("NP_NONNULL_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR", "Issue1642", "b");
+        assertBugAtField("NP_NONNULL_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR", "Issue1642", "c");
+        assertBugAtField("NP_NONNULL_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR", "Issue1642", "d");
+        assertBugAtField("NP_NONNULL_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR", "Issue1642", "x");
 
-        assertThat(getBugCollection(), containsExactly(1, fieldBMatcher));
-        assertThat(getBugCollection(), containsExactly(1, fieldCMatcher));
-        assertThat(getBugCollection(), containsExactly(1, fieldDMatcher));
-        assertThat(getBugCollection(), containsExactly(1, fieldXMatcher));
+        BugInstanceMatcher fieldYMatcher = new BugInstanceMatcherBuilder()
+                .bugType("NP_NONNULL_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR")
+                .atField("y").build();
         // y is matched twice, once on the field and once in the constructor
         assertThat(getBugCollection(), containsExactly(2, fieldYMatcher));
     }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1759Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1759Test.java
@@ -1,20 +1,13 @@
 package edu.umd.cs.findbugs.detect;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 import org.junit.jupiter.api.Test;
-
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 class Issue1759Test extends AbstractIntegrationTest {
 
     @Test
     void testIssue() {
         performAnalysis("ghIssues/Issue1759.class");
-        BugInstanceMatcher matcher = new BugInstanceMatcherBuilder()
-                .bugType("BC_IMPOSSIBLE_DOWNCAST_OF_TOARRAY").build();
-        assertThat(getBugCollection(), containsExactly(1, matcher));
+        assertBugTypeCount("BC_IMPOSSIBLE_DOWNCAST_OF_TOARRAY", 1);
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1764Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1764Test.java
@@ -1,12 +1,7 @@
 package edu.umd.cs.findbugs.detect;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
-
 import org.junit.jupiter.api.Test;
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @see <a href="https://github.com/spotbugs/spotbugs/issues/1764">GitHub issue</a>
@@ -17,10 +12,6 @@ class Issue1764Test extends AbstractIntegrationTest {
     void testIssue() {
         System.setProperty("frc.debug", "true");
         performAnalysis("ghIssues/Issue1764.class");
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType("ES_COMPARING_STRINGS_WITH_EQ")
-                .atLine(7)
-                .build();
-        assertThat(getBugCollection(), containsExactly(1, bugTypeMatcher));
+        assertBugAtLine("ES_COMPARING_STRINGS_WITH_EQ", 7);
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1765Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1765Test.java
@@ -1,20 +1,13 @@
 package edu.umd.cs.findbugs.detect;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 import org.junit.jupiter.api.Test;
-
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 class Issue1765Test extends AbstractIntegrationTest {
 
     @Test
     void testIssue() {
         performAnalysis("ghIssues/Issue1765.class");
-        BugInstanceMatcher matcher = new BugInstanceMatcherBuilder()
-                .bugType("HE_HASHCODE_USE_OBJECT_EQUALS").build();
-        assertThat(getBugCollection(), containsExactly(1, matcher));
+        assertBugTypeCount("HE_HASHCODE_USE_OBJECT_EQUALS", 1);
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1771Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1771Test.java
@@ -5,11 +5,6 @@ import org.junit.jupiter.api.condition.DisabledOnJre;
 import org.junit.jupiter.api.condition.JRE;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
-
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 class Issue1771Test extends AbstractIntegrationTest {
 
@@ -17,8 +12,6 @@ class Issue1771Test extends AbstractIntegrationTest {
     @DisabledOnJre(JRE.JAVA_8)
     void testIssue() {
         performAnalysis("../java11/ghIssues/Issue1771.class");
-        BugInstanceMatcher matcher = new BugInstanceMatcherBuilder()
-                .bugType("EI_EXPOSE_REP").build();
-        assertThat(getBugCollection(), containsExactly(0, matcher));
+        assertNoBugType("EI_EXPOSE_REP");
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1867Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1867Test.java
@@ -1,23 +1,13 @@
 package edu.umd.cs.findbugs.detect;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 import org.junit.jupiter.api.Test;
-
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 
 class Issue1867Test extends AbstractIntegrationTest {
 
     @Test
     void testIssue() {
         performAnalysis("ghIssues/Issue1867.class");
-        BugInstanceMatcher matcher = new BugInstanceMatcherBuilder()
-                .bugType("MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR")
-                .build();
-
-        assertThat(getBugCollection(), containsExactly(0, matcher));
+        assertNoBugType("MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR");
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1877Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1877Test.java
@@ -5,11 +5,6 @@ import org.junit.jupiter.api.condition.DisabledOnJre;
 import org.junit.jupiter.api.condition.JRE;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
-
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 class Issue1877Test extends AbstractIntegrationTest {
 
@@ -18,26 +13,9 @@ class Issue1877Test extends AbstractIntegrationTest {
     void testIssue() {
         performAnalysis("../java17/Issue1877.class");
 
-        assertBugCount("VA_FORMAT_STRING_USES_NEWLINE", 2);
+        assertBugTypeCount("VA_FORMAT_STRING_USES_NEWLINE", 2);
 
         assertBugAtLine("VA_FORMAT_STRING_USES_NEWLINE", 18);
         assertBugAtLine("VA_FORMAT_STRING_USES_NEWLINE", 37);
-    }
-
-    private void assertBugCount(String type, int expectedCount) {
-        BugInstanceMatcher bugMatcher = new BugInstanceMatcherBuilder()
-                .bugType(type)
-                .build();
-
-        assertThat(getBugCollection(), containsExactly(expectedCount, bugMatcher));
-    }
-
-    private void assertBugAtLine(String type, int line) {
-        BugInstanceMatcher bugMatcher = new BugInstanceMatcherBuilder()
-                .bugType(type)
-                .atLine(line)
-                .build();
-
-        assertThat(getBugCollection(), containsExactly(1, bugMatcher));
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2114Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2114Test.java
@@ -5,11 +5,6 @@ import org.junit.jupiter.api.condition.DisabledOnJre;
 import org.junit.jupiter.api.condition.JRE;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
-
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 class Issue2114Test extends AbstractIntegrationTest {
 
@@ -18,19 +13,10 @@ class Issue2114Test extends AbstractIntegrationTest {
     void testIssue() {
         performAnalysis("../java11/Issue2114.class");
 
-        assertDidNotFindDefaultEncodingRelianceInMethod("filesReadString");
-        assertDidNotFindDefaultEncodingRelianceInMethod("filesReadAllLines");
-        assertDidNotFindDefaultEncodingRelianceInMethod("filesWriteString");
-        assertDidNotFindDefaultEncodingRelianceInMethod("filesNewBufferedReader");
-        assertDidNotFindDefaultEncodingRelianceInMethod("filesNewBufferedWriter");
-    }
-
-    private void assertDidNotFindDefaultEncodingRelianceInMethod(String methodName) {
-        BugInstanceMatcher matcher = new BugInstanceMatcherBuilder()
-                .bugType("DM_DEFAULT_ENCODING")
-                .inMethod(methodName)
-                .build();
-
-        assertThat(getBugCollection(), containsExactly(0, matcher));
+        assertNoBugInMethod("DM_DEFAULT_ENCODING", "Issue2114", "filesReadString");
+        assertNoBugInMethod("DM_DEFAULT_ENCODING", "Issue2114", "filesReadAllLines");
+        assertNoBugInMethod("DM_DEFAULT_ENCODING", "Issue2114", "filesWriteString");
+        assertNoBugInMethod("DM_DEFAULT_ENCODING", "Issue2114", "filesNewBufferedReader");
+        assertNoBugInMethod("DM_DEFAULT_ENCODING", "Issue2114", "filesNewBufferedWriter");
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2120Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2120Test.java
@@ -5,11 +5,6 @@ import org.junit.jupiter.api.condition.DisabledOnJre;
 import org.junit.jupiter.api.condition.JRE;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
-
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 class Issue2120Test extends AbstractIntegrationTest {
 
@@ -19,8 +14,6 @@ class Issue2120Test extends AbstractIntegrationTest {
         performAnalysis("../java17/Issue2120.class",
                 "../java17/Issue2120$1MyEnum.class",
                 "../java17/Issue2120$1MyRecord.class");
-        BugInstanceMatcher matcher = new BugInstanceMatcherBuilder()
-                .bugType("UMAC_UNCALLABLE_METHOD_OF_ANONYMOUS_CLASS").build();
-        assertThat(getBugCollection(), containsExactly(0, matcher));
+        assertNoBugType("UMAC_UNCALLABLE_METHOD_OF_ANONYMOUS_CLASS");
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2142Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2142Test.java
@@ -3,12 +3,6 @@ package edu.umd.cs.findbugs.detect;
 import org.junit.jupiter.api.Test;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
-
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 class Issue2142Test extends AbstractIntegrationTest {
 
@@ -16,24 +10,9 @@ class Issue2142Test extends AbstractIntegrationTest {
     void testIssue() {
         performAnalysis("ghIssues/Issue2142.class",
                 "ghIssues/Issue2142$Inner.class");
-        BugInstanceMatcher matcher = new BugInstanceMatcherBuilder()
-                .bugType("SA_FIELD_SELF_ASSIGNMENT").build();
-        assertThat(getBugCollection(), containsExactly(2, matcher));
 
-        matcher = new BugInstanceMatcherBuilder()
-                .bugType("SA_FIELD_SELF_ASSIGNMENT")
-                .inClass("Issue2142")
-                .inMethod("foo1")
-                .atLine(6)
-                .build();
-        assertThat(getBugCollection(), hasItem(matcher));
-
-        matcher = new BugInstanceMatcherBuilder()
-                .bugType("SA_FIELD_SELF_ASSIGNMENT")
-                .inClass("Issue2142$Inner")
-                .inMethod("foo2")
-                .atLine(10)
-                .build();
-        assertThat(getBugCollection(), hasItem(matcher));
+        assertBugTypeCount("SA_FIELD_SELF_ASSIGNMENT", 2);
+        assertBugInMethodAtLine("SA_FIELD_SELF_ASSIGNMENT", "Issue2142", "foo1", 6);
+        assertBugInMethodAtLine("SA_FIELD_SELF_ASSIGNMENT", "Issue2142$Inner", "foo2", 10);
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2147Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2147Test.java
@@ -3,11 +3,6 @@ package edu.umd.cs.findbugs.detect;
 import org.junit.jupiter.api.Test;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
-
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 class Issue2147Test extends AbstractIntegrationTest {
 
@@ -17,8 +12,6 @@ class Issue2147Test extends AbstractIntegrationTest {
                 "ghIssues/Issue2147A.class",
                 "ghIssues/Issue2147B.class",
                 "ghIssues/Issue2147C.class");
-        BugInstanceMatcher matcher = new BugInstanceMatcherBuilder()
-                .bugType("URF_UNREAD_FIELD").build();
-        assertThat(getBugCollection(), containsExactly(0, matcher));
+        assertNoBugType("URF_UNREAD_FIELD");
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2182Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2182Test.java
@@ -5,11 +5,6 @@ import org.junit.jupiter.api.condition.DisabledOnJre;
 import org.junit.jupiter.api.condition.JRE;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItem;
 
 class Issue2182Test extends AbstractIntegrationTest {
 
@@ -17,12 +12,6 @@ class Issue2182Test extends AbstractIntegrationTest {
     @DisabledOnJre(JRE.JAVA_8)
     void testIssue() {
         performAnalysis("../java11/ghIssues/Issue2182.class");
-        BugInstanceMatcher matcher = new BugInstanceMatcherBuilder()
-                .bugType("SBSC_USE_STRINGBUFFER_CONCATENATION")
-                .inClass("Issue2182")
-                .inMethod("test")
-                .atLine(22)
-                .build();
-        assertThat(getBugCollection(), hasItem(matcher));
+        assertBugInMethodAtLine("SBSC_USE_STRINGBUFFER_CONCATENATION", "Issue2182", "test", 22);
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2183Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2183Test.java
@@ -6,11 +6,6 @@ import org.junit.jupiter.api.condition.JRE;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
 import edu.umd.cs.findbugs.annotations.Confidence;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItem;
 
 class Issue2183Test extends AbstractIntegrationTest {
 
@@ -18,13 +13,6 @@ class Issue2183Test extends AbstractIntegrationTest {
     @DisabledOnJre(JRE.JAVA_8)
     void testIssue() {
         performAnalysis("../java11/ghIssues/Issue2183.class");
-        BugInstanceMatcher matcher = new BugInstanceMatcherBuilder()
-                .bugType("SQL_NONCONSTANT_STRING_PASSED_TO_EXECUTE")
-                .inClass("Issue2183")
-                .inMethod("test")
-                .atLine(11)
-                .withConfidence(Confidence.HIGH)
-                .build();
-        assertThat(getBugCollection(), hasItem(matcher));
+        assertBugInMethodAtLineWithConfidence("SQL_NONCONSTANT_STRING_PASSED_TO_EXECUTE", "Issue2183", "test", 11, Confidence.HIGH);
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2184Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2184Test.java
@@ -5,11 +5,6 @@ import org.junit.jupiter.api.condition.DisabledOnJre;
 import org.junit.jupiter.api.condition.JRE;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItem;
 
 class Issue2184Test extends AbstractIntegrationTest {
 
@@ -17,12 +12,6 @@ class Issue2184Test extends AbstractIntegrationTest {
     @DisabledOnJre({ JRE.JAVA_8, JRE.JAVA_11 })
     void testIssue() {
         performAnalysis("../java17/ghIssues/Issue2184.class");
-        BugInstanceMatcher matcher = new BugInstanceMatcherBuilder()
-                .bugType("PT_RELATIVE_PATH_TRAVERSAL")
-                .inClass("Issue2184")
-                .inMethod("test")
-                .atLine(17)
-                .build();
-        assertThat(getBugCollection(), hasItem(matcher));
+        assertBugInMethodAtLine("PT_RELATIVE_PATH_TRAVERSAL", "Issue2184", "test", 17);
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2331Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2331Test.java
@@ -1,21 +1,13 @@
 package edu.umd.cs.findbugs.detect;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 import org.junit.jupiter.api.Test;
-
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 class Issue2331Test extends AbstractIntegrationTest {
 
     @Test
     void testIssue() {
         performAnalysis("infiniteLoop/Issue2331.class");
-        BugInstanceMatcher bugMatcher = new BugInstanceMatcherBuilder()
-                .bugType("IL_INFINITE_LOOP")
-                .build();
-        assertThat(getBugCollection(), containsExactly(1, bugMatcher));
+        assertBugTypeCount("IL_INFINITE_LOOP", 1);
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2370Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2370Test.java
@@ -1,15 +1,10 @@
 package edu.umd.cs.findbugs.detect;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.ParameterizedTest;
 import java.util.stream.Stream;
-
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 class Issue2370Test extends AbstractIntegrationTest {
 
@@ -28,9 +23,6 @@ class Issue2370Test extends AbstractIntegrationTest {
     @MethodSource("classes")
     void testInstance(String className) {
         performAnalysis(classLocation(className));
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType("DMI_RANDOM_USED_ONLY_ONCE")
-                .build();
-        assertThat(getBugCollection(), containsExactly(0, bugTypeMatcher));
+        assertNoBugType("DMI_RANDOM_USED_ONLY_ONCE");
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2379Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2379Test.java
@@ -1,14 +1,8 @@
 package edu.umd.cs.findbugs.detect;
 
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 import org.junit.jupiter.api.Test;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
-
 
 class Issue2379Test extends AbstractIntegrationTest {
     @Test
@@ -16,18 +10,9 @@ class Issue2379Test extends AbstractIntegrationTest {
         performAnalysis("ghIssues/Issue2379.class");
 
         // Check that we've found the uncalled `unusedValues` private method
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType("UPM_UNCALLED_PRIVATE_METHOD")
-                .inMethod("unusedValues")
-                .build();
-
-        assertThat(getBugCollection(), containsExactly(1, bugTypeMatcher));
+        assertBugInMethod("UPM_UNCALLED_PRIVATE_METHOD", "Issue2379", "unusedValues");
 
         // Check that it was the one and only bug we've found
-        bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType("UPM_UNCALLED_PRIVATE_METHOD")
-                .build();
-
-        assertThat(getBugCollection(), containsExactly(1, bugTypeMatcher));
+        assertBugTypeCount("UPM_UNCALLED_PRIVATE_METHOD", 1);
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2436Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2436Test.java
@@ -1,22 +1,13 @@
 package edu.umd.cs.findbugs.detect;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 import org.junit.jupiter.api.Test;
-
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 class Issue2436Test extends AbstractIntegrationTest {
 
     @Test
     void testIssue() {
         performAnalysis("ghIssues/Issue2436.class");
-        BugInstanceMatcher bugMatcher = new BugInstanceMatcherBuilder()
-                .bugType("SE_NO_SERIALVERSIONID")
-                .build();
-        assertThat(getBugCollection(), containsExactly(1, bugMatcher));
+        assertBugTypeCount("SE_NO_SERIALVERSIONID", 1);
     }
-
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2547Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2547Test.java
@@ -1,14 +1,7 @@
 package edu.umd.cs.findbugs.detect;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 import org.junit.jupiter.api.Test;
-
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItem;
-
 
 /**
  * @see <a href="https://github.com/spotbugs/spotbugs/issues/2547">GitHub issue #2547</a>
@@ -21,25 +14,8 @@ class Issue2547Test extends AbstractIntegrationTest {
                 "ghIssues/issue2547/MyEx.class",
                 "ghIssues/issue2547/ExceptionFactory.class");
 
-        assertBug(2);
-        assertBug("notThrowingExCtor", 15);
-        assertBug("notThrowingExCtorCaller", 26);
-    }
-
-    private void assertBug(int num) {
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType("RV_EXCEPTION_NOT_THROWN")
-                .build();
-        assertThat(getBugCollection(), containsExactly(num, bugTypeMatcher));
-    }
-
-    private void assertBug(String method, int line) {
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType("RV_EXCEPTION_NOT_THROWN")
-                .inClass("Issue2547")
-                .inMethod(method)
-                .atLine(line)
-                .build();
-        assertThat(getBugCollection(), hasItem(bugTypeMatcher));
+        assertBugTypeCount("RV_EXCEPTION_NOT_THROWN", 2);
+        assertBugInMethodAtLine("RV_EXCEPTION_NOT_THROWN", "Issue2547", "notThrowingExCtor", 15);
+        assertBugInMethodAtLine("RV_EXCEPTION_NOT_THROWN", "Issue2547", "notThrowingExCtorCaller", 26);
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2552Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2552Test.java
@@ -1,15 +1,10 @@
 package edu.umd.cs.findbugs.detect;
 
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnJre;
 import org.junit.jupiter.api.condition.JRE;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
 class Issue2552Test extends AbstractIntegrationTest {
 
@@ -18,25 +13,8 @@ class Issue2552Test extends AbstractIntegrationTest {
     void testIssue() {
         performAnalysis("../java17/ghIssues/Issue2552.class");
 
-        assertBugCount("EI_EXPOSE_REP", 1);
+        assertBugTypeCount("EI_EXPOSE_REP", 1);
 
         assertBugAtLine("EI_EXPOSE_REP", 12);
-    }
-
-    private void assertBugCount(String type, int expectedCount) {
-        BugInstanceMatcher bugMatcher = new BugInstanceMatcherBuilder()
-                .bugType(type)
-                .build();
-
-        assertThat(getBugCollection(), containsExactly(expectedCount, bugMatcher));
-    }
-
-    private void assertBugAtLine(String type, int line) {
-        BugInstanceMatcher bugMatcher = new BugInstanceMatcherBuilder()
-                .bugType(type)
-                .atLine(line)
-                .build();
-
-        assertThat(getBugCollection(), containsExactly(1, bugMatcher));
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2558Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2558Test.java
@@ -1,24 +1,13 @@
 package edu.umd.cs.findbugs.detect;
 
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 import org.junit.jupiter.api.Test;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
-
 
 class Issue2558Test extends AbstractIntegrationTest {
     @Test
     void test() {
         performAnalysis("ghIssues/Issue2558.class");
-
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType("NP_EQUALS_SHOULD_HANDLE_NULL_ARGUMENT")
-                .build();
-
-        assertThat(getBugCollection(), containsExactly(0, bugTypeMatcher));
+        assertNoBugType("NP_EQUALS_SHOULD_HANDLE_NULL_ARGUMENT");
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2647Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2647Test.java
@@ -1,22 +1,15 @@
 package edu.umd.cs.findbugs.detect;
 
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.jupiter.api.Test;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
 class Issue2647Test extends AbstractIntegrationTest {
     @Test
     void testIssue() {
         performAnalysis("ghIssues/Issue2647.class");
 
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .build();
-
-        assertThat(getBugCollection(), containsExactly(0, bugTypeMatcher));
+        assertNoBugType("DMI_DOH");
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2782Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2782Test.java
@@ -1,14 +1,9 @@
 package edu.umd.cs.findbugs.detect;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnJre;
 import org.junit.jupiter.api.condition.JRE;
-
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.*;
 
 class Issue2782Test extends AbstractIntegrationTest {
 
@@ -22,32 +17,15 @@ class Issue2782Test extends AbstractIntegrationTest {
                 "../java21/Issue2782$Impl2.class");
 
         // Checks for issue 2782
-        assertBugCount("BC_UNCONFIRMED_CAST", 1);
-        assertBugCount("BC_UNCONFIRMED_CAST_OF_RETURN_VALUE", 1);
+        assertBugTypeCount("BC_UNCONFIRMED_CAST", 1);
+        assertBugTypeCount("BC_UNCONFIRMED_CAST_OF_RETURN_VALUE", 1);
 
         assertBugAtLine("BC_UNCONFIRMED_CAST", 52);
         assertBugAtLine("BC_UNCONFIRMED_CAST_OF_RETURN_VALUE", 51);
 
         // Checks for issue 2736
-        assertBugCount("DLS_DEAD_LOCAL_STORE", 1);
+        assertBugTypeCount("DLS_DEAD_LOCAL_STORE", 1);
 
         assertBugAtLine("DLS_DEAD_LOCAL_STORE", 61);
-    }
-
-    private void assertBugCount(String type, int expectedCount) {
-        BugInstanceMatcher bugMatcher = new BugInstanceMatcherBuilder()
-                .bugType(type)
-                .build();
-
-        assertThat(getBugCollection(), containsExactly(expectedCount, bugMatcher));
-    }
-
-    private void assertBugAtLine(String type, int line) {
-        BugInstanceMatcher bugMatcher = new BugInstanceMatcherBuilder()
-                .bugType(type)
-                .atLine(line)
-                .build();
-
-        assertThat(getBugCollection(), containsExactly(1, bugMatcher));
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2793Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2793Test.java
@@ -1,15 +1,10 @@
 package edu.umd.cs.findbugs.detect;
 
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnJre;
 import org.junit.jupiter.api.condition.JRE;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
 class Issue2793Test extends AbstractIntegrationTest {
 
@@ -22,18 +17,10 @@ class Issue2793Test extends AbstractIntegrationTest {
                 "../java17/ghIssues/Issue2793$SerializableClass.class",
                 "../java17/ghIssues/Issue2793$YangLibModule.class");
 
-        assertBugCount("SE_NO_SERIALVERSIONID", 2);
+        assertBugTypeCount("SE_NO_SERIALVERSIONID", 2);
 
-        assertBugCount("SE_NO_SUITABLE_CONSTRUCTOR_FOR_EXTERNALIZATION", 0);
+        assertNoBugType("SE_NO_SUITABLE_CONSTRUCTOR_FOR_EXTERNALIZATION");
 
-        assertBugCount("SE_BAD_FIELD", 0);
-    }
-
-    private void assertBugCount(String type, int expectedCount) {
-        BugInstanceMatcher bugMatcher = new BugInstanceMatcherBuilder()
-                .bugType(type)
-                .build();
-
-        assertThat(getBugCollection(), containsExactly(expectedCount, bugMatcher));
+        assertNoBugType("SE_BAD_FIELD");
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2836Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2836Test.java
@@ -1,22 +1,16 @@
 package edu.umd.cs.findbugs.detect;
 
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.jupiter.api.Test;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
 class Issue2836Test extends AbstractIntegrationTest {
     @Test
     void testIssue() {
         performAnalysis("ghIssues/Issue2836.class");
 
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .build();
-
-        assertThat(getBugCollection(), containsExactly(0, bugTypeMatcher));
+        assertNoBugType("NP_LOAD_OF_KNOWN_NULL_VALUE");
+        assertNoBugType("RCN_REDUNDANT_NULLCHECK_OF_NULL_VALUE");
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2837Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2837Test.java
@@ -1,13 +1,7 @@
 package edu.umd.cs.findbugs.detect;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 import org.junit.jupiter.api.Test;
-
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 
 class Issue2837Test extends AbstractIntegrationTest {
 
@@ -15,24 +9,7 @@ class Issue2837Test extends AbstractIntegrationTest {
     void testIssue() {
         performAnalysis("ghIssues/Issue2837.class");
 
-        assertBugCount("MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR", 1);
+        assertBugTypeCount("MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR", 1);
         assertBugAtLine("MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR", 19);
-    }
-
-    private void assertBugCount(String type, int expectedCount) {
-        BugInstanceMatcher bugMatcher = new BugInstanceMatcherBuilder()
-                .bugType(type)
-                .build();
-
-        assertThat(getBugCollection(), containsExactly(expectedCount, bugMatcher));
-    }
-
-    private void assertBugAtLine(String type, int line) {
-        BugInstanceMatcher bugMatcher = new BugInstanceMatcherBuilder()
-                .bugType(type)
-                .atLine(line)
-                .build();
-
-        assertThat(getBugCollection(), containsExactly(1, bugMatcher));
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2864Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2864Test.java
@@ -1,13 +1,8 @@
 package edu.umd.cs.findbugs.detect;
 
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 import org.junit.jupiter.api.Test;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
 /**
  * @author gtoison
@@ -18,11 +13,6 @@ class Issue2864Test extends AbstractIntegrationTest {
     @Test
     void testIssue() {
         performAnalysis("../../../../src/classSamples/classEnhanceByHibernate/HibernateEnhancedEntity.class");
-
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType("DLS_DEAD_LOCAL_STORE")
-                .build();
-
-        assertThat(getBugCollection(), containsExactly(0, bugTypeMatcher));
+        assertNoBugType("DLS_DEAD_LOCAL_STORE");
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2968Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2968Test.java
@@ -1,12 +1,7 @@
 package edu.umd.cs.findbugs.detect;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 import org.junit.jupiter.api.Test;
-
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 class Issue2968Test extends AbstractIntegrationTest {
 
@@ -20,9 +15,6 @@ class Issue2968Test extends AbstractIntegrationTest {
                 "ghIssues/Issue2968$ActualException.class",
                 "ghIssues/Issue2968$RedHerring1Exception.class",
                 "ghIssues/Issue2968$RedHerring2Exception.class");
-        BugInstanceMatcher bugMatcher = new BugInstanceMatcherBuilder()
-                .bugType("BC_IMPOSSIBLE_INSTANCEOF")
-                .build();
-        assertThat(getBugCollection(), containsExactly(0, bugMatcher));
+        assertNoBugType("BC_IMPOSSIBLE_INSTANCEOF");
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3094Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3094Test.java
@@ -1,13 +1,8 @@
 package edu.umd.cs.findbugs.detect;
 
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 import org.junit.jupiter.api.Test;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
 /**
  * @author gtoison
@@ -18,11 +13,6 @@ class Issue3094Test extends AbstractIntegrationTest {
     @Test
     void testIssue() {
         performAnalysis("../../../../src/classSamples/kotlin/DummyBE.class", "kotlin/jvm/internal/Intrinsics.class");
-
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType("NP_NONNULL_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR")
-                .build();
-
-        assertThat(getBugCollection(), containsExactly(0, bugTypeMatcher));
+        assertNoBugType("NP_NONNULL_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR");
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue374Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue374Test.java
@@ -19,13 +19,7 @@
 package edu.umd.cs.findbugs.detect;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 import org.junit.jupiter.api.Test;
-
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 
 /**
  * @see <a href="https://github.com/spotbugs/spotbugs/issues/374">GitHub issue</a>
@@ -39,9 +33,6 @@ class Issue374Test extends AbstractIntegrationTest {
                 "ghIssues/issue374/ClassLevel.class",
                 "ghIssues/issue374/MethodLevel.class",
                 "ghIssues/issue374/PackageLevel.class");
-        BugInstanceMatcher matcher = new BugInstanceMatcherBuilder()
-                .bugType("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
-                .build();
-        assertThat(getBugCollection(), containsExactly(3, matcher));
+        assertBugTypeCount("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE", 3);
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue453Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue453Test.java
@@ -1,23 +1,12 @@
 package edu.umd.cs.findbugs.detect;
 
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 import org.junit.jupiter.api.Test;
-
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
 class Issue453Test extends AbstractIntegrationTest {
     @Test
     void testIssue() {
         performAnalysis("ghIssues/Issue453.class");
-
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType("UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR")
-                .build();
-
-        assertThat(getBugCollection(), containsExactly(0, bugTypeMatcher));
+        assertNoBugType("UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR");
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue463Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue463Test.java
@@ -1,13 +1,7 @@
 package edu.umd.cs.findbugs.detect;
 
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 import org.junit.jupiter.api.Test;
-
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
 /**
  * @see <a href="https://github.com/spotbugs/spotbugs/issues/463">GitHub issue</a>
@@ -17,9 +11,7 @@ class Issue463Test extends AbstractIntegrationTest {
     @Test
     void testAnnotatedClass() {
         performAnalysis("ghIssues/Issue463.class");
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder().bugType("RV_RETURN_VALUE_IGNORED")
-                .atLine(37).build();
-        assertThat(getBugCollection(), containsExactly(1, bugTypeMatcher));
+        assertBugAtLine("RV_RETURN_VALUE_IGNORED", 37);
     }
 
     /**
@@ -31,8 +23,6 @@ class Issue463Test extends AbstractIntegrationTest {
     @Test
     void testAnnotatedPackage() {
         performAnalysis("ghIssues/issue463/Issue463.class", "ghIssues/issue463/package-info.class");
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder().bugType("RV_RETURN_VALUE_IGNORED")
-                .atLine(34).build();
-        assertThat(getBugCollection(), containsExactly(1, bugTypeMatcher));
+        assertBugAtLine("RV_RETURN_VALUE_IGNORED", 34);
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue484Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue484Test.java
@@ -1,13 +1,7 @@
 package edu.umd.cs.findbugs.detect;
 
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 import org.junit.jupiter.api.Test;
-
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
 /**
  * @see <a href="https://github.com/spotbugs/spotbugs/issues/484">GitHub issue</a>
@@ -18,9 +12,6 @@ class Issue484Test extends AbstractIntegrationTest {
     @Test
     void testIssue() {
         performAnalysis("ghIssues/Issue484.class");
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder().bugType("NP_NONNULL_PARAM_VIOLATION")
-                .build();
-        assertThat(getBugCollection(), containsExactly(0, bugTypeMatcher));
+        assertNoBugType("NP_NONNULL_PARAM_VIOLATION");
     }
-
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue500Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue500Test.java
@@ -18,14 +18,11 @@
  */
 package edu.umd.cs.findbugs.detect;
 
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
 /**
  * @author William R. Price
@@ -34,9 +31,7 @@ class Issue500Test extends AbstractIntegrationTest {
 
     @Test
     void testIssue() {
-        performAnalysis("lambdas/Issue500.class");
-        BugInstanceMatcher bugMatcher = new BugInstanceMatcherBuilder().build();
-        assertThat(getBugCollection(), containsExactly(0, bugMatcher));
+        Assertions.assertDoesNotThrow(() -> performAnalysis("lambdas/Issue500.class"));
     }
 
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue560Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue560Test.java
@@ -1,14 +1,7 @@
 package edu.umd.cs.findbugs.detect;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
-
-
 import org.junit.jupiter.api.Test;
-
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 class Issue560Test extends AbstractIntegrationTest {
 
@@ -18,24 +11,7 @@ class Issue560Test extends AbstractIntegrationTest {
                 "ghIssues/Issue560$NotANestedTest.class",
                 "ghIssues/Issue560$NestedTest.class");
 
-        assertBugCount("SIC_INNER_SHOULD_BE_STATIC", 1);
+        assertBugTypeCount("SIC_INNER_SHOULD_BE_STATIC", 1);
         assertBugInClass("SIC_INNER_SHOULD_BE_STATIC", "ghIssues.Issue560$NotANestedTest");
-    }
-
-    private void assertBugCount(String type, int expectedCount) {
-        BugInstanceMatcher bugMatcher = new BugInstanceMatcherBuilder()
-                .bugType(type)
-                .build();
-
-        assertThat(getBugCollection(), containsExactly(expectedCount, bugMatcher));
-    }
-
-    private void assertBugInClass(String type, String className) {
-        BugInstanceMatcher bugMatcher = new BugInstanceMatcherBuilder()
-                .bugType(type)
-                .inClass(className)
-                .build();
-
-        assertThat(getBugCollection(), containsExactly(1, bugMatcher));
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue574Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue574Test.java
@@ -1,13 +1,7 @@
 package edu.umd.cs.findbugs.detect;
 
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 import org.junit.jupiter.api.Test;
-
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
 /**
  * SpotBugs should suppress "UNF_UNREAD_FIELD" warning when triggering fields have certain annotations.
@@ -24,10 +18,7 @@ class Issue574Test extends AbstractIntegrationTest {
     @Test
     void testSerializedNameAnnotation() {
         performAnalysis("ghIssues/issue574/Issue574SerializedName.class");
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType(DESIRED_BUG_TYPE)
-                .build();
-        assertThat(getBugCollection(), containsExactly(0, bugTypeMatcher));
+        assertNoBugType(DESIRED_BUG_TYPE);
     }
 
     /**
@@ -37,10 +28,7 @@ class Issue574Test extends AbstractIntegrationTest {
     @Test
     void testXmlElementAnnotation() {
         performAnalysis("ghIssues/issue574/Issue574XmlElement.class");
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType(DESIRED_BUG_TYPE)
-                .build();
-        assertThat(getBugCollection(), containsExactly(0, bugTypeMatcher));
+        assertNoBugType(DESIRED_BUG_TYPE);
     }
 
     /**
@@ -51,9 +39,6 @@ class Issue574Test extends AbstractIntegrationTest {
     void testRegisterExtensionAnnotation() {
         performAnalysis("ghIssues/issue574/Issue574RegisterExtension.class",
                 "ghIssues/issue574/BypassFileNotFoundExceptionExtension.class");
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType(DESIRED_BUG_TYPE)
-                .build();
-        assertThat(getBugCollection(), containsExactly(0, bugTypeMatcher));
+        assertNoBugType(DESIRED_BUG_TYPE);
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue582Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue582Test.java
@@ -1,13 +1,8 @@
 package edu.umd.cs.findbugs.detect;
 
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 import org.junit.jupiter.api.Test;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
 /**
  * SpotBugs should support both of {@code javax.annotation.CheckReturnValue} and
@@ -21,16 +16,12 @@ class Issue582Test extends AbstractIntegrationTest {
     @Test
     void testAnnnotatedClass() {
         performAnalysis("ghIssues/Issue582.class");
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder().bugType("RV_RETURN_VALUE_IGNORED")
-                .atLine(35).build();
-        assertThat(getBugCollection(), containsExactly(1, bugTypeMatcher));
+        assertBugAtLine("RV_RETURN_VALUE_IGNORED", 35);
     }
 
     @Test
     void testAnnotatedPackage() {
         performAnalysis("ghIssues/issue582/Issue582.class", "ghIssues/issue582/package-info.class");
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder().bugType("RV_RETURN_VALUE_IGNORED")
-                .atLine(34).build();
-        assertThat(getBugCollection(), containsExactly(1, bugTypeMatcher));
+        assertBugAtLine("RV_RETURN_VALUE_IGNORED", 34);
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue595Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue595Test.java
@@ -1,13 +1,7 @@
 package edu.umd.cs.findbugs.detect;
 
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 import org.junit.jupiter.api.Test;
-
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
 /**
  * @see <a href="https://github.com/spotbugs/spotbugs/issues/595">GitHub
@@ -18,46 +12,38 @@ class Issue595Test extends AbstractIntegrationTest {
     @Test
     void testIoOperationOk() {
         performAnalysis("rangeArray/IoOperationOk.class");
-        BugInstanceMatcher bugTypeMatcherLength = new BugInstanceMatcherBuilder().bugType("RANGE_ARRAY_LENGTH").build();
-        BugInstanceMatcher bugTypeMatcherOffset = new BugInstanceMatcherBuilder().bugType("RANGE_ARRAY_OFFSET").build();
-        assertThat(getBugCollection(), containsExactly(0, bugTypeMatcherLength));
-        assertThat(getBugCollection(), containsExactly(0, bugTypeMatcherOffset));
+        assertNoBugType("RANGE_ARRAY_LENGTH");
+        assertNoBugType("RANGE_ARRAY_OFFSET");
     }
 
     @Test
     void testIoOperationRangeArrayLengthExpected() {
         performAnalysis("rangeArray/IoOperationRangeArrayLengthExpected.class");
-        BugInstanceMatcher bugTypeMatcherLength = new BugInstanceMatcherBuilder().bugType("RANGE_ARRAY_LENGTH").build();
-        assertThat(getBugCollection(), containsExactly(5, bugTypeMatcherLength));
+        assertBugTypeCount("RANGE_ARRAY_LENGTH", 5);
     }
 
     @Test
     void testIoOperationRangeArrayOffsetExpected() {
         performAnalysis("rangeArray/IoOperationRangeArrayOffsetExpected.class");
-        BugInstanceMatcher bugTypeMatcherOffset = new BugInstanceMatcherBuilder().bugType("RANGE_ARRAY_OFFSET").build();
-        assertThat(getBugCollection(), containsExactly(2, bugTypeMatcherOffset));
+        assertBugTypeCount("RANGE_ARRAY_OFFSET", 2);
     }
 
     @Test
     void testStringConstructorOk() {
         performAnalysis("rangeArray/StringConstructorOk.class");
-        BugInstanceMatcher bugTypeMatcherLength = new BugInstanceMatcherBuilder().bugType("RANGE_ARRAY_LENGTH").build();
-        BugInstanceMatcher bugTypeMatcherOffset = new BugInstanceMatcherBuilder().bugType("RANGE_ARRAY_OFFSET").build();
-        assertThat(getBugCollection(), containsExactly(0, bugTypeMatcherLength));
-        assertThat(getBugCollection(), containsExactly(0, bugTypeMatcherOffset));
+        assertNoBugType("RANGE_ARRAY_LENGTH");
+        assertNoBugType("RANGE_ARRAY_OFFSET");
     }
 
     @Test
     void testStringConstructorRangeArrayLengthExpected() {
         performAnalysis("rangeArray/StringConstructorRangeArrayLengthExpected.class");
-        BugInstanceMatcher bugTypeMatcherLength = new BugInstanceMatcherBuilder().bugType("RANGE_ARRAY_LENGTH").build();
-        assertThat(getBugCollection(), containsExactly(5, bugTypeMatcherLength));
+        assertBugTypeCount("RANGE_ARRAY_LENGTH", 5);
     }
 
     @Test
     void testStringConstructorRangeArrayOffsetExpected() {
         performAnalysis("rangeArray/StringConstructorRangeArrayOffsetExpected.class");
-        BugInstanceMatcher bugTypeMatcherOffset = new BugInstanceMatcherBuilder().bugType("RANGE_ARRAY_OFFSET").build();
-        assertThat(getBugCollection(), containsExactly(2, bugTypeMatcherOffset));
+        assertBugTypeCount("RANGE_ARRAY_OFFSET", 2);
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue603Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue603Test.java
@@ -18,14 +18,8 @@
  */
 package edu.umd.cs.findbugs.detect;
 
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 import org.junit.jupiter.api.Test;
-
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
 /**
  * @see <a href="https://github.com/spotbugs/spotbugs/issues/603">GitHub issue</a>
@@ -35,9 +29,6 @@ class Issue603Test extends AbstractIntegrationTest {
     @Test
     void testIssue() {
         performAnalysis("ghIssues/Issue603.class");
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType("EI_EXPOSE_REP2")
-                .build();
-        assertThat(getBugCollection(), containsExactly(3, bugTypeMatcher));
+        assertBugTypeCount("EI_EXPOSE_REP2", 3);
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue744Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue744Test.java
@@ -1,13 +1,7 @@
 package edu.umd.cs.findbugs.detect;
 
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 import org.junit.jupiter.api.Test;
-
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
 /**
  * @see <a href="https://github.com/spotbugs/spotbugs/issues/744">GitHub issue #744</a>
@@ -16,9 +10,6 @@ class Issue744Test extends AbstractIntegrationTest {
     @Test
     void testIssue() {
         performAnalysis("ghIssues/Issue744.class");
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType("DM_BOXED_PRIMITIVE_FOR_PARSING")
-                .build();
-        assertThat(getBugCollection(), containsExactly(4, bugTypeMatcher));
+        assertBugTypeCount("DM_BOXED_PRIMITIVE_FOR_PARSING", 4);
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue782Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue782Test.java
@@ -1,12 +1,6 @@
 package edu.umd.cs.findbugs.detect;
 
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.*;
-
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
-
 import org.junit.jupiter.api.Test;
 
 class Issue782Test extends AbstractIntegrationTest {
@@ -17,25 +11,8 @@ class Issue782Test extends AbstractIntegrationTest {
                 "ghIssues/Issue782.class",
                 "ghIssues/Issue782$MyNullable.class");
 
-        assertBugCount("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", 1);
+        assertBugTypeCount("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", 1);
 
         assertBugAtLine("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", 27);
-    }
-
-    private void assertBugCount(String type, int expectedCount) {
-        BugInstanceMatcher bugMatcher = new BugInstanceMatcherBuilder()
-                .bugType(type)
-                .build();
-
-        assertThat(getBugCollection(), containsExactly(expectedCount, bugMatcher));
-    }
-
-    private void assertBugAtLine(String type, int line) {
-        BugInstanceMatcher bugMatcher = new BugInstanceMatcherBuilder()
-                .bugType(type)
-                .atLine(line)
-                .build();
-
-        assertThat(getBugCollection(), containsExactly(1, bugMatcher));
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue79Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue79Test.java
@@ -1,12 +1,8 @@
 package edu.umd.cs.findbugs.detect;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 import org.junit.jupiter.api.Test;
 
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * SpotBugs should remove the ResultSet obligation from all set
@@ -21,7 +17,6 @@ class Issue79Test extends AbstractIntegrationTest {
     @Test
     void testIssue() {
         performAnalysis("ghIssues/Issue79.class");
-        BugInstanceMatcher bugMatcher = new BugInstanceMatcherBuilder().build();
-        assertThat(getBugCollection(), containsExactly(0, bugMatcher));
+        assertNoBugType("OBL_UNSATIFIED_OBLIGATION");
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue872Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue872Test.java
@@ -1,12 +1,7 @@
 package edu.umd.cs.findbugs.detect;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 import org.junit.jupiter.api.Test;
-
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 class Issue872Test extends AbstractIntegrationTest {
 
@@ -15,27 +10,10 @@ class Issue872Test extends AbstractIntegrationTest {
         performAnalysis("ghIssues/Issue872.class",
                 "ghIssues/Issue872$Value.class");
 
-        assertBugCount("RV_RETURN_VALUE_IGNORED", 1);
-        assertBugCount("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT", 1);
+        assertBugTypeCount("RV_RETURN_VALUE_IGNORED", 1);
+        assertBugTypeCount("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT", 1);
 
         assertBugAtLine("RV_RETURN_VALUE_IGNORED", 12);
         assertBugAtLine("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT", 18);
-    }
-
-    private void assertBugCount(String type, int expectedCount) {
-        BugInstanceMatcher bugMatcher = new BugInstanceMatcherBuilder()
-                .bugType(type)
-                .build();
-
-        assertThat(getBugCollection(), containsExactly(expectedCount, bugMatcher));
-    }
-
-    private void assertBugAtLine(String type, int line) {
-        BugInstanceMatcher bugMatcher = new BugInstanceMatcherBuilder()
-                .bugType(type)
-                .atLine(line)
-                .build();
-
-        assertThat(getBugCollection(), containsExactly(1, bugMatcher));
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/MultipleInstantiationsOfSingletonsTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/MultipleInstantiationsOfSingletonsTest.java
@@ -1,14 +1,7 @@
 package edu.umd.cs.findbugs.detect;
 
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 import org.junit.jupiter.api.Test;
-
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 import org.junit.jupiter.api.condition.DisabledOnJre;
 import org.junit.jupiter.api.condition.JRE;
 
@@ -33,14 +26,14 @@ class MultipleInstantiationsOfSingletonsTest extends AbstractIntegrationTest {
         performAnalysis("singletons/InnerChildAndMoreInstance.class",
                 "singletons/InnerChildAndMoreInstance$1.class",
                 "singletons/InnerChildAndMoreInstance$Unknown.class");
-        assertNumOfSINGBugs("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR", 1);
-        assertSINGBug("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR", "InnerChildAndMoreInstance");
+        assertBugTypeCount("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR", 1);
+        assertBugInClass("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR", "InnerChildAndMoreInstance");
 
-        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_CLONEABLE", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_INDIRECTLY_IMPLEMENTS_CLONEABLE", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_CLONE_METHOD", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_SERIALIZABLE", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_GETTER_NOT_SYNCHRONIZED", 0);
+        assertNoBugType("SING_SINGLETON_IMPLEMENTS_CLONEABLE");
+        assertNoBugType("SING_SINGLETON_INDIRECTLY_IMPLEMENTS_CLONEABLE");
+        assertNoBugType("SING_SINGLETON_IMPLEMENTS_CLONE_METHOD");
+        assertNoBugType("SING_SINGLETON_IMPLEMENTS_SERIALIZABLE");
+        assertNoBugType("SING_SINGLETON_GETTER_NOT_SYNCHRONIZED");
     }
 
     @Test
@@ -48,14 +41,14 @@ class MultipleInstantiationsOfSingletonsTest extends AbstractIntegrationTest {
         performAnalysis("singletons/InnerChildAndMoreInstanceReordered.class",
                 "singletons/InnerChildAndMoreInstanceReordered$1.class",
                 "singletons/InnerChildAndMoreInstanceReordered$Unknown.class");
-        assertNumOfSINGBugs("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR", 1);
-        assertSINGBug("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR", "InnerChildAndMoreInstanceReordered");
+        assertBugTypeCount("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR", 1);
+        assertBugInClass("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR", "InnerChildAndMoreInstanceReordered");
 
-        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_CLONEABLE", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_INDIRECTLY_IMPLEMENTS_CLONEABLE", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_CLONE_METHOD", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_SERIALIZABLE", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_GETTER_NOT_SYNCHRONIZED", 0);
+        assertNoBugType("SING_SINGLETON_IMPLEMENTS_CLONEABLE");
+        assertNoBugType("SING_SINGLETON_INDIRECTLY_IMPLEMENTS_CLONEABLE");
+        assertNoBugType("SING_SINGLETON_IMPLEMENTS_CLONE_METHOD");
+        assertNoBugType("SING_SINGLETON_IMPLEMENTS_SERIALIZABLE");
+        assertNoBugType("SING_SINGLETON_GETTER_NOT_SYNCHRONIZED");
     }
 
     @Test
@@ -81,118 +74,118 @@ class MultipleInstantiationsOfSingletonsTest extends AbstractIntegrationTest {
     @Test
     void cloneableSingletonTest() {
         performAnalysis("singletons/CloneableSingleton.class");
-        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_CLONEABLE", 1);
-        assertSINGBug("SING_SINGLETON_IMPLEMENTS_CLONEABLE", "CloneableSingleton", "clone");
+        assertBugTypeCount("SING_SINGLETON_IMPLEMENTS_CLONEABLE", 1);
+        assertBugInMethod("SING_SINGLETON_IMPLEMENTS_CLONEABLE", "CloneableSingleton", "clone");
 
-        assertNumOfSINGBugs("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_INDIRECTLY_IMPLEMENTS_CLONEABLE", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_CLONE_METHOD", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_SERIALIZABLE", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_GETTER_NOT_SYNCHRONIZED", 0);
+        assertNoBugType("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR");
+        assertNoBugType("SING_SINGLETON_INDIRECTLY_IMPLEMENTS_CLONEABLE");
+        assertNoBugType("SING_SINGLETON_IMPLEMENTS_CLONE_METHOD");
+        assertNoBugType("SING_SINGLETON_IMPLEMENTS_SERIALIZABLE");
+        assertNoBugType("SING_SINGLETON_GETTER_NOT_SYNCHRONIZED");
     }
 
     @Test
     void indirectlyCloneableSingletonTest() {
         performAnalysis("singletons/IndirectlyCloneableSingleton.class", "singletons/CloneableClass.class");
-        assertNumOfSINGBugs("SING_SINGLETON_INDIRECTLY_IMPLEMENTS_CLONEABLE", 1);
-        assertSINGBug("SING_SINGLETON_INDIRECTLY_IMPLEMENTS_CLONEABLE", "IndirectlyCloneableSingleton");
+        assertBugTypeCount("SING_SINGLETON_INDIRECTLY_IMPLEMENTS_CLONEABLE", 1);
+        assertBugInClass("SING_SINGLETON_INDIRECTLY_IMPLEMENTS_CLONEABLE", "IndirectlyCloneableSingleton");
 
-        assertNumOfSINGBugs("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_CLONEABLE", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_CLONE_METHOD", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_SERIALIZABLE", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_GETTER_NOT_SYNCHRONIZED", 0);
+        assertNoBugType("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR");
+        assertNoBugType("SING_SINGLETON_IMPLEMENTS_CLONEABLE");
+        assertNoBugType("SING_SINGLETON_IMPLEMENTS_CLONE_METHOD");
+        assertNoBugType("SING_SINGLETON_IMPLEMENTS_SERIALIZABLE");
+        assertNoBugType("SING_SINGLETON_GETTER_NOT_SYNCHRONIZED");
     }
 
     @Test
     void defaultConstructorTest() {
         performAnalysis("singletons/DefaultConstructor.class");
-        assertNumOfSINGBugs("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR", 1);
-        assertSINGBug("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR", "DefaultConstructor");
+        assertBugTypeCount("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR", 1);
+        assertBugInClass("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR", "DefaultConstructor");
 
-        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_CLONEABLE", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_INDIRECTLY_IMPLEMENTS_CLONEABLE", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_CLONE_METHOD", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_SERIALIZABLE", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_GETTER_NOT_SYNCHRONIZED", 0);
+        assertNoBugType("SING_SINGLETON_IMPLEMENTS_CLONEABLE");
+        assertNoBugType("SING_SINGLETON_INDIRECTLY_IMPLEMENTS_CLONEABLE");
+        assertNoBugType("SING_SINGLETON_IMPLEMENTS_CLONE_METHOD");
+        assertNoBugType("SING_SINGLETON_IMPLEMENTS_SERIALIZABLE");
+        assertNoBugType("SING_SINGLETON_GETTER_NOT_SYNCHRONIZED");
     }
 
     @Test
     void protectedConstructorTest() {
         performAnalysis("singletons/ProtectedConstructor.class");
-        assertNumOfSINGBugs("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR", 1);
-        assertSINGBug("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR", "ProtectedConstructor");
+        assertBugTypeCount("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR", 1);
+        assertBugInClass("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR", "ProtectedConstructor");
 
-        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_CLONEABLE", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_INDIRECTLY_IMPLEMENTS_CLONEABLE", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_CLONE_METHOD", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_SERIALIZABLE", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_GETTER_NOT_SYNCHRONIZED", 0);
+        assertNoBugType("SING_SINGLETON_IMPLEMENTS_CLONEABLE");
+        assertNoBugType("SING_SINGLETON_INDIRECTLY_IMPLEMENTS_CLONEABLE");
+        assertNoBugType("SING_SINGLETON_IMPLEMENTS_CLONE_METHOD");
+        assertNoBugType("SING_SINGLETON_IMPLEMENTS_SERIALIZABLE");
+        assertNoBugType("SING_SINGLETON_GETTER_NOT_SYNCHRONIZED");
     }
 
     @Test
     void protectedConstructorStaticInitTest() {
         performAnalysis("singletons/ProtectedConstructorStaticInit.class");
-        assertNumOfSINGBugs("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR", 1);
-        assertSINGBug("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR", "ProtectedConstructorStaticInit");
+        assertBugTypeCount("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR", 1);
+        assertBugInClass("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR", "ProtectedConstructorStaticInit");
 
-        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_CLONEABLE", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_INDIRECTLY_IMPLEMENTS_CLONEABLE", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_CLONE_METHOD", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_SERIALIZABLE", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_GETTER_NOT_SYNCHRONIZED", 0);
+        assertNoBugType("SING_SINGLETON_IMPLEMENTS_CLONEABLE");
+        assertNoBugType("SING_SINGLETON_INDIRECTLY_IMPLEMENTS_CLONEABLE");
+        assertNoBugType("SING_SINGLETON_IMPLEMENTS_CLONE_METHOD");
+        assertNoBugType("SING_SINGLETON_IMPLEMENTS_SERIALIZABLE");
+        assertNoBugType("SING_SINGLETON_GETTER_NOT_SYNCHRONIZED");
     }
 
     @Test
     void protectedConstructorStaticInitReorderedTest() {
         performAnalysis("singletons/ProtectedConstructorStaticInitReordered.class");
-        assertNumOfSINGBugs("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR", 1);
-        assertSINGBug("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR", "ProtectedConstructorStaticInitReordered");
+        assertBugTypeCount("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR", 1);
+        assertBugInClass("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR", "ProtectedConstructorStaticInitReordered");
 
-        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_CLONEABLE", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_INDIRECTLY_IMPLEMENTS_CLONEABLE", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_CLONE_METHOD", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_SERIALIZABLE", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_GETTER_NOT_SYNCHRONIZED", 0);
+        assertNoBugType("SING_SINGLETON_IMPLEMENTS_CLONEABLE");
+        assertNoBugType("SING_SINGLETON_INDIRECTLY_IMPLEMENTS_CLONEABLE");
+        assertNoBugType("SING_SINGLETON_IMPLEMENTS_CLONE_METHOD");
+        assertNoBugType("SING_SINGLETON_IMPLEMENTS_SERIALIZABLE");
+        assertNoBugType("SING_SINGLETON_GETTER_NOT_SYNCHRONIZED");
     }
 
     @Test
     void notCloneableButHasCloneMethodTest() {
         performAnalysis("singletons/NotCloneableButHasCloneMethod.class");
-        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_CLONE_METHOD", 1);
-        assertSINGBug("SING_SINGLETON_IMPLEMENTS_CLONE_METHOD", "NotCloneableButHasCloneMethod", "clone");
+        assertBugTypeCount("SING_SINGLETON_IMPLEMENTS_CLONE_METHOD", 1);
+        assertBugInMethod("SING_SINGLETON_IMPLEMENTS_CLONE_METHOD", "NotCloneableButHasCloneMethod", "clone");
 
-        assertNumOfSINGBugs("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_CLONEABLE", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_INDIRECTLY_IMPLEMENTS_CLONEABLE", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_SERIALIZABLE", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_GETTER_NOT_SYNCHRONIZED", 0);
+        assertNoBugType("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR");
+        assertNoBugType("SING_SINGLETON_IMPLEMENTS_CLONEABLE");
+        assertNoBugType("SING_SINGLETON_INDIRECTLY_IMPLEMENTS_CLONEABLE");
+        assertNoBugType("SING_SINGLETON_IMPLEMENTS_SERIALIZABLE");
+        assertNoBugType("SING_SINGLETON_GETTER_NOT_SYNCHRONIZED");
     }
 
     @Test
     void serializableSingletonTest() {
         performAnalysis("singletons/SerializableSingleton.class");
-        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_SERIALIZABLE", 1);
-        assertSINGBug("SING_SINGLETON_IMPLEMENTS_SERIALIZABLE", "SerializableSingleton");
+        assertBugTypeCount("SING_SINGLETON_IMPLEMENTS_SERIALIZABLE", 1);
+        assertBugInClass("SING_SINGLETON_IMPLEMENTS_SERIALIZABLE", "SerializableSingleton");
 
-        assertNumOfSINGBugs("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_CLONEABLE", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_INDIRECTLY_IMPLEMENTS_CLONEABLE", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_CLONE_METHOD", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_GETTER_NOT_SYNCHRONIZED", 0);
+        assertNoBugType("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR");
+        assertNoBugType("SING_SINGLETON_IMPLEMENTS_CLONEABLE");
+        assertNoBugType("SING_SINGLETON_INDIRECTLY_IMPLEMENTS_CLONEABLE");
+        assertNoBugType("SING_SINGLETON_IMPLEMENTS_CLONE_METHOD");
+        assertNoBugType("SING_SINGLETON_GETTER_NOT_SYNCHRONIZED");
     }
 
     @Test
     void notSynchronizedSingletonTest() {
         performAnalysis("singletons/NotSynchronizedSingleton.class");
-        assertNumOfSINGBugs("SING_SINGLETON_GETTER_NOT_SYNCHRONIZED", 1);
-        assertSINGBug("SING_SINGLETON_GETTER_NOT_SYNCHRONIZED", "NotSynchronizedSingleton", "getInstance");
+        assertBugTypeCount("SING_SINGLETON_GETTER_NOT_SYNCHRONIZED", 1);
+        assertBugInMethod("SING_SINGLETON_GETTER_NOT_SYNCHRONIZED", "NotSynchronizedSingleton", "getInstance");
 
-        assertNumOfSINGBugs("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_CLONEABLE", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_INDIRECTLY_IMPLEMENTS_CLONEABLE", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_CLONE_METHOD", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_SERIALIZABLE", 0);
+        assertNoBugType("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR");
+        assertNoBugType("SING_SINGLETON_IMPLEMENTS_CLONEABLE");
+        assertNoBugType("SING_SINGLETON_INDIRECTLY_IMPLEMENTS_CLONEABLE");
+        assertNoBugType("SING_SINGLETON_IMPLEMENTS_CLONE_METHOD");
+        assertNoBugType("SING_SINGLETON_IMPLEMENTS_SERIALIZABLE");
     }
 
     @Test
@@ -200,14 +193,14 @@ class MultipleInstantiationsOfSingletonsTest extends AbstractIntegrationTest {
         performAnalysis("singletons/InappropriateSynchronization.class");
         // now cannot detect synchronization bug
         // because of the using of a monitor inside function
-        assertNumOfSINGBugs("SING_SINGLETON_GETTER_NOT_SYNCHRONIZED", 0);
+        assertBugTypeCount("SING_SINGLETON_GETTER_NOT_SYNCHRONIZED", 0);
         //assertSINGBug("SING_SINGLETON_GETTER_NOT_SYNCHRONIZED", "InappropriateSynchronization", "getInstance");
 
-        assertNumOfSINGBugs("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_CLONEABLE", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_INDIRECTLY_IMPLEMENTS_CLONEABLE", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_CLONE_METHOD", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_SERIALIZABLE", 0);
+        assertNoBugType("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR");
+        assertNoBugType("SING_SINGLETON_IMPLEMENTS_CLONEABLE");
+        assertNoBugType("SING_SINGLETON_INDIRECTLY_IMPLEMENTS_CLONEABLE");
+        assertNoBugType("SING_SINGLETON_IMPLEMENTS_CLONE_METHOD");
+        assertNoBugType("SING_SINGLETON_IMPLEMENTS_SERIALIZABLE");
     }
 
     @Test
@@ -268,27 +261,27 @@ class MultipleInstantiationsOfSingletonsTest extends AbstractIntegrationTest {
     @Test
     void multipleNonPrivateConstructorsTest() {
         performAnalysis("singletons/MultipleNonPrivateConstructors.class");
-        assertNumOfSINGBugs("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR", 1);
-        assertSINGBug("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR", "MultipleNonPrivateConstructors");
+        assertBugTypeCount("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR", 1);
+        assertBugInClass("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR", "MultipleNonPrivateConstructors");
 
-        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_CLONEABLE", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_INDIRECTLY_IMPLEMENTS_CLONEABLE", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_CLONE_METHOD", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_SERIALIZABLE", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_GETTER_NOT_SYNCHRONIZED", 0);
+        assertNoBugType("SING_SINGLETON_IMPLEMENTS_CLONEABLE");
+        assertNoBugType("SING_SINGLETON_INDIRECTLY_IMPLEMENTS_CLONEABLE");
+        assertNoBugType("SING_SINGLETON_IMPLEMENTS_CLONE_METHOD");
+        assertNoBugType("SING_SINGLETON_IMPLEMENTS_SERIALIZABLE");
+        assertNoBugType("SING_SINGLETON_GETTER_NOT_SYNCHRONIZED");
     }
 
     @Test
     void multipleNonPrivateConstructorsTest2() {
         performAnalysis("singletons/MultipleNonPrivateConstructors2.class");
-        assertNumOfSINGBugs("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR", 1);
-        assertSINGBug("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR", "MultipleNonPrivateConstructors2");
+        assertBugTypeCount("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR", 1);
+        assertBugInClass("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR", "MultipleNonPrivateConstructors2");
 
-        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_CLONEABLE", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_INDIRECTLY_IMPLEMENTS_CLONEABLE", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_CLONE_METHOD", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_SERIALIZABLE", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_GETTER_NOT_SYNCHRONIZED", 0);
+        assertNoBugType("SING_SINGLETON_IMPLEMENTS_CLONEABLE");
+        assertNoBugType("SING_SINGLETON_INDIRECTLY_IMPLEMENTS_CLONEABLE");
+        assertNoBugType("SING_SINGLETON_IMPLEMENTS_CLONE_METHOD");
+        assertNoBugType("SING_SINGLETON_IMPLEMENTS_SERIALIZABLE");
+        assertNoBugType("SING_SINGLETON_GETTER_NOT_SYNCHRONIZED");
     }
 
     @Test
@@ -299,35 +292,11 @@ class MultipleInstantiationsOfSingletonsTest extends AbstractIntegrationTest {
     }
 
     private void assertNoBugs() {
-        assertNumOfSINGBugs("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_CLONEABLE", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_INDIRECTLY_IMPLEMENTS_CLONEABLE", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_CLONE_METHOD", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_IMPLEMENTS_SERIALIZABLE", 0);
-        assertNumOfSINGBugs("SING_SINGLETON_GETTER_NOT_SYNCHRONIZED", 0);
-    }
-
-    private void assertNumOfSINGBugs(String bugType, int num) {
-        final BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType(bugType)
-                .build();
-        assertThat(getBugCollection(), containsExactly(num, bugTypeMatcher));
-    }
-
-    private void assertSINGBug(String bugType, String className) {
-        final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
-                .bugType(bugType)
-                .inClass(className)
-                .build();
-        assertThat(getBugCollection(), hasItem(bugInstanceMatcher));
-    }
-
-    private void assertSINGBug(String bugType, String className, String method) {
-        final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
-                .bugType(bugType)
-                .inClass(className)
-                .inMethod(method)
-                .build();
-        assertThat(getBugCollection(), hasItem(bugInstanceMatcher));
+        assertNoBugType("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR");
+        assertNoBugType("SING_SINGLETON_IMPLEMENTS_CLONEABLE");
+        assertNoBugType("SING_SINGLETON_INDIRECTLY_IMPLEMENTS_CLONEABLE");
+        assertNoBugType("SING_SINGLETON_IMPLEMENTS_CLONE_METHOD");
+        assertNoBugType("SING_SINGLETON_IMPLEMENTS_SERIALIZABLE");
+        assertNoBugType("SING_SINGLETON_GETTER_NOT_SYNCHRONIZED");
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/OverridingMethodMustInvokeSuperTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/OverridingMethodMustInvokeSuperTest.java
@@ -1,12 +1,7 @@
 package edu.umd.cs.findbugs.detect;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 import org.junit.jupiter.api.Test;
-
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 class OverridingMethodMustInvokeSuperTest extends AbstractIntegrationTest {
 
@@ -17,8 +12,6 @@ class OverridingMethodMustInvokeSuperTest extends AbstractIntegrationTest {
                 "NeedsCallOfSuper$DerivedClass.class",
                 "NeedsCallOfSuper$ConcreteClass.class",
                 "NeedsCallOfSuper$GenericClass.class");
-        BugInstanceMatcher bugMatcher = new BugInstanceMatcherBuilder().bugType("OVERRIDING_METHODS_MUST_INVOKE_SUPER").build();
-        assertThat(getBugCollection(), containsExactly(1, bugMatcher));
+        assertBugTypeCount("OVERRIDING_METHODS_MUST_INVOKE_SUPER", 1);
     }
-
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/PreconditionsCheckNotNullCanIgnoreReturnValueTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/PreconditionsCheckNotNullCanIgnoreReturnValueTest.java
@@ -3,16 +3,12 @@ package edu.umd.cs.findbugs.detect;
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.Matchers.emptyIterable;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 class PreconditionsCheckNotNullCanIgnoreReturnValueTest extends AbstractIntegrationTest {
 
     @Test
     void testDoNotWarnOnCanIgnoreReturnValue() {
         performAnalysis("bugPatterns/RV_RETURN_VALUE_IGNORED_Guava_Preconditions.class");
-        assertThat(getBugCollection(), is(emptyIterable()));
+        assertNoBugType("RV_RETURN_VALUE_IGNORED");
     }
 
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/PreventOverwriteOfExternalizableObjectTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/PreventOverwriteOfExternalizableObjectTest.java
@@ -2,20 +2,15 @@ package edu.umd.cs.findbugs.detect;
 
 import org.junit.jupiter.api.Test;
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
-
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItem;
 
 class PreventOverwriteOfExternalizableObjectTest extends AbstractIntegrationTest {
+    private static final String BUG_TYPE = "SE_PREVENT_EXT_OBJ_OVERWRITE";
 
     @Test
     void testBadReadExternal() {
         performAnalysis("externalizable/BadExternalizableTest.class");
 
-        assertNumOfBugs(2);
+        assertBugTypeCount(BUG_TYPE, 2);
         assertBug("BadExternalizableTest", 20);
         assertBug("BadExternalizableTest", 21);
     }
@@ -24,7 +19,7 @@ class PreventOverwriteOfExternalizableObjectTest extends AbstractIntegrationTest
     void testBadReadExternal2() {
         performAnalysis("externalizable/BadExternalizableTest2.class");
 
-        assertNumOfBugs(1);
+        assertBugTypeCount(BUG_TYPE, 1);
         assertBug("BadExternalizableTest2", 28);
     }
 
@@ -32,7 +27,7 @@ class PreventOverwriteOfExternalizableObjectTest extends AbstractIntegrationTest
     void testBadReadExternal3() {
         performAnalysis("externalizable/BadExternalizableTest3.class");
 
-        assertNumOfBugs(1);
+        assertBugTypeCount(BUG_TYPE, 1);
         assertBug("BadExternalizableTest3", 21);
     }
 
@@ -40,7 +35,7 @@ class PreventOverwriteOfExternalizableObjectTest extends AbstractIntegrationTest
     void testBadReadExternal4() {
         performAnalysis("externalizable/BadExternalizableTest4.class");
 
-        assertNumOfBugs(1);
+        assertBugTypeCount(BUG_TYPE, 1);
         assertBug("BadExternalizableTest4", 28);
     }
 
@@ -48,7 +43,7 @@ class PreventOverwriteOfExternalizableObjectTest extends AbstractIntegrationTest
     void testBadReadExternal5() {
         performAnalysis("externalizable/BadExternalizableTest5.class");
 
-        assertNumOfBugs(2);
+        assertBugTypeCount(BUG_TYPE, 2);
         assertBug("BadExternalizableTest5", 22);
         assertBug("BadExternalizableTest5", 23);
     }
@@ -57,7 +52,7 @@ class PreventOverwriteOfExternalizableObjectTest extends AbstractIntegrationTest
     void testBadReadExternal6() {
         performAnalysis("externalizable/BadExternalizableTest6.class");
 
-        assertNumOfBugs(2);
+        assertBugTypeCount(BUG_TYPE, 2);
         assertBug("BadExternalizableTest6", 22);
         assertBug("BadExternalizableTest6", 23);
     }
@@ -66,7 +61,7 @@ class PreventOverwriteOfExternalizableObjectTest extends AbstractIntegrationTest
     void testBadReadExternal7() {
         performAnalysis("externalizable/BadExternalizableTest7.class");
 
-        assertNumOfBugs(2);
+        assertBugTypeCount(BUG_TYPE, 2);
         assertBug("BadExternalizableTest7", 22);
         assertBug("BadExternalizableTest7", 23);
     }
@@ -74,64 +69,52 @@ class PreventOverwriteOfExternalizableObjectTest extends AbstractIntegrationTest
     @Test
     void testGoodReadExternal() {
         performAnalysis("externalizable/GoodExternalizableTest.class");
-        assertNumOfBugs(0);
+        assertNoBugType(BUG_TYPE);
     }
 
     @Test
     void testGoodReadExternal2() {
         performAnalysis("externalizable/GoodExternalizableTest2.class");
-        assertNumOfBugs(0);
+        assertNoBugType(BUG_TYPE);
     }
 
     @Test
     void testGoodReadExternal3() {
         performAnalysis("externalizable/GoodExternalizableTest3.class");
-        assertNumOfBugs(0);
+        assertNoBugType(BUG_TYPE);
     }
 
     @Test
     void testGoodReadExternal4() {
         performAnalysis("externalizable/GoodExternalizableTest4.class");
-        assertNumOfBugs(0);
+        assertNoBugType(BUG_TYPE);
     }
 
     @Test
     void testGoodReadExternal5() {
         performAnalysis("externalizable/GoodExternalizableTest5.class");
-        assertNumOfBugs(0);
+        assertNoBugType(BUG_TYPE);
     }
 
     @Test
     void testGoodReadExternal6() {
         performAnalysis("externalizable/GoodExternalizableTest6.class");
-        assertNumOfBugs(0);
+        assertNoBugType(BUG_TYPE);
     }
 
     @Test
     void testGoodReadExternal7() {
         performAnalysis("externalizable/GoodExternalizableTest7.class");
-        assertNumOfBugs(0);
+        assertNoBugType(BUG_TYPE);
     }
 
     @Test
     void testGoodReadExternal8() {
         performAnalysis("externalizable/GoodExternalizableTest8.class");
-        assertNumOfBugs(0);
-    }
-
-    private void assertNumOfBugs(int num) {
-        final BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType("SE_PREVENT_EXT_OBJ_OVERWRITE").build();
-        assertThat(getBugCollection(), containsExactly(num, bugTypeMatcher));
+        assertNoBugType(BUG_TYPE);
     }
 
     private void assertBug(String className, int line) {
-        final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
-                .bugType("SE_PREVENT_EXT_OBJ_OVERWRITE")
-                .inClass(className)
-                .inMethod("readExternal")
-                .atLine(line)
-                .build();
-        assertThat(getBugCollection(), hasItem(bugInstanceMatcher));
+        assertBugInMethodAtLine(BUG_TYPE, className, "readExternal", line);
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/RegressionIdeas2008091415Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/RegressionIdeas2008091415Test.java
@@ -1,30 +1,15 @@
 package edu.umd.cs.findbugs.detect;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 import org.junit.jupiter.api.Test;
-
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 class RegressionIdeas2008091415Test extends AbstractIntegrationTest {
     @Test
     void test() {
         performAnalysis("bugIdeas/Ideas_2008_09_14.class", "bugIdeas/Ideas_2008_09_15.class");
 
-        assertBugInMethod("Ideas_2008_09_14", "foo", 6);
-        assertBugInMethod("Ideas_2008_09_15", "alternativesToInstanceof", 6);
-        assertBugInMethod("Ideas_2008_09_15", "alternativesToInstanceofAndCheckedCast", 12);
-    }
-
-    private void assertBugInMethod(String className, String method, int line) {
-        final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
-                .bugType("BC_IMPOSSIBLE_CAST")
-                .inClass(className)
-                .inMethod(method)
-                .atLine(line)
-                .build();
-        assertThat(getBugCollection(), containsExactly(1, bugInstanceMatcher));
+        assertBugInMethodAtLine("BC_IMPOSSIBLE_CAST", "Ideas_2008_09_14", "foo", 6);
+        assertBugInMethodAtLine("BC_IMPOSSIBLE_CAST", "Ideas_2008_09_15", "alternativesToInstanceof", 6);
+        assertBugInMethodAtLine("BC_IMPOSSIBLE_CAST", "Ideas_2008_09_15", "alternativesToInstanceofAndCheckedCast", 12);
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/RegressionIdeas20110722Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/RegressionIdeas20110722Test.java
@@ -1,14 +1,8 @@
 package edu.umd.cs.findbugs.detect;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItem;
 
 class RegressionIdeas20110722Test extends AbstractIntegrationTest {
 
@@ -18,57 +12,25 @@ class RegressionIdeas20110722Test extends AbstractIntegrationTest {
     void testArgumentAssertions() {
         performAnalysis("bugIdeas/Ideas_2011_07_22.class");
 
-        assertNumOfBugs("NP_NULL_ON_SOME_PATH", 0);
-        assertNumOfBugs("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE", 4);
-        assertNumOfBugs("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE", 2);
+        assertNoBugType("NP_NULL_ON_SOME_PATH");
+        assertBugTypeCount("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE", 4);
+        assertBugTypeCount("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE", 2);
 
-        assertNoNpBugInMethod("getHashCode");
-        assertNoNpBugInMethod("getHashCode1");
-        assertNoNpBugInMethod("getHashCode2");
-        assertNoNpBugInMethod("getHashCode3");
+        assertNoBugInMethod("NP_NULL_ON_SOME_PATH", "Ideas_2011_07_22", "getHashCode");
+        assertNoBugInMethod("NP_NULL_ON_SOME_PATH", "Ideas_2011_07_22", "getHashCode1");
+        assertNoBugInMethod("NP_NULL_ON_SOME_PATH", "Ideas_2011_07_22", "getHashCode2");
+        assertNoBugInMethod("NP_NULL_ON_SOME_PATH", "Ideas_2011_07_22", "getHashCode3");
         assertRCNBug("getHashCode3", "x", 34);
-        assertNoNpBugInMethod("getHashCode4");
+        assertNoBugInMethod("NP_NULL_ON_SOME_PATH", "Ideas_2011_07_22", "getHashCode4");
         assertRCNBug("getHashCode4", "x", 41);
-        assertNoNpBugInMethod("getHashCode5");
+        assertNoBugInMethod("NP_NULL_ON_SOME_PATH", "Ideas_2011_07_22", "getHashCode5");
         assertRCNBug("getHashCode5", "x", 48);
         assertRCNBug("getHashCode6", "x", 55);
-        assertNpParamBug("getHashCode6", "x");
-        assertNpParamBug("getHashCode7", "x");
-    }
-
-    private void assertNumOfBugs(String error, int num) {
-        final BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType(error).build();
-        assertThat(getBugCollection(), containsExactly(num, bugTypeMatcher));
-    }
-
-    private void assertNoNpBugInMethod(String method) {
-        final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
-                .bugType("NP_NULL_ON_SOME_PATH")
-                .inClass("Ideas_2011_07_22")
-                .inMethod(method)
-                .build();
-        assertThat(getBugCollection(), containsExactly(0, bugInstanceMatcher));
+        assertBugInMethodAtVariable("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE", "Ideas_2011_07_22", "getHashCode6", "x");
+        assertBugInMethodAtVariable("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE", "Ideas_2011_07_22", "getHashCode7", "x");
     }
 
     private void assertRCNBug(String method, String variable, int line) {
-        final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
-                .bugType("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
-                .inClass("Ideas_2011_07_22")
-                .inMethod(method)
-                .atVariable(variable)
-                .atLine(line)
-                .build();
-        assertThat(getBugCollection(), hasItem(bugInstanceMatcher));
-    }
-
-    private void assertNpParamBug(String method, String variable) {
-        final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
-                .bugType("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
-                .inClass("Ideas_2011_07_22")
-                .inMethod(method)
-                .atVariable(variable)
-                .build();
-        assertThat(getBugCollection(), hasItem(bugInstanceMatcher));
+        assertBugAtVar("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE", "Ideas_2011_07_22", method, variable, line);
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/RegressionIdeas20111219Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/RegressionIdeas20111219Test.java
@@ -1,13 +1,7 @@
 package edu.umd.cs.findbugs.detect;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 import org.junit.jupiter.api.Test;
-
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItem;
 
 class RegressionIdeas20111219Test extends AbstractIntegrationTest {
     @Test
@@ -15,16 +9,16 @@ class RegressionIdeas20111219Test extends AbstractIntegrationTest {
         performAnalysis("bugIdeas/Ideas_2011_12_19.class");
 
         assertNoNpBugInMethod("f");
-        assertBugInMethod("NP_ALWAYS_NULL", "f2", 21);
-        assertBugInMethod("NP_LOAD_OF_KNOWN_NULL_VALUE", "f2", 21);
+        assertBugInMethodAtLine("NP_ALWAYS_NULL", "Ideas_2011_12_19", "f2", 21);
+        assertBugInMethodAtLine("NP_LOAD_OF_KNOWN_NULL_VALUE", "Ideas_2011_12_19", "f2", 21);
         assertNoNpBugInMethod("f3");
         assertNoNpBugInMethod("f4");
-        assertBugInMethod("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", "f5a", 48);
+        assertBugInMethodAtLine("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", "Ideas_2011_12_19", "f5a", 48);
         assertNoNpBugInMethod("f5b");
         assertNoNpBugInMethod("f5c");
         assertNoNpBugInMethod("f5e");
         assertNoNpBugInMethod("f5f");
-        assertBugInMethod("NP_NULL_ON_SOME_PATH", "f5g", 81);
+        assertBugInMethodAtLine("NP_NULL_ON_SOME_PATH", "Ideas_2011_12_19", "f5g", 81);
     }
 
     private void assertNoNpBugInMethod(String method) {
@@ -44,22 +38,7 @@ class RegressionIdeas20111219Test extends AbstractIntegrationTest {
             "NP_METHOD_PARAMETER_RELAXING_ANNOTATION",
         };
         for (String bugtype : bugtypes) {
-            final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
-                    .bugType(bugtype)
-                    .inClass("Bug3277814")
-                    .inMethod(method)
-                    .build();
-            assertThat(getBugCollection(), containsExactly(0, bugInstanceMatcher));
+            assertNoBugInMethod(bugtype, "Bug3277814", method);
         }
-    }
-
-    private void assertBugInMethod(String bugtype, String method, int line) {
-        final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
-                .bugType(bugtype)
-                .inClass("Ideas_2011_12_19")
-                .inMethod(method)
-                .atLine(line)
-                .build();
-        assertThat(getBugCollection(), hasItem(bugInstanceMatcher));
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/SynchronizationOnSharedBuiltinConstantTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/SynchronizationOnSharedBuiltinConstantTest.java
@@ -1,84 +1,50 @@
 package edu.umd.cs.findbugs.detect;
 
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 import org.junit.jupiter.api.Test;
-
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
 class SynchronizationOnSharedBuiltinConstantTest extends AbstractIntegrationTest {
 
     @Test
     void lockOn_noncompliantBooleanLockObject() {
         performAnalysis("synchronizationOnSharedBuiltinConstant/SynchronizationOnSharedBuiltinConstantBad.class");
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType("DL_SYNCHRONIZATION_ON_BOOLEAN")
-                .inMethod("noncompliantBooleanLockObject")
-                .build();
-        assertThat(getBugCollection(), containsExactly(1, bugTypeMatcher));
+        assertBugInMethod("DL_SYNCHRONIZATION_ON_BOOLEAN", "SynchronizationOnSharedBuiltinConstantBad", "noncompliantBooleanLockObject");
     }
 
     @Test
     void lockOn_noncompliantBoxedPrimitive() {
         performAnalysis("synchronizationOnSharedBuiltinConstant/SynchronizationOnSharedBuiltinConstantBad.class");
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType("DL_SYNCHRONIZATION_ON_BOXED_PRIMITIVE")
-                .inMethod("noncompliantBoxedPrimitive")
-                .build();
-        assertThat(getBugCollection(), containsExactly(1, bugTypeMatcher));
+        assertBugInMethod("DL_SYNCHRONIZATION_ON_BOXED_PRIMITIVE", "SynchronizationOnSharedBuiltinConstantBad", "noncompliantBoxedPrimitive");
     }
 
     @Test
     void lockOn_compliantInteger() {
         performAnalysis("synchronizationOnSharedBuiltinConstant/SynchronizationOnSharedBuiltinConstantGood.class");
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType("DL_SYNCHRONIZATION_ON_BOXED_PRIMITIVE")
-                .inMethod("compliantInteger")
-                .build();
-        assertThat(getBugCollection(), containsExactly(0, bugTypeMatcher));
+        assertNoBugInMethod("DL_SYNCHRONIZATION_ON_BOXED_PRIMITIVE", "SynchronizationOnSharedBuiltinConstantGood", "compliantInteger");
     }
 
     @Test
     void lockOn_noncompliantInternedStringObject() {
         performAnalysis("synchronizationOnSharedBuiltinConstant/SynchronizationOnSharedBuiltinConstantBad.class");
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType("DL_SYNCHRONIZATION_ON_INTERNED_STRING")
-                .inMethod("noncompliantInternedStringObject")
-                .build();
-        assertThat(getBugCollection(), containsExactly(1, bugTypeMatcher));
+        assertBugInMethod("DL_SYNCHRONIZATION_ON_INTERNED_STRING", "SynchronizationOnSharedBuiltinConstantBad", "noncompliantInternedStringObject");
     }
 
     @Test
     void lockOn_noncompliantStringLiteral() {
         performAnalysis("synchronizationOnSharedBuiltinConstant/SynchronizationOnSharedBuiltinConstantBad.class");
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType("DL_SYNCHRONIZATION_ON_SHARED_CONSTANT")
-                .inMethod("noncompliantStringLiteral")
-                .build();
-        assertThat(getBugCollection(), containsExactly(1, bugTypeMatcher));
+        assertBugInMethod("DL_SYNCHRONIZATION_ON_SHARED_CONSTANT", "SynchronizationOnSharedBuiltinConstantBad", "noncompliantStringLiteral");
     }
 
     @Test
     void lockOn_compliantStringInstance() {
         performAnalysis("synchronizationOnSharedBuiltinConstant/SynchronizationOnSharedBuiltinConstantGood.class");
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType("DL_SYNCHRONIZATION_ON_SHARED_CONSTANT")
-                .inMethod("compliantStringInstance")
-                .build();
-        assertThat(getBugCollection(), containsExactly(0, bugTypeMatcher));
+        assertNoBugInMethod("DL_SYNCHRONIZATION_ON_SHARED_CONSTANT", "SynchronizationOnSharedBuiltinConstantGood", "compliantStringInstance");
     }
 
     @Test
     void lockOn_compliantPrivateFinalLockObject() {
         performAnalysis("synchronizationOnSharedBuiltinConstant/SynchronizationOnSharedBuiltinConstantGood.class");
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType("DL_SYNCHRONIZATION_ON_BOXED_PRIMITIVE")
-                .inMethod("compliantPrivateFinalLockObject")
-                .build();
-        assertThat(getBugCollection(), containsExactly(0, bugTypeMatcher));
+        assertNoBugInMethod("DL_SYNCHRONIZATION_ON_BOXED_PRIMITIVE", "SynchronizationOnSharedBuiltinConstantGood", "compliantPrivateFinalLockObject");
     }
 
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/TestASMTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/TestASMTest.java
@@ -1,13 +1,7 @@
 package edu.umd.cs.findbugs.detect;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 import org.junit.jupiter.api.Test;
-
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItem;
 
 class TestASMTest extends AbstractIntegrationTest {
 
@@ -15,52 +9,19 @@ class TestASMTest extends AbstractIntegrationTest {
     void testASM() {
         performAnalysis("TestASM.class");
 
-        assertNumOfBugs(1, "NM_METHOD_NAMING_CONVENTION");
-        assertNumOfBugs(6, "NM_FIELD_NAMING_CONVENTION");
+        assertBugTypeCount("NM_METHOD_NAMING_CONVENTION", 1);
+        assertBugTypeCount("NM_FIELD_NAMING_CONVENTION", 6);
         // It is reported both by TestASM and IDivResultCastToDouble
-        assertNumOfBugs(2, "ICAST_INT_CAST_TO_DOUBLE_PASSED_TO_CEIL");
+        assertBugTypeCount("ICAST_INT_CAST_TO_DOUBLE_PASSED_TO_CEIL", 2);
 
-        assertMethodNamingBug("BadMethodName");
-        assertFieldNamingBug("badFieldNamePublicStaticFinal");
-        assertFieldNamingBug("BadFieldNamePublicStatic");
-        assertFieldNamingBug("BadFieldNamePublic");
-        assertFieldNamingBug("BadFieldNameProtectedStatic");
-        assertFieldNamingBug("BadFieldNameProtected");
-        assertFieldNamingBug("BadFieldNamePrivate");
-        assertMethodNamingBug("BadMethodName");
-        assertCastBug("BadMethodName");
-    }
-
-    private void assertNumOfBugs(int num, String bugType) {
-        final BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType(bugType).build();
-        assertThat(getBugCollection(), containsExactly(num, bugTypeMatcher));
-    }
-
-    private void assertMethodNamingBug(String method) {
-        final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
-                .bugType("NM_METHOD_NAMING_CONVENTION")
-                .inClass("TestASM")
-                .inMethod(method)
-                .build();
-        assertThat(getBugCollection(), hasItem(bugInstanceMatcher));
-    }
-
-    private void assertFieldNamingBug(String field) {
-        final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
-                .bugType("NM_FIELD_NAMING_CONVENTION")
-                .inClass("TestASM")
-                .atField(field)
-                .build();
-        assertThat(getBugCollection(), hasItem(bugInstanceMatcher));
-    }
-
-    private void assertCastBug(String method) {
-        final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
-                .bugType("ICAST_INT_CAST_TO_DOUBLE_PASSED_TO_CEIL")
-                .inClass("TestASM")
-                .inMethod(method)
-                .build();
-        assertThat(getBugCollection(), hasItem(bugInstanceMatcher));
+        assertBugInMethod("NM_METHOD_NAMING_CONVENTION", "TestASM", "BadMethodName");
+        assertBugAtField("NM_FIELD_NAMING_CONVENTION", "TestASM", "badFieldNamePublicStaticFinal");
+        assertBugAtField("NM_FIELD_NAMING_CONVENTION", "TestASM", "BadFieldNamePublicStatic");
+        assertBugAtField("NM_FIELD_NAMING_CONVENTION", "TestASM", "BadFieldNamePublic");
+        assertBugAtField("NM_FIELD_NAMING_CONVENTION", "TestASM", "BadFieldNameProtectedStatic");
+        assertBugAtField("NM_FIELD_NAMING_CONVENTION", "TestASM", "BadFieldNameProtected");
+        assertBugAtField("NM_FIELD_NAMING_CONVENTION", "TestASM", "BadFieldNamePrivate");
+        assertBugInMethod("NM_METHOD_NAMING_CONVENTION", "TestASM", "BadMethodName");
+        assertBugInMethod("ICAST_INT_CAST_TO_DOUBLE_PASSED_TO_CEIL", "TestASM", "BadMethodName");
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/ThrowingExceptionsTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/ThrowingExceptionsTest.java
@@ -1,14 +1,7 @@
 package edu.umd.cs.findbugs.detect;
 
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 import org.junit.jupiter.api.Test;
-
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
 class ThrowingExceptionsTest extends AbstractIntegrationTest {
 
@@ -17,37 +10,17 @@ class ThrowingExceptionsTest extends AbstractIntegrationTest {
         performAnalysis("MethodsThrowingExceptions.class", "MethodsThrowingExceptions$ThrowThrowable.class",
                 "MethodsThrowingExceptions$1.class", "MethodsThrowingExceptions$2.class");
 
-        assertNumOfTHROWSBugs("THROWS_METHOD_THROWS_RUNTIMEEXCEPTION", 1);
-        assertNumOfTHROWSBugs("THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION", 1);
-        assertNumOfTHROWSBugs("THROWS_METHOD_THROWS_CLAUSE_THROWABLE", 2);
+        assertBugTypeCount("THROWS_METHOD_THROWS_RUNTIMEEXCEPTION", 1);
+        assertBugTypeCount("THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION", 1);
+        assertBugTypeCount("THROWS_METHOD_THROWS_CLAUSE_THROWABLE", 2);
 
-        assertNumOfTHROWSBugs("THROWS_METHOD_THROWS_RUNTIMEEXCEPTION", "MethodsThrowingExceptions", 1, "isCapitalizedThrowingRuntimeException");
-        assertNumOfTHROWSBugs("THROWS_METHOD_THROWS_RUNTIMEEXCEPTION", "MethodsThrowingExceptions", 0, "isCapitalizedThrowingSpecializedException");
+        assertBugInMethod("THROWS_METHOD_THROWS_RUNTIMEEXCEPTION", "MethodsThrowingExceptions", "isCapitalizedThrowingRuntimeException");
+        assertNoBugInMethod("THROWS_METHOD_THROWS_RUNTIMEEXCEPTION", "MethodsThrowingExceptions", "isCapitalizedThrowingSpecializedException");
 
-        assertNumOfTHROWSBugs("THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION", "MethodsThrowingExceptions", 1, "methodThrowingBasicException");
-        assertNumOfTHROWSBugs("THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION", "MethodsThrowingExceptions", 0, "methodThrowingIOException");
+        assertBugInMethod("THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION", "MethodsThrowingExceptions", "methodThrowingBasicException");
+        assertNoBugInMethod("THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION", "MethodsThrowingExceptions", "methodThrowingIOException");
 
-        assertNumOfTHROWSBugs("THROWS_METHOD_THROWS_CLAUSE_THROWABLE", "MethodsThrowingExceptions", 1, "methodThrowingThrowable");
-        assertNumOfTHROWSBugs("THROWS_METHOD_THROWS_CLAUSE_THROWABLE", "MethodsThrowingExceptions$ThrowThrowable", 1, "run");
-    }
-
-    @SuppressWarnings("SameParameterValue")
-    private void assertNumOfTHROWSBugs(String bugType, int num) {
-        final BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType(bugType)
-                .build();
-        assertThat(getBugCollection(), containsExactly(num, bugTypeMatcher));
-    }
-
-    private void assertNumOfTHROWSBugs(String bugType, String className, int num, String method) {
-        final BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType(bugType)
-                .inClass(className)
-                .inMethod(method)
-                .build();
-        if (num > 0) {
-            assertThat(getBugCollection(), hasItem(bugTypeMatcher));
-        }
-        assertThat(getBugCollection(), containsExactly(num, bugTypeMatcher));
+        assertBugInMethod("THROWS_METHOD_THROWS_CLAUSE_THROWABLE", "MethodsThrowingExceptions", "methodThrowingThrowable");
+        assertBugInMethod("THROWS_METHOD_THROWS_CLAUSE_THROWABLE", "MethodsThrowingExceptions$ThrowThrowable", "run");
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/UnnecessaryEnvUsageTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/UnnecessaryEnvUsageTest.java
@@ -1,65 +1,43 @@
 package edu.umd.cs.findbugs.detect;
 
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItem;
-
 import org.junit.jupiter.api.Test;
-
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
 class UnnecessaryEnvUsageTest extends AbstractIntegrationTest {
     @Test
     void testingEnvUsages() {
+        final String bugType = "ENV_USE_PROPERTY_INSTEAD_OF_ENV";
+        final String className = "UnnecessaryEnvUsage";
+
         performAnalysis("UnnecessaryEnvUsage.class");
-        assertBug(23);
-        assertBug("replaceableEnvUsage", 5);
-        assertBug("replaceableEnvUsage", 6);
-        assertBug("replaceableEnvUsage", 7);
-        assertBug("replaceableEnvUsage", 8);
-        assertBug("replaceableEnvUsage", 9);
-        assertBug("replaceableEnvUsage", 10);
-        assertBug("replaceableEnvUsage", 11);
-        assertBug("replaceableEnvUsage", 12);
-        assertBug("replaceableEnvUsage", 13);
-        assertBug("replaceableEnvUsage", 14);
-        assertBug("replaceableEnvUsage", 15);
-        assertBug("replaceableEnvUsage", 16);
+        assertBugTypeCount(bugType, 23);
+        assertBugInMethodAtLine(bugType, className, "replaceableEnvUsage", 5);
+        assertBugInMethodAtLine(bugType, className, "replaceableEnvUsage", 6);
+        assertBugInMethodAtLine(bugType, className, "replaceableEnvUsage", 7);
+        assertBugInMethodAtLine(bugType, className, "replaceableEnvUsage", 8);
+        assertBugInMethodAtLine(bugType, className, "replaceableEnvUsage", 9);
+        assertBugInMethodAtLine(bugType, className, "replaceableEnvUsage", 10);
+        assertBugInMethodAtLine(bugType, className, "replaceableEnvUsage", 11);
+        assertBugInMethodAtLine(bugType, className, "replaceableEnvUsage", 12);
+        assertBugInMethodAtLine(bugType, className, "replaceableEnvUsage", 13);
+        assertBugInMethodAtLine(bugType, className, "replaceableEnvUsage", 14);
+        assertBugInMethodAtLine(bugType, className, "replaceableEnvUsage", 15);
+        assertBugInMethodAtLine(bugType, className, "replaceableEnvUsage", 16);
 
-        assertBug("replaceableEnvUsageFromMap", 20);
-        assertBug("replaceableEnvUsageFromMapWithVar", 25);
-        assertBug("replaceableEnvUsageFromMapWithVar", 26);
+        assertBugInMethodAtLine(bugType, className, "replaceableEnvUsageFromMap", 20);
+        assertBugInMethodAtLine(bugType, className, "replaceableEnvUsageFromMapWithVar", 25);
+        assertBugInMethodAtLine(bugType, className, "replaceableEnvUsageFromMapWithVar", 26);
 
-        assertBug("replaceableEnvUsageWithVar", 31);
-        assertBug("replaceableEnvUsageWithField", 36);
+        assertBugInMethodAtLine(bugType, className, "replaceableEnvUsageWithVar", 31);
+        assertBugInMethodAtLine(bugType, className, "replaceableEnvUsageWithField", 36);
 
-        assertBug("replaceableEnvUsageWithVarFromMap", 41);
-        assertBug("replaceableEnvUsageWithFieldFromMap", 46);
+        assertBugInMethodAtLine(bugType, className, "replaceableEnvUsageWithVarFromMap", 41);
+        assertBugInMethodAtLine(bugType, className, "replaceableEnvUsageWithFieldFromMap", 46);
 
-        assertBug("replaceableEnvUsageWithVarFromMapWithVar", 53);
-        assertBug("replaceableEnvUsageWithVarFromMapWithVar", 54);
+        assertBugInMethodAtLine(bugType, className, "replaceableEnvUsageWithVarFromMapWithVar", 53);
+        assertBugInMethodAtLine(bugType, className, "replaceableEnvUsageWithVarFromMapWithVar", 54);
 
-        assertBug("replaceableEnvUsageWithFieldFromMapWithVar", 61);
-        assertBug("replaceableEnvUsageWithFieldFromMapWithVar", 62);
-    }
-
-    private void assertBug(int num) {
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType("ENV_USE_PROPERTY_INSTEAD_OF_ENV")
-                .build();
-        assertThat(getBugCollection(), containsExactly(num, bugTypeMatcher));
-    }
-
-    public void assertBug(String methodName, int line) {
-        performAnalysis("UnnecessaryEnvUsage.class");
-        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType("ENV_USE_PROPERTY_INSTEAD_OF_ENV")
-                .inClass("UnnecessaryEnvUsage")
-                .inMethod(methodName)
-                .atLine(line)
-                .build();
-        assertThat(getBugCollection(), hasItem(bugTypeMatcher));
+        assertBugInMethodAtLine(bugType, className, "replaceableEnvUsageWithFieldFromMapWithVar", 61);
+        assertBugInMethodAtLine(bugType, className, "replaceableEnvUsageWithFieldFromMapWithVar", 62);
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/integration/FindNullDerefIntegrationTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/integration/FindNullDerefIntegrationTest.java
@@ -19,53 +19,29 @@
 
 package edu.umd.cs.findbugs.integration;
 
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.MatcherAssert.assertThat;
-
-import java.io.IOException;
-
 import org.junit.jupiter.api.Test;
-
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
 class FindNullDerefIntegrationTest extends AbstractIntegrationTest {
-
     @Test
     void testNullFromReturnOnLambda() {
         performAnalysis("Elvis.class");
 
         // There should only be 1 issue of this type
-        final BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType("SI_INSTANCE_BEFORE_FINALS_ASSIGNED").build();
-        assertThat(getBugCollection(), containsExactly(1, bugTypeMatcher));
+        assertBugTypeCount("SI_INSTANCE_BEFORE_FINALS_ASSIGNED", 1);
 
         // It must be on the INSTANCE field
-        final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
-                .bugType("SI_INSTANCE_BEFORE_FINALS_ASSIGNED")
-                .inClass("Elvis")
-                .atField("INSTANCE")
-                .build();
-        assertThat(getBugCollection(), hasItem(bugInstanceMatcher));
+        assertBugAtField("SI_INSTANCE_BEFORE_FINALS_ASSIGNED", "Elvis", "INSTANCE");
     }
 
     @Test
-    void testLambdaIssue20() throws IOException, InterruptedException {
+    void testLambdaIssue20() {
         performAnalysis("lambdas/Issue20.class");
 
         // There should only be 1 issue of this type
-        final BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
-                .bugType("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE").build();
-        assertThat(getBugCollection(), containsExactly(1, bugTypeMatcher));
+        assertBugTypeCount("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", 1);
 
         // It must be on the lambda method, checking by line number
-        final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
-                .bugType("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
-                .inClass("Issue20")
-                .atLine(24)
-                .build();
-        assertThat(getBugCollection(), hasItem(bugInstanceMatcher));
+        assertBugAtLine("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", 24);
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/nullness/IssueRequireNotNullTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/nullness/IssueRequireNotNullTest.java
@@ -1,15 +1,7 @@
 package edu.umd.cs.findbugs.nullness;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.BugCollection;
-
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
-
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 import org.junit.jupiter.api.Test;
-
 
 /**
  * Unit test to reproduce <a href="https://github.com/spotbugs/spotbugs/issues/456">#456</a>.
@@ -34,29 +26,10 @@ class IssueRequireNotNullTest extends AbstractIntegrationTest {
     void testIssue() {
         performAnalysis("nullnessAnnotations/TestNonNull7.class");
 
-        assertHasNoNpBug(getBugCollection());
-        assertBugNum(getBugCollection(), "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", 1);
-        assertBug(getBugCollection(), "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", "objectsrequireNonNullFalse");
-    }
-
-    private void assertHasNoNpBug(BugCollection bugCollection) {
         for (String bugtype : bugtypes) {
-            assertBugNum(bugCollection, bugtype, 0);
+            assertNoBugType(bugtype);
         }
-    }
-
-    private void assertBugNum(BugCollection bugCollection, String bugType, int bugNum) {
-        final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
-                .bugType(bugType)
-                .build();
-        assertThat(bugCollection, containsExactly(bugNum, bugInstanceMatcher));
-    }
-
-    private void assertBug(BugCollection bugCollection, String bugType, String method) {
-        final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
-                .bugType(bugType)
-                .inMethod(method)
-                .build();
-        assertThat(bugCollection, containsExactly(1, bugInstanceMatcher));
+        assertBugTypeCount("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", 1);
+        assertBugInMethod("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", "TestNonNull7", "objectsrequireNonNullFalse");
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/nullness/TestCheckerFrameworkTypeAnnotations.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/nullness/TestCheckerFrameworkTypeAnnotations.java
@@ -1,14 +1,9 @@
 package edu.umd.cs.findbugs.nullness;
 
-import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 
 /**
  * Checks the effect of CheckerFramework @NonNull annotation on method return value
@@ -22,77 +17,49 @@ class TestCheckerFrameworkTypeAnnotations extends AbstractIntegrationTest {
 
     @Test
     void methodReturns() {
-        assertBugsSpottedCount("NP_NONNULL_RETURN_VIOLATION", 2);
+        assertBugInClassCount("NP_NONNULL_RETURN_VIOLATION", "CheckerFrameworkTypeAnnotations", 2);
     }
 
     @Test
     void returningNullOnNonNullMethod() {
-        assertBugSpotted("NP_NONNULL_RETURN_VIOLATION", "returningNullOnNonNullMethod", 13);
+        assertBugInMethodAtLine("NP_NONNULL_RETURN_VIOLATION", "CheckerFrameworkTypeAnnotations", "returningNullOnNonNullMethod", 13);
     }
 
     @Test
     void returningNullWithNonNullOnGenerics() {
-        assertNoBugSpotted("NP_NONNULL_RETURN_VIOLATION", "returningNullWithNonNullOnGenerics");
+        assertNoBugInMethod("NP_NONNULL_RETURN_VIOLATION", "CheckerFrameworkTypeAnnotations", "returningNullWithNonNullOnGenerics");
     }
 
     @Test
     void returningNullOnNonNullMethodWithNonNullOnGenerics() {
-        assertBugSpotted("NP_NONNULL_RETURN_VIOLATION", "returningNullOnNonNullMethodWithNonNullOnGenerics", 25);
+        assertBugInMethodAtLine("NP_NONNULL_RETURN_VIOLATION", "CheckerFrameworkTypeAnnotations", "returningNullOnNonNullMethodWithNonNullOnGenerics",
+                25);
     }
 
     @Test
     void methodParametersTests() {
-        assertBugsSpottedCount("NP_NONNULL_PARAM_VIOLATION", 2);
+        assertBugInClassCount("NP_NONNULL_PARAM_VIOLATION", "CheckerFrameworkTypeAnnotations", 2);
     }
 
     @Test
     void usingNullForNonNullParameter() {
-        assertBugSpotted("NP_NONNULL_PARAM_VIOLATION", "usingNullForNonNullParameter", 30);
+        assertBugInMethodAtLine("NP_NONNULL_PARAM_VIOLATION", "CheckerFrameworkTypeAnnotations", "usingNullForNonNullParameter", 30);
     }
 
     @Test
     void usingNullParameterWithNonNullOnGenerics() {
-        assertNoBugSpotted("NP_NONNULL_PARAM_VIOLATION", "usingNullParameterWithNonNullOnGenerics");
+        assertNoBugInMethod("NP_NONNULL_PARAM_VIOLATION", "CheckerFrameworkTypeAnnotations", "usingNullParameterWithNonNullOnGenerics");
     }
 
     @Test
     void usingNullOnNonNullParameterWithNonNullOnGenerics() {
-        assertBugSpotted("NP_NONNULL_PARAM_VIOLATION", "usingNullOnNonNullParameterWithNonNullOnGenerics", 47);
+        assertBugInMethodAtLine("NP_NONNULL_PARAM_VIOLATION", "CheckerFrameworkTypeAnnotations", "usingNullOnNonNullParameterWithNonNullOnGenerics",
+                47);
     }
 
     @Test
     void usingNonNullArrayOfNullable() {
-        assertNoBugSpotted("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", "usingNonNullArrayOfNullable");
+        assertNoBugInMethod("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", "CheckerFrameworkTypeAnnotations", "usingNonNullArrayOfNullable");
 
-    }
-
-    private void assertBugSpotted(String bugType, String method, int line) {
-        final BugInstanceMatcher matcher = new BugInstanceMatcherBuilder()
-                .bugType(bugType)
-                .inClass("CheckerFrameworkTypeAnnotations")
-                .inMethod(method)
-                .atLine(line)
-                .build();
-
-        assertThat(getBugCollection(), containsExactly(1, matcher));
-    }
-
-    private void assertNoBugSpotted(String bugType, String method) {
-        final BugInstanceMatcher matcher = new BugInstanceMatcherBuilder()
-                .bugType(bugType)
-                .inClass("CheckerFrameworkTypeAnnotations")
-                .inMethod(method)
-                .build();
-
-        assertThat(getBugCollection(), containsExactly(0, matcher));
-    }
-
-    private void assertBugsSpottedCount(String bugType, int expectedCount) {
-        final BugInstanceMatcher matcher = new BugInstanceMatcherBuilder()
-                .bugType(bugType)
-                .inClass("CheckerFrameworkTypeAnnotations")
-                .build();
-
-        assertThat(getBugCollection(), containsExactly(expectedCount, matcher));
     }
 }

--- a/test-harness/src/main/java/edu/umd/cs/findbugs/test/matcher/BugInstanceMatcher.java
+++ b/test-harness/src/main/java/edu/umd/cs/findbugs/test/matcher/BugInstanceMatcher.java
@@ -54,7 +54,7 @@ public class BugInstanceMatcher extends BaseMatcher<BugInstance> {
      * @param bugType
      *            Expected bug type
      * @param className
-     *            Class name
+     *            Class name, matches to any of the following: fully dotted class name, simple name, in case of inner classes the simple name with the container class separated by $.
      * @param methodName
      *            Method name
      * @param fieldName


### PR DESCRIPTION
There is a lot of code repetition in the tests with asserting the expected number and type of bugs. This PR creates functions for these in the super class, `AbstractIntegrationTest`, and uses them in the child tests.
With this PR, the `BugInstanceMatcherBuilder` only used in the following instances:
- inside itself, `BugInstanceMatcherBuilder`,
- inside the tests super class, `AbstractIntegrationTest`,
- in tests which are extended with `SpotBugsExtension` and not descends from `AbstractIntegrationTest`,
- when the BugInstanceMatcher configuration is only used in one class: Issue1642Test.
	- however `assertBugInMethodAtField` is only used in `FindReturnRefTest` and `assertBugAtFieldAtLine` is only used in `FindPublicAttributesTest`, these used more than once and seemed useful.

The PR also fixes some issues in the tests. E.g. when a test asserts for a bug without any restriction at all, it is likely to break in the future and these cases the original issue was about something else - either about specific bugtypes or the analysis itself throwing an exception. In these cases I checked the issues and modified the tests according to these (see the comments). These changes are in the second commit.