### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Recognize some classes as immutable, fixing EI_EXPOSE and MS_EXPOSE FPs ([#3137](https://github.com/spotbugs/spotbugs/pull/3137))
 
 ### Cleanup
-- Cleaup thread issue and regex issue in test-harness ([#3130](https://github.com/spotbugs/spotbugs/issues/3130))
+- Cleanup thread issue and regex issue in test-harness ([#3130](https://github.com/spotbugs/spotbugs/issues/3130))
 - Remove extra blank lines and remove public from interface objects as inherently already public ([#3131](https://github.com/spotbugs/spotbugs/issues/3131))
 - Fix order of modifiers on properties/methods and ensure correct location in file ([#3132](https://github.com/spotbugs/spotbugs/issues/3132))
 - Return objects directly instead of creating more garbage collection by defining them ([#3133](https://github.com/spotbugs/spotbugs/issues/3133))
@@ -596,7 +596,7 @@ This version contains no change, except for the solution for [a deployment probl
 * Replace to try-with-resources
 * Reset DataAnalysis.DEBUG back when analysis reaches MAX_ITER
 * Remove unused methods in `BCELUtil`
-* Remove unused methods and deperecated methods in `edu.umd.cs.findbugs.util.Util`
+* Remove unused methods and deprecated methods in `edu.umd.cs.findbugs.util.Util`
 * Change to removeIf from Iterator and Iterator.remove
 * Use Map.computeIfAbsent instead of Map.get and Map.put
 * Use for-each instead of for-loop and while-loop
@@ -661,7 +661,7 @@ This version contains no change, except for the solution for [a deployment probl
 * edu.umd.cs.findbugs.util.ClassName#assertIsSlashed return type is changed to void
 
 ### Deprecated
-* edu.umd.cs.findbugs.classfile.ClassDescriptor#toDottedClassName() is depricated and getDottedClassName() can be used instead.
+* edu.umd.cs.findbugs.classfile.ClassDescriptor#toDottedClassName() is deprecated and getDottedClassName() can be used instead.
 
 ## 3.1.9 - 2018-11-20
 

--- a/docs/locale/ja/LC_MESSAGES/bugDescriptions.po
+++ b/docs/locale/ja/LC_MESSAGES/bugDescriptions.po
@@ -3978,7 +3978,7 @@ msgstr ""
 #: ../../generated/bugDescriptionList.inc:3908
 msgid ""
 "    <p>\n"
-"This partical method invocation doesn't make sense, for reasons that "
+"This partial method invocation doesn't make sense, for reasons that "
 "should be apparent from inspection.\n"
 "</p>"
 msgstr ""

--- a/eclipsePlugin/RELEASENOTES
+++ b/eclipsePlugin/RELEASENOTES
@@ -40,7 +40,7 @@ Release 1.3.8 - Andrey Loskutov
 - feature: added FindBugs perspective link to all Java perspectives
 - feature 2022229: have workspace level preferences for FindBugs
     per default, workspace settings are used for new plugins
-    plugins with existing .fbprefs files are assumed to have custom preferences until they explicitely disable project prefs
+    plugins with existing .fbprefs files are assumed to have custom preferences until they explicitly disable project prefs
     per default, Eclipse will not enable categories EXPERIMENTAL,I18N,MALICIOUS_CODE,SECURITY for new projects
     FilterFiles tab: now dialog will disallow invalid selection of filter files
 - internal rework of job scheduling: use same rule for all FB jobs.
@@ -50,7 +50,7 @@ Release 1.3.8 - Andrey Loskutov
 - feature: property view shows bug counts info for elements selected in bug explorer
 - feature: added "navigate - Show In - Bug Explorer" menu entry in all Java perspectives
 - feature: added "Show Bug Details" action to Java editor ruler
-- feature: replaced bug details view with standart properties view, supporting Java editor
+- feature: replaced bug details view with standard properties view, supporting Java editor
     bug details view exists no more, perspective definition changed
 - bugfix: fixed bug explorer (common navigator) errors with Eclipse 3.5
 - feature: filtering by specific pattern from bug explorer
@@ -142,14 +142,14 @@ Release 1.3.0 - FindBugs team
 - Include/Exclude filter-file selector now sanity-checks selection
 
 Release 1.2.2 - major code cleanup and refactoring by Andrey Loskutov
-- fixed non-Eclipse-like behavoir of view selection/activation/opening (work in progress)
+- fixed non-Eclipse-like behavior of view selection/activation/opening (work in progress)
 - bud tree view monitors resource changes now
 - refactoring of all FindBugs views
 - created new icons for findbugs action and views
 - created new FindBugs perspective
 - fixed popup contribution for the problems view (was never functional)
-- no system.out.println callls without if(DEBUG) flag
-- no printStackTrace() callls without if(DEBUG) flag
+- no system.out.println calls without if(DEBUG) flag
+- no printStackTrace() calls without if(DEBUG) flag
 - other code cleanup
 
 Release 0.1.0 - some enhancements by Peter Friese

--- a/eclipsePlugin/doc/installing_findbugsplugin.txt
+++ b/eclipsePlugin/doc/installing_findbugsplugin.txt
@@ -65,7 +65,7 @@ Manual mode
 ------------
 Since running the FindBugs plug-in in automatic mode can be vey time-consuming,
 you may choose to run the plug-in in manual mode. As the name implies, you
-have to start the bug pattern detecion manually when the plug-in is in manual mode.
+have to start the bug pattern detection manually when the plug-in is in manual mode.
 
 To enable manual mode:
 1) Make sure that the [Run FindBugs automatically] checkbox on the Java project properties

--- a/eclipsePlugin/src/de/tobject/findbugs/FindbugsSaveParticipant.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/FindbugsSaveParticipant.java
@@ -26,7 +26,7 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import de.tobject.findbugs.util.ProjectUtilities;
 
 /**
- * Callback object responsible for saving the uncomitted state of any
+ * Callback object responsible for saving the uncommitted state of any
  * FindBugs-enabled projects.
  *
  * @author David Hovemeyer

--- a/eclipsePlugin/src/de/tobject/findbugs/actions/MarkerRulerAction.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/actions/MarkerRulerAction.java
@@ -84,7 +84,7 @@ public class MarkerRulerAction implements IEditorActionDelegate, IUpdate, MouseL
     @Override
     public void setActiveEditor(IAction callerAction, IEditorPart targetEditor) {
         Control control;
-        // See if we're already listenting to an editor; if so, stop listening
+        // See if we're already listening to an editor; if so, stop listening
         if (editor != null) {
             if (ruler != null) {
                 control = ruler.getControl();

--- a/eclipsePlugin/src/de/tobject/findbugs/builder/FindBugsBuilder.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/builder/FindBugsBuilder.java
@@ -94,7 +94,7 @@ public class FindBugsBuilder extends IncrementalProjectBuilder {
         default: {
 
             FindbugsPlugin.getDefault()
-                    .logWarning("UKNOWN BUILD kind" + kind);
+                    .logWarning("UNKNOWN BUILD kind" + kind);
             doBuild(args, monitor, kind);
             break;
         }

--- a/eclipsePlugin/src/de/tobject/findbugs/reporter/JdtUtils.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/reporter/JdtUtils.java
@@ -2,7 +2,7 @@
  * Contributions to FindBugs
  * Copyright (C) 2009, Andrei Loskutov
  *
- * The original code was developed by Andrei Loskutov under the BSD lizense for the
+ * The original code was developed by Andrei Loskutov under the BSD license for the
  * Bytecode Outline plugin at http://andrei.gmxhome.de/bytecode/index.html
  *
  * This library is free software; you can redistribute it and/or
@@ -419,7 +419,7 @@ public class JdtUtils {
      * opposite to rule 2)
      *
      * @param javaElement
-     * @return priority - lesser mean wil be compiled later, a value > 0
+     * @return priority - lesser mean will be compiled later, a value > 0
      */
     private static int getAnonCompilePriority50(IJavaElement javaElement, IJavaElement firstAncestor, IJavaElement topAncestor) {
 

--- a/eclipsePlugin/src/de/tobject/findbugs/reporter/MarkerReporter.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/reporter/MarkerReporter.java
@@ -125,7 +125,7 @@ public class MarkerReporter implements IWorkspaceRunnable {
                 oldMarker.delete();
             }
         }
-        // XXX With Eclipse 4.19, we could use *single* method to create marker with attribures
+        // XXX With Eclipse 4.19, we could use *single* method to create marker with attributes
         // see https://bugs.eclipse.org/bugs/show_bug.cgi?id=570914
         // We can use that once we have 4.19 as minimum platform
         IMarker newMarker = markerTarget.createMarker(mp.markerType);

--- a/eclipsePlugin/src/de/tobject/findbugs/util/EditorUtil.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/util/EditorUtil.java
@@ -54,7 +54,7 @@ public class EditorUtil {
         if (document != null) {
             IRegion lineInfo = null;
             try {
-                // line count internaly starts with 0, and not with 1 like in
+                // line count internally starts with 0, and not with 1 like in
                 // GUI
                 lineInfo = document.getLineInformation(lineNumber - 1);
             } catch (BadLocationException e) {

--- a/eclipsePlugin/src/de/tobject/findbugs/view/explorer/BugContentProvider.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/view/explorer/BugContentProvider.java
@@ -508,7 +508,7 @@ public class BugContentProvider implements ICommonContentProvider {
                 break;
             default:
                 FindbugsPlugin.getDefault()
-                        .logWarning("UKNOWN delta change kind" + delta.changeKind);
+                        .logWarning("UNKNOWN delta change kind" + delta.changeKind);
 
             }
         }

--- a/eclipsePlugin/src/de/tobject/findbugs/view/explorer/FilterBugsDialog.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/view/explorer/FilterBugsDialog.java
@@ -340,7 +340,7 @@ public class FilterBugsDialog extends SelectionDialog {
             // allow to specify filters using text area (no validation checks
             // yet)
             // TODO validate text entered by user and throw away
-            // invalide/duplicated entries
+            // invalid/duplicated entries
             selectedAsText = text;
         } else {
             selectedAsText = computed;
@@ -492,7 +492,7 @@ public class FilterBugsDialog extends SelectionDialog {
         final ContainerCheckedTreeViewer viewer = new ContainerCheckedTreeViewer(parent, style | SWT.SINGLE | SWT.BORDER
                 | SWT.V_SCROLL | SWT.H_SCROLL | SWT.RESIZE) {
             /**
-             * Overriden to re-set checked state of elements after filter change
+             * Overridden to re-set checked state of elements after filter change
              */
             @Override
             public void refresh(boolean updateLabels) {

--- a/eclipsePlugin/src/edu/umd/cs/findbugs/plugin/eclipse/quickfix/BugResolutionAssociations.java
+++ b/eclipsePlugin/src/edu/umd/cs/findbugs/plugin/eclipse/quickfix/BugResolutionAssociations.java
@@ -38,7 +38,7 @@ import de.tobject.findbugs.FindbugsPlugin;
 
 /**
  * The <CODE>BugResolutionAssociations</CODE> is the container for the loaded
- * bug-resolutions. For each registred bug pattern, at least one resolution-class
+ * bug-resolutions. For each registered bug pattern, at least one resolution-class
  * has to be specified. Also an instance of a bug resolution can be associated
  * with a bug pattern.
  *

--- a/eclipsePlugin/src/edu/umd/cs/findbugs/plugin/eclipse/quickfix/BugResolutionGenerator.java
+++ b/eclipsePlugin/src/edu/umd/cs/findbugs/plugin/eclipse/quickfix/BugResolutionGenerator.java
@@ -32,7 +32,7 @@ import de.tobject.findbugs.FindbugsPlugin;
 import de.tobject.findbugs.reporter.MarkerUtil;
 
 /**
- * The <CODE>BugResolutionGenerator</CODE> searchs for bug-resolutions, that can
+ * The <CODE>BugResolutionGenerator</CODE> searches for bug-resolutions, that can
  * be used to fix the specific bug-type.
  *
  * @author <a href="mailto:twyss@hsr.ch">Thierry Wyss</a>

--- a/eclipsePlugin/src/edu/umd/cs/findbugs/plugin/eclipse/quickfix/util/ASTUtil.java
+++ b/eclipsePlugin/src/edu/umd/cs/findbugs/plugin/eclipse/quickfix/util/ASTUtil.java
@@ -183,7 +183,7 @@ public class ASTUtil {
     }
 
     /**
-     * Searchs the first <CODE>ASTNode</CODE> between the specified
+     * Searches the first <CODE>ASTNode</CODE> between the specified
      * <CODE>startLine</CODE> and <CODE>endLine</CODE>. If the source line
      * doesn't contain an <CODE>ASTNode</CODE>, a
      * <CODE>ASTNodeNotFoundException</CODE> is thrown.
@@ -196,7 +196,7 @@ public class ASTUtil {
      * @param endLine
      *            the ending source line number.
      * @throws ASTNodeNotFoundException
-     *             if no <CODE>ASTNode</CODE> found between the specifed start
+     *             if no <CODE>ASTNode</CODE> found between the specified start
      *             and end line.
      */
     public static ASTNode getASTNode(CompilationUnit compilationUnit, int startLine, int endLine) throws ASTNodeNotFoundException {

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindArgumentAssertionsTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindArgumentAssertionsTest.java
@@ -46,7 +46,7 @@ class FindArgumentAssertionsTest extends AbstractIntegrationTest {
         assertNoBugInMethod(BUG_TYPE, "ArgumentAssertions", "privateFinalMethod");
         assertNoBugInMethod(BUG_TYPE, "ArgumentAssertions", "privateStaticMethod");
         assertDABug("assertingArgInFor", 198);
-        // assertDABug("lambda$assertingArgInStream$0", 206); // assertations inside streams are not supported yet
+        // assertDABug("lambda$assertingArgInStream$0", 206); // assertions inside streams are not supported yet
     }
 
     private void assertDABug(String method, int line) {

--- a/spotbugs/design/DecouplingFromBCEL.txt
+++ b/spotbugs/design/DecouplingFromBCEL.txt
@@ -23,7 +23,7 @@ Issues:
 - We are reliant on BCEL's Constants and Visitor classes
 
 - The bytecode analysis (ba) package makes heavy use of
-  BCEL tree-based reprentation (generic package) and also
+  BCEL tree-based representation (generic package) and also
   the BCEL Repository and type classes (both of which have
   significant shortcomings).  The detectors which use
   the bytecode analysis package are also tightly coupled

--- a/spotbugs/etc/docbook/soextblx.dtd
+++ b/spotbugs/etc/docbook/soextblx.dtd
@@ -54,7 +54,7 @@
 
      Other miscellaneous changes:
 
-       - Tag ommission indicators have been removed
+       - Tag omission indicators have been removed
        - Comments have been removed from declarations
        - NUMBER attributes have been changed to NMTOKEN
        - NUTOKEN attributes have been to changed to NMTOKEN
@@ -162,7 +162,7 @@ current application.
 
 Note, however, that changes may have significant effect on the ability to
 interchange table information.  These changes may manifest themselves
-in useability, presentation, and possible structure information degradation.
+in usability, presentation, and possible structure information degradation.
 -->
 
 <!ENTITY % tbl.table.name       "table">

--- a/spotbugs/etc/messages.xml
+++ b/spotbugs/etc/messages.xml
@@ -9141,7 +9141,7 @@ Using floating-point variables should not be used as loop counters, as they are 
   </BugPattern>
   <BugPattern type="VSC_VULNERABLE_SECURITY_CHECK_METHODS">
     <ShortDescription>Non-Private and non-final security check methods are vulnerable</ShortDescription>
-    <LongDescription>The method '{1}' performs security check by using '{2}' method of Security Manager Class, but is overrideable. Declare the method final or private in order to resolve the issue. </LongDescription>
+    <LongDescription>The method '{1}' performs security check by using '{2}' method of Security Manager Class, but is overridable. Declare the method final or private in order to resolve the issue. </LongDescription>
     <Details>
       <![CDATA[<p>
         Methods that perform security checks should be prevented from being overridden, so they must be declared as

--- a/spotbugs/src/doc/Changes.html
+++ b/spotbugs/src/doc/Changes.html
@@ -230,7 +230,7 @@
                         href="http://findbugs.sourceforge.net/bugDescriptions.html#NP_METHOD_PARAMETER_TIGHTENS_ANNOTATION">NP_METHOD_PARAMETER_TIGHTENS_ANNOTATION</a>
                     </li>
                     <li>Add the ability in the GUI to save the currently viewable/filtered bugs to HTML output.
-                    <li>When dataflow does't terminate, make sure we continue with
+                    <li>When dataflow doesn't terminate, make sure we continue with
                         analysis.
 
                     <li>Fix some problems that resulting in dataflow analysis not
@@ -350,7 +350,7 @@
                         strict type qualifier is required.
                     <li>Complain about missing classes only if they are
                         encountered while analyzing application classes; ignore missing
-                        classes that are encounted while analyzing classes loaded from the
+                        classes that are encountered while analyzing classes loaded from the
                         auxclasspath. Fix for <a
                         href="https://sourceforge.net/tracker/?func=detail&aid=3588379&group_id=96405&atid=614693">Bug3588379</a>
                     <li>Fixed false positive null pointer warning coming from
@@ -2468,7 +2468,7 @@
                     <li>Allow for command line options 'files' using the @ symbol
                         (David Hovemeyer)</li>
                     <li>New -adjustPriority command line option to for adjusting
-                        bug priorites (David Hovemeyer)</li>
+                        bug priorities (David Hovemeyer)</li>
                     <li>Added an Edit menu (cut/copy/paste) to Swing GUI (Dave
                         Brosius)</li>
                     <li>French translation supplied (David Cotton) <!-- Bug fixes -->

--- a/spotbugs/src/doc/FAQ.html
+++ b/spotbugs/src/doc/FAQ.html
@@ -195,7 +195,7 @@ which bundles FindBugs, PMD and CheckStyle. Use the following
 update site:
 <a href="http://deadlock.netbeans.org/hudson/job/sqe/lastStableBuild/artifact/build/full-sqe-updatecenter/updates.xml
 ">http://deadlock.netbeans.org/hudson/job/sqe/lastStableBuild/artifact/build/full-sqe-updatecenter/updates.xml</a>
-<p>Pease note that the SQE plugin is not maintained by the FindBugs developers,
+<p>Please note that the SQE plugin is not maintained by the FindBugs developers,
 so we can't answer questions about it.
 </p>
 

--- a/spotbugs/src/doc/manual.xml
+++ b/spotbugs/src/doc/manual.xml
@@ -1993,13 +1993,13 @@ In other words, each of the children must be true for the predicate to be true.
    </para><para>
                For more coarse-grained matching, use <literal>code</literal> attribute. It takes
                a comma-separated list of bug abbreviations. For most-coarse grained matching use
-               <literal>category</literal> attriute, that takes a comma separated list of bug category names:
+               <literal>category</literal> attribute, that takes a comma separated list of bug category names:
                <literal>CORRECTNESS</literal>, <literal>MT_CORRECTNESS</literal>,
                <literal>BAD_PRACTICICE</literal>, <literal>PERFORMANCE</literal>, <literal>STYLE</literal>.
    </para><para>
                If more than one of the attributes mentioned above are specified on the same
                <literal>&lt;Bug&gt;</literal> element, all bug patterns that match either one of specified
-               pattern names, or abreviations, or categories will be matched.
+               pattern names, or abbreviations, or categories will be matched.
    </para><para>
                As a backwards compatibility measure, <literal>&lt;BugPattern&gt;</literal> and
                <literal>&lt;BugCode&gt;</literal> elements may be used instead of
@@ -2723,7 +2723,7 @@ on those parameters, methods or fields that you want to allow to be null.
     </listitem>
     <listitem>
       <para>
-This is same as the DefaultAnnotation except it only applys to fields.
+This is same as the DefaultAnnotation except it only applies to fields.
       </para>
     </listitem>
   </varlistentry>
@@ -2754,7 +2754,7 @@ This is same as the DefaultAnnotation except it only applys to fields.
     </listitem>
     <listitem>
       <para>
-This is same as the DefaultAnnotation except it only applys to methods.
+This is same as the DefaultAnnotation except it only applies to methods.
       </para>
     </listitem>
   </varlistentry>
@@ -2785,7 +2785,7 @@ This is same as the DefaultAnnotation except it only applys to methods.
     </listitem>
     <listitem>
       <para>
-This is same as the DefaultAnnotation except it only applys to method parameters.
+This is same as the DefaultAnnotation except it only applies to method parameters.
       </para>
     </listitem>
   </varlistentry>
@@ -2852,7 +2852,7 @@ Used to annotate a method that, if overridden, must (or should) be invoke super
 in the overriding method. Examples of such methods include finalize() and clone().
 The argument to the method indicates when the super invocation should occur:
 at any time, at the beginning of the overriding method, or at the end of the overriding method.
-(This anotation is not implmemented in FindBugs as of September 8, 2006).
+(This annotation is not implmemented in FindBugs as of September 8, 2006).
       </para>
     </listitem>
   </varlistentry>
@@ -3600,7 +3600,7 @@ a table header.</para>
     <sect1 id="examples">
         <title>Examples</title>
 <sect2 id="unixscriptsexamples">
-   <title>Mining history using proveded shell scrips</title>
+   <title>Mining history using proveded shell scripts</title>
 <para>In all of the following, the commands are given in a directory that contains
 directories jdk1.6.0-b12, jdk1.6.0-b13, ..., jdk1.6.0-b60.</para>
 

--- a/spotbugs/src/doc/sysprops.html
+++ b/spotbugs/src/doc/sysprops.html
@@ -72,7 +72,7 @@ gives information if the field is set to true.
 	</tr>
 	<tr>
 		<td>ba.checkAssertions</td>
-		<td>throw excptions on certain illegal class type signatures</td>
+		<td>throw exceptions on certain illegal class type signatures</td>
 	</tr>
 	<tr>
 		<td>ba.verifyIntegrity</td>

--- a/spotbugs/src/doc/updateChecking.html
+++ b/spotbugs/src/doc/updateChecking.html
@@ -30,7 +30,7 @@
      java-version="1.6" language="en" country="US" uuid="-4bcf8f48ba2842d2"&gt;
   &lt;plugin id="edu.umd.cs.findbugs.plugins.core" name="Core FindBugs plugin" version="2.0.0-rc1"/&gt;
   &lt;plugin id="edu.umd.cs.findbugs.plugins.appengine" name="FindBugs Cloud Plugin" version=""/&gt;
-  &lt;plugin id="edu.umd.cs.findbugs.plugins.poweruser" name="Power user commnand line tools" version=""/&gt;
+  &lt;plugin id="edu.umd.cs.findbugs.plugins.poweruser" name="Power user command line tools" version=""/&gt;
 &lt;/findbugs-invocation&gt;
 </pre>
 

--- a/spotbugs/src/doc/users.html
+++ b/spotbugs/src/doc/users.html
@@ -36,7 +36,7 @@
 						have a list of all the users of FindBugs, and we don't have
 						permission to identify many of the companies where we know
 						FindBugs is being used (getting this permission often involves red
-						tape and lawyers). But here are some statics from Google Analytics
+						tape and lawyers). But here are some statistics from Google Analytics
 						showing unique visitors to the FindBugs web pages for the months
 						of June through August, 2006.
 
@@ -102,7 +102,7 @@
 					</h2>
 					<p>
 						The following companies, organizations and institutions provide
-						financial support for FindBugs. Tax deductable donations to
+						financial support for FindBugs. Tax deductible donations to
 						support FindBugs can be made to the University of Maryland.
 
 					</p>

--- a/spotbugs/src/gui/main/edu/umd/cs/findbugs/gui2/BugTreeModel.java
+++ b/spotbugs/src/gui/main/edu/umd/cs/findbugs/gui2/BugTreeModel.java
@@ -461,7 +461,7 @@ public class BugTreeModel implements TreeModel, TableColumnModelListener, TreeEx
     // new BugSet?
     {
         if (TRACE) {
-            System.out.println("Reseting data in bug tree model");
+            System.out.println("Resetting data in bug tree model");
         }
         bugSet = new BugSet(bugSet);
     }

--- a/spotbugs/src/gui/main/edu/umd/cs/findbugs/gui2/GUISaveState.java
+++ b/spotbugs/src/gui/main/edu/umd/cs/findbugs/gui2/GUISaveState.java
@@ -507,7 +507,7 @@ public class GUISaveState {
 
     /**
      * @param splitSummary
-     *            The location of the summar divider to set.
+     *            The location of the summary divider to set.
      */
     public void setSplitSummary(int splitSummary) {
         this.splitSummary = splitSummary;

--- a/spotbugs/src/gui/main/edu/umd/cs/findbugs/gui2/PreferencesFrame.java
+++ b/spotbugs/src/gui/main/edu/umd/cs/findbugs/gui2/PreferencesFrame.java
@@ -526,7 +526,7 @@ public class PreferencesFrame extends FBDialog {
 
         if (tabSize < TAB_MIN || tabSize > TAB_MAX) {
             JOptionPane.showMessageDialog(instance, "Tab size exceedes range (" + TAB_MIN + " - " + TAB_MAX + ").",
-                    "Tab Size Excedes Range", JOptionPane.INFORMATION_MESSAGE);
+                    "Tab Size Exceeds Range", JOptionPane.INFORMATION_MESSAGE);
             return;
         }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/Analyze.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/Analyze.java
@@ -155,7 +155,7 @@ public class Analyze {
      *            Known type of object
      * @param y
      *            Type queried about
-     * @return 0 - 1 value indicating probablility
+     * @return 0 - 1 value indicating probability
      */
 
     public static double deepInstanceOf(@DottedClassName String x, @DottedClassName String y) throws ClassNotFoundException {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/BugInstance.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/BugInstance.java
@@ -692,7 +692,7 @@ public class BugInstance implements Comparable<BugInstance>, XMLWriteable, Clone
      * @param name
      *            name of the property to get
      * @param defaultValue
-     *            default value to return if propery is not set
+     *            default value to return if property is not set
      * @return the value of the named property, or the default value if the
      *         property has not been set
      */

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/FindBugs2.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/FindBugs2.java
@@ -1122,7 +1122,7 @@ public class FindBugs2 implements IFindBugsEngine, AutoCloseable {
                                 LOG.warn("Thread interrupted during analysis", e);
                                 Thread.currentThread().interrupt();
                             } catch (ExecutionException e) {
-                                throw new AnalysisException("Exeption was thrown during analysis", e);
+                                throw new AnalysisException("Exception was thrown during analysis", e);
                             }
                         });
                         if (Thread.interrupted()) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/FindBugsCommandLine.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/FindBugsCommandLine.java
@@ -68,7 +68,7 @@ public abstract class FindBugsCommandLine extends CommandLine {
     }
 
     /**
-     * Additional constuctor just as hack for decoupling the core package from
+     * Additional constructor just as hack for decoupling the core package from
      * gui2 package
      *
      * @param modernGui

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/PluginLoader.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/PluginLoader.java
@@ -486,7 +486,7 @@ public class PluginLoader implements AutoCloseable {
                 u = u.substring(0, u.indexOf(findBugsClassFile));
                 from = new URL(u);
             } else {
-                throw new IllegalArgumentException("Unknown url shema: " + u);
+                throw new IllegalArgumentException("Unknown url schema: " + u);
             }
 
         } catch (MalformedURLException e) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/SourceLineAnnotation.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/SourceLineAnnotation.java
@@ -429,7 +429,7 @@ public class SourceLineAnnotation implements BugAnnotation {
      * @param methodDescriptor
      *            MethodDescriptor identifying analyzed method
      * @param location
-     *            Location of instruction within analyed method
+     *            Location of instruction within analyzed method
      * @return SourceLineAnnotation describing visited instruction
      */
     public static SourceLineAnnotation fromVisitedInstruction(MethodDescriptor methodDescriptor, Location location) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/BytecodeScanner.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/BytecodeScanner.java
@@ -290,7 +290,7 @@ public class BytecodeScanner {
                     index += 5;
                     wide = false;
                 } else {
-                    // Skip opcode, one byte index, and one byte immedate value.
+                    // Skip opcode, one byte index, and one byte immediate value.
                     index += 3;
                 }
                 break;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/CFG.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/CFG.java
@@ -303,7 +303,7 @@ public class CFG extends AbstractGraph<Edge, BasicBlock> implements Debug {
     }
 
     /*
-     * * Get an Iteratable over the nodes (BasicBlocks) of the control flow
+     * * Get an Iterable over the nodes (BasicBlocks) of the control flow
      * graph.
      */
     public Iterable<BasicBlock> blocks() {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/PruneInfeasibleExceptionEdges.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/PruneInfeasibleExceptionEdges.java
@@ -62,7 +62,7 @@ public class PruneInfeasibleExceptionEdges implements EdgeTypes {
 
     /**
      * A memento to remind us of how we classified a particular exception edge.
-     * If pruning and classifying succeeds, then these momentos can be applied
+     * If pruning and classifying succeeds, then these mementos can be applied
      * to actually change the state of the edges. The issue is that the entire
      * pruning/classifying operation must either fail or succeed as a whole.
      * Thus, we don't commit any CFG changes until we know everything was

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/bcp/Variable.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/bcp/Variable.java
@@ -21,7 +21,7 @@ package edu.umd.cs.findbugs.ba.bcp;
 
 /**
  * A Variable is either a LocalVariable or a FieldVariable. The only
- * functinality of a Variable is to determine whether it is the same as some
+ * functionality of a Variable is to determine whether it is the same as some
  * other Variable.
  */
 public interface Variable {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/IsNullValue.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/IsNullValue.java
@@ -32,7 +32,7 @@ import edu.umd.cs.findbugs.classfile.FieldDescriptor;
 
 /**
  * A class to abstractly represent values in stack slots, indicating whether
- * thoses values can be null, non-null, null on some incoming path, or unknown.
+ * those values can be null, non-null, null on some incoming path, or unknown.
  *
  * @author David Hovemeyer
  * @see IsNullValueFrame

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/type/ExtendedTypes.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/type/ExtendedTypes.java
@@ -73,7 +73,7 @@ public interface ExtendedTypes {
 
     /**
      * A Type code that is available for "user-defined" types. Any type code
-     * equal or greated than this one is guaranteed to be distinct from both
+     * equal or greater than this one is guaranteed to be distinct from both
      * standard and extended types.
      */
     public static final byte T_AVAIL_TYPE = 100;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/bcel/CFGDetector.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/bcel/CFGDetector.java
@@ -97,7 +97,7 @@ public abstract class CFGDetector implements Detector2 {
 
     /**
      * Visit the CFG (control flow graph) of a method to be analyzed. Should be
-     * overridded by subclasses.
+     * overridden by subclasses.
      *
      * @param methodDescriptor
      * @param cfg

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/ClassPathImpl.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/ClassPathImpl.java
@@ -175,7 +175,7 @@ public class ClassPathImpl implements IClassPath {
      * @param codeBaseList
      *            list of codebases to search
      * @param resourceName
-     *            name of resourse
+     *            name of resource
      * @return codebase entry for the named resource, or null if the named
      *         resource cannot be found
      */

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/config/ProjectFilterSettings.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/config/ProjectFilterSettings.java
@@ -223,7 +223,7 @@ public class ProjectFilterSettings implements Cloneable {
     }
 
     /**
-     * set the hidden bug categories on the specifed ProjectFilterSettings from
+     * set the hidden bug categories on the specified ProjectFilterSettings from
      * an encoded string
      *
      * @param result
@@ -378,7 +378,7 @@ public class ProjectFilterSettings implements Cloneable {
     /**
      * Return set of active (enabled) bug categories.
      *
-     * Note that bug categories that are not explicity hidden will appear active
+     * Note that bug categories that are not explicitly hidden will appear active
      * even if they are not members of this set.
      *
      * @return the set of active categories

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/config/SortedProperties.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/config/SortedProperties.java
@@ -12,7 +12,7 @@ import java.util.Set;
  */
 public final class SortedProperties extends Properties {
     /**
-     * Overriden to be able to write properties sorted by keys to the disk
+     * Overridden to be able to write properties sorted by keys to the disk
      *
      * @see java.util.Hashtable#keys()
      */

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindJSR166LockMonitorenter.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindJSR166LockMonitorenter.java
@@ -117,14 +117,14 @@ public final class FindJSR166LockMonitorenter implements Detector, StatelessDete
         try {
             cfg = classContext.getCFG(method);
         } catch (CFGBuilderException e1) {
-            AnalysisContext.logError("Coult not get CFG", e1);
+            AnalysisContext.logError("Could not get CFG", e1);
             return;
         }
         TypeDataflow typeDataflow;
         try {
             typeDataflow = classContext.getTypeDataflow(method);
         } catch (CheckedAnalysisException e1) {
-            AnalysisContext.logError("Coult not get Type dataflow", e1);
+            AnalysisContext.logError("Could not get Type dataflow", e1);
             return;
         }
 
@@ -191,7 +191,7 @@ public final class FindJSR166LockMonitorenter implements Detector, StatelessDete
                         }
 
                     } catch (CheckedAnalysisException e) {
-                        AnalysisContext.logError("Coult not get Type dataflow", e);
+                        AnalysisContext.logError("Could not get Type dataflow", e);
                         continue;
                     }
 
@@ -210,7 +210,7 @@ public final class FindJSR166LockMonitorenter implements Detector, StatelessDete
                 }
                 type = frame.getInstance(ins, cpg);
             } catch (CheckedAnalysisException e) {
-                AnalysisContext.logError("Coult not get Type dataflow", e);
+                AnalysisContext.logError("Could not get Type dataflow", e);
                 continue;
             }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindUnsatisfiedObligation.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindUnsatisfiedObligation.java
@@ -647,7 +647,7 @@ public class FindUnsatisfiedObligation extends CFGDetector {
             // If we're tracking, e.g., InputStream obligations,
             // and we see a FileInputStream reference being assigned
             // to a field (or returned from a method),
-            // then the false-positive supressions heuristic should apply.
+            // then the false-positive suppressions heuristic should apply.
             //
 
             return subtypes2.isSubtype(type, obligationType);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InefficientMemberAccess.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InefficientMemberAccess.java
@@ -85,12 +85,12 @@ public class InefficientMemberAccess extends BytecodeScanningDetector implements
                 access = AnalysisContext.currentAnalysisContext().getInnerClassAccessMap().getInnerClassAccess(dottedClassConstantOperand,
                         methodName);
                 if (access != null) {
-                    // if the enclosing class of the field differs from the enclosing class of the method, we shouln't report
+                    // if the enclosing class of the field differs from the enclosing class of the method, we shouldn't report
                     // because there is nothing wrong: see bug 1226
                     if (!access.getField().getClassName().equals(dottedClassConstantOperand)) {
                         return;
                     }
-                    // the access method is created to access the synthetic reference to the enclosing class, we shouln't report
+                    // the access method is created to access the synthetic reference to the enclosing class, we shouldn't report
                     // user can't do anything here, see bug 1191
                     if (access.getField().isSynthetic()) {
                         return;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InfiniteRecursiveLoop.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InfiniteRecursiveLoop.java
@@ -152,7 +152,7 @@ public class InfiniteRecursiveLoop extends OpcodeStackDetector implements Statel
 
                 boolean sameMethod = seen == Const.INVOKESTATIC || Const.CONSTRUCTOR_NAME.equals(getNameConstantOperand());
                 if (!sameMethod) {
-                    // Have to check if first parmeter is the same
+                    // Have to check if first parameter is the same
                     // know there must be a this argument
                     if (DEBUG) {
                         System.out.println("Stack is " + stack);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/Naming.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/Naming.java
@@ -391,7 +391,7 @@ public class Naming extends PreorderVisitor implements Detector {
         if (name.endsWith("Exception")) {
             // Does it ultimately inherit from Throwable?
             if (!mightInheritFromException(DescriptorFactory.createClassDescriptor(obj))) {
-                // It doens't, so the name is misleading
+                // It doesn't, so the name is misleading
                 bugReporter.reportBug(new BugInstance(this, "NM_CLASS_NOT_EXCEPTION", NORMAL_PRIORITY).addClass(this));
             }
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/NumberConstructor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/NumberConstructor.java
@@ -50,7 +50,7 @@ import edu.umd.cs.findbugs.internalAnnotations.SlashedClassName;
  * why those are reported as low priority.
  *
  * All invokes of Number constructor with a constant argument are flagged as
- * high priority and invokes with unknwon value are normal priority.
+ * high priority and invokes with unknown value are normal priority.
  *
  * @author Mikko Tiihonen
  */

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/StaticCalendarDetector.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/StaticCalendarDetector.java
@@ -55,7 +55,7 @@ import edu.umd.cs.findbugs.internalAnnotations.SlashedClassName;
  * Detector for static fields of type {@link java.util.Calendar} or
  * {@link java.text.DateFormat} and their subclasses. Because
  * {@link java.util.Calendar} is unsafe for multithreaded use, static fields
- * look suspicous. To work correctly, all access would need to be synchronized
+ * look suspicious. To work correctly, all access would need to be synchronized
  * by the client which cannot be guaranteed.
  *
  * @author Daniel Schneller

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/TrainNonNullAnnotations.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/TrainNonNullAnnotations.java
@@ -61,7 +61,7 @@ public class TrainNonNullAnnotations extends BuildNonNullAnnotationDatabase impl
      */
     @Override
     public void report() {
-        // TODO: FIX for new version of annnotations
+        // TODO: FIX for new version of annotations
         // AnalysisContext.currentAnalysisContext().storePropertyDatabase(
         // getNonNullDatabase(),
         // AnalysisContext.DEFAULT_NONNULL_PARAM_DATABASE_FILENAME,

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/filter/NameMatch.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/filter/NameMatch.java
@@ -36,7 +36,7 @@ import javax.annotation.CheckForNull;
  * java.util.regex.Pattern, with the ~ character omitted. The pattern will be
  * matched against whole value (ie Matcher.match(), not Matcher.find())
  *
- * If matchSpec is a non-null String with any other initial charcter, exact
+ * If matchSpec is a non-null String with any other initial character, exact
  * matching using String.equals(String) will be performed.
  *
  * @author rafal@caltha.pl

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/jaif/JAIFEvents.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/jaif/JAIFEvents.java
@@ -20,7 +20,7 @@
 package edu.umd.cs.findbugs.jaif;
 
 /**
- * Callbacks for parsing an extenal annotation file.
+ * Callbacks for parsing an external annotation file.
  *
  * @author David Hovemeyer
  * @see <a

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/log/Profiler.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/log/Profiler.java
@@ -385,7 +385,7 @@ public class Profiler implements IProfiler, XMLWriteable {
 
     /**
      * Default implementation uses {@link TotalTimeComparator} and prints out
-     * class statistics based on total time spent fot a class
+     * class statistics based on total time spent for a class
      * @deprecated use {@link ProfileSummary#report} instead.
      */
     @Deprecated
@@ -431,7 +431,7 @@ public class Profiler implements IProfiler, XMLWriteable {
 
     /**
      * Clears the previously accumulated data. This method is public because it
-     * can be accessed explicitely from clients (like Eclipse).
+     * can be accessed explicitly from clients (like Eclipse).
      * <p>
      * There is no need to clear profiler data after each run, because a new
      * profiler instance is used for each analysis run (see

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/model/IdentityClassNameRewriter.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/model/IdentityClassNameRewriter.java
@@ -22,7 +22,7 @@ package edu.umd.cs.findbugs.model;
 import java.io.Serializable;
 
 /**
- * ClassNameRewriter that leaves classe names unchanged.
+ * ClassNameRewriter that leaves classes names unchanged.
  *
  * @author David Hovemeyer
  */

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/plugins/DuplicatePluginIdError.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/plugins/DuplicatePluginIdError.java
@@ -48,7 +48,7 @@ public class DuplicatePluginIdError extends Error {
      * @param loadedFrom
      */
     public DuplicatePluginIdError(String pluginId, URL loadedFrom, URL previouslyLoadedFrom) {
-        super("Manditory plugin " + pluginId + " from " + loadedFrom + " already loaded from " + previouslyLoadedFrom);
+        super("Mandatory plugin " + pluginId + " from " + loadedFrom + " already loaded from " + previouslyLoadedFrom);
         this.pluginId = pluginId;
         this.loadedFrom = loadedFrom;
         this.previouslyLoadedFrom = previouslyLoadedFrom;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/Strings.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/Strings.java
@@ -216,7 +216,7 @@ public class Strings {
                  * the pattern is compiled from a final string, so this
                  * exception should never be thrown
                  */
-                System.err.println("Imposible error:  " + "static final regular expression pattern "
+                System.err.println("Impossible error:  " + "static final regular expression pattern "
                         + "failed to compile.  Exception:  " + pse.toString());
                 return false;
             }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/visitclass/DismantleBytecode.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/visitclass/DismantleBytecode.java
@@ -643,7 +643,7 @@ abstract public class DismantleBytecode extends AnnotationVisitor {
                             throw new IllegalStateException(String.format("bad wide bytecode %d: %s", opcode, Const.getOpcodeName(opcode)));
                         }
                     } else {
-                        throw new IllegalStateException(String.format("bad unpredicatable bytecode %d: %s", opcode, Const.getOpcodeName(opcode)));
+                        throw new IllegalStateException(String.format("bad unpredictable bytecode %d: %s", opcode, Const.getOpcodeName(opcode)));
                     }
                 } else {
                     if (byteStreamArgCount < 0) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/Update.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/Update.java
@@ -101,7 +101,7 @@ public class Update {
             addOption("-output", "output file", "explicit filename for merged results (standard out used if not specified)");
             addOption("-maxRank", "max rank", "maximum rank for issues to store");
 
-            addSwitch("-quiet", "don't generate any outout to standard out unless there is an error");
+            addSwitch("-quiet", "don't generate any output to standard out unless there is an error");
             addSwitch("-useAnalysisTimes", "use analysis timestamp rather than code timestamp in history");
             addSwitch("-withMessages", "Add bug description");
             addOption("-onlyMostRecent", "number", "only use the last # input files");

--- a/spotbugsTestCases/src/java/CloneIdiom4.java
+++ b/spotbugsTestCases/src/java/CloneIdiom4.java
@@ -1,7 +1,7 @@
 /**
  * non-final class with final clone() method.
  *
- * This is probably bug, but the detector shoud be careful that the final
+ * This is probably bug, but the detector should be careful that the final
  * clone() implementation doesn't directly or indirectly invoke some kind of
  * non-final copy() method.
  */

--- a/spotbugsTestCases/src/java/StaticCalender.java
+++ b/spotbugsTestCases/src/java/StaticCalender.java
@@ -86,7 +86,7 @@ public class StaticCalender {
         // test 1
         Calendar tCal1 = calStatic; // should fire
         if (tCal1.equals(calStatic)) // hide from unused variable detector;
-                                     // shoud fire
+                                     // should fire
             System.out.println("Cal1 equals calStatic");
 
         // test 2

--- a/spotbugsTestCases/src/java/bugIdeas/Ideas_2009_01_14.java
+++ b/spotbugsTestCases/src/java/bugIdeas/Ideas_2009_01_14.java
@@ -25,7 +25,7 @@ public class Ideas_2009_01_14 {
             result = "four";
             break;
         default:
-            throw new IllegalArgumentException("Illegal agrument: " + value);
+            throw new IllegalArgumentException("Illegal argument: " + value);
 
         }
         return "Answer is " + result;

--- a/spotbugsTestCases/src/java/com/google/errorprone/bugpatterns/PreconditionsCheckNotNullPositiveCase3.java
+++ b/spotbugsTestCases/src/java/com/google/errorprone/bugpatterns/PreconditionsCheckNotNullPositiveCase3.java
@@ -19,7 +19,7 @@ package com.google.errorprone.bugpatterns;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
- * Test case for static import of Precondtions.checkNotNull.
+ * Test case for static import of Preconditions.checkNotNull.
  * @author eaftan@google.com (Eddie Aftandilian)
  */
 public class PreconditionsCheckNotNullPositiveCase3 {

--- a/spotbugsTestCases/src/java/constructorthrow/ConstructorThrowTest6.java
+++ b/spotbugsTestCases/src/java/constructorthrow/ConstructorThrowTest6.java
@@ -3,7 +3,7 @@ package constructorthrow;
 /**
  * In this test case the constructor throws an unchecked exception,
  * there is no throws declaration, and there is a finalize method, that is
- * not overriding void#finalize(). A Warning still should be emited.
+ * not overriding void#finalize(). A Warning still should be emitted.
  * Inspired by @KengoToda's suggestion.
  */
 public class ConstructorThrowTest6 {

--- a/spotbugsTestCases/src/java/ghIssues/Issue1472.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue1472.java
@@ -3,21 +3,21 @@ package ghIssues;
 public class Issue1472 {
     int testSA_LOCAL_SELF_COMPUTATION(){
         int flags = 1;
-        return flags ^ flags; // expeected SA_LOCAL_SELF_COMPUTATION
+        return flags ^ flags; // expected SA_LOCAL_SELF_COMPUTATION
     }
 
     int testSA_LOCAL_SELF_COMPUTATION1(){
         int flags = 1;
-        return flags & flags; //  expeected SA_LOCAL_SELF_COMPUTATION
+        return flags & flags; //  expected SA_LOCAL_SELF_COMPUTATION
     }
 
     int testSA_LOCAL_SELF_COMPUTATION2(){
         int flags = 1;
-        return flags - flags; //  expeected SA_LOCAL_SELF_COMPUTATION
+        return flags - flags; //  expected SA_LOCAL_SELF_COMPUTATION
     }
 
     int testSA_LOCAL_SELF_COMPUTATION3(){
         int flags = 1;
-        return flags | flags; //  expeected SA_LOCAL_SELF_COMPUTATION
+        return flags | flags; //  expected SA_LOCAL_SELF_COMPUTATION
     }
 }

--- a/spotbugsTestCases/src/java/npe/FalsePositiveOnExceptionPath.java
+++ b/spotbugsTestCases/src/java/npe/FalsePositiveOnExceptionPath.java
@@ -19,11 +19,11 @@ import java.io.IOException;
  *  r = a.MyClass.getInstance()
  * }
  * catch (IOException e) {
- *  log.warn("IO Exeption" + e.getMessage());
+ *  log.warn("IO Exception" + e.getMessage());
  *  return null;
  * }
  * catch (MyException e) {
- *  log.warn("My Exeption" + e.getMessage());
+ *  log.warn("My Exception" + e.getMessage());
  *    return null;
  * }
  *
@@ -52,10 +52,10 @@ public class FalsePositiveOnExceptionPath {
         try {
             r = getInstance(i);
         } catch (IOException e) {
-            System.out.println("IO Exeption" + e.getMessage());
+            System.out.println("IO Exception" + e.getMessage());
             return null;
         } catch (IllegalArgumentException e) {
-            System.out.println("My Exeption" + e.getMessage());
+            System.out.println("My Exception" + e.getMessage());
             return null;
         }
 

--- a/spotbugsTestCases/src/java/sfBugs/Bug1663624.java
+++ b/spotbugsTestCases/src/java/sfBugs/Bug1663624.java
@@ -19,7 +19,7 @@ public class Bug1663624 {
     public void show(SomeInterface reference) {
         Object object = reference.condition1() ? reference.get() : null;
         if (reference.condition2()) {
-            foo(object); // (*) object may bu null!
+            foo(object); // (*) object may be null!
         }
     }
 

--- a/spotbugsTestCases/src/java/sfBugs/Bug1795838.java
+++ b/spotbugsTestCases/src/java/sfBugs/Bug1795838.java
@@ -4,7 +4,7 @@ package sfBugs;
  * Submitted By: Heiko W.Rupp - pilhuhn Summary: (?) NPE and NFE concerning
  * types like Integer not found
  *
- * The attache file contains three Exception throwing locations that all are not
+ * The attached file contains three Exception throwing locations that all are not
  * detected.
  *
  * The first one is from autounboxing NULL as Integer into an int. The second

--- a/spotbugsTestCases/src/java/sfBugs/Bug2003267.java
+++ b/spotbugsTestCases/src/java/sfBugs/Bug2003267.java
@@ -17,7 +17,7 @@ public class Bug2003267 {
             target = new Works();
         }
 
-        target.bar(param); // < reports a "possible null pointer derefence" for
+        target.bar(param); // < reports a "possible null pointer dereference" for
         // < target (NP_NULL_ON_SOME_PATH): Correctly detected
     }
 

--- a/spotbugsTestCases/src/java/sfBugs/Bug2177967.java
+++ b/spotbugsTestCases/src/java/sfBugs/Bug2177967.java
@@ -31,7 +31,7 @@ public class Bug2177967 {
         // Load the properties from the file
         InputStream in = loader.getResourceAsStream(propertiesFile);
         if (in == null) {
-            throw new RuntimeException("Cound not locate " + propertiesFile);
+            throw new RuntimeException("Could not locate " + propertiesFile);
         }
         properties.load(in);
 
@@ -42,7 +42,7 @@ public class Bug2177967 {
         // Load the properties from the file
         InputStream in = new FileInputStream(propertiesFile);
         if (in == null) {
-            throw new RuntimeException("Cound not locate " + propertiesFile);
+            throw new RuntimeException("Could not locate " + propertiesFile);
         }
         properties.load(in);
 

--- a/spotbugsTestCases/src/java/sfBugs/Bug3559113.java
+++ b/spotbugsTestCases/src/java/sfBugs/Bug3559113.java
@@ -38,7 +38,7 @@ package sfBugs;
 ** Revision 1.4  2010/06/02 12:50:53  Toshifumi_Kojima
 ** [p112960] Mag:WF7.6.11HF:Special char escapes in category tree
 **  Use encodeURIComponent() function at tree.js instead of escape().
-**  Use java.net.URLDecoder.deocde() method at decode() of RequiredFields class.
+**  Use java.net.URLDecoder.decode() method at decode() of RequiredFields class.
 **
 ** Revision 1.3  2010/04/11 16:48:58  Peter_Lenahan
 ** [p111674][>branch7701] [>branch7610_hotfix] [>branch7611_hotfix] Periods in Category tree cause tree and bread crumb trail to fail.

--- a/spotbugsTestCases/src/java/sfBugs/Patch1244562.java
+++ b/spotbugsTestCases/src/java/sfBugs/Patch1244562.java
@@ -18,7 +18,7 @@ public class Patch1244562 {
         am.usePattern(okpat);
         am.usePattern(null);
         try {
-            String uee = new String(new byte[] { 'a', 'b' }, "unkown charset");
+            String uee = new String(new byte[] { 'a', 'b' }, "unknown charset");
             String okname = new String(new byte[] { 'a', 'b' }, "iso-8859-7");
         } catch (java.io.UnsupportedEncodingException e) {
         }

--- a/spotbugsTestCases/src/java/sfBugsNew/Bug1184.java
+++ b/spotbugsTestCases/src/java/sfBugsNew/Bug1184.java
@@ -7,7 +7,7 @@ import edu.umd.cs.findbugs.annotations.DesireWarning;
 import edu.umd.cs.findbugs.annotations.NoWarning;
 
 public class Bug1184 {
-    @DesireWarning("BX_UNBOXING_IMMEDIATELY_REBOXED") // not generated under Jave 1.8
+    @DesireWarning("BX_UNBOXING_IMMEDIATELY_REBOXED") // not generated under Java 1.8
     public static void main(String[] args) {
         List<Integer> list = new ArrayList<>();
         list.add(1);

--- a/spotbugsTestCases/src/java/worseThanFailure/Post20071210.java
+++ b/spotbugsTestCases/src/java/worseThanFailure/Post20071210.java
@@ -11,7 +11,7 @@ public class Post20071210 {
         // security reasones to burn away any remains of the key from
         // memory.
         // For maximum security the memory previous allocated for the
-        // key should be zeroed for atleast a few seconds, else it is
+        // key should be zeroed for at least a few seconds, else it is
         // possible to extract the key with some technology.
         // If the key is stored to disk, it shall after it is used be
         // overwritten by random data several times, at least 7 but 32


### PR DESCRIPTION
Fix typos in documentation, comments, etc.

Via [codespell](https://github.com/codespell-project/codespell/).
