### PR TITLE
Fixing #3159 - Method call graph ignores constructors and non-parametric void methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Fixed some CWE mappings ([#3124](https://github.com/spotbugs/spotbugs/pull/3124))
 - Recognize some classes as immutable, fixing EI_EXPOSE and MS_EXPOSE FPs ([#3137](https://github.com/spotbugs/spotbugs/pull/3137))
 - Do not report UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR for fields initialized in method annotated with TestNG's @BeforeClass. ([#3152](https://github.com/spotbugs/spotbugs/issues/3152))
+- Fix call graph, include non-parametric void methods ([#3160](https://github.com/spotbugs/spotbugs/pull/3160))
 
 ### Cleanup
 - Cleanup thread issue and regex issue in test-harness ([#3130](https://github.com/spotbugs/spotbugs/issues/3130))

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/classfile/MethodsCallOrderTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/classfile/MethodsCallOrderTest.java
@@ -88,4 +88,35 @@ class MethodsCallOrderTest {
 
         assertEquals(expected, actual);
     }
+
+    @Test
+    void testShortcutPathTest() {
+        try {
+            load("../spotbugsTestCases/build/classes/java/main/MethodsCallOrder$ShortcutPathTest.class");
+        } catch (CheckedAnalysisException | IOException | InterruptedException e) {
+            fail("Unable to add MethodsCallOrder$SimpleTest.class to the build: " + e.getMessage(), e);
+        }
+
+        ClassDescriptor classDescriptor = DescriptorFactory.createClassDescriptor("MethodsCallOrder$ShortcutPathTest");
+
+        List<String> actual = new ArrayList<>();
+
+        try {
+            ClassContext classContext = Global.getAnalysisCache().getClassAnalysis(ClassContext.class, classDescriptor);
+            for (Method method : classContext.getMethodsInCallOrder()) {
+                actual.add(method.getName() + method.getSignature());
+            }
+        } catch (CheckedAnalysisException e) {
+            fail("Unable to get ClassContext analysis for MethodsCallOrder: " + e.getMessage(), e);
+        }
+
+        List<String> expected = Arrays.asList(new String[] {
+            "methodC()V",
+            "methodB()V",
+            "methodA()V",
+            "<init>()V"
+        });
+
+        assertEquals(expected, actual);
+    }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/classfile/MethodsCallOrderTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/classfile/MethodsCallOrderTest.java
@@ -1,0 +1,74 @@
+package edu.umd.cs.findbugs.classfile;
+
+import edu.umd.cs.findbugs.*;
+import edu.umd.cs.findbugs.ba.AnalysisContext;
+import edu.umd.cs.findbugs.ba.ClassContext;
+import edu.umd.cs.findbugs.classfile.impl.ClassFactory;
+import org.apache.bcel.classfile.Method;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * @author Tomas Polesovsky
+ */
+public class MethodsCallOrderTest {
+
+    @Test
+    void testSimpleName() {
+        PrintingBugReporter bugReporter = new PrintingBugReporter();
+        IClassFactory classFactory = ClassFactory.instance();
+        IClassPath classPath = classFactory.createClassPath();
+
+        IAnalysisCache analysisCache = classFactory.createAnalysisCache(classPath, bugReporter);
+        Global.setAnalysisCacheForCurrentThread(analysisCache);
+        FindBugs2.registerBuiltInAnalysisEngines(analysisCache);
+
+        Project project = new Project();
+        AnalysisContext analysisContext = new AnalysisContext(project);
+        AnalysisContext.setCurrentAnalysisContext(analysisContext);
+
+        IClassPathBuilder builder = classFactory.createClassPathBuilder(bugReporter);
+        builder.addCodeBase(classFactory.createFilesystemCodeBaseLocator("../spotbugsTestCases/build/classes/java/main/MethodsCallOrder.class"),
+                true);
+        try {
+            builder.build(classPath, new NoOpFindBugsProgress());
+        } catch (CheckedAnalysisException | IOException | InterruptedException e) {
+            fail("Unable to add MethodsCallOrder.class to the build: " + e.getMessage(), e);
+        }
+
+        ClassDescriptor classDescriptor = DescriptorFactory.createClassDescriptor("MethodsCallOrder");
+
+        List<String> actual = new ArrayList<>();
+
+        try {
+            ClassContext classContext = analysisCache.getClassAnalysis(ClassContext.class, classDescriptor);
+            for (Method method : classContext.getMethodsInCallOrder()) {
+                actual.add(method.getName() + method.getSignature());
+            }
+        } catch (CheckedAnalysisException e) {
+            fail("Unable to get ClassContext analysis for MethodsCallOrder: " + e.getMessage(), e);
+        }
+
+        List<String> expected = Arrays.asList(new String[] {
+            "method4()V",
+            "method3()V",
+            "method2()V",
+            "method1()V",
+            "<init>(Ljava/lang/Object;)V",
+            "<init>()V",
+            "staticMethod4()V",
+            "staticMethod3()V",
+            "staticMethod2()V",
+            "staticMethod1()V",
+            "<clinit>()V" });
+
+        assertEquals(expected, actual);
+    }
+}

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/classfile/MethodsCallOrderTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/classfile/MethodsCallOrderTest.java
@@ -18,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  * @author Tomas Polesovsky
  */
-public class MethodsCallOrderTest {
+class MethodsCallOrderTest {
 
     @Test
     void testSimpleName() {

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/classfile/MethodsCallOrderTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/classfile/MethodsCallOrderTest.java
@@ -35,7 +35,8 @@ class MethodsCallOrderTest {
         AnalysisContext.setCurrentAnalysisContext(analysisContext);
 
         IClassPathBuilder builder = classFactory.createClassPathBuilder(bugReporter);
-        builder.addCodeBase(classFactory.createFilesystemCodeBaseLocator("../spotbugsTestCases/build/classes/java/main/MethodsCallOrder.class"),
+        builder.addCodeBase(classFactory.createFilesystemCodeBaseLocator(
+                "../spotbugsTestCases/build/classes/java/main/MethodsCallOrder$SimpleTest.class"),
                 true);
         try {
             builder.build(classPath, new NoOpFindBugsProgress());
@@ -43,7 +44,7 @@ class MethodsCallOrderTest {
             fail("Unable to add MethodsCallOrder.class to the build: " + e.getMessage(), e);
         }
 
-        ClassDescriptor classDescriptor = DescriptorFactory.createClassDescriptor("MethodsCallOrder");
+        ClassDescriptor classDescriptor = DescriptorFactory.createClassDescriptor("MethodsCallOrder$SimpleTest");
 
         List<String> actual = new ArrayList<>();
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/SelfMethodCalls.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/SelfMethodCalls.java
@@ -41,7 +41,7 @@ import edu.umd.cs.findbugs.util.MultiMap;
 public class SelfMethodCalls {
 
     static private boolean interestingSignature(String signature) {
-        return !"()V".equals(signature);
+        return true;
     }
 
     public static <T> MultiMap<T, T> getSelfCalls(final ClassDescriptor classDescriptor, final Map<String, T> methods) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/SelfMethodCalls.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/SelfMethodCalls.java
@@ -40,10 +40,6 @@ import edu.umd.cs.findbugs.util.MultiMap;
  */
 public class SelfMethodCalls {
 
-    static private boolean interestingSignature(String signature) {
-        return true;
-    }
-
     public static <T> MultiMap<T, T> getSelfCalls(final ClassDescriptor classDescriptor, final Map<String, T> methods) {
         final MultiMap<T, T> map = new MultiMap<>(HashSet.class);
 
@@ -62,7 +58,7 @@ public class SelfMethodCalls {
                 return new MethodVisitor(FindBugsASM.ASM_VERSION) {
                     @Override
                     public void visitMethodInsn(int opcode, String owner, String name2, String desc2, boolean itf) {
-                        if (owner.equals(classDescriptor.getClassName()) && interestingSignature(desc2)) {
+                        if (owner.equals(classDescriptor.getClassName())) {
                             T from = methods.get(name + desc + ((access & Opcodes.ACC_STATIC) != 0));
                             T to = methods.get(name2 + desc2 + (opcode == Opcodes.INVOKESTATIC));
                             map.add(from, to);

--- a/spotbugsTestCases/src/java/MethodsCallOrder.java
+++ b/spotbugsTestCases/src/java/MethodsCallOrder.java
@@ -3,41 +3,49 @@
  */
 public class MethodsCallOrder {
 
-	static {
-		staticMethod1();
-	}
+	static class SimpleTest {
+		static {
+			staticMethod1();
+		}
 
-	public static void staticMethod1(){
-		staticMethod2();
-	}
-	public static void staticMethod2(){
-		staticMethod3();
-	}
-	public static void staticMethod3(){
-		staticMethod4();
-	}
-	public static void staticMethod4(){
-		new MethodsCallOrder();
-	}
+		public static void staticMethod1() {
+			staticMethod2();
+		}
 
-	public MethodsCallOrder() {
-		this(null);
-	}
+		public static void staticMethod2() {
+			staticMethod3();
+		}
 
-	public MethodsCallOrder(Object o) {
-		method1();
-	}
+		public static void staticMethod3() {
+			staticMethod4();
+		}
 
-	public void method1() {
-		method2();
-	}
-	public void method2() {
-		method3();
-	}
-	public void method3() {
-		method4();
-	}
-	public void method4() {
-		System.out.println("HERE WE GO!");
+		public static void staticMethod4() {
+			new MethodsCallOrder.SimpleTest();
+		}
+
+		public SimpleTest() {
+			this(null);
+		}
+
+		public SimpleTest(Object o) {
+			method1();
+		}
+
+		public void method1() {
+			method2();
+		}
+
+		public void method2() {
+			method3();
+		}
+
+		public void method3() {
+			method4();
+		}
+
+		public void method4() {
+			System.out.println("HERE WE GO!");
+		}
 	}
 }

--- a/spotbugsTestCases/src/java/MethodsCallOrder.java
+++ b/spotbugsTestCases/src/java/MethodsCallOrder.java
@@ -48,4 +48,27 @@ public class MethodsCallOrder {
 			System.out.println("HERE WE GO!");
 		}
 	}
+
+	static class ShortcutPathTest {
+		public ShortcutPathTest() {
+			methodA();
+		}
+
+		public void methodA(){
+			if (System.currentTimeMillis() % 2 == 1) {
+				methodB();
+			} else {
+				methodC();
+			}
+		}
+
+		public void methodB(){
+			methodC();
+		}
+
+		public void methodC(){
+			System.out.println("HERE WE GO!");
+		}
+	}
+
 }

--- a/spotbugsTestCases/src/java/MethodsCallOrder.java
+++ b/spotbugsTestCases/src/java/MethodsCallOrder.java
@@ -1,0 +1,43 @@
+/**
+ * @author Tomas Polesovsky
+ */
+public class MethodsCallOrder {
+
+	static {
+		staticMethod1();
+	}
+
+	public static void staticMethod1(){
+		staticMethod2();
+	}
+	public static void staticMethod2(){
+		staticMethod3();
+	}
+	public static void staticMethod3(){
+		staticMethod4();
+	}
+	public static void staticMethod4(){
+		new MethodsCallOrder();
+	}
+
+	public MethodsCallOrder() {
+		this(null);
+	}
+
+	public MethodsCallOrder(Object o) {
+		method1();
+	}
+
+	public void method1() {
+		method2();
+	}
+	public void method2() {
+		method3();
+	}
+	public void method3() {
+		method4();
+	}
+	public void method4() {
+		System.out.println("HERE WE GO!");
+	}
+}


### PR DESCRIPTION
Looks like the problem is there [from the very beginnings](https://github.com/spotbugs/spotbugs/commit/a5b3c2de4045e2f94858ccac2a4543f480265f3b) where the logic ignored all non-parametric methods as "not interesting". 

Omitting those methods from the MultiMap doesn't give TopologySort any information about the graph orientation and these methods are randomly misplaced when calling `ClassContext#getMethodsInCallOrder`. 

Part of the PR is a test that has a simple call stack from the default `static{}` constructor `<clinit>()V` through several static methods to a non-parametric class constructor, one more constructor and then instantiated class methods which creates a very simple DAG that any topological sorting algorithm should have no problem analyzing.

After fixing the `interestingSignature` method from ` return !"()V".equals(signature);` to `return true;`, it works! :) 

FYI: required for proper FindSecurityBugs taint analysis of derived methods. Without proper order they are skipped by the analysis engine as unknown.