### PR TITLE
Return objects directly instead of assigning to temporary variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Cleanup thread issue and regex issue in test-harness ([#3130](https://github.com/spotbugs/spotbugs/issues/3130))
 - Remove extra blank lines and remove public from interface objects as inherently already public ([#3131](https://github.com/spotbugs/spotbugs/issues/3131))
 - Fix order of modifiers on properties/methods and ensure correct location in file ([#3132](https://github.com/spotbugs/spotbugs/issues/3132))
-- Return objects directly instead of creating more garbage collection by defining them ([#3133](https://github.com/spotbugs/spotbugs/issues/3133))
+- Return objects directly instead of creating more garbage collection by defining them ([#3133](https://github.com/spotbugs/spotbugs/pull/3133), [#3175](https://github.com/spotbugs/spotbugs/pull/3175))
 - Cleanup double initization and fix comments referring to findbugs instead of spotbugs([#3134](https://github.com/spotbugs/spotbugs/issues/3134))
 
 ### Changed

--- a/eclipsePlugin-test/src/de/tobject/findbugs/properties/test/PropertiesPageTest.java
+++ b/eclipsePlugin-test/src/de/tobject/findbugs/properties/test/PropertiesPageTest.java
@@ -491,8 +491,7 @@ class PropertiesPageTest extends AbstractFindBugsTest {
     }
 
     private FindbugsPropertyPageTestSubclass createWorkspacePropertiesPage() {
-        FindbugsPropertyPageTestSubclass page = new FindbugsPropertyPageTestSubclass();
-        return page;
+        return new FindbugsPropertyPageTestSubclass();
     }
 
     private String getBugsFileProjectRelativePath() {
@@ -504,8 +503,7 @@ class PropertiesPageTest extends AbstractFindBugsTest {
     }
 
     private Shell getParentShell() {
-        Shell shell = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
-        return shell;
+        return PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
     }
 
     private UserPreferences getWorkspacePreferences() {

--- a/eclipsePlugin-test/src/de/tobject/findbugs/reporter/test/JdtUtilTest.java
+++ b/eclipsePlugin-test/src/de/tobject/findbugs/reporter/test/JdtUtilTest.java
@@ -90,13 +90,11 @@ class JdtUtilTest extends AbstractPluginTest {
     }
 
     protected IType getTypeC() throws JavaModelException {
-        IType type = getJavaProject().findType("C");
-        return type;
+        return getJavaProject().findType("C");
     }
 
     protected IType getTypeE() throws JavaModelException {
-        IType type = getJavaProject().findType("C.E");
-        return type;
+        return getJavaProject().findType("C.E");
     }
 
     private void doNullTest(IType parentType, String anonymousClassNumber) {

--- a/eclipsePlugin/src/de/tobject/findbugs/AntPropertyValueProvider.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/AntPropertyValueProvider.java
@@ -7,8 +7,7 @@ public class AntPropertyValueProvider implements IAntPropertyValueProvider {
     @Override
     public String getAntPropertyValue(String antPropertyName) {
         if ("findbugs.home".equals(antPropertyName)) {
-            String home = FindbugsPlugin.getFindBugsEnginePluginLocation();
-            return home;
+            return FindbugsPlugin.getFindBugsEnginePluginLocation();
         }
         throw new IllegalArgumentException("No property " + antPropertyName);
     }

--- a/eclipsePlugin/src/de/tobject/findbugs/FindbugsPlugin.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/FindbugsPlugin.java
@@ -1134,8 +1134,7 @@ public class FindbugsPlugin extends AbstractUIPlugin {
     }
 
     public static Set<BugCode> getKnownPatternTypes() {
-        Set<BugCode> patterns = new TreeSet<>(DetectorFactoryCollection.instance().getBugCodes());
-        return patterns;
+        return new TreeSet<>(DetectorFactoryCollection.instance().getBugCodes());
     }
 
     public static Set<String> getFilteredIds() {

--- a/eclipsePlugin/src/de/tobject/findbugs/actions/FindBugsAction.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/actions/FindBugsAction.java
@@ -147,8 +147,7 @@ public class FindBugsAction implements IObjectActionDelegate {
         if (resource == null) {
             return null;
         }
-        IProject project = resource.getProject();
-        return project;
+        return resource.getProject();
     }
 
     protected String getDialogSettingsId() {

--- a/eclipsePlugin/src/de/tobject/findbugs/actions/SaveXmlAction.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/actions/SaveXmlAction.java
@@ -131,9 +131,8 @@ public class SaveXmlAction extends FindBugsAction {
                 try {
                     bugCollection.writeXML(fileName);
                 } catch (IOException e) {
-                    CoreException ex = new CoreException(FindbugsPlugin.createErrorStatus(
+                    throw new CoreException(FindbugsPlugin.createErrorStatus(
                             "Can't write SpotBugs bug collection from project " + project + " to file " + fileName, e));
-                    throw ex;
                 }
             }
         };

--- a/eclipsePlugin/src/de/tobject/findbugs/builder/FindBugsWorker.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/builder/FindBugsWorker.java
@@ -386,9 +386,7 @@ public class FindBugsWorker {
         // unknown bug instances appearing (merged collection doesn't contain
         // all bugs)
         boolean copyDeadBugs = incremental;
-        SortedBugCollection merged = (SortedBugCollection) (update.mergeCollections(firstCollection, secondCollection,
-                copyDeadBugs, incremental));
-        return merged;
+        return (SortedBugCollection) (update.mergeCollections(firstCollection, secondCollection, copyDeadBugs, incremental));
     }
 
     private Map<String, Boolean> relativeToAbsolute(Map<String, Boolean> map) {
@@ -486,8 +484,7 @@ public class FindBugsWorker {
             return filePath;
         }
         // since Equinox 3.5 we can use IPath.makeRelativeTo(IPath)
-        IPath relativeTo = filePath.makeRelativeTo(commonPath);
-        return relativeTo;
+        return filePath.makeRelativeTo(commonPath);
     }
 
     /**

--- a/eclipsePlugin/src/de/tobject/findbugs/builder/WorkItem.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/builder/WorkItem.java
@@ -305,8 +305,7 @@ public class WorkItem {
             recursive = true;
         }
         IMarker[] markers = MarkerUtil.getMarkers(markerTarget, recursive ? IResource.DEPTH_INFINITE : IResource.DEPTH_ONE);
-        Set<IMarker> forJavaElement = MarkerUtil.findMarkerForJavaElement(javaElt, markers, recursive);
-        return forJavaElement;
+        return MarkerUtil.findMarkerForJavaElement(javaElt, markers, recursive);
     }
 
     /**

--- a/eclipsePlugin/src/de/tobject/findbugs/view/AbstractFindbugsView.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/view/AbstractFindbugsView.java
@@ -216,9 +216,7 @@ public abstract class AbstractFindbugsView extends ViewPart implements IMarkerSe
      * @return IWorkbenchSiteProgressService or <code>null</code>.
      */
     protected IWorkbenchSiteProgressService getProgressService() {
-        IWorkbenchSiteProgressService service = (IWorkbenchSiteProgressService) getSite().getAdapter(
-                IWorkbenchSiteProgressService.class);
-        return service;
+        return getSite().getAdapter(IWorkbenchSiteProgressService.class);
     }
 
     /**

--- a/eclipsePlugin/src/de/tobject/findbugs/view/explorer/BugLabelProvider.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/view/explorer/BugLabelProvider.java
@@ -124,8 +124,7 @@ public class BugLabelProvider implements /* IStyledLabelProvider, */ ICommonLabe
             }
             int filtered = getFilteredMarkersCount(group);
             String filterCount = filtered > 0 ? "/" + filtered + " filtered" : "";
-            String str = group.getShortDescription() + " (" + (group.getMarkersCount() - filtered) + filterCount + ")";
-            return str;
+            return group.getShortDescription() + " (" + (group.getMarkersCount() - filtered) + filterCount + ")";
         }
         if (element instanceof IMarker) {
             IMarker marker = (IMarker) element;

--- a/eclipsePlugin/src/de/tobject/findbugs/view/explorer/FilterBugsDialog.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/view/explorer/FilterBugsDialog.java
@@ -201,8 +201,7 @@ public class FilterBugsDialog extends SelectionDialog {
 
         public boolean isFiltering() {
             String filterString = getFilterString();
-            boolean yes = filterString != null && filterString.length() > 0 && !filterString.equals(getInitialText());
-            return yes;
+            return filterString != null && filterString.length() > 0 && !filterString.equals(getInitialText());
         }
     }
 

--- a/spotbugs-ant/src/main/java/edu/umd/cs/findbugs/anttask/UnionBugs.java
+++ b/spotbugs-ant/src/main/java/edu/umd/cs/findbugs/anttask/UnionBugs.java
@@ -133,8 +133,7 @@ public class UnionBugs extends Task {
             parts.add(f.getAbsolutePath());
         }
 
-        String[] args = parts.toArray(new String[parts.size()]);
-        return args;
+        return parts.toArray(new String[parts.size()]);
     }
 
     /**

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/BugInstance.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/BugInstance.java
@@ -2080,8 +2080,7 @@ public class BugInstance implements Comparable<BugInstance>, XMLWriteable, Clone
         if (age < 0) {
             age = 0;
         }
-        int ageInDays = (int) (age / 1000 / 3600 / 24);
-        return ageInDays;
+        return (int) (age / 1000 / 3600 / 24);
     }
 
     /*

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/DiscoverSourceDirectories.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/DiscoverSourceDirectories.java
@@ -309,9 +309,7 @@ public class DiscoverSourceDirectories {
                 packageName += "/";
             }
 
-            String fullyQualifiedSourceFile = packageName + sourceFile;
-
-            return fullyQualifiedSourceFile;
+            return packageName + sourceFile;
         } catch (CheckedAnalysisException e) {
             errorLogger.logError("Could scan class " + classDesc.toDottedClassName(), e);
             throw e;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/FuzzyBugComparator.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/FuzzyBugComparator.java
@@ -271,9 +271,7 @@ public class FuzzyBugComparator implements WarningComparator {
         }
 
         // Compare for exact match
-        int cmp = lhsMethod.compareTo(rhsMethod);
-
-        return cmp;
+        return lhsMethod.compareTo(rhsMethod);
     }
 
     /**

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/PackageStats.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/PackageStats.java
@@ -234,8 +234,7 @@ public class PackageStats extends BugCounts implements XMLWriteable {
     }
 
     public @CheckForNull ClassStats getClassStatsOrNull(String name) {
-        ClassStats result = packageMembers.get(name);
-        return result;
+        return packageMembers.get(name);
     }
 
     @Override

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/PluginLoader.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/PluginLoader.java
@@ -1268,8 +1268,7 @@ public class PluginLoader implements AutoCloseable {
         }
         try {
             SimpleDateFormat releaseDateFormat = new SimpleDateFormat("MM/dd/yyyy hh:mm aa z", Locale.ENGLISH);
-            Date result = releaseDateFormat.parse(releaseDate);
-            return result;
+            return releaseDateFormat.parse(releaseDate);
         } catch (ParseException e) {
             AnalysisContext.logError("unable to parse date " + releaseDate, e);
             return null;
@@ -1630,8 +1629,7 @@ public class PluginLoader implements AutoCloseable {
         Reader r = UTF8.bufferedReader(in);
         try {
             SAXReader reader = XMLUtil.buildSAXReader();
-            Document d = reader.read(r);
-            return d;
+            return reader.read(r);
         } finally {
             Util.closeSilently(r);
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/SourceLineAnnotation.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/SourceLineAnnotation.java
@@ -213,9 +213,8 @@ public class SourceLineAnnotation implements BugAnnotation {
      */
     @Nonnull
     public static SourceLineAnnotation createUnknown(@DottedClassName String className, String sourceFile, int startBytecode, int endBytecode) {
-        SourceLineAnnotation result = new SourceLineAnnotation(className, sourceFile, -1, -1, startBytecode, endBytecode);
+        return new SourceLineAnnotation(className, sourceFile, -1, -1, startBytecode, endBytecode);
         // result.setDescription("SOURCE_LINE_UNKNOWN");
-        return result;
     }
 
     /**
@@ -227,10 +226,7 @@ public class SourceLineAnnotation implements BugAnnotation {
      * @return the SourceLineAnnotation
      */
     public static SourceLineAnnotation fromVisitedMethod(PreorderVisitor visitor) {
-
-        SourceLineAnnotation sourceLines = getSourceAnnotationForMethod(visitor.getDottedClassName(), visitor.getMethodName(),
-                visitor.getMethodSig());
-        return sourceLines;
+        return getSourceAnnotationForMethod(visitor.getDottedClassName(), visitor.getMethodName(), visitor.getMethodSig());
     }
 
     /**

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/StringAnnotation.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/StringAnnotation.java
@@ -107,8 +107,7 @@ public class StringAnnotation implements BugAnnotation {
 
     @Override
     public String format(String key, ClassAnnotation primaryClass) {
-        String txt = value;
-        return txt;
+        return value;
     }
 
     @Override

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/AssertionMethods.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/AssertionMethods.java
@@ -228,9 +228,6 @@ public class AssertionMethods {
     }
 
     public boolean isAssertionCall(InvokeInstruction inv) {
-
-        boolean isAssertionMethod = assertionMethodRefSet.get(inv.getIndex());
-
-        return isAssertionMethod;
+        return assertionMethodRefSet.get(inv.getIndex());
     }
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/ClassHash.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/ClassHash.java
@@ -321,9 +321,7 @@ public class ClassHash implements XMLWriteable, Comparable<ClassHash> {
      */
     @Override
     public int compareTo(ClassHash other) {
-        int cmp = MethodHash.compareHashes(this.classHash, other.classHash);
-        // System.out.println(this + " <=> " + other + ": compareTo=" + cmp);
-        return cmp;
+        return MethodHash.compareHashes(this.classHash, other.classHash);
     }
 
     /*

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/Hierarchy.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/Hierarchy.java
@@ -502,10 +502,7 @@ public class Hierarchy {
         for (Method method : methodList) {
             if (method.getName().equals(methodName) && method.getSignature().equals(methodSig)
                     && accessFlagsAreConcrete(method.getAccessFlags())) {
-                JavaClassAndMethod m = new JavaClassAndMethod(javaClass, method);
-
-                return m;
-
+                return new JavaClassAndMethod(javaClass, method);
             }
         }
         if (DEBUG_METHOD_LOOKUP) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/Location.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/Location.java
@@ -118,8 +118,7 @@ public class Location implements Comparable<Location> {
 
     @Override
     public int compareTo(Location other) {
-        int pos = handle.getPosition() - other.handle.getPosition();
-        return pos;
+        return handle.getPosition() - other.handle.getPosition();
     }
 
     @Override

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/NullnessAnnotationDatabase.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/NullnessAnnotationDatabase.java
@@ -112,8 +112,7 @@ public class NullnessAnnotationDatabase extends AnnotationDatabase<NullnessAnnot
                     return NullnessAnnotation.NONNULL;
                 }
             }
-            NullnessAnnotation result = super.getResolvedAnnotation(o, getMinimal);
-            return result;
+            return super.getResolvedAnnotation(o, getMinimal);
         } finally {
             profiler.end(this.getClass());
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/SignatureParser.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/SignatureParser.java
@@ -77,8 +77,7 @@ public class SignatureParser {
 
     public int getSlotsFromTopOfStackForParameter(int paramNum) {
         int offset = getParameterOffset()[paramNum];
-        int result = totalArgumentSize - offset;
-        return result;
+        return totalArgumentSize - offset;
     }
 
     private class ParameterSignatureIterator implements Iterator<String> {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/XFactory.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/XFactory.java
@@ -647,8 +647,7 @@ public class XFactory {
     public static XMethod createXMethod(PreorderVisitor visitor) {
         JavaClass javaClass = visitor.getThisClass();
         Method method = visitor.getMethod();
-        XMethod m = createXMethod(javaClass, method);
-        return m;
+        return createXMethod(javaClass, method);
     }
 
     /**
@@ -662,8 +661,7 @@ public class XFactory {
     public static XField createXField(PreorderVisitor visitor) {
         JavaClass javaClass = visitor.getThisClass();
         Field field = visitor.getField();
-        XField f = createXField(javaClass, field);
-        return f;
+        return createXField(javaClass, field);
     }
 
     public static XMethod createXMethod(MethodGen methodGen) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/deref/UnconditionalValueDerefSet.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/deref/UnconditionalValueDerefSet.java
@@ -285,8 +285,7 @@ public class UnconditionalValueDerefSet {
      * @return the set of dereference Locations
      */
     public Set<Location> getDerefLocationSet(ValueNumber vn) {
-        Set<Location> derefLocationSet = derefLocationSetMap.computeIfAbsent(vn, k -> new HashSet<>());
-        return derefLocationSet;
+        return derefLocationSetMap.computeIfAbsent(vn, k -> new HashSet<>());
     }
 
     /**

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/TypeQualifierApplications.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/TypeQualifierApplications.java
@@ -254,8 +254,7 @@ public class TypeQualifierApplications {
         When when = whenValue == null ? When.ALWAYS : When.valueOf(whenValue.value);
         ClassDescriptor annotationClass = v.getAnnotationClass();
         TypeQualifierValue<?> tqv = TypeQualifierValue.getValue(annotationClass, v.getValue("value"));
-        TypeQualifierAnnotation tqa = TypeQualifierAnnotation.getValue(tqv, when);
-        return tqa;
+        return TypeQualifierAnnotation.getValue(tqv, when);
     }
 
     /**

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/TypeQualifierValueSet.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/TypeQualifierValueSet.java
@@ -146,11 +146,8 @@ public class TypeQualifierValueSet {
 
     private static Set<SourceSinkInfo> getOrCreateSourceSinkInfoSet(Map<ValueNumber, Set<SourceSinkInfo>> sourceSinkInfoSetMap,
             ValueNumber vn) {
-        Set<SourceSinkInfo> sourceSinkInfoSet = sourceSinkInfoSetMap.computeIfAbsent(vn, k -> new HashSet<>(3));
-        return sourceSinkInfoSet;
+        return sourceSinkInfoSetMap.computeIfAbsent(vn, k -> new HashSet<>(3));
     }
-
-
 
     public FlowValue getValue(ValueNumber vn) {
         FlowValue result = valueMap.get(vn);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/ParameterNullnessPropertyDatabase.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/ParameterNullnessPropertyDatabase.java
@@ -43,8 +43,7 @@ public class ParameterNullnessPropertyDatabase extends MethodPropertyDatabase<Pa
     protected ParameterProperty decodeProperty(String propStr) throws PropertyDatabaseFormatException {
         try {
             int unconditionalDerefSet = Integer.parseInt(propStr);
-            ParameterProperty prop = new ParameterProperty(unconditionalDerefSet);
-            return prop;
+            return new ParameterProperty(unconditionalDerefSet);
         } catch (NumberFormatException e) {
             throw new PropertyDatabaseFormatException("Invalid unconditional deref param set: " + propStr);
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/TypeQualifierNullnessAnnotationDatabase.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/TypeQualifierNullnessAnnotationDatabase.java
@@ -112,8 +112,7 @@ public class TypeQualifierNullnessAnnotationDatabase implements INullnessAnnotat
         try {
             TypeQualifierAnnotation tqa = TypeQualifierApplications.getInheritedTypeQualifierAnnotation(m,
                     parameter, nonnullTypeQualifierValue);
-            NullnessAnnotation result = toNullnessAnnotation(tqa);
-            return result;
+            return toNullnessAnnotation(tqa);
         } finally {
             profiler.end(this.getClass());
         }
@@ -124,8 +123,7 @@ public class TypeQualifierNullnessAnnotationDatabase implements INullnessAnnotat
         profiler.start(this.getClass());
         try {
             TypeQualifierAnnotation tqa = TypeQualifierApplications.getInheritedTypeQualifierAnnotation(m, nonnullTypeQualifierValue);
-            NullnessAnnotation result = toNullnessAnnotation(tqa);
-            return result;
+            return toNullnessAnnotation(tqa);
         } finally {
             profiler.end(this.getClass());
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/vna/ValueNumberSourceInfo.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/vna/ValueNumberSourceInfo.java
@@ -168,10 +168,7 @@ public abstract class ValueNumberSourceInfo {
         if (valueNumber.hasFlag(ValueNumber.CONSTANT_CLASS_OBJECT)) {
             return null;
         }
-        BugAnnotation variableAnnotation = findAnnotationFromValueNumber(method, location, valueNumber, vnaFrame, "VALUE_OF");
-
-        return variableAnnotation;
-
+        return findAnnotationFromValueNumber(method, location, valueNumber, vnaFrame, "VALUE_OF");
     }
 
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/ClassParser.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/ClassParser.java
@@ -302,9 +302,7 @@ public class ClassParser implements ClassParserInterface {
         checkConstantTag(constant, IClassConstants.CONSTANT_Class);
 
         int refIndex = ((Integer) constant.data[0]).intValue();
-        String stringValue = getUtf8String(refIndex);
-
-        return stringValue;
+        return getUtf8String(refIndex);
     }
 
     /**

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/asm/ClassReaderAnalysisEngine.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/asm/ClassReaderAnalysisEngine.java
@@ -45,9 +45,7 @@ public class ClassReaderAnalysisEngine extends RecomputableClassAnalysisEngine<F
 
         ClassData classData = analysisCache.getClassAnalysis(ClassData.class, descriptor);
 
-        FBClassReader classReader = new FBClassReader(classData.getData());
-
-        return classReader;
+        return new FBClassReader(classData.getData());
     }
 
     /*

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/bcel/ClassContextClassAnalysisEngine.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/bcel/ClassContextClassAnalysisEngine.java
@@ -47,8 +47,7 @@ public class ClassContextClassAnalysisEngine extends RecomputableClassAnalysisEn
     public ClassContext analyze(IAnalysisCache analysisCache, ClassDescriptor descriptor) throws CheckedAnalysisException {
 
         JavaClass javaClass = analysisCache.getClassAnalysis(JavaClass.class, descriptor);
-        ClassContext classContext = new ClassContext(javaClass, AnalysisContext.currentAnalysisContext());
-        return classContext;
+        return new ClassContext(javaClass, AnalysisContext.currentAnalysisContext());
     }
 
     /*

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/ClassFactory.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/ClassFactory.java
@@ -147,7 +147,6 @@ public class ClassFactory implements IClassFactory {
      */
     @Override
     public IAnalysisCache createAnalysisCache(IClassPath classPath, BugReporter errorLogger) {
-        IAnalysisCache analysisCache = new AnalysisCache(classPath, errorLogger);
-        return analysisCache;
+        return new AnalysisCache(classPath, errorLogger);
     }
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/ClassPathBuilder.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/ClassPathBuilder.java
@@ -544,8 +544,7 @@ public class ClassPathBuilder implements IClassPathBuilder {
         File dir = new File(extDir);
         File[] fileList = dir.listFiles((FileFilter) pathname -> {
             String path = pathname.getPath();
-            boolean isArchive = Archive.isArchiveFileName(path);
-            return isArchive;
+            return Archive.isArchiveFileName(path);
         });
         if (fileList == null) {
             return;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindRefComparison.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindRefComparison.java
@@ -1319,10 +1319,8 @@ public class FindRefComparison implements Detector, ExtendedTypes {
         String invoked = inv.getClassName(cpg);
         String methodName = inv.getMethodName(cpg);
         String methodSig = inv.getSignature(cpg);
-        MethodDescriptor invokedMethod =
-                DescriptorFactory.instance().getMethodDescriptor(ClassName.toSlashedClassName(invoked), methodName, methodSig,
-                        inv instanceof INVOKESTATIC);
-        return invokedMethod;
+        return DescriptorFactory.instance().getMethodDescriptor(ClassName.toSlashedClassName(invoked), methodName, methodSig,
+                inv instanceof INVOKESTATIC);
     }
 
     private boolean checkForWeirdEquals(String lhsSig, String rhsSig, Set<XMethod> targets) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InitializeNonnullFieldsInConstructor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InitializeNonnullFieldsInConstructor.java
@@ -85,8 +85,7 @@ public class InitializeNonnullFieldsInConstructor extends OpcodeStackDetector {
         }
         NullnessAnnotation annotation = AnalysisContext.currentAnalysisContext().getNullnessAnnotationDatabase()
                 .getResolvedAnnotation(f, false);
-        boolean isNonnull = annotation == NullnessAnnotation.NONNULL;
-        return isNonnull;
+        return annotation == NullnessAnnotation.NONNULL;
     }
 
     @Override

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/TrainLongInstantfParams.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/TrainLongInstantfParams.java
@@ -43,8 +43,7 @@ public class TrainLongInstantfParams extends PreorderVisitor implements Detector
         protected ParameterProperty decodeProperty(String propStr) throws PropertyDatabaseFormatException {
             try {
                 int longInstants = Integer.parseInt(propStr);
-                ParameterProperty prop = new ParameterProperty(longInstants);
-                return prop;
+                return new ParameterProperty(longInstants);
             } catch (NumberFormatException e) {
                 throw new PropertyDatabaseFormatException("Invalid unconditional deref param set: " + propStr);
             }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/Archive.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/Archive.java
@@ -67,8 +67,7 @@ public class Archive {
         if (lastDot < 0) {
             return fileName;
         }
-        String extension = fileName.substring(lastDot).toLowerCase(Locale.ENGLISH);
-        return extension;
+        return fileName.substring(lastDot).toLowerCase(Locale.ENGLISH);
     }
 
     @Deprecated

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/LaunchBrowser.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/LaunchBrowser.java
@@ -145,8 +145,7 @@ public class LaunchBrowser {
 
     static Process launchViaExec(URL url) throws IOException {
         ProcessBuilder builder = new ProcessBuilder(execCommand, url.toString());
-        Process p = builder.start();
-        return p;
+        return builder.start();
     }
 
     /**

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/NestedAccessUtil.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/NestedAccessUtil.java
@@ -149,8 +149,7 @@ public class NestedAccessUtil {
         for (Attribute sourceAttribute : sourceAttributes) {
             if (sourceAttribute instanceof NestMembers) {
                 NestMembers nestMembersAttribute = (NestMembers) sourceAttribute;
-                String[] nestMemberClassNames = nestMembersAttribute.getClassNames();
-                return nestMemberClassNames;
+                return nestMembersAttribute.getClassNames();
             }
         }
         return null;
@@ -173,8 +172,7 @@ public class NestedAccessUtil {
                 NestHost nestHostAttribute = (NestHost) attribute;
                 int targetHostClassIndex = nestHostAttribute.getHostClassIndex();
                 ConstantPool constantPool = nestHostAttribute.getConstantPool();
-                String nestHostClassName = constantPool.getConstantString(targetHostClassIndex, Const.CONSTANT_Class);
-                return nestHostClassName;
+                return constantPool.getConstantString(targetHostClassIndex, Const.CONSTANT_Class);
             }
         }
         return null;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/Util.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/Util.java
@@ -332,8 +332,7 @@ public class Util {
 
     static public @Nonnull MessageDigest getMD5Digest() {
         try {
-            MessageDigest digest = MessageDigest.getInstance("MD5");
-            return digest;
+            return MessageDigest.getInstance("MD5");
         } catch (NoSuchAlgorithmException e) {
             throw new Error("Unable to get MD5 digest", e);
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/SourceSearcher.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/SourceSearcher.java
@@ -53,8 +53,7 @@ public class SourceSearcher {
             return false;
         }
 
-        boolean result = sourceFinder.hasSourceFile(srcLine);
-        return result;
+        return sourceFinder.hasSourceFile(srcLine);
     }
 
     public boolean findSource0(SourceLineAnnotation srcLine) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/TreemapVisualization.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/TreemapVisualization.java
@@ -54,8 +54,7 @@ public class TreemapVisualization {
         if (i == -1) {
             return "";
         }
-        String p = packageName.substring(0, i);
-        return p;
+        return packageName.substring(0, i);
     }
 
     public boolean isInteriorPackage(String packageName) {


### PR DESCRIPTION
Fixing "Immediately return this expression instead of assigning it to temporary variable" issues.
