### PR TITLE
Cleanup: use diamond operator in constructor calls of Collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Do not consider Records as Singletons ([#2981](https://github.com/spotbugs/spotbugs/issues/2981))
 - Keep a maximum of 10000 cached analysis entries for plugin's analysis engines ([#3025](https://github.com/spotbugs/spotbugs/pull/3025))
 - Only report `MC_OVERRIDABLE_METHOD_CALL_IN_READ_OBJECT` when calling own methods ([#2957](https://github.com/spotbugs/spotbugs/issues/2957))
-- Check the actual caught exceptions (instead of the their common type) when analyzing multi-catch blocks ([#2968](https://github.com/spotbugs/spotbugs/issues/2968))
+- Check the actual caught exceptions (instead of their common type) when analyzing multi-catch blocks ([#2968](https://github.com/spotbugs/spotbugs/issues/2968))
 - System property `findbugs.refcomp.reportAll` is now being used. For some new conditions, it will emit an experimental warning ([#2988](https://github.com/spotbugs/spotbugs/pull/2988))
 - `-version` flag prints the version to the standard output ([#2797](https://github.com/spotbugs/spotbugs/issues/2797))
 - Revert the changes from ([#2894](https://github.com/spotbugs/spotbugs/pull/2894)) to get HTML stylesheets to work again ([#2969](https://github.com/spotbugs/spotbugs/issues/2969))
@@ -34,7 +34,8 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Remove extra blank lines and remove public from interface objects as inherently already public ([#3131](https://github.com/spotbugs/spotbugs/issues/3131))
 - Fix order of modifiers on properties/methods and ensure correct location in file ([#3132](https://github.com/spotbugs/spotbugs/issues/3132))
 - Return objects directly instead of creating more garbage collection by defining them ([#3133](https://github.com/spotbugs/spotbugs/pull/3133), [#3175](https://github.com/spotbugs/spotbugs/pull/3175))
-- Cleanup double initization and fix comments referring to findbugs instead of spotbugs([#3134](https://github.com/spotbugs/spotbugs/issues/3134))
+- Cleanup double initialization and fix comments referring to findbugs instead of spotbugs([#3134](https://github.com/spotbugs/spotbugs/issues/3134))
+- Use diamond operator in constructor calls of Collections ([#3176](https://github.com/spotbugs/spotbugs/pull/3176))
 
 ### Changed
 - Bump up Java version to 11

--- a/eclipsePlugin-test/src/de/tobject/findbugs/test/AbstractFindBugsTest.java
+++ b/eclipsePlugin-test/src/de/tobject/findbugs/test/AbstractFindBugsTest.java
@@ -87,7 +87,7 @@ public abstract class AbstractFindBugsTest extends AbstractPluginTest {
         // here
         FindbugsPlugin.setProjectSettingsEnabled(getProject(), null, true);
         UserPreferences preferences = FindbugsPlugin.getUserPreferences(getProject());
-        HashMap<String, Boolean> map = new HashMap<String, Boolean>();
+        HashMap<String, Boolean> map = new HashMap<>();
         if (on) {
             map.put(getBugsFileLocation(), Boolean.TRUE);
             preferences.setExcludeBugsFiles(map);
@@ -105,12 +105,12 @@ public abstract class AbstractFindBugsTest extends AbstractPluginTest {
         // here
         FindbugsPlugin.setProjectSettingsEnabled(getProject(), null, true);
         UserPreferences preferences = FindbugsPlugin.getUserPreferences(getProject());
-        HashMap<String, Boolean> map = new HashMap<String, Boolean>();
+        HashMap<String, Boolean> map = new HashMap<>();
         if (on) {
             map.put(getFilterFileLocation(), Boolean.TRUE);
             preferences.setExcludeFilterFiles(map);
         } else {
-            preferences.setExcludeFilterFiles(new HashMap<String, Boolean>());
+            preferences.setExcludeFilterFiles(new HashMap<>());
         }
         FindbugsPlugin.saveUserPreferences(getProject(), preferences);
     }

--- a/eclipsePlugin-test/src/de/tobject/findbugs/test/TestScenario.java
+++ b/eclipsePlugin-test/src/de/tobject/findbugs/test/TestScenario.java
@@ -41,7 +41,7 @@ public enum TestScenario {
 
     private boolean usesJUnit;
 
-    private final Map<String, Integer> visibleBugsHistogram = new HashMap<String, Integer>();
+    private final Map<String, Integer> visibleBugsHistogram = new HashMap<>();
 
     private int visibleBugsCount;
 

--- a/eclipsePlugin-test/src/de/tobject/findbugs/view/test/AbstractBugExplorerViewTest.java
+++ b/eclipsePlugin-test/src/de/tobject/findbugs/view/test/AbstractBugExplorerViewTest.java
@@ -47,7 +47,7 @@ import de.tobject.findbugs.view.explorer.Grouping;
 public abstract class AbstractBugExplorerViewTest extends AbstractFindBugsTest {
 
     protected static <T> Set<T> setOf(T... a) {
-        return new HashSet<T>(Arrays.asList(a));
+        return new HashSet<>(Arrays.asList(a));
     }
 
     @Override
@@ -65,7 +65,7 @@ public abstract class AbstractBugExplorerViewTest extends AbstractFindBugsTest {
     }
 
     protected Grouping getDefaultGrouping() {
-        List<GroupType> types = new ArrayList<GroupType>();
+        List<GroupType> types = new ArrayList<>();
         types.add(GroupType.Project);
         types.add(GroupType.Pattern);
         types.add(GroupType.Marker);
@@ -80,7 +80,7 @@ public abstract class AbstractBugExplorerViewTest extends AbstractFindBugsTest {
     }
 
     protected Grouping getProjectPatternPackageMarkerGrouping() {
-        List<GroupType> types = new ArrayList<GroupType>();
+        List<GroupType> types = new ArrayList<>();
         types.add(GroupType.Project);
         types.add(GroupType.Pattern);
         types.add(GroupType.Package);

--- a/eclipsePlugin/src/de/tobject/findbugs/builder/FindBugs2Eclipse.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/builder/FindBugs2Eclipse.java
@@ -258,10 +258,10 @@ public class FindBugs2Eclipse extends FindBugs2 {
         SoftReference<List<String>> wr = auxClassPaths.get(project);
         List<String> oldAuxCp = wr != null ? wr.get() : null;
         if (oldAuxCp != null && !oldAuxCp.equals(auxClassPath)) {
-            auxClassPaths.put(project, new SoftReference<List<String>>(new ArrayList<>(auxClassPath)));
+            auxClassPaths.put(project, new SoftReference<>(new ArrayList<>(auxClassPath)));
             classAnalysisCache.remove(project);
         } else if (oldAuxCp == null) {
-            auxClassPaths.put(project, new SoftReference<List<String>>(new ArrayList<>(auxClassPath)));
+            auxClassPaths.put(project, new SoftReference<>(new ArrayList<>(auxClassPath)));
         }
     }
 }

--- a/eclipsePlugin/src/de/tobject/findbugs/view/explorer/BugContentProvider.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/view/explorer/BugContentProvider.java
@@ -385,7 +385,7 @@ public class BugContentProvider implements ICommonContentProvider {
                 continue;
             }
             if (!groupIds.containsKey(id)) {
-                groupIds.put(id, new HashSet<IMarker>());
+                groupIds.put(id, new HashSet<>());
             }
             groupIds.get(id).add(marker);
         }

--- a/eclipsePlugin/src/de/tobject/findbugs/view/properties/PropertyPageAdapterFactory.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/view/properties/PropertyPageAdapterFactory.java
@@ -211,7 +211,7 @@ public class PropertyPageAdapterFactory implements IAdapterFactory {
             List<IPropertyDescriptor> props = new ArrayList<>();
             try {
                 Map<?, ?> attributes = marker.getAttributes();
-                Set<?> keySet = new TreeSet<Object>(attributes.keySet());
+                Set<?> keySet = new TreeSet<>(attributes.keySet());
                 for (Object object : keySet) {
                     props.add(new PropertyDescriptor(object, "" + object));
                 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/DetectorFactoryCollection.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/DetectorFactoryCollection.java
@@ -73,11 +73,11 @@ public class DetectorFactoryCollection {
     final Map<String, Plugin> globalOptionsSetter = new HashMap<>();
 
     public DetectorFactoryCollection() {
-        this(true, false, Plugin.getAllPlugins(), new ArrayList<Plugin>());
+        this(true, false, Plugin.getAllPlugins(), new ArrayList<>());
     }
 
     public DetectorFactoryCollection(Plugin onlyPlugin) {
-        this(false, true, Collections.singleton(onlyPlugin), new ArrayList<Plugin>());
+        this(false, true, Collections.singleton(onlyPlugin), new ArrayList<>());
     }
 
     protected DetectorFactoryCollection(Collection<Plugin> enabled) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/PrintingBugReporter.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/PrintingBugReporter.java
@@ -171,7 +171,7 @@ public class PrintingBugReporter extends TextUIBugReporter {
         boolean bugsReported = false;
         RuntimeException storedException = null;
 
-        Bag<String> lowRank = new Bag<>(new TreeMap<String, Integer>());
+        Bag<String> lowRank = new Bag<>(new TreeMap<>());
         for (BugInstance warning : bugCollection.getCollection()) {
             if (!reporter.isApplySuppressions() || !bugCollection.getProject().getSuppressionFilter().match(warning)) {
                 int rank = warning.getBugRank();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/AnnotationDatabase.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/AnnotationDatabase.java
@@ -64,10 +64,10 @@ public class AnnotationDatabase<AnnotationEnum extends AnnotationEnumeration<Ann
 
     // private Subtypes subtypes;
     public AnnotationDatabase() {
-        defaultAnnotation.put(Target.ANY, new HashMap<String, AnnotationEnum>());
-        defaultAnnotation.put(Target.PARAMETER, new HashMap<String, AnnotationEnum>());
-        defaultAnnotation.put(Target.METHOD, new HashMap<String, AnnotationEnum>());
-        defaultAnnotation.put(Target.FIELD, new HashMap<String, AnnotationEnum>());
+        defaultAnnotation.put(Target.ANY, new HashMap<>());
+        defaultAnnotation.put(Target.PARAMETER, new HashMap<>());
+        defaultAnnotation.put(Target.METHOD, new HashMap<>());
+        defaultAnnotation.put(Target.FIELD, new HashMap<>());
         // if (!Subtypes.DO_NOT_USE) {
         // subtypes = AnalysisContext.currentAnalysisContext().getSubtypes();
         // }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/ch/Subtypes2.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/ch/Subtypes2.java
@@ -1021,7 +1021,7 @@ public class Subtypes2 {
      *             if the start vertex cannot be resolved
      */
     public void traverseSupertypesDepthFirst(ClassDescriptor start, SupertypeTraversalVisitor visitor) throws ClassNotFoundException {
-        this.traverseSupertypesDepthFirstHelper(start, visitor, new HashSet<ClassDescriptor>());
+        this.traverseSupertypesDepthFirstHelper(start, visitor, new HashSet<>());
     }
 
     private void traverseSupertypesDepthFirstHelper(ClassDescriptor cur, SupertypeTraversalVisitor visitor,

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/TypeQualifierResolver.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/TypeQualifierResolver.java
@@ -91,7 +91,7 @@ public class TypeQualifierResolver {
      */
     public static Collection<AnnotationValue> resolveTypeQualifiers(AnnotationValue value) {
         LinkedList<AnnotationValue> result = new LinkedList<>();
-        resolveTypeQualifierNicknames(value, result, new LinkedList<ClassDescriptor>());
+        resolveTypeQualifierNicknames(value, result, new LinkedList<>());
         return result;
     }
 
@@ -233,7 +233,7 @@ public class TypeQualifierResolver {
                     if (e.desc.equals(elementTypeDescriptor) && e.value.equals(defaultFor.name())) {
                         for (ClassDescriptor d : c.getAnnotationDescriptors()) {
                             if (!d.equals(typeQualifierDefault)) {
-                                resolveTypeQualifierNicknames(c.getAnnotation(d), result, new LinkedList<ClassDescriptor>());
+                                resolveTypeQualifierNicknames(c.getAnnotation(d), result, new LinkedList<>());
                             }
                         }
                         break;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/analysis/FieldInfo.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/analysis/FieldInfo.java
@@ -309,7 +309,7 @@ public class FieldInfo extends FieldDescriptor implements XField {
                 // we don't know
                 // if it has a
                 // generic type
-                isStatic ? Const.ACC_STATIC : 0, new HashMap<ClassDescriptor, AnnotationValue>(), false);
+                isStatic ? Const.ACC_STATIC : 0, new HashMap<>(), false);
     }
 
     @Override

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/bcel/ValueRangeAnalysisFactory.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/bcel/ValueRangeAnalysisFactory.java
@@ -259,7 +259,7 @@ public class ValueRangeAnalysisFactory implements IMethodAnalysisEngine<ValueRan
         @Override
         public Iterator<LongRangeSet> iterator() {
             final Iterator<Entry<Long, Long>> iterator = map.entrySet().iterator();
-            return new Iterator<ValueRangeAnalysisFactory.LongRangeSet>() {
+            return new Iterator<>() {
                 @Override
                 public boolean hasNext() {
                     return iterator.hasNext();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindRefComparison.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindRefComparison.java
@@ -1250,7 +1250,7 @@ public class FindRefComparison implements Detector, ExtendedTypes {
         if (result == IncompatibleTypes.ARRAY_AND_NON_ARRAY || result == IncompatibleTypes.ARRAY_AND_OBJECT) {
             String lhsSig = lhsType_.getSignature();
             String rhsSig = rhsType_.getSignature();
-            boolean allOk = checkForWeirdEquals(lhsSig, rhsSig, new HashSet<XMethod>());
+            boolean allOk = checkForWeirdEquals(lhsSig, rhsSig, new HashSet<>());
             if (allOk) {
                 priorityModifier += 2;
             }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/FractionalMultiset.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/FractionalMultiset.java
@@ -85,7 +85,7 @@ public class FractionalMultiset<K> {
 
     @SuppressFBWarnings("DMI_ENTRY_SETS_MAY_REUSE_ENTRY_OBJECTS")
     public Iterable<Map.Entry<K, Double>> entriesInDecreasingOrder() {
-        TreeSet<Map.Entry<K, Double>> result = new TreeSet<>(new DecreasingOrderEntryComparator<K>());
+        TreeSet<Map.Entry<K, Double>> result = new TreeSet<>(new DecreasingOrderEntryComparator<>());
         result.addAll(map.entrySet());
         if (result.size() != map.size()) {
             throw new IllegalStateException("Map " + map.getClass().getSimpleName()
@@ -96,7 +96,7 @@ public class FractionalMultiset<K> {
 
     @SuppressFBWarnings("DMI_ENTRY_SETS_MAY_REUSE_ENTRY_OBJECTS")
     public Iterable<Map.Entry<K, Double>> entriesInIncreasingOrder() {
-        TreeSet<Map.Entry<K, Double>> result = new TreeSet<>(new DecreasingOrderEntryComparator<K>());
+        TreeSet<Map.Entry<K, Double>> result = new TreeSet<>(new DecreasingOrderEntryComparator<>());
         result.addAll(map.entrySet());
         if (result.size() != map.size()) {
             throw new IllegalStateException("Map " + map.getClass().getSimpleName()

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/Multiset.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/Multiset.java
@@ -109,7 +109,7 @@ public class Multiset<K> {
 
     @SuppressFBWarnings("DMI_ENTRY_SETS_MAY_REUSE_ENTRY_OBJECTS")
     public Iterable<Map.Entry<K, Integer>> entriesInDecreasingFrequency() {
-        TreeSet<Map.Entry<K, Integer>> result = new TreeSet<>(new EntryComparator<K>());
+        TreeSet<Map.Entry<K, Integer>> result = new TreeSet<>(new EntryComparator<>());
         result.addAll(map.entrySet());
         if (result.size() != map.size()) {
             throw new IllegalStateException("Map " + map.getClass().getSimpleName()

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/TestingGround.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/TestingGround.java
@@ -83,8 +83,8 @@ public class TestingGround {
         ArrayList<Bag<String>> died = new ArrayList<>();
         Bag<String> allBugs = new Bag<>();
         for (int i = 0; i <= bugCollection.getSequenceNumber(); i++) {
-            live.add(new Bag<String>());
-            died.add(new Bag<String>());
+            live.add(new Bag<>());
+            died.add(new Bag<>());
         }
         for (BugInstance b : bugCollection) {
             int first = (int) b.getFirstVersion();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/TreemapVisualization.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/TreemapVisualization.java
@@ -37,9 +37,9 @@ public class TreemapVisualization {
 
     HashSet<String> interiorPackages = new HashSet<>();
 
-    Bag<String> goodCodeSize = new Bag<>(new TreeMap<String, Integer>());
+    Bag<String> goodCodeSize = new Bag<>(new TreeMap<>());
 
-    Bag<String> goodCodeCount = new Bag<>(new TreeMap<String, Integer>());
+    Bag<String> goodCodeCount = new Bag<>(new TreeMap<>());
 
     public void addInteriorPackages(String packageName) {
         String p = superpackage(packageName);


### PR DESCRIPTION
Fixing "Replace the type specification in this constructor call with the diamond operator ("<>")." issues.