### PR TITLE
Cleanup: set abstract classes ctor's visibility from public to protected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Fix order of modifiers on properties/methods and ensure correct location in file ([#3132](https://github.com/spotbugs/spotbugs/issues/3132))
 - Return objects directly instead of creating more garbage collection by defining them ([#3133](https://github.com/spotbugs/spotbugs/pull/3133), [#3175](https://github.com/spotbugs/spotbugs/pull/3175))
 - Cleanup double initization and fix comments referring to findbugs instead of spotbugs([#3134](https://github.com/spotbugs/spotbugs/issues/3134))
+- Restrict the constructor of abstract classes visibility to protected ([#3178](https://github.com/spotbugs/spotbugs/pull/3178)) 
 
 ### Changed
 - Bump up Java version to 11

--- a/eclipsePlugin-test/src/de/tobject/findbugs/test/AbstractPluginTest.java
+++ b/eclipsePlugin-test/src/de/tobject/findbugs/test/AbstractPluginTest.java
@@ -214,7 +214,7 @@ public abstract class AbstractPluginTest {
         }
     }
 
-    public AbstractPluginTest() {
+    protected AbstractPluginTest() {
         super();
     }
 

--- a/eclipsePlugin/src/de/tobject/findbugs/FindBugsJob.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/FindBugsJob.java
@@ -73,7 +73,7 @@ public abstract class FindBugsJob extends Job {
         }
     }
 
-    public FindBugsJob(String name, IResource resource) {
+    protected FindBugsJob(String name, IResource resource) {
         super(name);
         this.resource = resource;
         setRule(new MutexSchedulingRule(resource));

--- a/eclipsePlugin/src/de/tobject/findbugs/view/AbstractFindbugsView.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/view/AbstractFindbugsView.java
@@ -65,7 +65,7 @@ public abstract class AbstractFindbugsView extends ViewPart implements IMarkerSe
 
     private Action actionShowPerspective;
 
-    public AbstractFindbugsView() {
+    protected AbstractFindbugsView() {
         super();
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/AbstractBugReporter.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/AbstractBugReporter.java
@@ -132,7 +132,7 @@ public abstract class AbstractBugReporter implements BugReporter {
 
     private final ProjectStats projectStats;
 
-    public AbstractBugReporter() {
+    protected AbstractBugReporter() {
         super();
         verbosityLevel = NORMAL;
         missingClassMessageList = new LinkedHashSet<>();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/BugAnnotationWithSourceLines.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/BugAnnotationWithSourceLines.java
@@ -31,7 +31,7 @@ public abstract class BugAnnotationWithSourceLines implements BugAnnotation {
     /**
      *
      */
-    public BugAnnotationWithSourceLines() {
+    protected BugAnnotationWithSourceLines() {
         super();
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/FindBugsCommandLine.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/FindBugsCommandLine.java
@@ -54,7 +54,7 @@ public abstract class FindBugsCommandLine extends CommandLine {
     /**
      * Constructor. Adds shared options/switches.
      */
-    public FindBugsCommandLine() {
+    protected FindBugsCommandLine() {
         super();
         project = new Project();
         startOptionGroup("General FindBugs options:");
@@ -74,7 +74,7 @@ public abstract class FindBugsCommandLine extends CommandLine {
      * @param modernGui
      *            ignored. In any case, gui2 options are added here.
      */
-    public FindBugsCommandLine(boolean modernGui) {
+    protected FindBugsCommandLine(boolean modernGui) {
         this();
         addOption("-f", "font size", "set font size");
         addSwitch("-clear", "clear saved GUI settings and exit");

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ResourceTrackingDetector.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ResourceTrackingDetector.java
@@ -60,7 +60,7 @@ public abstract class ResourceTrackingDetector<Resource, ResourceTrackerType ext
 
     protected BugReporter bugReporter;
 
-    public ResourceTrackingDetector(BugReporter bugReporter) {
+    protected ResourceTrackingDetector(BugReporter bugReporter) {
         this.bugReporter = bugReporter;
         this.bugAccumulator = new BugAccumulator(bugReporter);
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/TextUIBugReporter.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/TextUIBugReporter.java
@@ -51,7 +51,7 @@ public abstract class TextUIBugReporter extends AbstractBugReporter implements C
 
     protected PrintWriter outputStream = UTF8.printWriter(System.out, true);
 
-    public TextUIBugReporter() {
+    protected TextUIBugReporter() {
         reportStackTrace = true;
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/asm/AbstractFBMethodVisitor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/asm/AbstractFBMethodVisitor.java
@@ -25,7 +25,7 @@ package edu.umd.cs.findbugs.asm;
  */
 public abstract class AbstractFBMethodVisitor extends FBMethodVisitor {
 
-    public AbstractFBMethodVisitor() {
+    protected AbstractFBMethodVisitor() {
         super();
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/asm/ClassNodeDetector.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/asm/ClassNodeDetector.java
@@ -47,7 +47,7 @@ abstract public class ClassNodeDetector extends ClassNode implements Detector2 {
      * @param bugReporter
      *            the BugReporter that bug should be reporter to.
      */
-    public ClassNodeDetector(BugReporter bugReporter) {
+    protected ClassNodeDetector(BugReporter bugReporter) {
         super(FindBugsASM.ASM_VERSION);
         this.bugReporter = bugReporter;
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/asm/FBMethodVisitor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/asm/FBMethodVisitor.java
@@ -25,11 +25,11 @@ import edu.umd.cs.findbugs.classfile.engine.asm.FindBugsASM;
 
 public abstract class FBMethodVisitor extends MethodVisitor {
 
-    public FBMethodVisitor() {
+    protected FBMethodVisitor() {
         super(FindBugsASM.ASM_VERSION);
     }
 
-    public FBMethodVisitor(MethodVisitor mv) {
+    protected FBMethodVisitor(MethodVisitor mv) {
         super(FindBugsASM.ASM_VERSION, mv);
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/AbstractBlockOrder.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/AbstractBlockOrder.java
@@ -35,7 +35,7 @@ public abstract class AbstractBlockOrder implements BlockOrder {
     private final ArrayList<BasicBlock> blockList;
     private final Comparator<BasicBlock> comparator;
 
-    public AbstractBlockOrder(CFG cfg, Comparator<BasicBlock> comparator) {
+    protected AbstractBlockOrder(CFG cfg, Comparator<BasicBlock> comparator) {
         this.comparator = comparator;
 
         // Put the blocks in an array

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/AbstractDominatorsAnalysis.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/AbstractDominatorsAnalysis.java
@@ -59,7 +59,7 @@ public abstract class AbstractDominatorsAnalysis extends BasicAbstractDataflowAn
      * @param ignoreExceptionEdges
      *            true if exception edges should be ignored
      */
-    public AbstractDominatorsAnalysis(CFG cfg, final boolean ignoreExceptionEdges) {
+    protected AbstractDominatorsAnalysis(CFG cfg, final boolean ignoreExceptionEdges) {
         this(cfg, edge -> {
             return !(ignoreExceptionEdges && edge.isExceptionEdge());
         });
@@ -73,7 +73,7 @@ public abstract class AbstractDominatorsAnalysis extends BasicAbstractDataflowAn
      * @param edgeChooser
      *            EdgeChooser to choose which Edges to consider significant
      */
-    public AbstractDominatorsAnalysis(CFG cfg, EdgeChooser edgeChooser) {
+    protected AbstractDominatorsAnalysis(CFG cfg, EdgeChooser edgeChooser) {
         this.cfg = cfg;
         this.edgeChooser = edgeChooser;
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/AbstractFrameModelingVisitor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/AbstractFrameModelingVisitor.java
@@ -63,7 +63,7 @@ public abstract class AbstractFrameModelingVisitor<Value, FrameType extends Fram
      * @param cpg
      *            the ConstantPoolGen of the method to be analyzed
      */
-    public AbstractFrameModelingVisitor(ConstantPoolGen cpg) {
+    protected AbstractFrameModelingVisitor(ConstantPoolGen cpg) {
         this.frame = null;
         this.cpg = cpg;
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/BackwardDataflowAnalysis.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/BackwardDataflowAnalysis.java
@@ -32,7 +32,7 @@ public abstract class BackwardDataflowAnalysis<Fact> extends AbstractDataflowAna
 
     private final DepthFirstSearch dfs;
 
-    public BackwardDataflowAnalysis(ReverseDepthFirstSearch rdfs, DepthFirstSearch dfs) {
+    protected BackwardDataflowAnalysis(ReverseDepthFirstSearch rdfs, DepthFirstSearch dfs) {
         if (rdfs == null || dfs == null) {
             throw new IllegalArgumentException();
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/BasicAbstractDataflowAnalysis.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/BasicAbstractDataflowAnalysis.java
@@ -45,7 +45,7 @@ public abstract class BasicAbstractDataflowAnalysis<Fact> implements DataflowAna
     /**
      * Constructor.
      */
-    public BasicAbstractDataflowAnalysis() {
+    protected BasicAbstractDataflowAnalysis() {
         this.startFactMap = new IdentityHashMap<>();
         this.resultFactMap = new IdentityHashMap<>();
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/ForwardDataflowAnalysis.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/ForwardDataflowAnalysis.java
@@ -30,7 +30,7 @@ package edu.umd.cs.findbugs.ba;
 public abstract class ForwardDataflowAnalysis<Fact> extends AbstractDataflowAnalysis<Fact> {
     private final DepthFirstSearch dfs;
 
-    public ForwardDataflowAnalysis(DepthFirstSearch dfs) {
+    protected ForwardDataflowAnalysis(DepthFirstSearch dfs) {
         if (dfs == null) {
             throw new IllegalArgumentException();
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/Frame.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/Frame.java
@@ -108,7 +108,7 @@ public abstract class Frame<ValueType> {
      * @param numLocals
      *            number of local variable slots in the method
      */
-    public Frame(int numLocals) {
+    protected Frame(int numLocals) {
         this.numLocals = numLocals;
         this.slotList = new ArrayList<>(numLocals + DEFAULT_STACK_CAPACITY);
         for (int i = 0; i < numLocals; ++i) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/FrameDataflowAnalysis.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/FrameDataflowAnalysis.java
@@ -33,7 +33,7 @@ import javax.annotation.CheckForNull;
  */
 public abstract class FrameDataflowAnalysis<ValueType, FrameType extends Frame<ValueType>> extends
         ForwardDataflowAnalysis<FrameType> {
-    public FrameDataflowAnalysis(DepthFirstSearch dfs) {
+    protected FrameDataflowAnalysis(DepthFirstSearch dfs) {
         super(dfs);
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/ResourceValueFrameModelingVisitor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/ResourceValueFrameModelingVisitor.java
@@ -35,7 +35,7 @@ import org.apache.bcel.generic.PUTFIELD;
 import org.apache.bcel.generic.PUTSTATIC;
 
 public abstract class ResourceValueFrameModelingVisitor extends AbstractFrameModelingVisitor<ResourceValue, ResourceValueFrame> {
-    public ResourceValueFrameModelingVisitor(ConstantPoolGen cpg) {
+    protected ResourceValueFrameModelingVisitor(ConstantPoolGen cpg) {
         super(cpg);
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/bcp/FieldAccess.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/bcp/FieldAccess.java
@@ -50,7 +50,7 @@ public abstract class FieldAccess extends SingleInstruction {
      *            name of the variable to bind to the value store in or loaded
      *            from the field
      */
-    public FieldAccess(String fieldVarName, String valueVarName) {
+    protected FieldAccess(String fieldVarName, String valueVarName) {
         this.fieldVarName = fieldVarName;
         this.valueVarName = valueVarName;
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/bcp/OneVariableInstruction.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/bcp/OneVariableInstruction.java
@@ -34,7 +34,7 @@ public abstract class OneVariableInstruction extends SingleInstruction {
      * @param varName
      *            the name of the Variable used in this instruction
      */
-    public OneVariableInstruction(String varName) {
+    protected OneVariableInstruction(String varName) {
         this.varName = varName;
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/ch/OverriddenMethodsVisitor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/ch/OverriddenMethodsVisitor.java
@@ -41,7 +41,7 @@ public abstract class OverriddenMethodsVisitor implements SupertypeTraversalVisi
      * @param xmethod
      *            a derived method
      */
-    public OverriddenMethodsVisitor(XMethod xmethod) {
+    protected OverriddenMethodsVisitor(XMethod xmethod) {
         assert !xmethod.isStatic();
         this.xmethod = xmethod;
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/heap/FieldSetAnalysis.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/heap/FieldSetAnalysis.java
@@ -46,7 +46,7 @@ public abstract class FieldSetAnalysis extends ForwardDataflowAnalysis<FieldSet>
 
     private final Map<InstructionHandle, XField> instructionToFieldMap;
 
-    public FieldSetAnalysis(DepthFirstSearch dfs, ConstantPoolGen cpg) {
+    protected FieldSetAnalysis(DepthFirstSearch dfs, ConstantPoolGen cpg) {
         super(dfs);
         this.cpg = cpg;
         this.instructionToFieldMap = new HashMap<>();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/TypeQualifierDataflowAnalysis.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/TypeQualifierDataflowAnalysis.java
@@ -118,7 +118,7 @@ public abstract class TypeQualifierDataflowAnalysis extends AbstractDataflowAnal
      * @param typeQualifierValue
      *            the TypeQualifierValue we want the dataflow analysis to check
      */
-    public TypeQualifierDataflowAnalysis(XMethod xmethod, CFG cfg, ValueNumberDataflow vnaDataflow, ConstantPoolGen cpg,
+    protected TypeQualifierDataflowAnalysis(XMethod xmethod, CFG cfg, ValueNumberDataflow vnaDataflow, ConstantPoolGen cpg,
             TypeQualifierValue<?> typeQualifierValue) {
         this.xmethod = xmethod;
         this.cfg = cfg;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/bcel/OpcodeStackDetector.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/bcel/OpcodeStackDetector.java
@@ -37,7 +37,7 @@ abstract public class OpcodeStackDetector extends BytecodeScanningDetector {
 
     private final boolean isUsingCustomUserValue;
 
-    public OpcodeStackDetector() {
+    protected OpcodeStackDetector() {
         super();
         isUsingCustomUserValue = getClass().isAnnotationPresent(OpcodeStack.CustomUserValue.class);
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/bugReporter/BugReporterDecorator.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/bugReporter/BugReporterDecorator.java
@@ -51,7 +51,7 @@ public abstract class BugReporterDecorator extends DelegatingBugReporter {
 
     final ComponentPlugin<BugReporterDecorator> plugin;
 
-    public BugReporterDecorator(ComponentPlugin<BugReporterDecorator> plugin, BugReporter delegate) {
+    protected BugReporterDecorator(ComponentPlugin<BugReporterDecorator> plugin, BugReporter delegate) {
         super(delegate);
         this.plugin = plugin;
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/FieldOrMethodDescriptor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/FieldOrMethodDescriptor.java
@@ -42,7 +42,7 @@ public abstract class FieldOrMethodDescriptor implements FieldOrMethodName {
 
     private final int nameSigHashCode;
 
-    public FieldOrMethodDescriptor(@SlashedClassName String slashedClassName, String name, String signature, boolean isStatic) {
+    protected FieldOrMethodDescriptor(@SlashedClassName String slashedClassName, String name, String signature, boolean isStatic) {
         assert slashedClassName.indexOf('.') == -1 : "class name not in VM format: " + slashedClassName;
 
         this.slashedClassName = slashedClassName;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/AbstractFieldAnnotationVisitor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/AbstractFieldAnnotationVisitor.java
@@ -29,7 +29,7 @@ import edu.umd.cs.findbugs.classfile.engine.asm.FindBugsASM;
  */
 public abstract class AbstractFieldAnnotationVisitor extends FieldVisitor {
 
-    public AbstractFieldAnnotationVisitor() {
+    protected AbstractFieldAnnotationVisitor() {
         super(FindBugsASM.ASM_VERSION);
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/AbstractMethodVisitor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/AbstractMethodVisitor.java
@@ -32,7 +32,7 @@ import edu.umd.cs.findbugs.classfile.engine.asm.FindBugsASM;
 public abstract class AbstractMethodVisitor extends MethodVisitor {
 
 
-    public AbstractMethodVisitor() {
+    protected AbstractMethodVisitor() {
         super(FindBugsASM.ASM_VERSION);
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/bcel/AnalysisFactory.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/bcel/AnalysisFactory.java
@@ -53,7 +53,7 @@ public abstract class AnalysisFactory<Analysis> implements IMethodAnalysisEngine
      * @param analysisName
      *            name of the analysis factory: for diagnostics/debugging
      */
-    public AnalysisFactory(String analysisName, Class<Analysis> analysisClass) {
+    protected AnalysisFactory(String analysisName, Class<Analysis> analysisClass) {
         this.analysisName = analysisName;
         this.analysisClass = analysisClass;
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/AbstractScannableCodeBase.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/AbstractScannableCodeBase.java
@@ -45,7 +45,7 @@ public abstract class AbstractScannableCodeBase implements IScannableCodeBase {
 
     private final Map<String, String> resourceNameTranslationMap;
 
-    public AbstractScannableCodeBase(ICodeBaseLocator codeBaseLocator) {
+    protected AbstractScannableCodeBase(ICodeBaseLocator codeBaseLocator) {
         this.codeBaseLocator = codeBaseLocator;
         this.lastModifiedTime = -1L;
         this.resourceNameTranslationMap = new HashMap<>();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/config/CommandLine.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/config/CommandLine.java
@@ -64,7 +64,7 @@ public abstract class CommandLine {
 
     int maxWidth;
 
-    public CommandLine() {
+    protected CommandLine() {
         this.unlistedOptions = new HashSet<>();
         this.optionList = new LinkedList<>();
         this.optionGroups = new HashMap<>();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BuildUnconditionalParamDerefDatabase.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BuildUnconditionalParamDerefDatabase.java
@@ -72,7 +72,7 @@ public abstract class BuildUnconditionalParamDerefDatabase implements Detector {
 
     abstract protected void reportBug(BugInstance bug);
 
-    public BuildUnconditionalParamDerefDatabase() {
+    protected BuildUnconditionalParamDerefDatabase() {
         this.nonnullTypeQualifierValue = TypeQualifierValue.getValue(javax.annotation.Nonnull.class, null);
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/TypeReturnNull.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/TypeReturnNull.java
@@ -42,7 +42,7 @@ public abstract class TypeReturnNull extends OpcodeStackDetector {
 
     protected final BugAccumulator bugAccumulator;
 
-    public TypeReturnNull(BugReporter bugReporter) {
+    protected TypeReturnNull(BugReporter bugReporter) {
         this.bugAccumulator = new BugAccumulator(bugReporter);
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/graph/AbstractDepthFirstSearch.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/graph/AbstractDepthFirstSearch.java
@@ -92,7 +92,7 @@ public abstract class AbstractDepthFirstSearch<GraphType extends Graph<EdgeType,
      * @throws IllegalArgumentException
      *             if the graph has not had edge ids assigned yet
      */
-    public AbstractDepthFirstSearch(GraphType graph) {
+    protected AbstractDepthFirstSearch(GraphType graph) {
         this.graph = graph;
 
         int numBlocks = graph.getNumVertexLabels();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/graph/AbstractGraph.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/graph/AbstractGraph.java
@@ -132,7 +132,7 @@ public abstract class AbstractGraph<EdgeType extends AbstractEdge<EdgeType, Vert
      * ----------------------------------------------------------------------
      */
 
-    public AbstractGraph() {
+    protected AbstractGraph() {
         this.vertexList = new ArrayList<>();
         this.edgeList = new ArrayList<>();
         this.maxVertexLabel = 0;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/MergeMap.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/MergeMap.java
@@ -55,11 +55,11 @@ public abstract class MergeMap<K, V> {
 
     protected abstract V mergeValues(V oldValue, V newValue);
 
-    public MergeMap() {
+    protected MergeMap() {
         map = new HashMap<>();
     }
 
-    public MergeMap(Map<K, V> map) {
+    protected MergeMap(Map<K, V> map) {
         this.map = map;
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/xml/QuoteMetaCharacters.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/xml/QuoteMetaCharacters.java
@@ -43,7 +43,7 @@ public abstract class QuoteMetaCharacters {
      * @param map
      *            the MetaCharacterMap
      */
-    public QuoteMetaCharacters(@Nonnull String text, @Nonnull MetaCharacterMap map) {
+    protected QuoteMetaCharacters(@Nonnull String text, @Nonnull MetaCharacterMap map) {
         if (text == null) {
             throw new NullPointerException("text must be nonnull");
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/xml/XPathFind.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/xml/XPathFind.java
@@ -44,7 +44,7 @@ import org.dom4j.io.SAXReader;
 public abstract class XPathFind {
     private final Document document;
 
-    public XPathFind(Document document) {
+    protected XPathFind(Document document) {
         this.document = document;
     }
 


### PR DESCRIPTION
Fixing "Constructors of an "abstract" class should not be declared "public"" issues. See the [issue in SonarCloud](https://sonarcloud.io/organizations/spotbugs/rules?open=java%3AS5993&rule_key=java%3AS5993).