### PR TITLE
Cleanup: use method reference instead of lambda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Fix order of modifiers on properties/methods and ensure correct location in file ([#3132](https://github.com/spotbugs/spotbugs/issues/3132))
 - Return objects directly instead of creating more garbage collection by defining them ([#3133](https://github.com/spotbugs/spotbugs/pull/3133), [#3175](https://github.com/spotbugs/spotbugs/pull/3175))
 - Cleanup double initization and fix comments referring to findbugs instead of spotbugs([#3134](https://github.com/spotbugs/spotbugs/issues/3134))
+- Use method references instead of lambdas where possible ([#3179](https://github.com/spotbugs/spotbugs/pull/3179))
 
 ### Changed
 - Bump up Java version to 11

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/DiscoverSourceDirectories.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/DiscoverSourceDirectories.java
@@ -238,7 +238,7 @@ public class DiscoverSourceDirectories {
 
         // Find all directories underneath the root source directory
         progress.startRecursiveDirectorySearch();
-        RecursiveFileSearch rfs = new RecursiveFileSearch(rootSourceDirectory, pathname -> pathname.isDirectory());
+        RecursiveFileSearch rfs = new RecursiveFileSearch(rootSourceDirectory, File::isDirectory);
         rfs.search();
         progress.doneRecursiveDirectorySearch();
         List<String> candidateSourceDirList = rfs.getDirectoriesScanned();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/CFG.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/CFG.java
@@ -321,7 +321,7 @@ public class CFG extends AbstractGraph<Edge, BasicBlock> implements Debug {
      * Get an Iterator over the Locations in the control flow graph.
      */
     public Iterable<Location> locations() {
-        return () -> locationIterator();
+        return this::locationIterator;
     }
 
     /**

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/SignatureParser.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/SignatureParser.java
@@ -181,7 +181,7 @@ public class SignatureParser {
     }
 
     public Iterable<String> parameterSignatures() {
-        return () -> new ParameterSignatureIterator();
+        return ParameterSignatureIterator::new;
 
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/BugCollectionAnalyser.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/BugCollectionAnalyser.java
@@ -55,13 +55,13 @@ class BugCollectionAnalyser {
 
     JsonArray getRules() {
         JsonArray array = new JsonArray();
-        rules.stream().map(Rule::toJsonObject).forEach((jsonObject) -> array.add(jsonObject));
+        rules.stream().map(Rule::toJsonObject).forEach(array::add);
         return array;
     }
 
     JsonArray getResults() {
         JsonArray array = new JsonArray();
-        results.stream().map(Result::toJsonObject).forEach((jsonObject) -> array.add(jsonObject));
+        results.stream().map(Result::toJsonObject).forEach(array::add);
         return array;
     }
 
@@ -98,7 +98,7 @@ class BugCollectionAnalyser {
 
         JsonArray taxaJson = new JsonArray();
 
-        taxa.stream().map(Taxon::toJsonObject).forEach((taxonJson) -> taxaJson.add(taxonJson));
+        taxa.stream().map(Taxon::toJsonObject).forEach(taxaJson::add);
 
         JsonObject shortDescriptionJson = new JsonObject();
         shortDescriptionJson.addProperty("text", "The MITRE Common Weakness Enumeration");

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Invocation.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Invocation.java
@@ -41,7 +41,7 @@ class Invocation {
         JsonArray execNotificationArray = new JsonArray();
         toolExecutionNotifications.stream()
                 .map(Notification::toJsonObject)
-                .forEach(json -> execNotificationArray.add(json));
+                .forEach(execNotificationArray::add);
         if (execNotificationArray.size() > 0) {
             result.add("toolExecutionNotifications", execNotificationArray);
         }
@@ -49,7 +49,7 @@ class Invocation {
         JsonArray configNotificationArray = new JsonArray();
         toolConfigurationNotifications.stream()
                 .map(Notification::toJsonObject)
-                .forEach(json -> configNotificationArray.add(json));
+                .forEach(configNotificationArray::add);
         if (configNotificationArray.size() > 0) {
             result.add("toolConfigurationNotifications", configNotificationArray);
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Location.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Location.java
@@ -60,7 +60,7 @@ class Location {
         }
 
         JsonArray logicalLocationArray = new JsonArray();
-        logicalLocations.stream().map(LogicalLocation::toJsonObject).forEach(logicalLocation -> logicalLocationArray.add(logicalLocation));
+        logicalLocations.stream().map(LogicalLocation::toJsonObject).forEach(logicalLocationArray::add);
         if (logicalLocationArray.size() > 0) {
             result.add("logicalLocations", logicalLocationArray);
         }
@@ -288,7 +288,7 @@ class Location {
 
         JsonObject toJsonObject() {
             JsonObject propertiesBag = new JsonObject();
-            properties.forEach((k, v) -> propertiesBag.addProperty(k, v));
+            properties.forEach(propertiesBag::addProperty);
             JsonObject locationJson = new JsonObject();
             locationJson.addProperty("name", name);
             if (decoratedName != null) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Result.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Result.java
@@ -35,7 +35,7 @@ final class Result {
         result.addProperty("level", level.toJsonString());
 
         JsonArray locationArray = new JsonArray();
-        locations.stream().map(Location::toJsonObject).forEach(location -> locationArray.add(location));
+        locations.stream().map(Location::toJsonObject).forEach(locationArray::add);
         if (locationArray.size() > 0) {
             result.add("locations", locationArray);
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Rule.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Rule.java
@@ -67,7 +67,7 @@ final class Rule {
         }
         if (!tags.isEmpty()) {
             JsonArray propertyArray = new JsonArray();
-            tags.forEach((prop) -> propertyArray.add(prop));
+            tags.forEach(propertyArray::add);
             JsonObject propertyBag = new JsonObject();
             propertyBag.add("tags", propertyArray);
             result.add("properties", propertyBag);


### PR DESCRIPTION
Fixing "Lambdas should be replaced with method references" issues.
