### PR TITLE
Escape array types when creating a regex method signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Fixed detector `FindReturnRef` not finding references exposed from nested and inner classes ([#2042](https://github.com/spotbugs/spotbugs/issues/2042))
 - Fix call graph, include non-parametric void methods ([#3160](https://github.com/spotbugs/spotbugs/pull/3160))
 - Added missing comma between line number and confidence when describing matching and mismatching bugs for tests ([#3187](https://github.com/spotbugs/spotbugs/pull/3187))
+- Fixed method matchers with array types ([#3203](https://github.com/spotbugs/spotbugs/issues/3203))
 
 ### Cleanup
 - Cleanup thread issue and regex issue in test-harness ([#3130](https://github.com/spotbugs/spotbugs/issues/3130))

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/filter/SignatureUtilTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/filter/SignatureUtilTest.java
@@ -63,4 +63,15 @@ class SignatureUtilTest {
         assertThat(SignatureUtil.createMethodSignature(null, "long"), is("~\\(.*\\)J"));
         assertThat(SignatureUtil.createMethodSignature("", null), is("~\\(\\).*"));
     }
+
+    /**
+     * If the method signature is a regex and there are array types we should escape the '[' or it we be processed as a regex group start.
+     *
+     * @see NameMatch This class uses {@code ~} to judge signature is regexp or not.
+     */
+    @Test
+    void testCreateMethodSignatureWithArrayTypes() {
+        assertThat(SignatureUtil.createMethodSignature(null, "long[]"), is("~\\(.*\\)\\[J"));
+        assertThat(SignatureUtil.createMethodSignature("byte[], short, byte", null), is("~\\(\\[BSB\\).*"));
+    }
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/filter/SignatureUtil.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/filter/SignatureUtil.java
@@ -29,6 +29,11 @@ import java.util.regex.Pattern;
  */
 public class SignatureUtil {
 
+    /**
+     * @param params The parameters for this method signature, or null, for instance <code>int, long</code>
+     * @param returns The return for this method signature, or null, for instance <code>double</code>
+     * @return The method signature or (in case either <code>params</code> or <code>returns</code> are null) a regex pattern matching the signatures. When a regex is returned the first character will be '~'.
+     */
     public static String createMethodSignature(String params, String returns) {
         if (params == null && returns == null) {
             return null;
@@ -42,7 +47,7 @@ public class SignatureUtil {
 
             StringTokenizer tok = new StringTokenizer(params, " \t\n\r\f,");
             while (tok.hasMoreTokens()) {
-                String param = typeToSignature(tok.nextToken());
+                String param = typeToSignature(tok.nextToken(), returns == null);
                 buf.append(param);
             }
             pString = buf.toString();
@@ -50,7 +55,7 @@ public class SignatureUtil {
         if (returns == null) {
             rString = ".*";
         } else {
-            rString = typeToSignature(returns);
+            rString = typeToSignature(returns, params == null);
         }
         if (params == null || returns == null) {
             String result = "~\\(" + pString + "\\)" + rString;
@@ -66,12 +71,18 @@ public class SignatureUtil {
         if (type == null) {
             return null;
         }
-        return typeToSignature(type);
+        return typeToSignature(type, false);
     }
 
-    private static String typeToSignature(String type) {
+    private static String typeToSignature(String type, boolean regex) {
         if (type.endsWith("[]")) {
-            return "[" + typeToSignature(type.substring(0, type.length() - 2));
+            String typeString = "[" + typeToSignature(type.substring(0, type.length() - 2), regex);
+            if (regex) {
+                // When we're building a regex we need to escape the '[' or it will be processed as a regex group
+                return "\\" + typeString;
+            } else {
+                return typeString;
+            }
         } else {
             return scalarTypeToSignature(type);
         }


### PR DESCRIPTION
When a method signature is created as a regex (either when the parameters or the return type were not specified), the opening bracket ([) corresponding to array types need to be escaped to get a valid regex