### PR TITLE
Use SignatureParser to extract the arguments of a method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Fix call graph, include non-parametric void methods ([#3160](https://github.com/spotbugs/spotbugs/pull/3160))
 - Added missing comma between line number and confidence when describing matching and mismatching bugs for tests ([#3187](https://github.com/spotbugs/spotbugs/pull/3187))
 - Fixed method matchers with array types ([#3203](https://github.com/spotbugs/spotbugs/issues/3203))
+- Fixed an error in the detection of bridge methods causing analysis crashes ([#3208](https://github.com/spotbugs/spotbugs/issues/3208))
 
 ### Cleanup
 - Cleanup thread issue and regex issue in test-harness ([#3130](https://github.com/spotbugs/spotbugs/issues/3130))

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/analysis/ClassInfo.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/analysis/ClassInfo.java
@@ -32,10 +32,7 @@ import java.util.Set;
 import javax.annotation.CheckForNull;
 
 import edu.umd.cs.findbugs.SystemProperties;
-import edu.umd.cs.findbugs.ba.AnalysisContext;
-import edu.umd.cs.findbugs.ba.XClass;
-import edu.umd.cs.findbugs.ba.XField;
-import edu.umd.cs.findbugs.ba.XMethod;
+import edu.umd.cs.findbugs.ba.*;
 import edu.umd.cs.findbugs.classfile.CheckedAnalysisException;
 import edu.umd.cs.findbugs.classfile.ClassDescriptor;
 import edu.umd.cs.findbugs.classfile.DescriptorFactory;
@@ -103,14 +100,6 @@ public class ClassInfo extends ClassNameAndSuperclassInfo implements XClass {
 
         boolean hasStubs;
 
-        private static String arguments(String signature) {
-            int i = signature.indexOf('(');
-            if (i == -1) {
-                return signature;
-            }
-            return signature.substring(0, i + 1);
-        }
-
         @Override
         public ClassInfo build() {
             AnalysisContext context = AnalysisContext.currentAnalysisContext();
@@ -129,11 +118,14 @@ public class ClassInfo extends ClassNameAndSuperclassInfo implements XClass {
                     if (DEBUG) {
                         System.out.println("Have bridge method:" + m);
                     }
+
+                    String[] mArguments = new SignatureParser(m.getSignature()).getArguments();
+
                     for (MethodInfo to : methodInfoList) {
                         if (m != to) {
                             if (!to.isBridge()
                                     && m.getName().equals(to.getName())
-                                    && arguments(m.getSignature()).equals(arguments(to.getSignature()))) {
+                                    && Arrays.equals(mArguments, new SignatureParser(to.getSignature()).getArguments())) {
                                 if (DEBUG) {
                                     System.out.println("  to method:" + to);
                                 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/analysis/ClassInfo.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/analysis/ClassInfo.java
@@ -33,6 +33,7 @@ import javax.annotation.CheckForNull;
 
 import edu.umd.cs.findbugs.SystemProperties;
 import edu.umd.cs.findbugs.ba.AnalysisContext;
+import edu.umd.cs.findbugs.ba.SignatureParser;
 import edu.umd.cs.findbugs.ba.XClass;
 import edu.umd.cs.findbugs.ba.XField;
 import edu.umd.cs.findbugs.ba.XMethod;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/analysis/ClassInfo.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/analysis/ClassInfo.java
@@ -32,7 +32,10 @@ import java.util.Set;
 import javax.annotation.CheckForNull;
 
 import edu.umd.cs.findbugs.SystemProperties;
-import edu.umd.cs.findbugs.ba.*;
+import edu.umd.cs.findbugs.ba.AnalysisContext;
+import edu.umd.cs.findbugs.ba.XClass;
+import edu.umd.cs.findbugs.ba.XField;
+import edu.umd.cs.findbugs.ba.XMethod;
 import edu.umd.cs.findbugs.classfile.CheckedAnalysisException;
 import edu.umd.cs.findbugs.classfile.ClassDescriptor;
 import edu.umd.cs.findbugs.classfile.DescriptorFactory;


### PR DESCRIPTION
ClassInfo.Builder.arguments() was incorrectly extracting the arguments from a method signature: for instance the output for "(Xyz)V" was "(" instead of the expected "Xyz".
As a result the ClassInfo.Builder.build() was incorrectly matching methods with same name (but different arguments) as bridge methods. This caused errors ("Can't push void") in
TypeFrameModelingVisitor.pushValue() when the mismatched method had a void return type.

I tried making a unit test reproducing the problem in #3208 but was not able to extract the problematic case.
This should fix #3208 