### PR TITLE
fix `FinalizerNullsFields` not checking method signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Fix call graph, include non-parametric void methods ([#3160](https://github.com/spotbugs/spotbugs/pull/3160))
 - Added missing comma between line number and confidence when describing matching and mismatching bugs for tests ([#3187](https://github.com/spotbugs/spotbugs/pull/3187))
 - Fixed method matchers with array types ([#3203](https://github.com/spotbugs/spotbugs/issues/3203))
+- Fixed `FI_FINALIZER_NULLS_FIELDS` FPs for functions called finalize() but not with the correct signature. ([#3207](https://github.com/spotbugs/spotbugs/issues/3207))
 
 ### Cleanup
 - Cleanup thread issue and regex issue in test-harness ([#3130](https://github.com/spotbugs/spotbugs/issues/3130))

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FinalizerNullsFields.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FinalizerNullsFields.java
@@ -24,7 +24,6 @@ package edu.umd.cs.findbugs.detect;
 
 import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
-import org.apache.bcel.classfile.Field;
 import org.apache.bcel.classfile.Method;
 
 import edu.umd.cs.findbugs.BugAccumulator;
@@ -53,16 +52,7 @@ public class FinalizerNullsFields extends BytecodeScanningDetector {
 
     @Override
     public void visit(Method obj) {
-        if ("finalize".equals(obj.getName())) {
-            inFinalize = true;
-        } else {
-            inFinalize = false;
-        }
-    }
-
-    @Override
-    public void visit(Field obj) {
-
+        inFinalize = "finalize".equals(obj.getName()) && "()V".equals(obj.getSignature());
     }
 
     @Override


### PR DESCRIPTION
This PR fixes https://github.com/spotbugs/spotbugs/issues/3207.
