### PR TITLE
fix SARIF Exception message property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Fix call graph, include non-parametric void methods ([#3160](https://github.com/spotbugs/spotbugs/pull/3160))
 - Added missing comma between line number and confidence when describing matching and mismatching bugs for tests ([#3187](https://github.com/spotbugs/spotbugs/pull/3187))
 - Fixed method matchers with array types ([#3203](https://github.com/spotbugs/spotbugs/issues/3203))
+- Fix SARIF report's message property in Exception to meet the standard ([#3197](https://github.com/spotbugs/spotbugs/issues/3197))
 
 ### Cleanup
 - Cleanup thread issue and regex issue in test-harness ([#3130](https://github.com/spotbugs/spotbugs/issues/3130))

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/SarifException.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/SarifException.java
@@ -1,6 +1,7 @@
 package edu.umd.cs.findbugs.sarif;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import edu.umd.cs.findbugs.ba.SourceFinder;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonArray;
@@ -20,16 +21,16 @@ import java.util.stream.Collectors;
 class SarifException {
     @NonNull
     final String kind;
-    @NonNull
+    @Nullable
     final String message;
     @NonNull
     final Stack stack;
     @NonNull
     final List<SarifException> innerExceptions;
 
-    SarifException(@NonNull String kind, @NonNull String message, @NonNull Stack stack, @NonNull List<SarifException> innerExceptions) {
+    SarifException(@NonNull String kind, @Nullable String message, @NonNull Stack stack, @NonNull List<SarifException> innerExceptions) {
         this.kind = Objects.requireNonNull(kind);
-        this.message = Objects.requireNonNull(message);
+        this.message = message;
         this.stack = Objects.requireNonNull(stack);
         this.innerExceptions = Collections.unmodifiableList(Objects.requireNonNull(innerExceptions));
     }
@@ -37,9 +38,6 @@ class SarifException {
     @NonNull
     static SarifException fromThrowable(@NonNull Throwable throwable, @NonNull SourceFinder sourceFinder, @NonNull Map<URI, String> baseToId) {
         String message = throwable.getMessage();
-        if (message == null) {
-            message = "no message given";
-        }
         List<Throwable> innerThrowables = new ArrayList<>();
         innerThrowables.add(throwable.getCause());
         innerThrowables.addAll(Arrays.asList(throwable.getSuppressed()));
@@ -51,12 +49,11 @@ class SarifException {
     }
 
     JsonObject toJsonObject() {
-        JsonObject textJson = new JsonObject();
-        textJson.addProperty("text", message);
-
         JsonObject result = new JsonObject();
         result.addProperty("kind", kind);
-        result.add("message", textJson);
+        if (message != null) {
+            result.addProperty("message", message);
+        }
         result.add("stack", stack.toJsonObject());
 
         JsonArray exceptionArray = new JsonArray();


### PR DESCRIPTION
In the SARIF report the [Exception](https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html#_Toc141791154)'s message should be string property, not the [message object](https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html#_Toc141790709) as it is in the [Notification](https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html#_Toc141791144). Also, it can be absent, so it's logical to have it as nullable. See the SARIF's specification for [Exception's message](https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html#_Toc141791157): 
 > An exception object **SHOULD** contain a property named message whose value is a string that describes the exception.
If the tool does not have access to an appropriate property of the thrown object, the message property **SHALL** be absent.

This PR fixes https://github.com/spotbugs/spotbugs/issues/3197. 