### PR TITLE
Change macos-latest to macos-13 in GHA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-13]
         java: [11, 17, 21, 23]
       max-parallel: 6
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
The current macos-latest gha is macos-14 with the softwares of [macos-14-arm64](https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md) according to the github actions [runner images repo](https://github.com/actions/runner-images/tree/main?tab=readme-ov-file#available-images). This image does [not contain java 8](https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md#java), which is currently still seems to be necessary for the build of the eclipse plugin.
The [macos-13](https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md#java) image has java 8. 
With using macos-13 instead of macos-latest the [build job is successful](https://github.com/JuditKnoll/spotbugs/actions/runs/12121006111/job/33790996092), not only because of timeout.

The [macos-14](https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md#java) image also has java 8, which is the macos-latest-large or macos-14-large image, but "[larger runners are only available for organizations and enterprises using the GitHub Team or GitHub Enterprise Cloud plans](https://docs.github.com/en/actions/using-github-hosted-runners/using-larger-runners/about-larger-runners)" and not free.

This is a workaround, a temporary fix for https://github.com/spotbugs/spotbugs/issues/3099.