### PR TITLE
Cleanup: use Boolean.parseBoolean for string-to-boolean conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Use diamond operator in constructor calls of Collections ([#3176](https://github.com/spotbugs/spotbugs/pull/3176))
 - Use `Collection.isEmpty()` to test for emptiness ([#3180](https://github.com/spotbugs/spotbugs/pull/3180))
 - Use method references instead of lambdas where possible ([#3179](https://github.com/spotbugs/spotbugs/pull/3179))
+- Use `Boolean.parseBoolean()` for string-to-boolean conversion. ([#3217](https://github.com/spotbugs/spotbugs/pull/3217))
 
 ### Changed
 - Bump up Java version to 11

--- a/eclipsePlugin/src/de/tobject/findbugs/FindbugsPlugin.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/FindbugsPlugin.java
@@ -473,27 +473,27 @@ public class FindbugsPlugin extends AbstractUIPlugin {
         if (isDebugging()) {
             // debugging for the plugin itself
             String option = Platform.getDebugOption(PLUGIN_DEBUG);
-            FindbugsPlugin.DEBUG = Boolean.valueOf(option).booleanValue();
+            FindbugsPlugin.DEBUG = Boolean.parseBoolean(option);
 
             // debugging for the builder and friends
             option = Platform.getDebugOption(BUILDER_DEBUG);
-            FindBugsBuilder.DEBUG = Boolean.valueOf(option).booleanValue();
+            FindBugsBuilder.DEBUG = Boolean.parseBoolean(option);
             FindBugsWorker.DEBUG = FindBugsBuilder.DEBUG;
 
             // debugging for the nature
             option = Platform.getDebugOption(NATURE_DEBUG);
-            FindBugsNature.DEBUG = Boolean.valueOf(option).booleanValue();
+            FindBugsNature.DEBUG = Boolean.parseBoolean(option);
 
             // debugging for the reporter
             option = Platform.getDebugOption(REPORTER_DEBUG);
-            Reporter.DEBUG = Boolean.valueOf(option).booleanValue();
+            Reporter.DEBUG = Boolean.parseBoolean(option);
 
             // debugging for the content provider
             option = Platform.getDebugOption(CONTENT_DEBUG);
-            BugContentProvider.DEBUG = Boolean.valueOf(option).booleanValue();
+            BugContentProvider.DEBUG = Boolean.parseBoolean(option);
 
             option = Platform.getDebugOption(PROFILER_DEBUG);
-            if (Boolean.valueOf(option).booleanValue()) {
+            if (Boolean.parseBoolean(option)) {
                 System.setProperty("profiler.report", "true");
             }
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/BugProperty.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/BugProperty.java
@@ -102,7 +102,7 @@ public class BugProperty implements XMLWriteable, Serializable, Cloneable {
      * @return value of property as a boolean
      */
     public boolean getValueAsBoolean() {
-        return Boolean.valueOf(getValue()).booleanValue();
+        return Boolean.parseBoolean(getValue());
     }
 
     /**

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/PluginLoader.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/PluginLoader.java
@@ -773,7 +773,7 @@ public class PluginLoader implements AutoCloseable {
 
                 try {
                     String propertiesLocation = componentNode.valueOf("@properties");
-                    boolean disabled = Boolean.valueOf(componentNode.valueOf("@disabled"));
+                    boolean disabled = Boolean.parseBoolean(componentNode.valueOf("@disabled"));
 
                     Node filterMessageNode = findMessageNode(messageCollectionList,
                             "/MessageCollection/PluginComponent[@id='" + componentId + "']",
@@ -822,7 +822,7 @@ public class PluginLoader implements AutoCloseable {
                                 + " loaded from " + loadedFrom);
                     }
                     String kind = main.valueOf("@kind");
-                    boolean analysis = Boolean.valueOf(main.valueOf("@analysis"));
+                    boolean analysis = Boolean.parseBoolean(main.valueOf("@analysis"));
                     Element mainMessageNode = (Element) findMessageNode(messageCollectionList,
                             "/MessageCollection/FindBugsMain[@cmd='" + cmd
                             // + " and @class='" + className
@@ -867,7 +867,7 @@ public class PluginLoader implements AutoCloseable {
                 }
                 DetectorFactory factory = new DetectorFactory(plugin, className, detectorClass, !"true".equals(disabled), speed,
                         reports, requireJRE);
-                if (Boolean.valueOf(hidden).booleanValue()) {
+                if (Boolean.parseBoolean(hidden)) {
                     factory.setHidden(true);
                 }
                 factory.setPositionSpecifiedInPluginDescriptor(detectorCount++);
@@ -927,7 +927,7 @@ public class PluginLoader implements AutoCloseable {
             }
             BugCategory bc = plugin.addOrCreateBugCategory(key);
 
-            boolean hidden = Boolean.valueOf(categoryNode.valueOf("@hidden"));
+            boolean hidden = Boolean.parseBoolean(categoryNode.valueOf("@hidden"));
             if (hidden) {
                 bc.setHidden(hidden);
             }
@@ -1006,7 +1006,7 @@ public class PluginLoader implements AutoCloseable {
 
             try {
                 String deprecatedStr = bugPatternNode.valueOf("@deprecated");
-                boolean deprecated = deprecatedStr.length() > 0 && Boolean.valueOf(deprecatedStr).booleanValue();
+                boolean deprecated = deprecatedStr.length() > 0 && Boolean.parseBoolean(deprecatedStr);
                 if (deprecated) {
                     bugPattern.setDeprecated(deprecated);
                 }
@@ -1288,7 +1288,7 @@ public class PluginLoader implements AutoCloseable {
 
         node = constraintElement.selectSingleNode("./" + singleDetectorElementName + "Category");
         if (node != null) {
-            boolean spanPlugins = Boolean.valueOf(node.valueOf("@spanplugins")).booleanValue();
+            boolean spanPlugins = Boolean.parseBoolean(node.valueOf("@spanplugins"));
 
             String categoryName = node.valueOf("@name");
             if (!"".equals(categoryName)) {
@@ -1307,7 +1307,7 @@ public class PluginLoader implements AutoCloseable {
 
         node = constraintElement.selectSingleNode("./" + singleDetectorElementName + "Subtypes");
         if (node != null) {
-            boolean spanPlugins = Boolean.valueOf(node.valueOf("@spanplugins")).booleanValue();
+            boolean spanPlugins = Boolean.parseBoolean(node.valueOf("@spanplugins"));
 
             String superName = node.valueOf("@super");
             if (!"".equals(superName)) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/PluginLoader.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/PluginLoader.java
@@ -851,7 +851,7 @@ public class PluginLoader implements AutoCloseable {
                 String reports = detectorNode.valueOf("@reports");
                 String requireJRE = detectorNode.valueOf("@requirejre");
                 String hidden = detectorNode.valueOf("@hidden");
-                if (speed == null || speed.length() == 0) {
+                if (speed == null || speed.isEmpty()) {
                     speed = "fast";
                 }
                 // System.out.println("Found detector: class="+className+", disabled="+disabled);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/TextUICommandLine.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/TextUICommandLine.java
@@ -401,7 +401,7 @@ public class TextUICommandLine extends FindBugsCommandLine {
         } else if ("-quiet".equals(option)) {
             quiet = true;
         } else if ("-nested".equals(option)) {
-            scanNestedArchives = "".equals(optionExtraPart) || Boolean.valueOf(optionExtraPart).booleanValue();
+            scanNestedArchives = "".equals(optionExtraPart) || Boolean.parseBoolean(optionExtraPart);
         } else if ("-exitcode".equals(option)) {
             setExitCode = true;
         } else if ("-auxclasspathFromInput".equals(option)) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/config/ProjectFilterSettings.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/config/ProjectFilterSettings.java
@@ -197,7 +197,7 @@ public class ProjectFilterSettings implements Cloneable {
                 displayFalseWarnings = s;
                 s = "";
             }
-            result.setDisplayFalseWarnings(Boolean.valueOf(displayFalseWarnings).booleanValue());
+            result.setDisplayFalseWarnings(Boolean.parseBoolean(displayFalseWarnings));
         }
 
         if (s.length() > 0) {
@@ -282,7 +282,7 @@ public class ProjectFilterSettings implements Cloneable {
         }
 
         if (!displayFalseWarnings) {
-            boolean isFalseWarning = !Boolean.valueOf(bugInstance.getProperty(BugProperty.IS_BUG, "true")).booleanValue();
+            boolean isFalseWarning = !Boolean.parseBoolean(bugInstance.getProperty(BugProperty.IS_BUG, "true"));
             if (isFalseWarning) {
                 return false;
             }


### PR DESCRIPTION
Fixing "use `Boolean.parseBoolean()` for string-to-boolean conversion" issues.
