### PR TITLE
Cleanup: remove unnecessary semicolons

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/SAXBugCollectionHandlerTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/SAXBugCollectionHandlerTest.java
@@ -20,7 +20,7 @@ class SAXBugCollectionHandlerTest {
 
     @BeforeEach
     void setUp() {
-        IAnalysisCache analysisCache = ClassFactory.instance().createAnalysisCache(new ClassPathImpl(), new PrintingBugReporter());;
+        IAnalysisCache analysisCache = ClassFactory.instance().createAnalysisCache(new ClassPathImpl(), new PrintingBugReporter());
         Global.setAnalysisCacheForCurrentThread(analysisCache);
         FindBugs2.registerBuiltInAnalysisEngines(analysisCache);
     }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/VersionInsensitiveBugComparatorTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/VersionInsensitiveBugComparatorTest.java
@@ -23,7 +23,7 @@ class VersionInsensitiveBugComparatorTest {
 
         @Override
         public void accept(BugAnnotationVisitor visitor) {
-            ;
+
         }
 
         @Override

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/JrtfsCodeBase.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/JrtfsCodeBase.java
@@ -116,7 +116,7 @@ public class JrtfsCodeBase extends AbstractScannableCodeBase {
                     e.printStackTrace();
                 }
             });
-        } ;
+        }
         return packageToModule;
     }
 


### PR DESCRIPTION
Removing unnecessary semicolons. I did not add a changelog to this change, because I don't think it needs it.