### PR TITLE
Cleanup: remove unnecessary throws declarations from methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Use diamond operator in constructor calls of Collections ([#3176](https://github.com/spotbugs/spotbugs/pull/3176))
 - Use `Collection.isEmpty()` to test for emptiness ([#3180](https://github.com/spotbugs/spotbugs/pull/3180))
 - Use method references instead of lambdas where possible ([#3179](https://github.com/spotbugs/spotbugs/pull/3179))
+- Remove unnecessary throws declarations ([#3220](https://github.com/spotbugs/spotbugs/pull/3220))
 
 ### Changed
 - Bump up Java version to 11

--- a/eclipsePlugin-test/src/de/tobject/findbugs/quickfix/test/QuickfixMulti.java
+++ b/eclipsePlugin-test/src/de/tobject/findbugs/quickfix/test/QuickfixMulti.java
@@ -33,7 +33,6 @@ import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.ui.IMarkerResolution;
 import org.eclipse.ui.views.markers.WorkbenchMarkerResolution;
 import org.junit.jupiter.api.BeforeAll;

--- a/eclipsePlugin-test/src/de/tobject/findbugs/quickfix/test/QuickfixMulti.java
+++ b/eclipsePlugin-test/src/de/tobject/findbugs/quickfix/test/QuickfixMulti.java
@@ -118,7 +118,7 @@ class QuickfixMulti extends AbstractQuickfixTest {
         checkJavaFiles(project.members());
     }
 
-    private void checkJavaFiles(IResource[] iResources) throws CoreException, IOException, JavaModelException {
+    private void checkJavaFiles(IResource[] iResources) throws CoreException, IOException {
         for (IResource resource : iResources) {
             if (resource instanceof IFile) {
                 String fileName = resource.getName();

--- a/eclipsePlugin/src/de/tobject/findbugs/FindbugsPlugin.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/FindbugsPlugin.java
@@ -738,11 +738,10 @@ public class FindbugsPlugin extends AbstractUIPlugin {
      *            the bug collection
      * @param monitor
      *            progress monitor
-     * @throws IOException
      * @throws CoreException
      */
     public static void storeBugCollection(IProject project, final SortedBugCollection bugCollection, IProgressMonitor monitor)
-            throws IOException, CoreException {
+            throws CoreException {
 
         // Store the bug collection and findbugs project in the session
         project.setSessionProperty(SESSION_PROPERTY_BUG_COLLECTION, bugCollection);

--- a/eclipsePlugin/src/de/tobject/findbugs/builder/FindBugsBuilder.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/builder/FindBugsBuilder.java
@@ -125,9 +125,8 @@ public class FindBugsBuilder extends IncrementalProjectBuilder {
      * @param kind
      *            kind the kind of build being requested, see
      *            IncrementalProjectBuilder
-     * @throws CoreException
      */
-    private void doBuild(final Map<?, ?> args, final IProgressMonitor monitor, int kind) throws CoreException {
+    private void doBuild(final Map<?, ?> args, final IProgressMonitor monitor, int kind) {
         boolean incremental = (kind == IncrementalProjectBuilder.INCREMENTAL_BUILD
                 || kind == IncrementalProjectBuilder.AUTO_BUILD);
         IProject project = getProject();

--- a/eclipsePlugin/src/de/tobject/findbugs/builder/FindBugsWorker.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/builder/FindBugsWorker.java
@@ -367,8 +367,6 @@ public class FindBugsWorker {
             // props
             st.newPoint("storeBugCollection");
             FindbugsPlugin.storeBugCollection(project, resultCollection, monitor);
-        } catch (IOException e) {
-            FindbugsPlugin.getDefault().logException(e, "Error performing SpotBugs results update");
         } catch (CoreException e) {
             FindbugsPlugin.getDefault().logException(e, "Error performing SpotBugs results update");
         }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/CurrentThreadExecutorServiceTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/CurrentThreadExecutorServiceTest.java
@@ -62,7 +62,7 @@ class CurrentThreadExecutorServiceTest {
     }
 
     @Test
-    void awaitTerminationWithoutShutdown() throws InterruptedException {
+    void awaitTerminationWithoutShutdown() {
         ExecutorService executorService = new CurrentThreadExecutorService();
         Assertions.assertThrows(IllegalStateException.class, () -> {
             executorService.awaitTermination(1, TimeUnit.SECONDS);

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/DetectorsTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/DetectorsTest.java
@@ -89,7 +89,7 @@ class DetectorsTest {
     }
 
     @BeforeEach
-    void setUp() throws Exception {
+    void setUp() {
         loadFindbugsPlugin();
     }
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/ch/Subtypes2Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/ch/Subtypes2Test.java
@@ -94,7 +94,7 @@ class Subtypes2Test extends FindBugsTestCase {
     ObjectType typeParameterString;
 
     @BeforeEach
-    void setUp() throws Exception {
+    void setUp() {
         typeSerializable = ObjectTypeFactory.getInstance("java.io.Serializable");
         typeClonable = ObjectTypeFactory.getInstance("java.lang.Cloneable");
         typeObject = ObjectTypeFactory.getInstance(Values.DOTTED_JAVA_LANG_OBJECT);

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/filter/AnnotationMatcherTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/filter/AnnotationMatcherTest.java
@@ -128,7 +128,7 @@ class AnnotationMatcherTest {
     }
 
     @Test
-    void testPerformAnalysis(SpotBugsRunner spotbugs) throws Exception {
+    void testPerformAnalysis(SpotBugsRunner spotbugs) {
         BugCollection bugCollection = spotbugs.performAnalysis(
                 Paths.get("../spotbugsTestCases/build/classes/java/main/org/immutables/value/Generated.class"),
                 Paths.get("../spotbugsTestCases/build/classes/java/main/org/immutables/value/Value.class"),

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/filter/NotMatcherTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/filter/NotMatcherTest.java
@@ -42,7 +42,7 @@ class NotMatcherTest {
     private final BugInstance bug = new BugInstance("UUF_UNUSED_FIELD", 0);
 
     @Test
-    void invertsResultsFromWrappedMatcher_doesntMatchWhenWrappedDoesMatch() throws Exception {
+    void invertsResultsFromWrappedMatcher_doesntMatchWhenWrappedDoesMatch() {
         Matcher wrappedMatcher = new TestMatcher(true);
         NotMatcher notMatcher = new NotMatcher();
         notMatcher.addChild(wrappedMatcher);
@@ -51,7 +51,7 @@ class NotMatcherTest {
     }
 
     @Test
-    void invertsResultsFromWrappedMatcher_doesMatchWhenWrappedDoesnt() throws Exception {
+    void invertsResultsFromWrappedMatcher_doesMatchWhenWrappedDoesnt() {
         Matcher wrappedMatcher = new TestMatcher(false);
         NotMatcher notMatcher = new NotMatcher();
         notMatcher.addChild(wrappedMatcher);

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/filter/SourceMatcherTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/filter/SourceMatcherTest.java
@@ -96,7 +96,7 @@ class SourceMatcherTest {
 
 
     @Test
-    void match() throws Exception {
+    void match() {
         SourceMatcher sm = new SourceMatcher(fileName);
 
         // no source set: test incomplete data
@@ -131,7 +131,7 @@ class SourceMatcherTest {
     }
 
     @Test
-    void testRealPathMatchWithRegexpAndProject() throws Exception {
+    void testRealPathMatchWithRegexpAndProject() {
         // add this test class as the bug target
         bug.addClass("SourceMatcherTest", null);
         ClassAnnotation primaryClass = bug.getPrimaryClass();
@@ -155,7 +155,7 @@ class SourceMatcherTest {
     }
 
     @Test
-    void testRealPathMatchWithRegexpAndAnalysisContext() throws Exception {
+    void testRealPathMatchWithRegexpAndAnalysisContext() {
         // add this test class as the bug target
         bug.addClass("SourceMatcherTest", null);
         ClassAnnotation primaryClass = bug.getPrimaryClass();

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/sarif/SarifBugReporterTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/sarif/SarifBugReporterTest.java
@@ -34,7 +34,6 @@ import edu.umd.cs.findbugs.BugPattern;
 import edu.umd.cs.findbugs.DetectorFactoryCollection;
 import edu.umd.cs.findbugs.FindBugs2;
 import edu.umd.cs.findbugs.Plugin;
-import edu.umd.cs.findbugs.PluginException;
 import edu.umd.cs.findbugs.PluginLoader;
 import edu.umd.cs.findbugs.Priorities;
 import edu.umd.cs.findbugs.Project;

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/sarif/SarifBugReporterTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/sarif/SarifBugReporterTest.java
@@ -308,7 +308,7 @@ class SarifBugReporterTest {
     }
 
     @Test
-    void testExtensions() throws PluginException {
+    void testExtensions() {
         PluginLoader pluginLoader = DetectorFactoryCollection.instance().getCorePlugin().getPluginLoader();
         Plugin plugin = new Plugin("pluginId", "version", null, pluginLoader, true, false);
         DetectorFactoryCollection dfc = new DetectorFactoryCollection(plugin);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/PluginLoader.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/PluginLoader.java
@@ -1178,7 +1178,7 @@ public class PluginLoader implements AutoCloseable {
         return constructedPlugin;
     }
 
-    public Document getPluginDescriptor() throws PluginException, PluginDoesntContainMetadataException {
+    public Document getPluginDescriptor() throws PluginException {
         Document pluginDescriptor;
 
         // Read the plugin descriptor

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/SourceFinder.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/SourceFinder.java
@@ -267,7 +267,7 @@ public class SourceFinder implements AutoCloseable {
         return r;
     }
 
-    SourceRepository makeJarURLConnectionSourceRepository(final String url) throws MalformedURLException, IOException {
+    SourceRepository makeJarURLConnectionSourceRepository(final String url) throws IOException {
         final File file = File.createTempFile("jar_cache", null);
         file.deleteOnExit();
         final BlockingSourceRepository r = new BlockingSourceRepository();
@@ -288,7 +288,7 @@ public class SourceFinder implements AutoCloseable {
      * @throws IOException
      * @throws MalformedURLException
      */
-    private InputStream open(final String url) throws IOException, MalformedURLException {
+    private InputStream open(final String url) throws IOException {
         InputStream in = null;
         URLConnection connection = new URL(url).openConnection();
         if (getProject().isGuiAvaliable()) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/DirectoryCodeBase.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/DirectoryCodeBase.java
@@ -149,7 +149,7 @@ public class DirectoryCodeBase extends AbstractScannableCodeBase {
         return new DirectoryCodeBaseEntry(this, resourceName);
     }
 
-    InputStream openFile(String resourceName) throws FileNotFoundException, IOException {
+    InputStream openFile(String resourceName) throws IOException {
         File path = getFullPathOfResource(resourceName);
         return new BufferedInputStream(new FileInputStream(path));
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/CallToUnsupportedMethod.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/CallToUnsupportedMethod.java
@@ -89,7 +89,7 @@ public class CallToUnsupportedMethod implements Detector {
      * @param classContext
      * @param method
      */
-    private void analyzeMethod(ClassContext classContext, Method method) throws MethodUnprofitableException, CFGBuilderException,
+    private void analyzeMethod(ClassContext classContext, Method method) throws CFGBuilderException,
             DataflowAnalysisException {
         if (BCELUtil.isSynthetic(method) || (method.getAccessFlags() & Const.ACC_BRIDGE) == Const.ACC_BRIDGE) {
             return;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/CheckTypeQualifiers.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/CheckTypeQualifiers.java
@@ -256,7 +256,7 @@ public class CheckTypeQualifiers extends CFGDetector {
 
     private void checkDataflow(XMethod xmethod, CFG cfg, TypeQualifierValue<?> typeQualifierValue,
             ValueNumberDataflow vnaDataflow, ForwardTypeQualifierDataflow forwardDataflow,
-            BackwardTypeQualifierDataflow backwardDataflow) throws DataflowAnalysisException, CheckedAnalysisException {
+            BackwardTypeQualifierDataflow backwardDataflow) throws CheckedAnalysisException {
         for (Iterator<Location> i = cfg.locationIterator(); i.hasNext();) {
             Location loc = i.next();
 
@@ -371,7 +371,7 @@ public class CheckTypeQualifiers extends CFGDetector {
 
     private void checkValueSources(XMethod xMethod, CFG cfg, TypeQualifierValue<?> typeQualifierValue,
             ValueNumberDataflow vnaDataflow, ForwardTypeQualifierDataflow forwardDataflow,
-            BackwardTypeQualifierDataflow backwardDataflow) throws DataflowAnalysisException, CheckedAnalysisException {
+            BackwardTypeQualifierDataflow backwardDataflow) throws CheckedAnalysisException {
 
         // Check to see if any backwards ALWAYS or NEVER values
         // reach incompatible sources.

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/RejarClassesForAnalysis.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/RejarClassesForAnalysis.java
@@ -626,7 +626,7 @@ public class RejarClassesForAnalysis {
         zipIn.close();
     }
 
-    private void advanceAuxiliaryOut() throws IOException, FileNotFoundException {
+    private void advanceAuxiliaryOut() throws IOException {
         auxiliaryOut.close();
         auxiliaryOut = createZipFile(getNextAuxiliaryFileOutput());
     }


### PR DESCRIPTION
Removing unnecessary throws declarations from methods, where the method body doesn't throw the listed exception, or a more general exception already listed.

See the issues in [SonarCloud](https://sonarcloud.io/project/issues?rules=java%3AS1130&issueStatuses=OPEN%2CCONFIRMED&id=com.github.spotbugs.spotbugs&open=AVzpu0ArZm7fF7LkQ57c).