### PR TITLE
Cleanup: move default to the end of switch-case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Use diamond operator in constructor calls of Collections ([#3176](https://github.com/spotbugs/spotbugs/pull/3176))
 - Use `Collection.isEmpty()` to test for emptiness ([#3180](https://github.com/spotbugs/spotbugs/pull/3180))
 - Use method references instead of lambdas where possible ([#3179](https://github.com/spotbugs/spotbugs/pull/3179))
+- Move default clauses to the end of switches ([#3222](https://github.com/spotbugs/spotbugs/pull/3222))
 
 ### Changed
 - Bump up Java version to 11

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/CheckAnalysisContextContainedAnnotation.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/CheckAnalysisContextContainedAnnotation.java
@@ -102,8 +102,6 @@ public class CheckAnalysisContextContainedAnnotation extends OpcodeStackDetector
     @Override
     public void sawOpcode(int seen) {
         switch (seen) {
-        default:
-            break;
         case Const.IF_ICMPEQ:
         case Const.IF_ICMPNE:
             OpcodeStack.Item left = stack.getStackItem(1);
@@ -113,6 +111,8 @@ public class CheckAnalysisContextContainedAnnotation extends OpcodeStackDetector
                         .addValueSource(left, this).addValueSource(right, this)
                         .addString("Just check the sign of the result of compare or compareTo, not specific values such as 1 or -1"), this);
             }
+            break;
+        default:
             break;
         }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ViewCFG.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ViewCFG.java
@@ -112,9 +112,6 @@ public class ViewCFG implements Detector {
             BasicBlock src = edge.getSource();
             BasicBlock tgt = edge.getTarget();
             switch (edge.getType()) {
-            default:
-                out.println("  Node" + src.getLabel() + " -> Node" + tgt.getLabel() + ";");
-                break;
             case IFCMP_EDGE:
                 out.println("  Node" + src.getLabel() + " -> Node" + tgt.getLabel() +
                         " [shape=plaintext label=\" True branch\"];");
@@ -160,6 +157,9 @@ public class ViewCFG implements Detector {
             case GOTO_EDGE:
                 out.println("  Node" + src.getLabel() + " -> Node" + tgt.getLabel() +
                         " [shape=plaintext label=\" GOTO statement\"];");
+                break;
+            default:
+                out.println("  Node" + src.getLabel() + " -> Node" + tgt.getLabel() + ";");
                 break;
             }
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/visitclass/DismantleBytecode.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/visitclass/DismantleBytecode.java
@@ -200,14 +200,13 @@ public abstract class DismantleBytecode extends AnnotationVisitor {
 
     public boolean isMethodCall() {
         switch (opcode) {
-        default:
-            return false;
         case Const.INVOKEINTERFACE:
         case Const.INVOKESPECIAL:
         case Const.INVOKEVIRTUAL:
         case Const.INVOKESTATIC:
             return true;
-
+        default:
+            return false;
         }
     }
 


### PR DESCRIPTION
Fixing ""default" clauses should be the last in switch cases" issues.
See in [SonarCloud](https://sonarcloud.io/project/issues?impactSeverities=HIGH&rules=java%3AS4524&issueStatuses=OPEN%2CCONFIRMED&id=com.github.spotbugs.spotbugs&open=AWuIQwpCpB8UmjzrO1f6).