### PR TITLE
Correct syntax so the bug descriptions aren't corrupted

### DIFF
--- a/spotbugs/etc/messages.xml
+++ b/spotbugs/etc/messages.xml
@@ -2586,7 +2586,7 @@ will need to be changed in order to compile it in later versions of Java.</p>
         <p> This code invokes a method that requires a security permission check.
         If this code will be granted security permissions, but might be invoked by code that does not
         have security permissions, then the invocation needs to occur inside a doPrivileged block.</p>
-        The <code>java.security.AccessController<\code> class, which contains the <code>doPrivileged</code> methods,
+        The <code>java.security.AccessController</code> class, which contains the <code>doPrivileged</code> methods,
         got deprecated in Java 17 (see <a href="https://openjdk.org/jeps/411">JEP 411</a>), and removed in Java 24 (see <a href="https://openjdk.org/jeps/486">JEP 486</a>).
         For this reason, this bug isn't reported in classes targeted Java 17 and above.
       ]]>
@@ -2600,7 +2600,7 @@ will need to be changed in order to compile it in later versions of Java.</p>
         <p> This code invokes a method that requires a security permission check.
         If this code will be granted security permissions, but might be invoked by code that does not
         have security permissions, then the invocation needs to occur inside a doPrivileged block.</p>
-        The <code>java.security.AccessController<\code> class, which contains the <code>doPrivileged</code> methods,
+        The <code>java.security.AccessController</code> class, which contains the <code>doPrivileged</code> methods,
         got deprecated in Java 17 (see <a href="https://openjdk.org/jeps/411">JEP 411</a>), and removed in Java 24 (see <a href="https://openjdk.org/jeps/486">JEP 486</a>).
         For this reason, this bug isn't reported in classes targeted Java 17 and above.
       ]]>
@@ -2614,7 +2614,7 @@ will need to be changed in order to compile it in later versions of Java.</p>
         <p> This code creates a classloader,  which needs permission if a security manage is installed.
         If this code might be invoked by code that does not
         have security permissions, then the classloader creation needs to occur inside a doPrivileged block.</p>
-        The <code>java.security.AccessController<\code> class, which contains the <code>doPrivileged</code> methods,
+        The <code>java.security.AccessController</code> class, which contains the <code>doPrivileged</code> methods,
         got deprecated in Java 17 (see <a href="https://openjdk.org/jeps/411">JEP 411</a>), and removed in Java 24 (see <a href="https://openjdk.org/jeps/486">JEP 486</a>).
         For this reason, this bug isn't reported in classes targeted Java 17 and above.
       ]]>
@@ -9078,7 +9078,7 @@ Using floating-point variables should not be used as loop counters, as they are 
       <p>
       See SEI CERT rule <a href="https://wiki.sei.cmu.edu/confluence/display/java/SEC02-J.+Do+not+base+security+checks+on+untrusted+sources">SEC02-J. Do not base security checks on untrusted sources</a>.
       </p>
-      The <code>java.security.AccessController<\code> class, which contains the <code>doPrivileged</code> methods,
+      The <code>java.security.AccessController</code> class, which contains the <code>doPrivileged</code> methods,
       got deprecated in Java 17 (see <a href="https://openjdk.org/jeps/411">JEP 411</a>), and removed in Java 24 (see <a href="https://openjdk.org/jeps/486">JEP 486</a>).
       For this reason, this bug isn't reported in classes targeted Java 17 and above.
       ]]>


### PR DESCRIPTION
I noticed that the [bug descriptions](https://spotbugs.readthedocs.io/en/latest/bugDescriptions.html) are corrupt from [this point on](https://spotbugs.readthedocs.io/en/latest/bugDescriptions.html#dp-method-invoked-that-should-be-only-be-invoked-inside-a-doprivileged-block-dp-do-inside-do-privileged).  It looks like this is because there's a `code` tag which is incorrectly terminated with `<\code>` instead of `</code>`.

This PR fixes the syntax.

I looked for the same error in the other translations, but it seems like they don't have `<\code>` in the `messages` files (only the correctly formed `</code>`).