### PR TITLE
Add missing deprecation annotation to match javadocs as noted in all …

### DIFF
--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNullDeref.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNullDeref.java
@@ -914,6 +914,7 @@ public class FindNullDeref implements Detector, UseAnnotationDatabase, NullDeref
      *             {@link #foundNullDeref(Location,ValueNumber,IsNullValue,ValueNumberFrame,boolean)}
      *             instead
      */
+    @Deprecated
     @Override
     public void foundNullDeref(Location location, ValueNumber valueNumber, IsNullValue refValue, ValueNumberFrame vnaFrame) {
         foundNullDeref(location, valueNumber, refValue, vnaFrame, true);


### PR DESCRIPTION
did not add change log for this as it was already deprecated, just missing non javadoc annotation.