### PR TITLE
Move Eclipse to java 11 to match rest of the project

### DIFF
--- a/eclipsePlugin-test/build.gradle
+++ b/eclipsePlugin-test/build.gradle
@@ -34,7 +34,7 @@ dependencies {
 javadoc {
   doFirst {
     // This is supposed to enable everything except "missing" but doesn't work with gradle
-    // See http://docs.oracle.com/javase/8/docs/technotes/tools/unix/javadoc.html
+    // See https://docs.oracle.com/en/java/javase/11/tools/javadoc.html
     options.addBooleanOption('Xdoclint:all,-missing', true)
 
     // TODO remove command and warning below if the doclint can be properly configured

--- a/eclipsePlugin/build.gradle
+++ b/eclipsePlugin/build.gradle
@@ -7,12 +7,12 @@ plugins {
   id "eclipse-convention"
 }
 
-// Force Eclipse use Java 1.8, otherwise it will get Java 17 (!) from gradle
+// Force Eclipse use Java 11, otherwise it will get Java 17 (!) from gradle
 eclipse {
   jdt {
-    sourceCompatibility = 8
-    targetCompatibility = 8
-    javaRuntimeName = "JavaSE-1.8"
+    sourceCompatibility = 11
+    targetCompatibility = 11
+    javaRuntimeName = "JavaSE-11"
   }
 }
 
@@ -96,7 +96,7 @@ tasks.named('clean', Delete).configure {
 // This disables hundreds of javadoc warnings on missing tags etc, see #340
 tasks.named('javadoc', Javadoc).configure {
   // This is supposed to enable everything except "missing" but doesn't work with gradle
-  // See http://docs.oracle.com/javase/8/docs/technotes/tools/unix/javadoc.html
+  // See https://docs.oracle.com/en/java/javase/11/tools/javadoc.html
   options.addBooleanOption('Xdoclint:all,-missing', true)
 
   // TODO remove command and warning below if the doclint can be properly configured

--- a/spotbugs-annotations/build.gradle
+++ b/spotbugs-annotations/build.gradle
@@ -56,7 +56,7 @@ tasks.named('javadoc', Javadoc).configure {
   }
   doFirst {
     // This is supposed to enable everything except "missing" but doesn't work with gradle
-    // See http://docs.oracle.com/javase/8/docs/technotes/tools/unix/javadoc.html
+    // See https://docs.oracle.com/en/java/javase/11/tools/javadoc.html
     options.addBooleanOption('Xdoclint:all,-missing', true)
   }
   doLast {

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -7,12 +7,12 @@ tasks.named('compileJava', JavaCompile).configure {
     options.release = 11
 }
 
-// Force Eclipse use Java 1.8, otherwise it will get Java 17 (!) from gradle
+// Force Eclipse use Java 11, otherwise it will get Java 17 (!) from gradle
 eclipse {
   jdt {
-    sourceCompatibility = 8
-    targetCompatibility = 8
-    javaRuntimeName = "JavaSE-1.8"
+    sourceCompatibility = 11
+    targetCompatibility = 11
+    javaRuntimeName = "JavaSE-11"
   }
 }
 
@@ -234,7 +234,7 @@ def scripts = tasks.register('scripts', Copy) {
 javadoc {
   doFirst {
     // This is supposed to enable everything except "missing" but doesn't work with gradle
-    // See http://docs.oracle.com/javase/8/docs/technotes/tools/unix/javadoc.html
+    // See https://docs.oracle.com/en/java/javase/11/tools/javadoc.html
     options.addBooleanOption('Xdoclint:all,-missing', true)
 
     // TODO remove command and warning below if the doclint can be properly configured

--- a/spotbugsTestCases/build.gradle
+++ b/spotbugsTestCases/build.gradle
@@ -57,7 +57,7 @@ tasks.withType(JavaCompile).configureEach {
 // This disables hundreds of javadoc warnings on missing tags etc, see #340
 tasks.named('javadoc', Javadoc).configure {
   // This is supposed to enable everything except "missing" but doesn't work with gradle
-  // See http://docs.oracle.com/javase/8/docs/technotes/tools/unix/javadoc.html
+  // See https://docs.oracle.com/en/java/javase/11/tools/javadoc.html
   options.addBooleanOption('Xdoclint:all,-missing', true)
 
   // TODO remove command and warning below if the doclint can be properly configured


### PR DESCRIPTION
fixes #3099 amd replaces #3214.  This was missed in our upgrade to java 11.

Given, our change log already states we moved to java 11, did not indicate this.  Further, we were already using java 11 based Eclipse but had it compiling its portion to java 8.  Other than fact we target one set of tests to java 8, I believe all of the build is otherwise property targeting java 11.