### PR TITLE
Fix for FindReturnRef crash when the value of an expression is assigned to a field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 ### Fixed
 - Fixed the parsing of generics methods in `ThrowingExceptions` ([#3267](https://github.com/spotbugs/spotbugs/issues/3267))
 - Accept the 1st parameter of `java.util.concurrent.CompletableFuture`'s `completeOnTimeout()`, `getNow()` and `obtrudeValue()` functions as nullable ([#1001](https://github.com/spotbugs/spotbugs/issues/1001)).
+- Fixed the an analysis error when `FindReturnRef` was checking instructions corresponding to a CFG branch that was optimized away ([#3266](https://github.com/spotbugs/spotbugs/issues/3266))
 
 ## 4.9.0 - 2025-01-15
 ### Added

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3266Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3266Test.java
@@ -1,0 +1,14 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class Issue3266Test extends AbstractIntegrationTest {
+
+    @Test
+    void testIssue() {
+        performAnalysis("ghIssues/Issue3266.class");
+
+        assertBugTypeCount("MS_EXPOSE_REP", 0);
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindReturnRef.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindReturnRef.java
@@ -127,7 +127,10 @@ public class FindReturnRef extends OpcodeStackDetector {
                         for (Iterator<BasicBlock> bi = cfg.predecessorIterator(loc.getBasicBlock()); bi.hasNext();) {
                             BasicBlock previousBlock = bi.next();
                             InstructionHandle lastInstruction = previousBlock.getLastInstruction();
-                            if (lastInstruction != null) {
+
+                            // The CFG might have been optimized in BetterCFGBuilder2.optimize() :
+                            // The instruction targeters might be removed and some instructions are replaced by noop
+                            if (ih.hasTargeters() && lastInstruction != null) {
                                 OpcodeStack prevStack = OpcodeStackScanner.getStackAt(javaClass, m, lastInstruction.getPosition());
                                 if (prevStack.getStackDepth() > 1) {
                                     fieldValues.get(field).add(prevStack.getStackItem(0));

--- a/spotbugsTestCases/src/java/ghIssues/Issue3266.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3266.java
@@ -1,0 +1,9 @@
+package ghIssues;
+
+public class Issue3266 {
+	private boolean initialized;
+	
+	public void setValue(String x) {
+		initialized = x == null;
+	}
+}


### PR DESCRIPTION
As reported in #3266 FindReturnRef  crashes on:
```
        @Override
        public Builder setCharset(final Charset charset) {
            nullCharset = charset == null;
            return super.setCharset(charset);
        }
```

This seems to be triggered by the CFG optimization in:
https://github.com/spotbugs/spotbugs/blob/4f66ba3bfafcc30af276b68fa52a5e684bbc0ec1/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/BetterCFGBuilder2.java#L661-L703

For instance the following bytecode:
```
     0  aload_0 [this]
     1  aload_1 [x]
     2  ifnonnull 9
     5  iconst_1
     6  goto 10
     9  iconst_0
    10  putfield ghIssues.Issue3266.initialized : boolean [2]
    13  return
```

Is transformed to add the synthetic (made up) `NONNULL2Z` instruction and the instruction targeters are removed.

See #3080 

This should fix #3266 