### PR TITLE
add `CompletableFuture` function parameters as nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ### Fixed
 - Fixed the parsing of generics methods in `ThrowingExceptions` ([#3267](https://github.com/spotbugs/spotbugs/issues/3267))
+- Accept the 1st parameter of `java.util.concurrent.CompletableFuture`'s `completeOnTimeout()`, `getNow()` and `obtrudeValue()` functions as nullable ([#1001](https://github.com/spotbugs/spotbugs/issues/1001)).
 
 ## 4.9.0 - 2025-01-15
 ### Added

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/nullness/NullableFutureTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/nullness/NullableFutureTest.java
@@ -1,0 +1,18 @@
+package edu.umd.cs.findbugs.nullness;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class NullableFutureTest extends AbstractIntegrationTest {
+    @Test
+    void testIssue() {
+        performAnalysis("nullnessAnnotations/NullableFuture.class");
+        assertNoBugType("NP_NONNULL_PARAM_VIOLATION");
+    }
+
+    @Test
+    void testIssue1397() {
+        performAnalysis("../java11/ghIssues/Issue1397.class");
+        assertNoBugType("NP_NONNULL_PARAM_VIOLATION");
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/DefaultNullnessAnnotations.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/DefaultNullnessAnnotations.java
@@ -234,6 +234,13 @@ public class DefaultNullnessAnnotations {
                 "(Ljava/lang/Object;)Ljava/util/concurrent/CompletableFuture;", true, 0, NullnessAnnotation.NULLABLE);
         database.addMethodParameterAnnotation("java.util.concurrent.CompletableFuture", "completedStage",
                 "(Ljava/lang/Object;)Ljava/util/concurrent/CompletionStage;", true, 0, NullnessAnnotation.NULLABLE);
+        database.addMethodParameterAnnotation("java.util.concurrent.CompletableFuture", "completeOnTimeout",
+                "(Ljava/lang/Object;JLjava/util/concurrent/TimeUnit;)Ljava/util/concurrent/CompletableFuture;", false, 0,
+                NullnessAnnotation.NULLABLE);
+        database.addMethodParameterAnnotation("java.util.concurrent.CompletableFuture", "getNow",
+                "(Ljava/lang/Object;)Ljava/lang/Object;", false, 0, NullnessAnnotation.NULLABLE);
+        database.addMethodParameterAnnotation("java.util.concurrent.CompletableFuture", "obtrudeValue",
+                "(Ljava/lang/Object;)V", false, 0, NullnessAnnotation.NULLABLE);
 
         database.addMethodParameterAnnotation("java.util.concurrent.ExecutionException", "<init>", "(Ljava/lang/String;)V",
                 false, 0, NullnessAnnotation.CHECK_FOR_NULL);

--- a/spotbugsTestCases/src/java/nullnessAnnotations/NullableFuture.java
+++ b/spotbugsTestCases/src/java/nullnessAnnotations/NullableFuture.java
@@ -1,0 +1,30 @@
+package nullnessAnnotations;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * <blockquote>Arguments used to pass a completion result (that is, for parameters of type T) for methods accepting them may be null, but passing a null value for any other parameter will result in a NullPointerException being thrown.</blockquote>
+ * @see CompletableFuture
+ * @see <a href="https://docs.oracle.com/javase/9/docs/api/java/util/concurrent/CompletableFuture.html">CompletableFuture JDK9</a>
+ */
+public class NullableFuture {
+    /**
+     * @see <a href="https://github.com/spotbugs/spotbugs/issues/1001">GitHub issue #1001</a>
+     */
+    public void getNow() {
+        // 1st argument of CompletableFuture#getNow(T) should be nullable
+        CompletableFuture<Object> future = new CompletableFuture<>();
+        future.getNow(null);
+    }
+
+    public void completeOnTimeout() {
+        CompletableFuture<Object> future = new CompletableFuture<>();
+        future.completeOnTimeout(null, 1L, TimeUnit.MINUTES);
+    }
+
+    public void obtrudeValue() {
+        CompletableFuture<Object> future = new CompletableFuture<>();
+        future.obtrudeValue(null);
+    }
+}


### PR DESCRIPTION
According to `CompletableFuture`'s [Java 9 javadoc](https://docs.oracle.com/javase/9/docs/api/java/util/concurrent/CompletableFuture.html):

> Arguments used to pass a completion result (that is, for parameters of type T) for methods accepting them may be null, but passing a null value for any other parameter will result in a NullPointerException being thrown.

Some of these functions was already added (see https://github.com/spotbugs/spotbugs/issues/484), but it looks like some was left out.
Also, there was a code example for `CompletableFuture.completedStage(null)` ([Issue1397.java](https://github.com/spotbugs/spotbugs/blob/master/spotbugsTestCases/src/java11/Issue1397.java)), but I couldn't find the test for it, so added it.

Fixes https://github.com/spotbugs/spotbugs/issues/1001.

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
