### PR TITLE
Ensure scripts in dist archive have execute permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Fixed the parsing of generics methods in `ThrowingExceptions` ([#3267](https://github.com/spotbugs/spotbugs/issues/3267))
 - Accept the 1st parameter of `java.util.concurrent.CompletableFuture`'s `completeOnTimeout()`, `getNow()` and `obtrudeValue()` functions as nullable ([#1001](https://github.com/spotbugs/spotbugs/issues/1001)).
 - Fixed the an analysis error when `FindReturnRef` was checking instructions corresponding to a CFG branch that was optimized away ([#3266](https://github.com/spotbugs/spotbugs/issues/3266))
+- Added execute file permission to files in the distribution archive ([#3274](https://github.com/spotbugs/spotbugs/issues/3274))
 
 ## 4.9.0 - 2025-01-15
 ### Added

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -256,6 +256,9 @@ distributions {
     contents {
       from(scripts) {
         into 'bin'
+        filePermissions {
+          unix(0755)
+        }
       }
       from 'README.txt'
       from ('plugin') {


### PR DESCRIPTION
Adjust the distributions contents, to include execute file permissions for archived files. So that the archive can be unpacked and directly used, on Unix platforms.

Fixes: https://github.com/spotbugs/spotbugs/issues/3274
----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
