### PR TITLE
Fixed NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE false positive when add edu.umd.cs.findbugs.annotations.Nullable Annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Added execute file permission to files in the distribution archive ([#3274](https://github.com/spotbugs/spotbugs/issues/3274))
 - Fixed a stack overflow in  `MultipleInstantiationsOfSingletons` when a singleton initializer makes recursive calls ([#3280](https://github.com/spotbugs/spotbugs/issues/3280))
 - Fixed NPE in  `FindReturnRef` on inner class fields ([#3283](https://github.com/spotbugs/spotbugs/issues/3283))
+- Fixed NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE false positive when add edu.umd.cs.findbugs.annotations.Nullable ([#3243](https://github.com/spotbugs/spotbugs/issues/3243))
 
 ## 4.9.0 - 2025-01-15
 ### Added

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue3243Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue3243Test.java
@@ -1,0 +1,14 @@
+package edu.umd.cs.findbugs.ba;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+public class Issue3243Test extends AbstractIntegrationTest {
+
+    @Test
+    public void testBugSample() {
+        performAnalysis("ghIssues/Issue3243.class");
+
+        assertNoBugType("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE");
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/TypeQualifierResolver.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/TypeQualifierResolver.java
@@ -68,7 +68,8 @@ public class TypeQualifierResolver {
     };
 
     private static final ClassDescriptor[] NULLABLE_CLASS_DESCRIPTORS = new ClassDescriptor[] {
-        DescriptorFactory.createClassDescriptor("edu/umd/cs/findbugs/annotations/Nullable"),
+        // intentionally ignored, semantics is different to other Nullable annotations, see <a href="https://github.com/spotbugs/spotbugs/issues/3243">#3243</a>
+        // DescriptorFactory.createClassDescriptor("edu/umd/cs/findbugs/annotations/Nullable"),
         DescriptorFactory.createClassDescriptor("android/support/annotation/Nullable"),
         DescriptorFactory.createClassDescriptor("androidx/annotation/Nullable"),
         DescriptorFactory.createClassDescriptor("com/google/common/base/Nullable"),

--- a/spotbugsTestCases/src/java/ghIssues/Issue3243.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3243.java
@@ -1,0 +1,19 @@
+package ghIssues;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+public class Issue3243 {
+
+    @NonNull
+    String hoge = getHoge();
+
+    public void bugSample() {
+        System.out.println(hoge);
+    }
+
+    @Nullable
+    private String getHoge() {
+        return "sample";
+    }
+}


### PR DESCRIPTION
I created a pull request to correct the behavior that differs from what is described in the documentation.

Specifically, the behavior when adding the edu.umd.cs.findbugs.annotations.Nullable annotation differs from the definition in the documentation.
https://spotbugs.readthedocs.io/en/stable/annotations.html#edu-umd-cs-findbugs-annotations-nullable

See https://github.com/spotbugs/spotbugs/issues/3243

thank you.

FYI: recreated PR #3285 