### PR TITLE
Potential fix for code scanning alert no. 242: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/DirectoryCodeBase.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/DirectoryCodeBase.java
@@ -142,6 +142,10 @@ public class DirectoryCodeBase extends AbstractScannableCodeBase {
         // using the overridden name.
         resourceName = translateResourceName(resourceName);
 
+        if (resourceName.contains("..")) {
+            throw new IllegalArgumentException("Invalid resource name: " + resourceName);
+        }
+
         File file = getFullPathOfResource(resourceName);
         if (!file.exists()) {
             return null;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/ZipFileCodeBaseEntry.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/ZipFileCodeBaseEntry.java
@@ -81,7 +81,11 @@ public class ZipFileCodeBaseEntry extends AbstractScannableCodeBaseEntry {
      */
     @Override
     public String getRealResourceName() {
-        return zipEntry.getName();
+        String entryName = zipEntry.getName();
+        if (entryName.contains("..")) {
+            throw new IllegalArgumentException("Invalid zip entry name: " + entryName);
+        }
+        return entryName;
     }
 
     /*


### PR DESCRIPTION
Potential fix for [https://github.com/spotbugs/spotbugs/security/code-scanning/242](https://github.com/spotbugs/spotbugs/security/code-scanning/242)

To fix the problem, we need to ensure that the output paths constructed from zip archive entries are validated to prevent writing files to unexpected locations. This can be achieved by verifying that the normalized full path of the output file starts with a prefix that matches the destination directory. 

1. Modify the `getRealResourceName` method in `ZipFileCodeBaseEntry` to validate the zip entry name.
2. Ensure that the `lookupResource` method in `DirectoryCodeBase` validates the resource name before using it in file system operations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
