### PR TITLE
Fix gradle deprecated 'space' based equals in gradle files

### DIFF
--- a/gradle/checkstyle.gradle
+++ b/gradle/checkstyle.gradle
@@ -2,9 +2,9 @@
 apply plugin: 'checkstyle'
 
 checkstyle {
-  toolVersion '10.21.2'
-  ignoreFailures false
-  configFile file("$rootDir/spotbugs/etc/checkstyle.xml") // TODO : This config file is lame and should be moved out...
+  toolVersion = '10.21.2'
+  ignoreFailures = false
+  configFile = file("$rootDir/spotbugs/etc/checkstyle.xml") // TODO : This config file is lame and should be moved out...
 }
 
 tasks.register('checkstyle') {

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -1,7 +1,7 @@
 tasks.withType(Test) {
     testLogging {
         events 'FAILED'
-        exceptionFormat 'full'
+        exceptionFormat = 'full'
     }
     doFirst {
       jvmArgs += [

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -224,7 +224,7 @@ def scripts = tasks.register('scripts', Copy) {
   }
 
   into(layout.buildDirectory.dir("bin"))
-  duplicatesStrategy DuplicatesStrategy.FAIL
+  duplicatesStrategy = DuplicatesStrategy.FAIL
   filePermissions{
     unix (0755)
   }


### PR DESCRIPTION
no change log added as internal build configuration replacing deprecated usage.