### PR TITLE
Fix `AT_STALE_THREAD_WRITE_OF_PRIMITIVE` FP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Fixed an `HSM_HIDING_METHOD` false positive when ECJ generates a synthetic method for an enum switch ([#3305](https://github.com/spotbugs/spotbugs/issues/3305))
 - Fix `AT_UNSAFE_RESOURCE_ACCESS_IN_THREAD` false negatives, detector depending on method order.
 - Fix `THROWS_METHOD_THROWS_CLAUSE_THROWABLE` reported in a method calling `MethodHandle.invokeExact` due to its polymorphic signature ([#3309](https://github.com/spotbugs/spotbugs/issues/3309))
+- Fix `AT_STALE_THREAD_WRITE_OF_PRIMITIVE` false positive in inner class ([#3310](https://github.com/spotbugs/spotbugs/issues/3310)).
 
 ## 4.9.1 - 2025-02-02
 ### Added

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3310Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3310Test.java
@@ -10,6 +10,6 @@ class Issue3310Test extends AbstractIntegrationTest {
         performAnalysis("ghIssues/Issue3310.class",
                 "ghIssues/Issue3310$Result.class");
 
-        assertNoBugInClass("AT_STALE_THREAD_WRITE_OF_PRIMITIVE", "Issue3310");
+        assertNoBugType("AT_STALE_THREAD_WRITE_OF_PRIMITIVE");
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3310Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3310Test.java
@@ -1,0 +1,15 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class Issue3310Test extends AbstractIntegrationTest {
+
+    @Test
+    void testIssue() {
+        performAnalysis("ghIssues/Issue3310.class",
+                "ghIssues/Issue3310$Result.class");
+
+        assertNoBugInClass("AT_STALE_THREAD_WRITE_OF_PRIMITIVE", "Issue3310");
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SharedVariableAtomicityDetector.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SharedVariableAtomicityDetector.java
@@ -140,13 +140,13 @@ public class SharedVariableAtomicityDetector extends OpcodeStackDetector {
 
     private void collectFieldReadsAndInnerMethodCalls(int seen, XMethod method) {
         if (seen == Const.GETFIELD || seen == Const.GETSTATIC) {
-            addNonFinalFields(getXFieldOperand(), method, readFieldsByMethods);
+            addNonFinalFieldsOfClass(getXFieldOperand(), method, readFieldsByMethods);
 
         } else if (seen == Const.IFGE || seen == Const.IFGT || seen == Const.IFLT || seen == Const.IFLE || seen == Const.IFNE || seen == Const.IFEQ) {
-            XField lhs = stack.getStackItem(0).getXField();
+            XField lhs = stack.getStackDepth() > 0 ? stack.getStackItem(0).getXField() : null;
             XField rhs = stack.getStackDepth() > 1 ? stack.getStackItem(1).getXField() : null;
-            addNonFinalFields(lhs, method, readFieldsByMethods);
-            addNonFinalFields(rhs, method, readFieldsByMethods);
+            addNonFinalFieldsOfClass(lhs, method, readFieldsByMethods);
+            addNonFinalFieldsOfClass(rhs, method, readFieldsByMethods);
 
         } else if (seen == Const.INVOKEINTERFACE || seen == Const.INVOKESPECIAL || seen == Const.INVOKEVIRTUAL || seen == Const.INVOKESTATIC) {
             XMethod calledMethod = getXMethodOperand();
@@ -156,8 +156,8 @@ public class SharedVariableAtomicityDetector extends OpcodeStackDetector {
         }
     }
 
-    private void addNonFinalFields(XField field, XMethod method, Map<XMethod, Set<XField>> map) {
-        if (field != null && !field.isFinal()) {
+    private void addNonFinalFieldsOfClass(XField field, XMethod method, Map<XMethod, Set<XField>> map) {
+        if (field != null && !field.isFinal() && field.getClassDescriptor().equals(method.getClassDescriptor())) {
             map.computeIfAbsent(method, k -> new HashSet<>()).add(field);
         }
     }
@@ -196,7 +196,7 @@ public class SharedVariableAtomicityDetector extends OpcodeStackDetector {
             }
         } else if (seen == Const.PUTFIELD || seen == Const.PUTSTATIC) {
             XField field = getXFieldOperand();
-            if (field != null && !field.isFinal()) {
+            if (field != null && !field.isFinal() && !field.isSynthetic() && field.getClassDescriptor().equals(method.getClassDescriptor())) {
                 boolean fieldReadInOtherMethod = mapContainsFieldWithOtherMethod(field, method, readFieldsByMethods);
                 if (fieldReadInOtherMethod) {
                     if (!relevantFields.isEmpty() && relevantFields.contains(field) && isPrimitiveOrItsBoxingType(field.getSignature())) {

--- a/spotbugsTestCases/src/java/ghIssues/Issue3310.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3310.java
@@ -1,6 +1,5 @@
 package ghIssues;
 
-import java.lang.invoke.MethodHandle;
 import java.util.Map;
 
 public class Issue3310 {
@@ -19,10 +18,6 @@ public class Issue3310 {
 		} else {
 			return null;
 		}
-	}
-
-	public void setX(int x) {
-		this.x = x;
 	}
 
 	public static class Result {

--- a/spotbugsTestCases/src/java/ghIssues/Issue3310.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3310.java
@@ -1,0 +1,31 @@
+package ghIssues;
+
+import java.lang.invoke.MethodHandle;
+import java.util.Map;
+
+public class Issue3310 {
+	private volatile int x;
+
+	public <K, V> Object test(Map<K, V> map, K key) {
+		Result result = new Result();
+		map.compute(key, (k, oldValue) -> {
+			V newValue = oldValue;
+			result.written = true;
+			return newValue;
+		});
+
+		if (result.written) {
+			return result;
+		} else {
+			return null;
+		}
+	}
+
+	public void setX(int x) {
+		this.x = x;
+	}
+
+	public static class Result {
+		boolean written;
+	}
+}


### PR DESCRIPTION
Fix #3310 by only reporting `AT_STALE_THREAD_WRITE_OF_PRIMITIVE` (also `AT_NONATOMIC_OPERATIONS_ON_SHARED_VARIABLE` and `AT_NONATOMIC_64BIT_PRIMITIVE` from the same detector), if the field is defined in the visited class.
This way, we loose some true positives (e.g. if the field is defined in a super or an inner class and used incorrectly), but handling these edge cases would lead to unnecessary complexity. I also checked a few other detectors working with fields, and several of them only cares about the field of the visited class.

Thanks @gtoison for the reproducer at https://github.com/spotbugs/spotbugs/pull/3313. I hope you don't mind, that I created this fix PR on top of it.

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
