### PR TITLE
Avoid calling `File.getCanonicalPath` twice to improve performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Fix `AT_STALE_THREAD_WRITE_OF_PRIMITIVE` false positive in inner class ([#3310](https://github.com/spotbugs/spotbugs/issues/3310)).
 - Fix `AT_STALE_THREAD_WRITE_OF_PRIMITIVE` false positive for ECJ compiled enum switches ([#3316](https://github.com/spotbugs/spotbugs/issues/3316))
 - Fix `RC_REF_COMPARISON` false positive with Lombok With annotation ([#3319](https://github.com/spotbugs/spotbugs/pull/3319))
+- Avoid calling File.getCanonicalPath twice to improve performance ([#3325](https://github.com/spotbugs/spotbugs/pull/3325))
 
 ### Removed
 - Removed the `TLW_TWO_LOCK_NOTIFY`, `LI_LAZY_INIT_INSTANCE`, `BRSA_BAD_RESULTSET_ACCESS`, `BC_NULL_INSTANCEOF`, `NP_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR` and `RCN_REDUNDANT_CHECKED_NULL_COMPARISON` deprecated bug patterns.

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/ClassFactory.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/ClassFactory.java
@@ -83,6 +83,7 @@ public class ClassFactory implements IClassFactory {
         // It's not fatal if we can't.
         try {
             pathName = new File(pathName).getCanonicalPath();
+            return FilesystemCodeBaseLocator.fromCanonicalPath(pathName);
         } catch (IOException e) {
             // Ignore
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/ClassFactory.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/ClassFactory.java
@@ -79,15 +79,6 @@ public class ClassFactory implements IClassFactory {
      */
     @Override
     public ICodeBaseLocator createFilesystemCodeBaseLocator(String pathName) {
-        // Attempt to canonicalize the pathname.
-        // It's not fatal if we can't.
-        try {
-            pathName = new File(pathName).getCanonicalPath();
-            return FilesystemCodeBaseLocator.fromCanonicalPath(pathName);
-        } catch (IOException e) {
-            // Ignore
-        }
-
         return new FilesystemCodeBaseLocator(pathName);
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/FilesystemCodeBaseLocator.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/FilesystemCodeBaseLocator.java
@@ -34,35 +34,13 @@ public class FilesystemCodeBaseLocator implements ICodeBaseLocator {
     private final String pathName;
 
     public FilesystemCodeBaseLocator(String pathName) {
-        this(pathName, true);
-    }
-
-    /**
-     * @param canonicalizePathName Since {@link File#getCanonicalPath()} is expensive we do not want to call it twice. When the path was already canonicalized we want to skip this step.
-     */
-    private FilesystemCodeBaseLocator(String pathName, boolean canonicalizePathName) {
-        if (canonicalizePathName) {
-            this.pathName = canonicalizePathName(pathName);
-        } else {
-            this.pathName = pathName;
-        }
-    }
-
-    private static String canonicalizePathName(String pathName) {
         File file = new File(pathName);
         try {
             pathName = file.getCanonicalPath();
         } catch (IOException e) {
             assert true;
         }
-        return pathName;
-    }
-
-    /**
-     * @param canonicalPathName An already canonicalized path name
-     */
-    public static FilesystemCodeBaseLocator fromCanonicalPath(String canonicalPathName) {
-        return new FilesystemCodeBaseLocator(canonicalPathName, false);
+        this.pathName = pathName;
     }
 
     /**

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/FilesystemCodeBaseLocator.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/FilesystemCodeBaseLocator.java
@@ -34,13 +34,35 @@ public class FilesystemCodeBaseLocator implements ICodeBaseLocator {
     private final String pathName;
 
     public FilesystemCodeBaseLocator(String pathName) {
+        this(pathName, true);
+    }
+
+    /**
+     * @param canonicalizePathName Since {@link File#getCanonicalPath()} is expensive we do not want to call it twice. When the path was already canonicalized we want to skip this step.
+     */
+    private FilesystemCodeBaseLocator(String pathName, boolean canonicalizePathName) {
+        if (canonicalizePathName) {
+            this.pathName = canonicalizePathName(pathName);
+        } else {
+            this.pathName = pathName;
+        }
+    }
+
+    private static String canonicalizePathName(String pathName) {
         File file = new File(pathName);
         try {
             pathName = file.getCanonicalPath();
         } catch (IOException e) {
             assert true;
         }
-        this.pathName = pathName;
+        return pathName;
+    }
+
+    /**
+     * @param canonicalPathName An already canonicalized path name
+     */
+    public static FilesystemCodeBaseLocator fromCanonicalPath(String canonicalPathName) {
+        return new FilesystemCodeBaseLocator(canonicalPathName, false);
     }
 
     /**


### PR DESCRIPTION
On my computer calling `File.getCanonicalPath` twice from `ClassFactory` and then from `FilesystemCodeBaseLocator` adds ~15 seconds to the full build time.
According to JProfiler `File.getCanonicalPath` is the method where most of the time is spent, so halving the number of calls is significant.
Avoiding that double path normalization should improve SpotBugs' performance when analyzing folders of classes
