### PR TITLE
fix NPE in `ThrowingExceptions` detector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Fix `RC_REF_COMPARISON` false positive with Lombok With annotation ([#3319](https://github.com/spotbugs/spotbugs/pull/3319))
 - Avoid calling File.getCanonicalPath twice to improve performance ([#3325](https://github.com/spotbugs/spotbugs/pull/3325))
 - Fix `MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR` and `MC_OVERRIDABLE_METHOD_CALL_IN_CLONE` false positive when the overridable method is outside the class ([#3328](https://github.com/spotbugs/spotbugs/issues/3328)).
+- Fix NullPointerException thrown from `ThrowingExceptions` detector ([#3337](https://github.com/spotbugs/spotbugs/pull/3337)).
 
 ### Removed
 - Removed the `TLW_TWO_LOCK_NOTIFY`, `LI_LAZY_INIT_INSTANCE`, `BRSA_BAD_RESULTSET_ACCESS`, `BC_NULL_INSTANCEOF`, `NP_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR` and `RCN_REDUNDANT_CHECKED_NULL_COMPARISON` deprecated bug patterns.

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ThrowingExceptions.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ThrowingExceptions.java
@@ -134,7 +134,7 @@ public class ThrowingExceptions extends OpcodeStackDetector {
                         .filter(m -> method.getName().equals(m.getName()) && signatureMatches(method, m))
                         .findAny();
                 if (superMethod.isPresent()) {
-                    throwsEx = Arrays.asList(superMethod.get().getExceptionTable().getExceptionNames()).contains(exception);
+                    throwsEx = doesThrowException(superMethod.get(), exception);
                 } else {
                     throwsEx = parentThrows(ancestor, method, exception);
                 }
@@ -145,7 +145,7 @@ public class ThrowingExceptions extends OpcodeStackDetector {
                         .filter(m -> method.getName().equals(m.getName()) && signatureMatches(method, m))
                         .findAny();
                 if (superMethod.isPresent()) {
-                    throwsEx |= Arrays.asList(superMethod.get().getExceptionTable().getExceptionNames()).contains(exception);
+                    throwsEx |= doesThrowException(superMethod.get(), exception);
                 } else {
                     throwsEx |= parentThrows(intf, method, exception);
                 }
@@ -154,6 +154,11 @@ public class ThrowingExceptions extends OpcodeStackDetector {
             AnalysisContext.reportMissingClass(e);
         }
         return throwsEx;
+    }
+
+    private boolean doesThrowException(Method m, @DottedClassName String exception) {
+        ExceptionTable exceptionTable = m.getExceptionTable();
+        return exceptionTable != null && Arrays.asList(exceptionTable.getExceptionNames()).contains(exception);
     }
 
     private boolean signatureMatches(Method child, Method parent) {


### PR DESCRIPTION
The `ThrowingExceptions` detector throws NPE if the visited methods parent has no exception table. This PR fixes this problem.

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
