### PR TITLE
[cleanup] use collection.of() functions for initialization where possible

### DIFF
--- a/eclipsePlugin/src/edu/umd/cs/findbugs/plugin/eclipse/quickfix/UseValueOfResolution.java
+++ b/eclipsePlugin/src/edu/umd/cs/findbugs/plugin/eclipse/quickfix/UseValueOfResolution.java
@@ -24,7 +24,6 @@ package edu.umd.cs.findbugs.plugin.eclipse.quickfix;
 import static edu.umd.cs.findbugs.plugin.eclipse.quickfix.util.ASTUtil.addStaticImports;
 import static edu.umd.cs.findbugs.plugin.eclipse.quickfix.util.ASTUtil.getASTNode;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -64,14 +63,8 @@ public class UseValueOfResolution extends BugResolution {
 
     private static final String VALUE_OF_METHOD_NAME = "valueOf";
 
-    private static final Set<String> primitiveWrapperClasses = new HashSet<>();
-
-    static {
-        primitiveWrapperClasses.add("java.lang.Double");
-        primitiveWrapperClasses.add("java.lang.Integer");
-        primitiveWrapperClasses.add("java.lang.Boolean");
-        primitiveWrapperClasses.add("java.lang.Float");
-    }
+    private static final Set<String> primitiveWrapperClasses = Set.of("java.lang.Double", "java.lang.Integer", "java.lang.Boolean",
+            "java.lang.Float");
 
     private boolean isDouble;
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/FindBugs.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/FindBugs.java
@@ -21,7 +21,6 @@ package edu.umd.cs.findbugs;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Collections;
 import java.util.GregorianCalendar;
 import java.util.HashSet;
 import java.util.Set;
@@ -189,15 +188,7 @@ public abstract class FindBugs {
      * are assumed to be files.
      */
     @StaticConstant
-    public static final Set<String> knownURLProtocolSet;
-    static {
-        Set<String> protocols = new HashSet<>();
-        protocols.add("file");
-        protocols.add("http");
-        protocols.add("https");
-        protocols.add("jar");
-        knownURLProtocolSet = Collections.unmodifiableSet(protocols);
-    }
+    public static final Set<String> knownURLProtocolSet = Set.of("file", "http", "https", "jar");
 
     /**
      * Set the FindBugs home directory.

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/FuzzyBugComparator.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/FuzzyBugComparator.java
@@ -19,10 +19,10 @@
 
 package edu.umd.cs.findbugs;
 
-import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Set;
 
 import edu.umd.cs.findbugs.internalAnnotations.StaticConstant;
 import edu.umd.cs.findbugs.model.ClassNameRewriter;
@@ -310,42 +310,37 @@ public class FuzzyBugComparator implements WarningComparator {
 
     // See "FindBugsAnnotationDescriptions.properties"
     @StaticConstant
-    private static final HashSet<String> significantDescriptionSet = new HashSet<>();
-    static {
-        // Classes, methods, and fields are significant.
-        significantDescriptionSet.add("CLASS_DEFAULT");
-        significantDescriptionSet.add("CLASS_EXCEPTION");
-        significantDescriptionSet.add("CLASS_REFTYPE");
-        significantDescriptionSet.add(ClassAnnotation.SUPERCLASS_ROLE);
-        significantDescriptionSet.add(ClassAnnotation.IMPLEMENTED_INTERFACE_ROLE);
-        significantDescriptionSet.add(ClassAnnotation.INTERFACE_ROLE);
-        significantDescriptionSet.add("METHOD_DEFAULT");
-        significantDescriptionSet.add(MethodAnnotation.METHOD_CALLED);
-        significantDescriptionSet.add("METHOD_DANGEROUS_TARGET"); // but do NOT
-        // use safe
-        // targets
-        significantDescriptionSet.add("METHOD_DECLARED_NONNULL");
-        significantDescriptionSet.add("FIELD_DEFAULT");
-        significantDescriptionSet.add("FIELD_ON");
-        significantDescriptionSet.add("FIELD_SUPER");
-        significantDescriptionSet.add("FIELD_MASKED");
-        significantDescriptionSet.add("FIELD_MASKING");
-        significantDescriptionSet.add("FIELD_STORED");
-        significantDescriptionSet.add("TYPE_DEFAULT");
-        significantDescriptionSet.add("TYPE_EXPECTED");
-        significantDescriptionSet.add("TYPE_FOUND");
+    private static final Set<String> significantDescriptionSet = Set.of(
+            // Classes, methods, and fields are significant.
+            "CLASS_DEFAULT",
+            "CLASS_EXCEPTION",
+            "CLASS_REFTYPE",
+            ClassAnnotation.SUPERCLASS_ROLE,
+            ClassAnnotation.IMPLEMENTED_INTERFACE_ROLE,
+            ClassAnnotation.INTERFACE_ROLE,
+            "METHOD_DEFAULT",
+            MethodAnnotation.METHOD_CALLED,
+            "METHOD_DANGEROUS_TARGET", // but do NOT use safe targets
+            "METHOD_DECLARED_NONNULL",
+            "FIELD_DEFAULT",
+            "FIELD_ON",
+            "FIELD_SUPER",
+            "FIELD_MASKED",
+            "FIELD_MASKING",
+            "FIELD_STORED",
+            "TYPE_DEFAULT",
+            "TYPE_EXPECTED",
+            "TYPE_FOUND",
 
-        significantDescriptionSet.add("LOCAL_VARIABLE_NAMED");
+            "LOCAL_VARIABLE_NAMED",
 
-        // Many int annotations are NOT significant: e.g., sync %, biased locked
-        // %, bytecode offset, etc.
-        // The null parameter annotations, however, are definitely significant.
-        significantDescriptionSet.add("INT_NULL_ARG");
-        significantDescriptionSet.add("INT_MAYBE_NULL_ARG");
-        significantDescriptionSet.add("INT_NONNULL_PARAM");
-        // Only DEFAULT source line annotations are significant.
-        significantDescriptionSet.add("SOURCE_LINE_DEFAULT");
-    }
+            // Many int annotations are NOT significant: e.g., sync %, biased locked %, bytecode offset, etc.
+            // The null parameter annotations, however, are definitely significant.
+            "INT_NULL_ARG",
+            "INT_MAYBE_NULL_ARG",
+            "INT_NONNULL_PARAM",
+            // Only DEFAULT source line annotations are significant.
+            "SOURCE_LINE_DEFAULT");
 
     public static boolean ignore(BugAnnotation annotation) {
         return !significantDescriptionSet.contains(annotation.getDescription());

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/LaunchAppropriateUI.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/LaunchAppropriateUI.java
@@ -21,7 +21,6 @@ package edu.umd.cs.findbugs;
 
 import java.awt.GraphicsEnvironment;
 import java.lang.reflect.Method;
-import java.util.HashMap;
 import java.util.Map;
 
 import edu.umd.cs.findbugs.internalAnnotations.StaticConstant;
@@ -64,16 +63,13 @@ public class LaunchAppropriateUI {
      * Map of UI name strings to integer UI codes.
      */
     @StaticConstant
-    public static final Map<String, Integer> uiNameToCodeMap;
-    static {
-        uiNameToCodeMap = new HashMap<>();
-        uiNameToCodeMap.put("textui", TEXTUI);
-        uiNameToCodeMap.put("gui", GUI2);
-        uiNameToCodeMap.put("gui1", GUI1);
-        uiNameToCodeMap.put("gui2", GUI2);
-        uiNameToCodeMap.put("help", SHOW_HELP);
-        uiNameToCodeMap.put("version", SHOW_VERSION);
-    }
+    public static final Map<String, Integer> uiNameToCodeMap = Map.of(
+            "textui", TEXTUI,
+            "gui", GUI2,
+            "gui1", GUI1,
+            "gui2", GUI2,
+            "help", SHOW_HELP,
+            "version", SHOW_VERSION);
 
     // Fields
     /** Command line arguments. */

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/bcel/ValueRangeAnalysisFactory.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/bcel/ValueRangeAnalysisFactory.java
@@ -97,17 +97,13 @@ public class ValueRangeAnalysisFactory implements IMethodAnalysisEngine<ValueRan
         }
     }
 
-    private static final Map<String, TypeLongRange> typeRanges;
-
-    static {
-        typeRanges = new HashMap<>();
-        typeRanges.put("Z", new TypeLongRange(0, 1, "Z"));
-        typeRanges.put("B", new TypeLongRange(Byte.MIN_VALUE, Byte.MAX_VALUE, "B"));
-        typeRanges.put("S", new TypeLongRange(Short.MIN_VALUE, Short.MAX_VALUE, "S"));
-        typeRanges.put("I", new TypeLongRange(Integer.MIN_VALUE, Integer.MAX_VALUE, "I"));
-        typeRanges.put("J", new TypeLongRange(Long.MIN_VALUE, Long.MAX_VALUE, "J"));
-        typeRanges.put("C", new TypeLongRange(Character.MIN_VALUE, Character.MAX_VALUE, "C"));
-    }
+    private static final Map<String, TypeLongRange> typeRanges = Map.of(
+            "Z", new TypeLongRange(0, 1, "Z"),
+            "B", new TypeLongRange(Byte.MIN_VALUE, Byte.MAX_VALUE, "B"),
+            "S", new TypeLongRange(Short.MIN_VALUE, Short.MAX_VALUE, "S"),
+            "I", new TypeLongRange(Integer.MIN_VALUE, Integer.MAX_VALUE, "I"),
+            "J", new TypeLongRange(Long.MIN_VALUE, Long.MAX_VALUE, "J"),
+            "C", new TypeLongRange(Character.MIN_VALUE, Character.MAX_VALUE, "C"));
 
     public static class LongRangeSet implements Iterable<LongRangeSet> {
         private final SortedMap<Long, Long> map = new TreeMap<>();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/config/ProjectFilterSettings.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/config/ProjectFilterSettings.java
@@ -19,7 +19,6 @@
 
 package edu.umd.cs.findbugs.config;
 
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
@@ -62,13 +61,11 @@ public class ProjectFilterSettings implements Cloneable {
 
     /** Map of priority level names to their numeric values. */
     @StaticConstant
-    private static Map<String, Integer> priorityNameToValueMap = new HashMap<>();
-    static {
-        priorityNameToValueMap.put(HIGH_PRIORITY, (Priorities.HIGH_PRIORITY));
-        priorityNameToValueMap.put(MEDIUM_PRIORITY, (Priorities.NORMAL_PRIORITY));
-        priorityNameToValueMap.put(LOW_PRIORITY, (Priorities.LOW_PRIORITY));
-        priorityNameToValueMap.put(EXPERIMENTAL_PRIORITY, (Priorities.EXP_PRIORITY));
-    }
+    private static final Map<String, Integer> priorityNameToValueMap = Map.of(
+            HIGH_PRIORITY, Priorities.HIGH_PRIORITY,
+            MEDIUM_PRIORITY, Priorities.NORMAL_PRIORITY,
+            LOW_PRIORITY, Priorities.LOW_PRIORITY,
+            EXPERIMENTAL_PRIORITY, Priorities.EXP_PRIORITY);
 
     /**
      * The character used for delimiting whole fields in filter settings encoded

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BadResultSetAccess.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BadResultSetAccess.java
@@ -21,7 +21,6 @@
 package edu.umd.cs.findbugs.detect;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.bcel.Const;
@@ -37,35 +36,9 @@ import edu.umd.cs.findbugs.visitclass.PreorderVisitor;
 public class BadResultSetAccess extends OpcodeStackDetector {
 
     @StaticConstant
-    private static final Set<String> dbFieldTypesSet = new HashSet<String>() {
-        static final long serialVersionUID = -3510636899394546735L;
-        {
-            add("Array");
-            add("AsciiStream");
-            add("BigDecimal");
-            add("BinaryStream");
-            add("Blob");
-            add("Boolean");
-            add("Byte");
-            add("Bytes");
-            add("CharacterStream");
-            add("Clob");
-            add("Date");
-            add("Double");
-            add("Float");
-            add("Int");
-            add("Long");
-            add("Object");
-            add("Ref");
-            add("RowId");
-            add("Short");
-            add("String");
-            add("Time");
-            add("Timestamp");
-            add("UnicodeStream");
-            add("URL");
-        }
-    };
+    private static final Set<String> dbFieldTypesSet = Set.of("Array", "AsciiStream", "BigDecimal", "BinaryStream", "Blob", "Boolean", "Byte",
+            "Bytes", "CharacterStream", "Clob", "Date", "Double", "Float", "Int", "Long", "Object", "Ref", "RowId", "Short", "String", "Time",
+            "Timestamp", "UnicodeStream", "URL");
 
     private final BugReporter bugReporter;
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BuildCheckReturnAnnotationDatabase.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BuildCheckReturnAnnotationDatabase.java
@@ -19,7 +19,6 @@
 
 package edu.umd.cs.findbugs.detect;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.bcel.classfile.ArrayElementValue;
@@ -48,13 +47,11 @@ public class BuildCheckReturnAnnotationDatabase extends AnnotationVisitor {
     private static final String DEFAULT_ANNOTATION_ANNOTATION_CLASS = "DefaultAnnotation";
 
     @StaticConstant
-    private static final Map<String, AnnotationDatabase.Target> defaultKind = new HashMap<>();
-    static {
-        defaultKind.put("", AnnotationDatabase.Target.ANY);
-        defaultKind.put("ForParameters", AnnotationDatabase.Target.PARAMETER);
-        defaultKind.put("ForMethods", AnnotationDatabase.Target.METHOD);
-        defaultKind.put("ForFields", AnnotationDatabase.Target.FIELD);
-    }
+    private static final Map<String, AnnotationDatabase.Target> defaultKind = Map.of(
+            "", AnnotationDatabase.Target.ANY,
+            "ForParameters", AnnotationDatabase.Target.PARAMETER,
+            "ForMethods", AnnotationDatabase.Target.METHOD,
+            "ForFields", AnnotationDatabase.Target.FIELD);
 
     public BuildCheckReturnAnnotationDatabase() {
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BuildNonNullAnnotationDatabase.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BuildNonNullAnnotationDatabase.java
@@ -19,7 +19,6 @@
 
 package edu.umd.cs.findbugs.detect;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import javax.annotation.CheckForNull;
@@ -57,14 +56,11 @@ public class BuildNonNullAnnotationDatabase extends AnnotationVisitor {
     //    private static final String DEFAULT_ANNOTATION_ANNOTATION_CLASS = "DefaultAnnotation";
 
     @StaticConstant
-    private static final Map<String, AnnotationDatabase.Target> defaultKind = new HashMap<>();
-    static {
-        defaultKind.put("", AnnotationDatabase.Target.ANY);
-        defaultKind.put("ForParameters", AnnotationDatabase.Target.PARAMETER);
-        defaultKind.put("ForMethods", AnnotationDatabase.Target.METHOD);
-        defaultKind.put("ForFields", AnnotationDatabase.Target.FIELD);
-
-    }
+    private static final Map<String, AnnotationDatabase.Target> defaultKind = Map.of(
+            "", AnnotationDatabase.Target.ANY,
+            "ForParameters", AnnotationDatabase.Target.PARAMETER,
+            "ForMethods", AnnotationDatabase.Target.METHOD,
+            "ForFields", AnnotationDatabase.Target.FIELD);
 
     private final NullnessAnnotationDatabase database;
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BuildStringPassthruGraph.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BuildStringPassthruGraph.java
@@ -99,7 +99,7 @@ public class BuildStringPassthruGraph extends OpcodeStackDetector implements Non
     }
 
     public static class StringPassthruDatabase {
-        private static final List<MethodDescriptor> FILENAME_STRING_METHODS = Arrays.asList(
+        private static final List<MethodDescriptor> FILENAME_STRING_METHODS = List.of(
                 new MethodDescriptor("java/io/File", Const.CONSTRUCTOR_NAME, "(Ljava/lang/String;)V"),
                 new MethodDescriptor("java/io/File", Const.CONSTRUCTOR_NAME, "(Ljava/lang/String;Ljava/lang/String;)V"),
                 new MethodDescriptor("java/io/RandomAccessFile", Const.CONSTRUCTOR_NAME, "(Ljava/lang/String;Ljava/lang/String;)V"),

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DontIgnoreResultOfPutIfAbsent.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DontIgnoreResultOfPutIfAbsent.java
@@ -20,8 +20,8 @@
 package edu.umd.cs.findbugs.detect;
 
 import java.util.BitSet;
-import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 
 import org.apache.bcel.Const;
@@ -129,13 +129,7 @@ public class DontIgnoreResultOfPutIfAbsent implements Detector {
     static final boolean DEBUG = false;
 
     @edu.umd.cs.findbugs.internalAnnotations.StaticConstant
-    static HashSet<String> immutableClassNames = new HashSet<>();
-    static {
-        immutableClassNames.add("java/lang/Integer");
-        immutableClassNames.add("java/lang/Long");
-        immutableClassNames.add("java/lang/String");
-        immutableClassNames.add("java/util/Comparator");
-    }
+    static final Set<String> immutableClassNames = Set.of("java/lang/Integer", "java/lang/Long", "java/lang/String", "java/util/Comparator");
 
     private static int getPriorityForBeingMutable(Type type) {
         if (type instanceof ArrayType) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DontUseFloatsAsLoopCounters.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DontUseFloatsAsLoopCounters.java
@@ -7,10 +7,6 @@ import edu.umd.cs.findbugs.BugReporter;
 import edu.umd.cs.findbugs.StatelessDetector;
 import edu.umd.cs.findbugs.bcel.OpcodeStackDetector;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -18,41 +14,33 @@ public class DontUseFloatsAsLoopCounters extends OpcodeStackDetector implements 
 
     private final BugReporter bugReporter;
 
-    private static final Map<Integer, Integer> FLOAT_LOADERS;
-    static {
-        Map<Integer, Integer> tmp = new HashMap<>();
-        tmp.put((int) Const.FLOAD, 2);
-        tmp.put((int) Const.FLOAD_0, 1);
-        tmp.put((int) Const.FLOAD_1, 1);
-        tmp.put((int) Const.FLOAD_2, 1);
-        tmp.put((int) Const.FLOAD_3, 1);
-        tmp.put((int) Const.DLOAD, 2);
-        tmp.put((int) Const.DLOAD_0, 1);
-        tmp.put((int) Const.DLOAD_1, 1);
-        tmp.put((int) Const.DLOAD_2, 1);
-        tmp.put((int) Const.DLOAD_3, 1);
-        FLOAT_LOADERS = Collections.unmodifiableMap(tmp);
-    }
+    private static final Map<Integer, Integer> FLOAT_LOADERS = Map.of(
+            (int) Const.FLOAD, 2,
+            (int) Const.FLOAD_0, 1,
+            (int) Const.FLOAD_1, 1,
+            (int) Const.FLOAD_2, 1,
+            (int) Const.FLOAD_3, 1,
+            (int) Const.DLOAD, 2,
+            (int) Const.DLOAD_0, 1,
+            (int) Const.DLOAD_1, 1,
+            (int) Const.DLOAD_2, 1,
+            (int) Const.DLOAD_3, 1);
 
-    private static final Map<Integer, Integer> FLOAT_CONSTANT_PUSHERS;
-    static {
-        Map<Integer, Integer> tmp = new HashMap<>();
-        tmp.put((int) Const.FCONST_1, 1);
-        tmp.put((int) Const.FCONST_2, 1);
-        tmp.put((int) Const.DCONST_1, 1);
-        tmp.put((int) Const.LDC, 2);
-        tmp.put((int) Const.LDC_W, 3);
-        tmp.put((int) Const.LDC2_W, 3);
-        FLOAT_CONSTANT_PUSHERS = Collections.unmodifiableMap(tmp);
-    }
+    private static final Map<Integer, Integer> FLOAT_CONSTANT_PUSHERS = Map.of(
+            (int) Const.FCONST_1, 1,
+            (int) Const.FCONST_2, 1,
+            (int) Const.DCONST_1, 1,
+            (int) Const.LDC, 2,
+            (int) Const.LDC_W, 3,
+            (int) Const.LDC2_W, 3);
 
-    private static final Set<Integer> FLOAT_COMPARERS = new HashSet<>(Arrays.asList(
+    private static final Set<Integer> FLOAT_COMPARERS = Set.of(
             (int) Const.FCMPG,
             (int) Const.FCMPL,
             (int) Const.DCMPG,
-            (int) Const.DCMPL));
+            (int) Const.DCMPL);
 
-    private static final Set<Integer> FLOAT_STORERS = new HashSet<>(Arrays.asList(
+    private static final Set<Integer> FLOAT_STORERS = Set.of(
             (int) Const.FSTORE,
             (int) Const.FSTORE_0,
             (int) Const.FSTORE_1,
@@ -62,13 +50,13 @@ public class DontUseFloatsAsLoopCounters extends OpcodeStackDetector implements 
             (int) Const.DSTORE_0,
             (int) Const.DSTORE_1,
             (int) Const.DSTORE_2,
-            (int) Const.DSTORE_3));
+            (int) Const.DSTORE_3);
 
-    private static final Set<Integer> FLOAT_ADDITIVE_OPS = new HashSet<>(Arrays.asList(
+    private static final Set<Integer> FLOAT_ADDITIVE_OPS = Set.of(
             (int) Const.FADD,
             (int) Const.FSUB,
             (int) Const.DADD,
-            (int) Const.DSUB));
+            (int) Const.DSUB);
 
     public DontUseFloatsAsLoopCounters(BugReporter bugReporter) {
         this.bugReporter = bugReporter;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNoSideEffectMethods.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNoSideEffectMethods.java
@@ -77,23 +77,23 @@ public class FindNoSideEffectMethods extends OpcodeStackDetector implements NonR
     private static final FieldDescriptor TARGET_NEW = new FieldDescriptor("java/lang/Stub", "new", "V", false);
     private static final FieldDescriptor TARGET_OTHER = new FieldDescriptor("java/lang/Stub", "other", "V", false);
 
-    private static final Set<String> NUMBER_CLASSES = new HashSet<>(Arrays.asList("java/lang/Integer", "java/lang/Long",
+    private static final Set<String> NUMBER_CLASSES = Set.of("java/lang/Integer", "java/lang/Long",
             "java/lang/Double", "java/lang/Float", "java/lang/Byte", "java/lang/Short", "java/math/BigInteger",
-            "java/math/BigDecimal"));
+            "java/math/BigDecimal");
 
-    private static final Set<String> ALLOWED_EXCEPTIONS = new HashSet<>(Arrays.asList("java.lang.InternalError",
+    private static final Set<String> ALLOWED_EXCEPTIONS = Set.of("java.lang.InternalError",
             "java.lang.ArrayIndexOutOfBoundsException", "java.lang.StringIndexOutOfBoundsException",
-            "java.lang.IndexOutOfBoundsException"));
+            "java.lang.IndexOutOfBoundsException");
 
-    private static final Set<String> NO_SIDE_EFFECT_COLLECTION_METHODS = new HashSet<>(Arrays.asList("contains", "containsKey",
+    private static final Set<String> NO_SIDE_EFFECT_COLLECTION_METHODS = Set.of("contains", "containsKey",
             "containsValue", "get", "indexOf", "lastIndexOf", "iterator", "listIterator", "isEmpty", "size", "getOrDefault",
             "subList", "keys", "elements", "keySet", "entrySet", "values", "stream", "firstKey", "lastKey", "headMap", "tailMap",
-            "subMap", "peek", "mappingCount"));
+            "subMap", "peek", "mappingCount");
 
-    private static final Set<String> OBJECT_ONLY_CLASSES = new HashSet<>(Arrays.asList("java/lang/StringBuffer",
+    private static final Set<String> OBJECT_ONLY_CLASSES = Set.of("java/lang/StringBuffer",
             "java/lang/StringBuilder", "java/util/regex/Matcher", "java/io/ByteArrayOutputStream",
             "java/util/concurrent/atomic/AtomicBoolean", "java/util/concurrent/atomic/AtomicInteger",
-            "java/util/concurrent/atomic/AtomicLong", "java/awt/Point"));
+            "java/util/concurrent/atomic/AtomicLong", "java/awt/Point");
 
     // Usual implementation of stub methods which are expected to be more complex in derived classes
     private static final byte[][] STUB_METHODS = new byte[][] {
@@ -112,16 +112,16 @@ public class FindNoSideEffectMethods extends OpcodeStackDetector implements NonR
     /**
      * Known methods which change only this object
      */
-    private static final Set<MethodDescriptor> OBJECT_ONLY_METHODS = new HashSet<>(Arrays.asList(
+    private static final Set<MethodDescriptor> OBJECT_ONLY_METHODS = Set.of(
             ARRAY_STORE_STUB_METHOD, FIELD_STORE_STUB_METHOD,
             new MethodDescriptor("java/util/Iterator", "next", "()Ljava/lang/Object;"),
             new MethodDescriptor("java/util/Enumeration", "nextElement", "()Ljava/lang/Object;"),
-            new MethodDescriptor("java/lang/Throwable", "fillInStackTrace", "()Ljava/lang/Throwable;")));
+            new MethodDescriptor("java/lang/Throwable", "fillInStackTrace", "()Ljava/lang/Throwable;"));
 
     /**
      * Known methods which have no side-effect
      */
-    private static final Set<MethodDescriptor> NO_SIDE_EFFECT_METHODS = new HashSet<>(Arrays.asList(
+    private static final Set<MethodDescriptor> NO_SIDE_EFFECT_METHODS = Set.of(
             GET_CLASS, CLASS_GET_NAME, HASH_CODE,
             new MethodDescriptor("java/lang/reflect/Array", "newInstance", "(Ljava/lang/Class;I)Ljava/lang/Object;"),
             new MethodDescriptor("java/lang/Class", "getResource", "(Ljava/lang/String;)Ljava/net/URL;"),
@@ -138,13 +138,13 @@ public class FindNoSideEffectMethods extends OpcodeStackDetector implements NonR
             new MethodDescriptor("java/util/Iterator", "hasNext", "()Z"),
             new MethodDescriptor("java/util/Comparator", "compare", "(Ljava/lang/Object;Ljava/lang/Object;)I"),
             new MethodDescriptor("java/util/logging/LogManager", "getLogger", "(Ljava/lang/String;)Ljava/util/logging/Logger;", true),
-            new MethodDescriptor("org/apache/log4j/LogManager", "getLogger", "(Ljava/lang/String;)Lorg/apache/log4j/Logger;", true)));
+            new MethodDescriptor("org/apache/log4j/LogManager", "getLogger", "(Ljava/lang/String;)Lorg/apache/log4j/Logger;", true));
 
-    private static final Set<MethodDescriptor> NEW_OBJECT_RETURNING_METHODS = new HashSet<>(Arrays.asList(
+    private static final Set<MethodDescriptor> NEW_OBJECT_RETURNING_METHODS = Set.of(
             new MethodDescriptor("java/util/Vector", "elements", "()Ljava/util/Enumeration;"),
             new MethodDescriptor("java/util/Hashtable", "elements", "()Ljava/util/Enumeration;"),
             new MethodDescriptor("java/util/Hashtable", "keys", "()Ljava/util/Enumeration;"),
-            new MethodDescriptor("java/lang/reflect/Array", "newInstance", "(Ljava/lang/Class;I)Ljava/lang/Object;")));
+            new MethodDescriptor("java/lang/reflect/Array", "newInstance", "(Ljava/lang/Class;I)Ljava/lang/Object;"));
 
     private static enum SideEffectStatus {
         SIDE_EFFECT, UNSURE_OBJECT_ONLY, OBJECT_ONLY, UNSURE, NO_SIDE_EFFECT;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNullDeref.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNullDeref.java
@@ -576,8 +576,8 @@ public class FindNullDeref implements Detector, UseAnnotationDatabase, NullDeref
     }
 
     @StaticConstant
-    public static final Set<String> catchTypesForNull = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
-            "java/lang/NullPointerException", Values.SLASHED_JAVA_LANG_RUNTIMEEXCEPTION, Values.SLASHED_JAVA_LANG_EXCEPTION)));
+    public static final Set<String> catchTypesForNull = Set.of("java/lang/NullPointerException", Values.SLASHED_JAVA_LANG_RUNTIMEEXCEPTION,
+            Values.SLASHED_JAVA_LANG_EXCEPTION);
 
     public static boolean catchesNull(ConstantPool constantPool, Code code, Location location) {
         int position = location.getHandle().getPosition();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindRefComparison.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindRefComparison.java
@@ -137,18 +137,8 @@ public class FindRefComparison implements Detector, ExtendedTypes {
      * Classes that are suspicious if compared by reference.
      */
     @StaticConstant
-    private static final HashSet<String> DEFAULT_SUSPICIOUS_SET = new HashSet<>();
-
-    static {
-        DEFAULT_SUSPICIOUS_SET.add("java.lang.Boolean");
-        DEFAULT_SUSPICIOUS_SET.add("java.lang.Byte");
-        DEFAULT_SUSPICIOUS_SET.add("java.lang.Character");
-        DEFAULT_SUSPICIOUS_SET.add("java.lang.Double");
-        DEFAULT_SUSPICIOUS_SET.add("java.lang.Float");
-        DEFAULT_SUSPICIOUS_SET.add(Values.DOTTED_JAVA_LANG_INTEGER);
-        DEFAULT_SUSPICIOUS_SET.add("java.lang.Long");
-        DEFAULT_SUSPICIOUS_SET.add("java.lang.Short");
-    }
+    private static final Set<String> DEFAULT_SUSPICIOUS_SET = Set.of("java.lang.Boolean", "java.lang.Byte", "java.lang.Character", "java.lang.Double",
+            "java.lang.Float", Values.DOTTED_JAVA_LANG_INTEGER, "java.lang.Long", "java.lang.Short");
 
     /**
      * Set of opcodes that invoke instance methods on an object.

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindUnrelatedTypesInGenericContainer.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindUnrelatedTypesInGenericContainer.java
@@ -19,12 +19,10 @@
 
 package edu.umd.cs.findbugs.detect;
 
-import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Collection;
 import java.util.Hashtable;
 import java.util.Iterator;
-import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -300,12 +298,9 @@ public class FindUnrelatedTypesInGenericContainer implements Detector {
     }
 
     @StaticConstant
-    static final Set<String> baseGenericTypes = new LinkedHashSet<>();
-    static {
-        baseGenericTypes.addAll(Arrays.asList(new String[] { "java.util.Map", "java.util.Collection", "java.lang.Iterable",
+    static final Set<String> baseGenericTypes = Set.of("java.util.Map", "java.util.Collection", "java.lang.Iterable",
             "java.util.Iterator", "com.google.common.collect.Multimap", "com.google.common.collect.Multiset",
-            "com.google.common.collect.Table" }));
-    }
+            "com.google.common.collect.Table");
 
     private boolean isGenericCollection(ClassDescriptor operandClass) {
         String dottedClassName = operandClass.getDottedClassName();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindVulnerableSecurityCheckMethods.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindVulnerableSecurityCheckMethods.java
@@ -28,7 +28,6 @@ import edu.umd.cs.findbugs.bcel.OpcodeStackDetector;
 import org.apache.bcel.Const;
 import org.apache.bcel.classfile.JavaClass;
 
-import java.util.HashSet;
 import java.util.Set;
 
 /***
@@ -39,51 +38,44 @@ import java.util.Set;
  */
 public class FindVulnerableSecurityCheckMethods extends OpcodeStackDetector {
     private final BugReporter bugReporter;
-    private static final Set<String> badMethodNames;
+
+    private static final Set<String> badMethodNames = Set.of(
+            "checkAccept",
+            "checkAccess",
+            "checkAwtEventQueueAccess",
+            "checkConnect",
+            "checkCreateClassLoader",
+            "checkDelete",
+            "checkExec",
+            "checkExit",
+            "checkLink",
+            "checkListen",
+            "checkMemberAccess",
+            "checkMulticast",
+            "checkPackageAccess",
+            "checkPackageDefinition",
+            "checkPermission",
+            "checkPrintJobAccess",
+            "checkPropertiesAccess",
+            "checkRead",
+            "checkSecurityAccess",
+            "checkSetFactory",
+            "checkSystemClipboardAccess",
+            "checkTopLevelWindow",
+            "checkWrite",
+
+            //Deprecated Method Call Support
+            "classDepth",
+            "classLoaderDepth",
+            "currentClassLoader",
+            "currentLoadedClass",
+
+            "getInCheck",
+            "inClass",
+            "inClassLoader");
 
     public FindVulnerableSecurityCheckMethods(BugReporter bugReporter) {
         this.bugReporter = bugReporter;
-
-    }
-
-    static {
-        badMethodNames = new HashSet<String>() {
-            {
-                add("checkAccept");
-                add("checkAccess");
-                add("checkAwtEventQueueAccess");
-                add("checkConnect");
-                add("checkCreateClassLoader");
-                add("checkDelete");
-                add("checkExec");
-                add("checkExit");
-                add("checkLink");
-                add("checkListen");
-                add("checkMemberAccess");
-                add("checkMulticast");
-                add("checkPackageAccess");
-                add("checkPackageDefinition");
-                add("checkPermission");
-                add("checkPrintJobAccess");
-                add("checkPropertiesAccess");
-                add("checkRead");
-                add("checkSecurityAccess");
-                add("checkSetFactory");
-                add("checkSystemClipboardAccess");
-                add("checkTopLevelWindow");
-                add("checkWrite");
-
-                //Deprecated Method Call Support
-                add("classDepth");
-                add("classLoaderDepth");
-                add("currentClassLoader");
-                add("currentLoadedClass");
-
-                add("getInCheck");
-                add("inClass");
-                add("inClassLoader");
-            }
-        };
     }
 
     /**

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InefficientIndexOf.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InefficientIndexOf.java
@@ -19,7 +19,6 @@
 
 package edu.umd.cs.findbugs.detect;
 
-import java.util.Arrays;
 import java.util.List;
 
 import org.apache.bcel.Const;
@@ -41,7 +40,7 @@ import edu.umd.cs.findbugs.classfile.MethodDescriptor;
 public class InefficientIndexOf extends OpcodeStackDetector {
     private final BugReporter bugReporter;
 
-    private static final List<MethodDescriptor> methods = Arrays.asList(
+    private static final List<MethodDescriptor> methods = List.of(
             new MethodDescriptor("java/lang/String", "indexOf", "(Ljava/lang/String;)I"),
             new MethodDescriptor("java/lang/String", "lastIndexOf", "(Ljava/lang/String;)I"),
             new MethodDescriptor("java/lang/String", "indexOf", "(Ljava/lang/String;I)I"),

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InefficientInitializationInsideLoop.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InefficientInitializationInsideLoop.java
@@ -20,9 +20,7 @@
 package edu.umd.cs.findbugs.detect;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -61,8 +59,8 @@ public class InefficientInitializationInsideLoop extends OpcodeStackDetector {
     private static final MethodDescriptor STRING_SPLIT_2 = new MethodDescriptor("java/lang/String", "split",
             "(Ljava/lang/String;I)[Ljava/lang/String;");
 
-    private static final Set<MethodDescriptor> implicitPatternMethods = new HashSet<>(Arrays.asList(PATTERN_MATCHES,
-            STRING_MATCHES, STRING_REPLACEALL, STRING_REPLACEFIRST, STRING_SPLIT, STRING_SPLIT_2));
+    private static final Set<MethodDescriptor> implicitPatternMethods = Set.of(PATTERN_MATCHES,
+            STRING_MATCHES, STRING_REPLACEALL, STRING_REPLACEFIRST, STRING_SPLIT, STRING_SPLIT_2);
 
     private static final List<MethodDescriptor> methods = new ArrayList<>();
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/LostLoggerDueToWeakReference.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/LostLoggerDueToWeakReference.java
@@ -19,7 +19,6 @@
 
 package edu.umd.cs.findbugs.detect;
 
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 
@@ -45,7 +44,7 @@ import edu.umd.cs.findbugs.visitclass.PreorderVisitor;
  * that memory, which means that the logger configuration is lost.
  */
 public class LostLoggerDueToWeakReference extends OpcodeStackDetector {
-    private static final List<MethodDescriptor> methods = Arrays.asList(
+    private static final List<MethodDescriptor> methods = List.of(
             new MethodDescriptor("java/util/logging/Logger", "getLogger", "(Ljava/lang/String;)Ljava/util/logging/Logger;", true),
             new MethodDescriptor("java/util/logging/Logger", "getLogger", "(Ljava/lang/String;Ljava/lang/String;)Ljava/util/logging/Logger;", true));
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MutableStaticFields.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MutableStaticFields.java
@@ -19,7 +19,6 @@
 
 package edu.umd.cs.findbugs.detect;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -47,31 +46,23 @@ import edu.umd.cs.findbugs.classfile.Global;
 import edu.umd.cs.findbugs.util.MutableClasses;
 
 public class MutableStaticFields extends BytecodeScanningDetector {
-    private static final Set<String> COLLECTION_SUPERCLASSES = new HashSet<>(Arrays.asList("java/util/Collection",
+    private static final Set<String> COLLECTION_SUPERCLASSES = Set.of("java/util/Collection",
             "java/util/List", "java/util/Set", "java/util/Map", "java/util/AbstractList", "java/util/SortedSet",
-            "java/util/SortedMap", "java/util/NavigableMap", "java/util/Dictionary"));
+            "java/util/SortedMap", "java/util/NavigableMap", "java/util/Dictionary");
 
-    private static final Set<String> MUTABLE_COLLECTION_CLASSES = new HashSet<>(Arrays.asList("java/util/ArrayList",
+    private static final Set<String> MUTABLE_COLLECTION_CLASSES = Set.of("java/util/ArrayList",
             "java/util/HashSet", "java/util/HashMap", "java/util/Hashtable", "java/util/IdentityHashMap",
             "java/util/LinkedHashSet", "java/util/LinkedList", "java/util/LinkedHashMap", "java/util/TreeSet",
-            "java/util/TreeMap", "java/util/Properties"));
+            "java/util/TreeMap", "java/util/Properties");
 
     private static enum AllowedParameter {
         NONE, EMPTY_ARRAY
     }
 
-    private static final Map<String, Map<String, AllowedParameter>> MUTABLE_COLLECTION_METHODS = new HashMap<>();
-    static {
-        MUTABLE_COLLECTION_METHODS.put("java/util/Arrays", Collections.singletonMap("asList", AllowedParameter.EMPTY_ARRAY));
-        Map<String, AllowedParameter> listsMap = new HashMap<>();
-        listsMap.put("newArrayList", AllowedParameter.NONE);
-        listsMap.put("newLinkedList", AllowedParameter.NONE);
-        MUTABLE_COLLECTION_METHODS.put("com/google/common/collect/Lists", listsMap);
-        Map<String, AllowedParameter> setsMap = new HashMap<>();
-        setsMap.put("newHashSet", AllowedParameter.NONE);
-        setsMap.put("newTreeSet", AllowedParameter.NONE);
-        MUTABLE_COLLECTION_METHODS.put("com/google/common/collect/Sets", setsMap);
-    }
+    private static final Map<String, Map<String, AllowedParameter>> MUTABLE_COLLECTION_METHODS = Map.of(
+            "java/util/Arrays", Collections.singletonMap("asList", AllowedParameter.EMPTY_ARRAY),
+            "com/google/common/collect/Lists", Map.of("newArrayList", AllowedParameter.NONE, "newLinkedList", AllowedParameter.NONE),
+            "com/google/common/collect/Sets", Map.of("newHashSet", AllowedParameter.NONE, "newTreeSet", AllowedParameter.NONE));
 
     static String extractPackage(String c) {
         int i = c.lastIndexOf('/');

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/URLProblems.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/URLProblems.java
@@ -50,7 +50,7 @@ public class URLProblems extends OpcodeStackDetector {
     private static final String[] HASHMAP_KEY_METHODS = { "containsKey", "get", "remove" };
     private static final String[] HASHMAP_TWO_ARG_KEY_METHODS = { "put" };
 
-    private static final List<MethodDescriptor> methods = Arrays.asList(URL_EQUALS, URL_HASHCODE,
+    private static final List<MethodDescriptor> methods = List.of(URL_EQUALS, URL_HASHCODE,
             new MethodDescriptor("", "add", "(Ljava/lang/Object;)Z"),
             new MethodDescriptor("", "contains", "(Ljava/lang/Object;)Z"),
             new MethodDescriptor("", "remove", "(Ljava/lang/Object;)Z"),

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UnnecessaryEnvUsage.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UnnecessaryEnvUsage.java
@@ -18,8 +18,6 @@
 
 package edu.umd.cs.findbugs.detect;
 
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.bcel.Const;
@@ -34,22 +32,19 @@ import edu.umd.cs.findbugs.ba.XMethod;
 import edu.umd.cs.findbugs.bcel.OpcodeStackDetector;
 
 public class UnnecessaryEnvUsage extends OpcodeStackDetector {
-    private static final Map<String, String> envvarPropertyMap = Collections.unmodifiableMap(new HashMap<String, String>() {
-        {
-            put("JAVA_HOME", "java.home");
-            put("JAVA_VERSION", "java.version");
-            put("TEMP", "java.io.tmpdir");
-            put("TMP", "java.io.tmpdir");
-            put("PROCESSOR_ARCHITECTURE", "os.arch");
-            put("OS", "os.name");
-            put("USER", "user.name");
-            put("USERNAME", "user.name");
-            put("HOME", "user.home");
-            put("HOMEPATH", "user.home");
-            put("CD", "user.dir");
-            put("PWD", "user.dir");
-        }
-    });
+    private static final Map<String, String> envvarPropertyMap = Map.ofEntries(
+            Map.entry("JAVA_HOME", "java.home"),
+            Map.entry("JAVA_VERSION", "java.version"),
+            Map.entry("TEMP", "java.io.tmpdir"),
+            Map.entry("TMP", "java.io.tmpdir"),
+            Map.entry("PROCESSOR_ARCHITECTURE", "os.arch"),
+            Map.entry("OS", "os.name"),
+            Map.entry("USER", "user.name"),
+            Map.entry("USERNAME", "user.name"),
+            Map.entry("HOME", "user.home"),
+            Map.entry("HOMEPATH", "user.home"),
+            Map.entry("CD", "user.dir"),
+            Map.entry("PWD", "user.dir"));
 
     private final BugAccumulator bugAccumulator;
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UnnecessaryMath.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UnnecessaryMath.java
@@ -21,7 +21,6 @@
 package edu.umd.cs.findbugs.detect;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.bcel.Const;
@@ -56,56 +55,14 @@ public class UnnecessaryMath extends BytecodeScanningDetector implements Statele
     private double constValue;
 
     @edu.umd.cs.findbugs.internalAnnotations.StaticConstant
-    private static final Set<String> zeroMethods = new HashSet<String>() {
-        {
-            add("acos");
-            add("asin");
-            add("atan");
-            add("atan2");
-            add("cbrt");
-            add("cos");
-            add("cosh");
-            add("exp");
-            add("expm1");
-            add("log");
-            add("log10");
-            add("pow");
-            add("sin");
-            add("sinh");
-            add("sqrt");
-            add("tan");
-            add("tanh");
-            add("toDegrees");
-            add("toRadians");
-        }
-    };
+    private static final Set<String> zeroMethods = Set.of("acos", "asin", "atan", "atan2", "cbrt", "cos", "cosh", "exp", "expm1", "log", "log10",
+            "pow", "sin", "sinh", "sqrt", "tan", "tanh", "toDegrees", "toRadians");
 
     @edu.umd.cs.findbugs.internalAnnotations.StaticConstant
-    private static final Set<String> oneMethods = new HashSet<String>() {
-        {
-            add("acos");
-            add("asin");
-            add("atan");
-            add("cbrt");
-            add("exp");
-            add("log");
-            add("log10");
-            add("pow");
-            add("sqrt");
-            add("toDegrees");
-        }
-    };
+    private static final Set<String> oneMethods = Set.of("acos", "asin", "atan", "cbrt", "exp", "log", "log10", "pow", "sqrt", "toDegrees");
 
     @edu.umd.cs.findbugs.internalAnnotations.StaticConstant
-    private static final Set<String> anyMethods = new HashSet<String>() {
-        {
-            add("abs");
-            add("ceil");
-            add("floor");
-            add("rint");
-            add("round");
-        }
-    };
+    private static final Set<String> anyMethods = Set.of("abs", "ceil", "floor", "rint", "round");
 
     public UnnecessaryMath(BugReporter bugReporter) {
         this.bugReporter = bugReporter;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UnreadFields.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UnreadFields.java
@@ -19,7 +19,6 @@
 
 package edu.umd.cs.findbugs.detect;
 
-import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -96,7 +95,7 @@ import edu.umd.cs.findbugs.visitclass.PreorderVisitor;
 public class UnreadFields extends OpcodeStackDetector {
     private static final boolean DEBUG = SystemProperties.getBoolean("unreadfields.debug");
 
-    private static final List<String> INITIALIZER_ANNOTATIONS = Arrays.asList(
+    private static final List<String> INITIALIZER_ANNOTATIONS = List.of(
             "Ljakarta/annotation/PostConstruct;",
             "Ljavax/annotation/PostConstruct;",
             "Lorg/testng/annotations/BeforeClass;",
@@ -108,7 +107,7 @@ public class UnreadFields extends OpcodeStackDetector {
     /**
      * A list of annotations for fields that might be read by frameworks, even though they are private
      */
-    private static final List<ClassDescriptor> READ_BY_FRAMEWORK_ANNOTATIONS = Arrays.asList(
+    private static final List<ClassDescriptor> READ_BY_FRAMEWORK_ANNOTATIONS = List.of(
             DescriptorFactory.createClassDescriptor("com/google/gson/annotations/SerializedName"),
             DescriptorFactory.createClassDescriptor("javax/xml/bind/annotation/XmlElement"),
             DescriptorFactory.createClassDescriptor("javax/xml/bind/annotation/XmlAttribute"),

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/XMLFactoryBypass.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/XMLFactoryBypass.java
@@ -37,22 +37,9 @@ public class XMLFactoryBypass extends BytecodeScanningDetector {
     private final BugReporter bugReporter;
 
     @StaticConstant
-    private static final Set<String> xmlInterfaces = new HashSet<String>() {
-        static final long serialVersionUID = -9117982073509840017L;
-        {
-            add("javax.xml.parsers.DocumentBuilder");
-            add("org.w3c.dom.Document");
-            add("javax.xml.parsers.SAXParser");
-            add("org.xml.sax.XMLReader");
-            add("org.xml.sax.XMLFilter");
-            add("javax.xml.transform.Transformer");
-            add("org.w3c.dom.Attr");
-            add("org.w3c.dom.CDATASection");
-            add("org.w3c.dom.Comment");
-            add("org.w3c.dom.Element");
-            add("org.w3c.dom.Text");
-        }
-    };
+    private static final Set<String> xmlInterfaces = Set.of("javax.xml.parsers.DocumentBuilder", "org.w3c.dom.Document",
+            "javax.xml.parsers.SAXParser", "org.xml.sax.XMLReader", "org.xml.sax.XMLFilter", "javax.xml.transform.Transformer", "org.w3c.dom.Attr",
+            "org.w3c.dom.CDATASection", "org.w3c.dom.Comment", "org.w3c.dom.Element", "org.w3c.dom.Text");
 
     private final Set<String> rejectedXMLClasses = new HashSet<>();
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/Archive.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/Archive.java
@@ -19,8 +19,6 @@
 
 package edu.umd.cs.findbugs.util;
 
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
 
@@ -37,16 +35,7 @@ public class Archive {
      * File extensions that indicate an archive (zip, jar, or similar).
      */
     @StaticConstant
-    public static final Set<String> ARCHIVE_EXTENSION_SET;
-    static {
-        Set<String> extensions = new HashSet<>();
-        extensions.add(".jar");
-        extensions.add(".zip");
-        extensions.add(".war");
-        extensions.add(".ear");
-        extensions.add(".sar");
-        ARCHIVE_EXTENSION_SET = Collections.unmodifiableSet(extensions);
-    }
+    public static final Set<String> ARCHIVE_EXTENSION_SET = Set.of(".jar", ".zip", ".war", ".ear", ".sar");
 
     /**
      * Determine whether or not the given filename appears to identify a zip/jar

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/MutableClasses.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/MutableClasses.java
@@ -13,7 +13,7 @@ import edu.umd.cs.findbugs.ba.AnalysisContext;
 
 public class MutableClasses {
 
-    private static final Set<String> KNOWN_IMMUTABLE_CLASSES = new HashSet<>(Arrays.asList(
+    private static final Set<String> KNOWN_IMMUTABLE_CLASSES = Set.of(
             "java.lang.String", "java.lang.Integer", "java.lang.Byte", "java.lang.Character",
             "java.lang.Short", "java.lang.Boolean", "java.lang.Long", "java.lang.Double",
             "java.lang.Float", "java.lang.StackTraceElement", "java.lang.Class", "java.lang.ClassLoader",
@@ -62,17 +62,17 @@ public class MutableClasses {
             "java.util.Collections$UnmodifiableSortedSet",
             "java.util.ImmutableCollections$AbstractImmutableList",
             "java.util.ImmutableCollections$AbstractImmutableMap",
-            "java.util.ImmutableCollections$AbstractImmutableSet"));
+            "java.util.ImmutableCollections$AbstractImmutableSet");
 
-    private static final Set<String> KNOWN_IMMUTABLE_PACKAGES = new HashSet<>(Arrays.asList(
-            "java.math", "java.time", "java.util.function", "java.lang.constant"));
+    private static final Set<String> KNOWN_IMMUTABLE_PACKAGES = Set.of(
+            "java.math", "java.time", "java.util.function", "java.lang.constant");
 
-    private static final Set<String> CONSTRUCTOR_LIKE_NAMES = new HashSet<>(Arrays.asList(
+    private static final Set<String> CONSTRUCTOR_LIKE_NAMES = Set.of(
             Const.CONSTRUCTOR_NAME, Const.STATIC_INITIALIZER_NAME,
             "clone", "init", "initialize", "dispose", "finalize", "this",
-            "_jspInit", "jspDestroy"));
+            "_jspInit", "jspDestroy");
 
-    private static final List<String> SETTER_LIKE_PREFIXES = Arrays.asList(
+    private static final List<String> SETTER_LIKE_PREFIXES = List.of(
             "set", "put", "add", "insert", "delete", "remove", "erase", "clear", "push", "pop",
             "enqueue", "dequeue", "write", "append", "replace");
 


### PR DESCRIPTION
Use the `Set.of()`, `Map.of()` and `List.of()` functions for initializing, where the collection is already used as immutable.
This PR is only a cleanup, should not cause any change in functionality, so I haven't added changelog entry. LMK if you think I should.
