### PR TITLE
Introduce UselessSuppressionDetector to report the useless suppressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased - 2025-??-??
+### Added
+
+- Introduced `UselessSuppressionDetector` to report the useless annotations instead of `NoteSuppressedWarnings` ([#3348](https://github.com/spotbugs/spotbugs/issues/3348))
 
 ## 4.9.2 - 2025-03-01
 ### Added

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/SuppressionMatcherBugReporterTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/SuppressionMatcherBugReporterTest.java
@@ -6,6 +6,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -50,7 +51,7 @@ class SuppressionMatcherBugReporterTest {
         // when
         reporter.finish();
         // then
-        verify(matcher).validateSuppressionUsage(reporter);
+        verify(matcher).validateSuppressionUsage(eq(reporter), any());
         verify(upstreamReporter).finish();
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/SuppressionMatcherMockedTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/SuppressionMatcherMockedTest.java
@@ -7,6 +7,8 @@ import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import edu.umd.cs.findbugs.detect.UselessSuppressionDetector;
+
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
@@ -45,7 +47,7 @@ class SuppressionMatcherMockedTest {
         // then
         assertTrue(matcher.match(bugInstance), "Should match BugInstance");
         // and when
-        matcher.validateSuppressionUsage(bugReporter);
+        matcher.validateSuppressionUsage(bugReporter, new UselessSuppressionDetector());
         // then
         verifyNoInteractions(bugReporter);
     }
@@ -54,16 +56,16 @@ class SuppressionMatcherMockedTest {
     void shouldNotMatchBugInstance() {
         // given
         when(suppressor.match(bugInstance)).thenReturn(false);
-        when(suppressor.buildUselessSuppressionBugInstance()).thenReturn(uselessSuppressionBugInstance);
+        when(suppressor.buildUselessSuppressionBugInstance(any())).thenReturn(uselessSuppressionBugInstance);
         SuppressionMatcher matcher = new SuppressionMatcher();
         // when
         matcher.addSuppressor(suppressor);
         // then
         assertFalse(matcher.match(bugInstance), "Should not match BugInstance");
         // and when
-        matcher.validateSuppressionUsage(bugReporter);
+        matcher.validateSuppressionUsage(bugReporter, new UselessSuppressionDetector());
         // then
-        verify(suppressor).buildUselessSuppressionBugInstance();
+        verify(suppressor).buildUselessSuppressionBugInstance(any());
         verify(bugReporter).reportBug(uselessSuppressionBugInstance);
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/SuppressionMatcherTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/SuppressionMatcherTest.java
@@ -1,6 +1,8 @@
 package edu.umd.cs.findbugs;
 
 import edu.umd.cs.findbugs.annotations.SuppressMatchType;
+import edu.umd.cs.findbugs.detect.UselessSuppressionDetector;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -128,7 +130,7 @@ class SuppressionMatcherTest {
         matcher.addSuppressor(new ClassWarningSuppressor("UUF_UNUSED_FIELD", SuppressMatchType.DEFAULT, CLASS_ANNOTATION));
         // when
         matcher.match(bug);
-        matcher.validateSuppressionUsage(bugReporter);
+        matcher.validateSuppressionUsage(bugReporter, new UselessSuppressionDetector());
         // then
         verify(bugReporter).reportBug(bugCaptor.capture());
         assertThat("Bug type", bugCaptor.getValue().getBugPattern().getType(), startsWith("US_USELESS_SUPPRESSION_ON_CLASS"));
@@ -142,7 +144,7 @@ class SuppressionMatcherTest {
         matcher.addSuppressor(new ClassWarningSuppressor("UWF_NULL_FIELD", SuppressMatchType.DEFAULT, CLASS_ANNOTATION));
         // when
         matcher.match(bug);
-        matcher.validateSuppressionUsage(bugReporter);
+        matcher.validateSuppressionUsage(bugReporter, new UselessSuppressionDetector());
         // then
         verify(bugReporter).reportBug(bugCaptor.capture());
         assertThat("Bug type", bugCaptor.getValue().getBugPattern().getType(), startsWith("US_USELESS_SUPPRESSION"));

--- a/spotbugs/etc/findbugs.xml
+++ b/spotbugs/etc/findbugs.xml
@@ -298,6 +298,8 @@
           <Detector class="edu.umd.cs.findbugs.detect.FunctionsThatMightBeMistakenForProcedures" speed="fast"
                     reports="" hidden="true"/>
           <Detector class="edu.umd.cs.findbugs.detect.NoteSuppressedWarnings" speed="fast"
+                    reports="" hidden="true"/>
+          <Detector class="edu.umd.cs.findbugs.detect.UselessSuppressionDetector" speed="fast"
                     reports="US_USELESS_SUPPRESSION_ON_CLASS,US_USELESS_SUPPRESSION_ON_FIELD,US_USELESS_SUPPRESSION_ON_METHOD,US_USELESS_SUPPRESSION_ON_METHOD_PARAMETER,US_USELESS_SUPPRESSION_ON_PACKAGE"
                     hidden="true"/>
           <Detector class="edu.umd.cs.findbugs.detect.NoteAnnotationRetention" speed="fast"

--- a/spotbugs/etc/messages.xml
+++ b/spotbugs/etc/messages.xml
@@ -1875,6 +1875,13 @@ factory pattern to create these objects.</p>
       ]]>
     </Details>
   </Detector>
+  <Detector class="edu.umd.cs.findbugs.detect.UselessSuppressionDetector">
+    <Details>
+      <![CDATA[
+            <p> Looks for unnecessary uses of the edu.umd.cs.findbugs.annotations.NoteSuppressWarnings annotation.</p>
+      ]]>
+    </Details>
+  </Detector>
 
   <!--
   **********************************************************************

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ClassWarningSuppressor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ClassWarningSuppressor.java
@@ -1,6 +1,7 @@
 package edu.umd.cs.findbugs;
 
 import edu.umd.cs.findbugs.annotations.SuppressMatchType;
+import edu.umd.cs.findbugs.detect.UselessSuppressionDetector;
 
 public class ClassWarningSuppressor extends WarningSuppressor {
 
@@ -21,8 +22,8 @@ public class ClassWarningSuppressor extends WarningSuppressor {
     }
 
     @Override
-    public BugInstance buildUselessSuppressionBugInstance() {
-        return new BugInstance(BUG_TYPE, PRIORITY)
+    public BugInstance buildUselessSuppressionBugInstance(UselessSuppressionDetector detector) {
+        return new BugInstance(detector, BUG_TYPE, PRIORITY)
                 .addClass(clazz.getClassDescriptor());
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/Detector2.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/Detector2.java
@@ -49,5 +49,7 @@ public interface Detector2 extends Priorities {
      *
      * @return the name of the detector class.
      */
-    String getDetectorClassName();
+    default String getDetectorClassName() {
+        return getClass().getName();
+    }
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/FieldWarningSuppressor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/FieldWarningSuppressor.java
@@ -1,6 +1,7 @@
 package edu.umd.cs.findbugs;
 
 import edu.umd.cs.findbugs.annotations.SuppressMatchType;
+import edu.umd.cs.findbugs.detect.UselessSuppressionDetector;
 
 public class FieldWarningSuppressor extends ClassWarningSuppressor {
 
@@ -37,8 +38,8 @@ public class FieldWarningSuppressor extends ClassWarningSuppressor {
     }
 
     @Override
-    public BugInstance buildUselessSuppressionBugInstance() {
-        return new BugInstance(BUG_TYPE, PRIORITY)
+    public BugInstance buildUselessSuppressionBugInstance(UselessSuppressionDetector detector) {
+        return new BugInstance(detector, BUG_TYPE, PRIORITY)
                 .addClass(clazz.getClassDescriptor())
                 .addField(field);
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/MethodWarningSuppressor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/MethodWarningSuppressor.java
@@ -1,6 +1,7 @@
 package edu.umd.cs.findbugs;
 
 import edu.umd.cs.findbugs.annotations.SuppressMatchType;
+import edu.umd.cs.findbugs.detect.UselessSuppressionDetector;
 
 public class MethodWarningSuppressor extends ClassWarningSuppressor {
 
@@ -31,8 +32,8 @@ public class MethodWarningSuppressor extends ClassWarningSuppressor {
     }
 
     @Override
-    public BugInstance buildUselessSuppressionBugInstance() {
-        return new BugInstance(BUG_TYPE, PRIORITY)
+    public BugInstance buildUselessSuppressionBugInstance(UselessSuppressionDetector detector) {
+        return new BugInstance(detector, BUG_TYPE, PRIORITY)
                 .addClass(clazz.getClassDescriptor())
                 .addMethod(method);
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/PackageWarningSuppressor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/PackageWarningSuppressor.java
@@ -1,6 +1,7 @@
 package edu.umd.cs.findbugs;
 
 import edu.umd.cs.findbugs.annotations.SuppressMatchType;
+import edu.umd.cs.findbugs.detect.UselessSuppressionDetector;
 
 public class PackageWarningSuppressor extends WarningSuppressor {
 
@@ -35,7 +36,7 @@ public class PackageWarningSuppressor extends WarningSuppressor {
     }
 
     @Override
-    public BugInstance buildUselessSuppressionBugInstance() {
-        return new BugInstance(BUG_TYPE, PRIORITY).addClass(packageName);
+    public BugInstance buildUselessSuppressionBugInstance(UselessSuppressionDetector detector) {
+        return new BugInstance(detector, BUG_TYPE, PRIORITY).addClass(packageName);
     }
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ParameterWarningSuppressor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ParameterWarningSuppressor.java
@@ -1,6 +1,7 @@
 package edu.umd.cs.findbugs;
 
 import edu.umd.cs.findbugs.annotations.SuppressMatchType;
+import edu.umd.cs.findbugs.detect.UselessSuppressionDetector;
 
 public class ParameterWarningSuppressor extends ClassWarningSuppressor {
 
@@ -38,8 +39,8 @@ public class ParameterWarningSuppressor extends ClassWarningSuppressor {
     }
 
     @Override
-    public BugInstance buildUselessSuppressionBugInstance() {
-        return new BugInstance(BUG_TYPE, PRIORITY)
+    public BugInstance buildUselessSuppressionBugInstance(UselessSuppressionDetector detector) {
+        return new BugInstance(detector, BUG_TYPE, PRIORITY)
                 .addClass(clazz.getClassDescriptor())
                 .addMethod(method)
                 .addParameterAnnotation(register, LocalVariableAnnotation.PARAMETER_ROLE);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/SuppressionMatcher.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/SuppressionMatcher.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import edu.umd.cs.findbugs.detect.UselessSuppressionDetector;
 import edu.umd.cs.findbugs.filter.Matcher;
 import edu.umd.cs.findbugs.xml.XMLOutput;
 
@@ -86,11 +87,11 @@ public class SuppressionMatcher implements Matcher {
         return false;
     }
 
-    public void validateSuppressionUsage(BugReporter bugReporter) {
+    public void validateSuppressionUsage(BugReporter bugReporter, UselessSuppressionDetector detector) {
         Stream.concat(suppressedWarnings.values().stream(), suppressedPackageWarnings.values().stream())
                 .flatMap(Collection::stream)
                 .filter(w -> !matched.contains(w))
-                .map(WarningSuppressor::buildUselessSuppressionBugInstance)
+                .map(w -> w.buildUselessSuppressionBugInstance(detector))
                 .forEach(bugReporter::reportBug);
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/SuppressionMatcherBugReporter.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/SuppressionMatcherBugReporter.java
@@ -1,5 +1,7 @@
 package edu.umd.cs.findbugs;
 
+import edu.umd.cs.findbugs.detect.UselessSuppressionDetector;
+
 public class SuppressionMatcherBugReporter extends FilterBugReporter {
 
     private final SuppressionMatcher suppressionMatcher;
@@ -11,7 +13,8 @@ public class SuppressionMatcherBugReporter extends FilterBugReporter {
 
     @Override
     public void finish() {
-        suppressionMatcher.validateSuppressionUsage(this);
+        UselessSuppressionDetector detector = new UselessSuppressionDetector();
+        suppressionMatcher.validateSuppressionUsage(this, detector);
         super.finish();
     }
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/WarningSuppressor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/WarningSuppressor.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.regex.Pattern;
 
 import edu.umd.cs.findbugs.annotations.SuppressMatchType;
+import edu.umd.cs.findbugs.detect.UselessSuppressionDetector;
 import edu.umd.cs.findbugs.filter.Matcher;
 import edu.umd.cs.findbugs.xml.XMLOutput;
 
@@ -78,7 +79,7 @@ public abstract class WarningSuppressor implements Matcher {
         return true;
     }
 
-    public abstract BugInstance buildUselessSuppressionBugInstance();
+    public abstract BugInstance buildUselessSuppressionBugInstance(UselessSuppressionDetector detector);
 
     @Override
     public void writeXML(XMLOutput xmlOutput, boolean disabled) throws IOException {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UselessSuppressionDetector.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UselessSuppressionDetector.java
@@ -1,0 +1,56 @@
+/*
+ * SpotBugs - Find bugs in Java programs
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.BugReporter;
+import edu.umd.cs.findbugs.Detector2;
+import edu.umd.cs.findbugs.NonReportingDetector;
+import edu.umd.cs.findbugs.classfile.CheckedAnalysisException;
+import edu.umd.cs.findbugs.classfile.ClassDescriptor;
+
+/**
+ * An empty detector reporting:
+ * <ul>
+ * <li>US_USELESS_SUPPRESSION_ON_CLASS</li>
+ * <li>US_USELESS_SUPPRESSION_ON_FIELD</li>
+ * <li>US_USELESS_SUPPRESSION_ON_METHOD</li>
+ * <li>US_USELESS_SUPPRESSION_ON_METHOD_PARAMETER</li>
+ * <li>US_USELESS_SUPPRESSION_ON_PACKAGE</li>
+ * </ul>
+ *
+ * This is needed so the bug instances are not from {@link NoteSuppressedWarnings} which is a {@link NonReportingDetector}
+ */
+public class UselessSuppressionDetector implements Detector2 {
+    public UselessSuppressionDetector() {
+    }
+
+    public UselessSuppressionDetector(BugReporter reporter) {
+        // The detector is created via reflection and needs that constructor
+    }
+
+    @Override
+    public void visitClass(ClassDescriptor classDescriptor) throws CheckedAnalysisException {
+        // Does not actually analyzes classes
+    }
+
+    @Override
+    public void finishPass() {
+        // Nothing to do here
+    }
+}


### PR DESCRIPTION
Let the new `UselessSuppressionDetector` report the useless suppressions instead of `NoteSuppressedWarnings` which is a `NonReportingDetector`
This should fix #3348 