### PR TITLE
Remove redundant implementations of getDetectorClassName()

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/JUnitDetectorAdapter.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/JUnitDetectorAdapter.java
@@ -80,16 +80,6 @@ public class JUnitDetectorAdapter implements Detector2 {
     /*
      * (non-Javadoc)
      *
-     * @see edu.umd.cs.findbugs.Detector2#getDetectorClassName()
-     */
-    @Override
-    public String getDetectorClassName() {
-        return this.getClass().getName();
-    }
-
-    /*
-     * (non-Javadoc)
-     *
      * @see
      * edu.umd.cs.findbugs.Detector2#visitClass(edu.umd.cs.findbugs.classfile
      * .ClassDescriptor)

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/DetectorToDetector2Adapter.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/DetectorToDetector2Adapter.java
@@ -78,14 +78,4 @@ public class DetectorToDetector2Adapter implements Detector2 {
             profiler.end(detector.getClass());
         }
     }
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see edu.umd.cs.findbugs.Detector2#getDetectorClassName()
-     */
-    @Override
-    public String getDetectorClassName() {
-        return detector.getClass().getName();
-    }
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/asm/ClassNodeDetector.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/asm/ClassNodeDetector.java
@@ -53,11 +53,6 @@ public abstract class ClassNodeDetector extends ClassNode implements Detector2 {
     }
 
     @Override
-    public String getDetectorClassName() {
-        return this.getClass().getName();
-    }
-
-    @Override
     public void visitClass(ClassDescriptor classDescriptor) throws CheckedAnalysisException {
 
         FBClassReader cr = Global.getAnalysisCache().getClassAnalysis(FBClassReader.class, classDescriptor);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/bcel/CFGDetector.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/bcel/CFGDetector.java
@@ -48,16 +48,6 @@ public abstract class CFGDetector implements Detector2 {
     public void finishPass() {
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see edu.umd.cs.findbugs.Detector2#getDetectorClassName()
-     */
-    @Override
-    public String getDetectorClassName() {
-        return getClass().getName();
-    }
-
     protected ClassContext classContext;
     protected Method method;
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BuildObligationPolicyDatabase.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BuildObligationPolicyDatabase.java
@@ -282,11 +282,6 @@ public class BuildObligationPolicyDatabase implements Detector2, NonReportingDet
         }
     }
 
-    @Override
-    public String getDetectorClassName() {
-        return this.getClass().getName();
-    }
-
     private void addBuiltInPolicies() {
 
         // Add the database entries describing methods that add and delete

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/CheckExpectedWarnings.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/CheckExpectedWarnings.java
@@ -407,10 +407,4 @@ public class CheckExpectedWarnings implements Detector2, NonReportingDetector {
         }
 
     }
-
-    @Override
-    public String getDetectorClassName() {
-        return CheckExpectedWarnings.class.getName();
-    }
-
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/TestDataflowAnalysis.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/TestDataflowAnalysis.java
@@ -72,16 +72,6 @@ public class TestDataflowAnalysis<Fact, AnalysisType extends DataflowAnalysis<Fa
     /*
      * (non-Javadoc)
      *
-     * @see edu.umd.cs.findbugs.Detector2#getDetectorClassName()
-     */
-    @Override
-    public String getDetectorClassName() {
-        return getClass().getName();
-    }
-
-    /*
-     * (non-Javadoc)
-     *
      * @see
      * edu.umd.cs.findbugs.Detector2#visitClass(edu.umd.cs.findbugs.classfile
      * .ClassDescriptor)


### PR DESCRIPTION
Since #3349 `Dector.getDetectorClassName()` has a default implementation, this cleanup removes the implementations which are now redundant.