### PR TITLE
Do not report `US_USELESS_SUPPRESSION_ON_METHOD` on synthetic methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 - Introduced `UselessSuppressionDetector` to report the useless annotations instead of `NoteSuppressedWarnings` ([#3348](https://github.com/spotbugs/spotbugs/issues/3348))
 
+### Fixed
+- Do not report `US_USELESS_SUPPRESSION_ON_METHOD` on synthetic methods ([#3351](https://github.com/spotbugs/spotbugs/issues/3351))
+
 ## 4.9.2 - 2025-03-01
 ### Added
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/SuppressionMatcherMockedTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/SuppressionMatcherMockedTest.java
@@ -57,6 +57,8 @@ class SuppressionMatcherMockedTest {
         // given
         when(suppressor.match(bugInstance)).thenReturn(false);
         when(suppressor.buildUselessSuppressionBugInstance(any())).thenReturn(uselessSuppressionBugInstance);
+        when(suppressor.isUselessSuppressionReportable()).thenReturn(true);
+
         SuppressionMatcher matcher = new SuppressionMatcher();
         // when
         matcher.addSuppressor(suppressor);

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/SuppressionMatcherTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/SuppressionMatcherTest.java
@@ -66,7 +66,7 @@ class SuppressionMatcherTest {
         // given
         MethodAnnotation method = new MethodAnnotation(CLASS_NAME, "test", "bool test()", false);
         BugInstance bug = new BugInstance("UUF_UNUSED_FIELD", 1).addClass(CLASS_NAME).addMethod(method);
-        matcher.addSuppressor(new MethodWarningSuppressor("UUF_UNUSED_FIELD", SuppressMatchType.DEFAULT, CLASS_ANNOTATION, method));
+        matcher.addSuppressor(new MethodWarningSuppressor("UUF_UNUSED_FIELD", SuppressMatchType.DEFAULT, CLASS_ANNOTATION, method, false));
         // when
         boolean matched = matcher.match(bug);
         // then

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3351Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3351Test.java
@@ -1,0 +1,20 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class Issue3351Test extends AbstractIntegrationTest {
+
+    @Test
+    void testSuppression() {
+        performAnalysis("ghIssues/Issue3351.class",
+                "ghIssues/Issue3351$Issue3351SuppressedNoSuchElement.class",
+                "ghIssues/Issue3351$Issue3351NotSuppressedNoSuchElement.class");
+
+        assertBugInClassCount("US_USELESS_SUPPRESSION_ON_METHOD", "ghIssues.Issue3351$Issue3351SuppressedNoSuchElement", 0);
+        assertBugInClassCount("IT_NO_SUCH_ELEMENT", "ghIssues.Issue3351$Issue3351SuppressedNoSuchElement", 0);
+
+        assertBugInClassCount("US_USELESS_SUPPRESSION_ON_METHOD", "ghIssues.Issue3351$Issue3351NotSuppressedNoSuchElement", 0);
+        assertBugInClassCount("IT_NO_SUCH_ELEMENT", "ghIssues.Issue3351$Issue3351NotSuppressedNoSuchElement", 1);
+    }
+}

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3351Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3351Test.java
@@ -11,9 +11,11 @@ class Issue3351Test extends AbstractIntegrationTest {
                 "ghIssues/Issue3351$Issue3351SuppressedNoSuchElement.class",
                 "ghIssues/Issue3351$Issue3351NotSuppressedNoSuchElement.class");
 
+        // Case of a suppressed bug: check that we don't report an useless suppression
         assertBugInClassCount("US_USELESS_SUPPRESSION_ON_METHOD", "ghIssues.Issue3351$Issue3351SuppressedNoSuchElement", 0);
         assertBugInClassCount("IT_NO_SUCH_ELEMENT", "ghIssues.Issue3351$Issue3351SuppressedNoSuchElement", 0);
 
+        // Case of a true positive (not suppressed): check that we only report the bug
         assertBugInClassCount("US_USELESS_SUPPRESSION_ON_METHOD", "ghIssues.Issue3351$Issue3351NotSuppressedNoSuchElement", 0);
         assertBugInClassCount("IT_NO_SUCH_ELEMENT", "ghIssues.Issue3351$Issue3351NotSuppressedNoSuchElement", 1);
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/MethodWarningSuppressor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/MethodWarningSuppressor.java
@@ -7,11 +7,14 @@ public class MethodWarningSuppressor extends ClassWarningSuppressor {
 
     private static final String BUG_TYPE = "US_USELESS_SUPPRESSION_ON_METHOD";
 
-    MethodAnnotation method;
+    private final MethodAnnotation method;
+    private final boolean syntheticMethod;
 
-    public MethodWarningSuppressor(String bugPattern, SuppressMatchType matchType, ClassAnnotation clazz, MethodAnnotation method) {
+    public MethodWarningSuppressor(String bugPattern, SuppressMatchType matchType, ClassAnnotation clazz, MethodAnnotation method,
+            boolean syntheticMethod) {
         super(bugPattern, matchType, clazz);
         this.method = method;
+        this.syntheticMethod = syntheticMethod;
     }
 
     @Override
@@ -36,5 +39,10 @@ public class MethodWarningSuppressor extends ClassWarningSuppressor {
         return new BugInstance(detector, BUG_TYPE, PRIORITY)
                 .addClass(clazz.getClassDescriptor())
                 .addMethod(method);
+    }
+
+    @Override
+    public boolean isUselessSuppressionReportable() {
+        return !syntheticMethod;
     }
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/SuppressionMatcher.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/SuppressionMatcher.java
@@ -90,7 +90,7 @@ public class SuppressionMatcher implements Matcher {
     public void validateSuppressionUsage(BugReporter bugReporter, UselessSuppressionDetector detector) {
         Stream.concat(suppressedWarnings.values().stream(), suppressedPackageWarnings.values().stream())
                 .flatMap(Collection::stream)
-                .filter(w -> !matched.contains(w))
+                .filter(w -> w.isUselessSuppressionReportable() && !matched.contains(w))
                 .map(w -> w.buildUselessSuppressionBugInstance(detector))
                 .forEach(bugReporter::reportBug);
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/WarningSuppressor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/WarningSuppressor.java
@@ -79,6 +79,13 @@ public abstract class WarningSuppressor implements Matcher {
         return true;
     }
 
+    /**
+     * @return true if useless suppressions should be reported.
+     */
+    public boolean isUselessSuppressionReportable() {
+        return true;
+    }
+
     public abstract BugInstance buildUselessSuppressionBugInstance(UselessSuppressionDetector detector);
 
     @Override

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/NoteSuppressedWarnings.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/NoteSuppressedWarnings.java
@@ -139,8 +139,9 @@ public class NoteSuppressedWarnings extends AnnotationVisitor implements Detecto
         if (className.endsWith(".package-info")) {
             suppressionMatcher.addPackageSuppressor(new PackageWarningSuppressor(pattern, matchType, ClassName.toDottedClassName(getPackageName())));
         } else if (visitingMethod()) {
-            suppressionMatcher
-                    .addSuppressor(new MethodWarningSuppressor(pattern, matchType, clazz, MethodAnnotation.fromVisitedMethod(this)));
+            MethodWarningSuppressor suppressor = new MethodWarningSuppressor(pattern, matchType, clazz, MethodAnnotation.fromVisitedMethod(this),
+                    getMethod().isSynthetic());
+            suppressionMatcher.addSuppressor(suppressor);
         } else if (visitingField()) {
             suppressionMatcher.addSuppressor(new FieldWarningSuppressor(pattern, matchType, clazz, FieldAnnotation.fromVisitedField(this)));
         } else {

--- a/spotbugsTestCases/src/java/ghIssues/Issue3351.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3351.java
@@ -1,0 +1,33 @@
+package ghIssues;
+
+import java.util.Iterator;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+public class Issue3351 {
+	public static class Issue3351SuppressedNoSuchElement implements Iterator<Integer> {
+
+		@Override
+		public boolean hasNext() {
+			return false;
+		}
+
+		@Override
+		@SuppressFBWarnings(value = "IT_NO_SUCH_ELEMENT", justification = "testing bug suppression is not unnecessary")
+		public Integer next() {
+			return 42;
+		}
+	}
+	
+	public static class Issue3351NotSuppressedNoSuchElement implements Iterator<Integer> {
+		@Override
+		public boolean hasNext() {
+			return false;
+		}
+
+		@Override
+		public Integer next() { // Expecting IT_NO_SUCH_ELEMENT
+			return 42;
+		}
+	}
+}


### PR DESCRIPTION
Synthetic methods inherit the `@SuppressFBWarnings` of their parent method, so these generated suppressions might be reported as `US_USELESS_SUPPRESSION_ON_METHOD`.
Ignoring synthetic methods should fix #3351