### PR TITLE
Fix macos builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         java: [11, 17, 21, 23]
       max-parallel: 6
     runs-on: ${{ matrix.os }}
@@ -42,8 +42,8 @@ jobs:
       - name: Download Eclipse on Mac
         if: matrix.os == 'macos-latest'
         run: |
-          curl -L 'https://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops4/R-4.24-202206070700/eclipse-SDK-4.24-macosx-cocoa-x86_64.dmg&mirror_id=1' --output eclipse-SDK-4.24-macosx-cocoa-x86_64.dmg
-          hdiutil attach eclipse-SDK-4.24-macosx-cocoa-x86_64.dmg
+          curl -L 'https://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops4/R-4.24-202206070700/eclipse-SDK-4.24-macosx-cocoa-aarch64.dmg&mirror_id=1' --output eclipse-SDK-4.24-macosx-cocoa-aarch64.dmg
+          hdiutil attach eclipse-SDK-4.24-macosx-cocoa-aarch64.dmg
           cp -r /Volumes/Eclipse/Eclipse.app /Applications/
           hdiutil detach /Volumes/Eclipse
           echo "eclipseRoot.dir=/Applications/Eclipse.app" | tee eclipsePlugin/local.properties

--- a/eclipsePlugin/build.gradle
+++ b/eclipsePlugin/build.gradle
@@ -500,7 +500,8 @@ def generateP2Metadata = tasks.register('generateP2Metadata', Exec) {
     '-application', 'org.eclipse.equinox.p2.publisher.UpdateSitePublisher',
     '-metadataRepository', "file:${buildDir}/site/eclipse", // TODO : May not work on Windows
     '-artifactRepository', "file:${buildDir}/site/eclipse", // TODO : May not work on Windows
-    '-source', "${buildDir}/site/eclipse"
+    '-source', "${buildDir}/site/eclipse",
+    '-vm', "${System.getProperty('java.home')}/bin" // TODO : May not work on Windows
 }
 
 def generateCandidateP2Metadata = tasks.register('generateCandidateP2Metadata', Exec) {
@@ -516,7 +517,8 @@ def generateCandidateP2Metadata = tasks.register('generateCandidateP2Metadata', 
     '-application', 'org.eclipse.equinox.p2.publisher.UpdateSitePublisher',
     '-metadataRepository', "file:${buildDir}/site/eclipse-candidate", // TODO : May not work on Windows
     '-artifactRepository', "file:${buildDir}/site/eclipse-candidate", // TODO : May not work on Windows
-    '-source', "${buildDir}/site/eclipse-candidate"
+    '-source', "${buildDir}/site/eclipse-candidate",
+    '-vm', "${System.getProperty('java.home')}/bin" // TODO : May not work on Windows
 }
 
 def generateP2MetadataDaily = tasks.register('generateP2MetadataDaily', Exec) {
@@ -532,7 +534,8 @@ def generateP2MetadataDaily = tasks.register('generateP2MetadataDaily', Exec) {
     '-application', 'org.eclipse.equinox.p2.publisher.UpdateSitePublisher',
     '-metadataRepository', "file:${buildDir}/site/eclipse-daily", // TODO : May not work on Windows
     '-artifactRepository', "file:${buildDir}/site/eclipse-daily", // TODO : May not work on Windows
-    '-source', "${buildDir}/site/eclipse-daily"
+    '-source', "${buildDir}/site/eclipse-daily",
+    '-vm', "${System.getProperty('java.home')}/bin" // TODO : May not work on Windows
 }
 
 def generateP2MetadataStableLatest = tasks.register('generateP2MetadataStableLatest', Exec) {
@@ -548,7 +551,8 @@ def generateP2MetadataStableLatest = tasks.register('generateP2MetadataStableLat
     '-application', 'org.eclipse.equinox.p2.publisher.UpdateSitePublisher',
     '-metadataRepository', "file:${buildDir}/site/eclipse-stable-latest", // TODO : May not work on Windows
     '-artifactRepository', "file:${buildDir}/site/eclipse-stable-latest", // TODO : May not work on Windows
-    '-source', "${buildDir}/site/eclipse-stable-latest"
+    '-source', "${buildDir}/site/eclipse-stable-latest",
+    '-vm', "${System.getProperty('java.home')}/bin" // TODO : May not work on Windows
 }
 
 def eclipseSite = tasks.register('eclipseSite') {

--- a/eclipsePlugin/build.gradle
+++ b/eclipsePlugin/build.gradle
@@ -498,10 +498,10 @@ def generateP2Metadata = tasks.register('generateP2Metadata', Exec) {
   dependsOn confirmEclipse, pluginJar, featureJar, siteXml, siteHtml
   commandLine "${eclipseExecutable}", '-nosplash',
     '-application', 'org.eclipse.equinox.p2.publisher.UpdateSitePublisher',
-    '-metadataRepository', "file:${buildDir}/site/eclipse", // TODO : May not work on Windows
-    '-artifactRepository', "file:${buildDir}/site/eclipse", // TODO : May not work on Windows
+    '-metadataRepository', "file:${buildDir}/site/eclipse",
+    '-artifactRepository', "file:${buildDir}/site/eclipse",
     '-source', "${buildDir}/site/eclipse",
-    '-vm', "${System.getProperty('java.home')}/bin" // TODO : May not work on Windows
+    '-vm', "${System.getProperty('java.home')}/bin"
 }
 
 def generateCandidateP2Metadata = tasks.register('generateCandidateP2Metadata', Exec) {
@@ -515,10 +515,10 @@ def generateCandidateP2Metadata = tasks.register('generateCandidateP2Metadata', 
   dependsOn confirmEclipse, pluginCandidateJar, featureCandidateJar, siteCandidateXml, siteCandidateHtml
   commandLine "${eclipseExecutable}", '-nosplash',
     '-application', 'org.eclipse.equinox.p2.publisher.UpdateSitePublisher',
-    '-metadataRepository', "file:${buildDir}/site/eclipse-candidate", // TODO : May not work on Windows
-    '-artifactRepository', "file:${buildDir}/site/eclipse-candidate", // TODO : May not work on Windows
+    '-metadataRepository', "file:${buildDir}/site/eclipse-candidate",
+    '-artifactRepository', "file:${buildDir}/site/eclipse-candidate",
     '-source', "${buildDir}/site/eclipse-candidate",
-    '-vm', "${System.getProperty('java.home')}/bin" // TODO : May not work on Windows
+    '-vm', "${System.getProperty('java.home')}/bin"
 }
 
 def generateP2MetadataDaily = tasks.register('generateP2MetadataDaily', Exec) {
@@ -532,10 +532,10 @@ def generateP2MetadataDaily = tasks.register('generateP2MetadataDaily', Exec) {
   dependsOn confirmEclipse, pluginDailyJar, featureDailyJar, siteDailyXml, siteDailyHtml
   commandLine "${eclipseExecutable}", '-nosplash',
     '-application', 'org.eclipse.equinox.p2.publisher.UpdateSitePublisher',
-    '-metadataRepository', "file:${buildDir}/site/eclipse-daily", // TODO : May not work on Windows
-    '-artifactRepository', "file:${buildDir}/site/eclipse-daily", // TODO : May not work on Windows
+    '-metadataRepository', "file:${buildDir}/site/eclipse-daily",
+    '-artifactRepository', "file:${buildDir}/site/eclipse-daily",
     '-source', "${buildDir}/site/eclipse-daily",
-    '-vm', "${System.getProperty('java.home')}/bin" // TODO : May not work on Windows
+    '-vm', "${System.getProperty('java.home')}/bin"
 }
 
 def generateP2MetadataStableLatest = tasks.register('generateP2MetadataStableLatest', Exec) {
@@ -549,10 +549,10 @@ def generateP2MetadataStableLatest = tasks.register('generateP2MetadataStableLat
   dependsOn confirmEclipse, pluginStableLatestJar, featureStableLatestJar, siteStableLatestXml, siteStableLatestHtml
   commandLine "${eclipseExecutable}", '-nosplash',
     '-application', 'org.eclipse.equinox.p2.publisher.UpdateSitePublisher',
-    '-metadataRepository', "file:${buildDir}/site/eclipse-stable-latest", // TODO : May not work on Windows
-    '-artifactRepository', "file:${buildDir}/site/eclipse-stable-latest", // TODO : May not work on Windows
+    '-metadataRepository', "file:${buildDir}/site/eclipse-stable-latest",
+    '-artifactRepository', "file:${buildDir}/site/eclipse-stable-latest",
     '-source', "${buildDir}/site/eclipse-stable-latest",
-    '-vm', "${System.getProperty('java.home')}/bin" // TODO : May not work on Windows
+    '-vm', "${System.getProperty('java.home')}/bin"
 }
 
 def eclipseSite = tasks.register('eclipseSite') {


### PR DESCRIPTION
This works for me locally on macos aarch. I think it should work for CI x86-64 too. I don't know if it will work on Windows, so there might need to be some build changes made to only apply this change for macos.

Script for testing locally on aarch.
```bash
#!/usr/bin/env bash

curl -L 'https://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops4/R-4.24-202206070700/eclipse-SDK-4.24-macosx-cocoa-aarch64.dmg&mirror_id=1' --output eclipse-SDK-4.24-macosx-cocoa-aarch64.dmg
hdiutil attach eclipse-SDK-4.24-macosx-cocoa-aarch64.dmg
cp -r /Volumes/Eclipse/Eclipse.app /Applications/
hdiutil detach /Volumes/Eclipse
echo "eclipseRoot.dir=/Applications/Eclipse.app" | tee eclipsePlugin/local.properties
./gradlew spotlessCheck build smoketest --no-daemon --scan
```


<details>
<summary>Output of my local test using Java 11</summary>
<pre>
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $43059C44
Checksumming GPT Header (Primary GPT Header : 1)…
 GPT Header (Primary GPT Header : 1): verified   CRC32 $E245B8E7
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $40EF1BE6
Checksumming  (Apple_Free : 3)…
                    (Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
          disk image (Apple_HFS : 4): verified   CRC32 $6F731AC9
Checksumming  (Apple_Free : 5)…
                    (Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $40EF1BE6
Checksumming GPT Header (Backup GPT Header : 7)…
  GPT Header (Backup GPT Header : 7): verified   CRC32 $3995099D
verified   CRC32 $3B629654
/dev/disk4          	GUID_partition_scheme          	
/dev/disk4s1        	Apple_HFS                      	/Volumes/Eclipse
"disk4" ejected.
eclipseRoot.dir=/Applications/Eclipse.app
To honour the JVM settings for this build a single-use Daemon process will be forked. For more on this, please refer to https://docs.gradle.org/8.13/userguide/gradle_daemon.html#sec:disabling_the_daemon in the Gradle documentation.
Daemon will be stopped at the end of the build 
> Task :buildSrc:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :buildSrc:generateExternalPluginSpecBuilders UP-TO-DATE
> Task :buildSrc:extractPrecompiledScriptPluginPlugins UP-TO-DATE
> Task :buildSrc:compilePluginsBlocks UP-TO-DATE
> Task :buildSrc:generatePrecompiledScriptPluginAccessors UP-TO-DATE
> Task :buildSrc:generateScriptPluginAdapters UP-TO-DATE
> Task :buildSrc:compileKotlin UP-TO-DATE
> Task :buildSrc:compileJava NO-SOURCE
> Task :buildSrc:compileGroovy NO-SOURCE
> Task :buildSrc:pluginDescriptors UP-TO-DATE
> Task :buildSrc:processResources UP-TO-DATE
> Task :buildSrc:classes UP-TO-DATE
> Task :buildSrc:jar UP-TO-DATE

> Configure project :eclipsePlugin
found eclipseExecutable at /Applications/Eclipse.app/Contents/MacOS/eclipse

> Configure project :spotbugs
The signing key and password are null. This can be ignored if this is a pull request.

> Configure project :spotbugs-annotations
The signing key and password are null. This can be ignored if this is a pull request.

> Configure project :spotbugs-ant
The signing key and password are null. This can be ignored if this is a pull request.

> Configure project :test-harness
The signing key and password are null. This can be ignored if this is a pull request.

> Configure project :test-harness-core
The signing key and password are null. This can be ignored if this is a pull request.

> Configure project :test-harness-jupiter
The signing key and password are null. This can be ignored if this is a pull request.
skip tests for Java 17 features
skip tests for Java 21 features

> Task :spotlessInternalRegisterDependencies UP-TO-DATE
> Task :eclipsePlugin:spotlessJava UP-TO-DATE
> Task :eclipsePlugin:spotlessJavaCheck UP-TO-DATE
> Task :eclipsePlugin:spotlessCheck UP-TO-DATE
> Task :eclipsePlugin-junit:spotlessJava UP-TO-DATE
> Task :eclipsePlugin-junit:spotlessJavaCheck UP-TO-DATE
> Task :eclipsePlugin-junit:spotlessCheck UP-TO-DATE
> Task :eclipsePlugin-test:spotlessJava UP-TO-DATE
> Task :eclipsePlugin-test:spotlessJavaCheck UP-TO-DATE
> Task :eclipsePlugin-test:spotlessCheck UP-TO-DATE
> Task :spotbugs:spotlessJava UP-TO-DATE
> Task :spotbugs:spotlessJavaCheck UP-TO-DATE
> Task :spotbugs:spotlessCheck UP-TO-DATE
> Task :spotbugs-annotations:spotlessJava UP-TO-DATE
> Task :spotbugs-annotations:spotlessJavaCheck UP-TO-DATE
> Task :spotbugs-annotations:spotlessCheck UP-TO-DATE
> Task :spotbugs-ant:spotlessJava UP-TO-DATE
> Task :spotbugs-ant:spotlessJavaCheck UP-TO-DATE
> Task :spotbugs-ant:spotlessCheck UP-TO-DATE
> Task :spotbugs-tests:spotlessJava UP-TO-DATE
> Task :spotbugs-tests:spotlessJavaCheck UP-TO-DATE
> Task :spotbugs-tests:spotlessCheck UP-TO-DATE
> Task :test-harness:spotlessJava UP-TO-DATE
> Task :test-harness:spotlessJavaCheck UP-TO-DATE
> Task :test-harness:spotlessCheck UP-TO-DATE
> Task :test-harness-core:spotlessJava UP-TO-DATE
> Task :test-harness-core:spotlessJavaCheck UP-TO-DATE
> Task :test-harness-core:spotlessCheck UP-TO-DATE
> Task :test-harness-jupiter:spotlessJava UP-TO-DATE
> Task :test-harness-jupiter:spotlessJavaCheck UP-TO-DATE
> Task :test-harness-jupiter:spotlessCheck UP-TO-DATE
> Task :compileJava NO-SOURCE
> Task :processResources NO-SOURCE
> Task :classes UP-TO-DATE
> Task :jar UP-TO-DATE
> Task :assemble UP-TO-DATE
> Task :spotbugsMain NO-SOURCE
> Task :compileTestJava NO-SOURCE
> Task :processTestResources NO-SOURCE
> Task :testClasses UP-TO-DATE
> Task :spotbugsTest NO-SOURCE
> Task :test NO-SOURCE
> Task :jacocoTestReport SKIPPED
> Task :check UP-TO-DATE
> Task :build UP-TO-DATE
> Task :eclipsePlugin:confirmEclipse
> Task :eclipsePlugin:featureCandidateJar
> Task :eclipsePlugin:unzipPdeTool UP-TO-DATE
> Task :spotbugs-annotations:compileJava UP-TO-DATE
> Task :spotbugs:compileJava UP-TO-DATE
> Task :spotbugs:processResources UP-TO-DATE
> Task :spotbugs:classes UP-TO-DATE
> Task :spotbugs-annotations:processResources NO-SOURCE
> Task :spotbugs-annotations:classes UP-TO-DATE
> Task :spotbugs-annotations:jar UP-TO-DATE
> Task :spotbugs:compileGuiJava UP-TO-DATE
> Task :spotbugs:processGuiResources UP-TO-DATE
> Task :spotbugs:guiClasses UP-TO-DATE
> Task :spotbugs:copyLibsForEclipse UP-TO-DATE
> Task :spotbugs:updateManifest UP-TO-DATE
> Task :spotbugs:jar UP-TO-DATE
> Task :eclipsePlugin:compileJava UP-TO-DATE
> Task :eclipsePlugin:processResources UP-TO-DATE
> Task :eclipsePlugin:classes UP-TO-DATE
> Task :eclipsePlugin:copyLibsForEclipse UP-TO-DATE
> Task :eclipsePlugin:updateManifest UP-TO-DATE
> Task :eclipsePlugin:jar UP-TO-DATE
> Task :eclipsePlugin:pluginJar

> Task :eclipsePlugin:testPluginJar
Eclipse plugin contains spotbugs.jar

> Task :eclipsePlugin:pluginCandidateJar
> Task :eclipsePlugin:siteCandidateHtml
> Task :eclipsePlugin:siteCandidateXml

> Task :eclipsePlugin:generateCandidateP2Metadata
to sign eclipse plugins, set "keystorepass" project propertyGenerating metadata for ..
Generation completed with success [1 seconds].

> Task :eclipsePlugin:featureJar
> Task :eclipsePlugin:siteHtml
> Task :eclipsePlugin:siteXml

> Task :eclipsePlugin:generateP2Metadata
to sign eclipse plugins, set "keystorepass" project propertyGenerating metadata for ..
Generation completed with success [1 seconds].

> Task :eclipsePlugin:featureDailyJar
> Task :eclipsePlugin:pluginDailyJar
> Task :eclipsePlugin:siteDailyHtml
> Task :eclipsePlugin:siteDailyXml

> Task :eclipsePlugin:generateP2MetadataDaily
to sign eclipse plugins, set "keystorepass" project propertyGenerating metadata for ..
Generation completed with success [0 seconds].

> Task :eclipsePlugin:featureStableLatestJar
> Task :eclipsePlugin:pluginStableLatestJar
> Task :eclipsePlugin:siteStableLatestHtml
> Task :eclipsePlugin:siteStableLatestXml

> Task :eclipsePlugin:generateP2MetadataStableLatest
to sign eclipse plugins, set "keystorepass" project propertyGenerating metadata for ..
Generation completed with success [0 seconds].

> Task :eclipsePlugin:eclipseSite
> Task :eclipsePlugin:eclipseSiteZip
> Task :eclipsePlugin:assemble
> Task :eclipsePlugin:spotbugsMain UP-TO-DATE
> Task :eclipsePlugin:compileTestJava NO-SOURCE
> Task :eclipsePlugin:processTestResources NO-SOURCE
> Task :eclipsePlugin:testClasses UP-TO-DATE
> Task :eclipsePlugin:spotbugsTest NO-SOURCE
> Task :eclipsePlugin:test NO-SOURCE
> Task :eclipsePlugin:check UP-TO-DATE
> Task :eclipsePlugin:build
> Task :eclipsePlugin-junit:unzipPdeTool UP-TO-DATE
> Task :eclipsePlugin-junit:compileJava NO-SOURCE
> Task :eclipsePlugin-junit:processResources NO-SOURCE
> Task :eclipsePlugin-junit:classes UP-TO-DATE
> Task :eclipsePlugin-junit:jar UP-TO-DATE
> Task :eclipsePlugin-junit:assemble UP-TO-DATE
> Task :eclipsePlugin-junit:checkstyleMain NO-SOURCE
> Task :eclipsePlugin-junit:compileTestJava UP-TO-DATE
> Task :eclipsePlugin-junit:processTestResources NO-SOURCE
> Task :eclipsePlugin-junit:testClasses UP-TO-DATE
> Task :eclipsePlugin-junit:checkstyleTest UP-TO-DATE
> Task :eclipsePlugin-junit:spotbugsMain NO-SOURCE
> Task :eclipsePlugin-junit:spotbugsTest UP-TO-DATE
> Task :eclipsePlugin-junit:test UP-TO-DATE
> Task :eclipsePlugin-junit:jacocoTestReport SKIPPED
> Task :eclipsePlugin-junit:check UP-TO-DATE
> Task :eclipsePlugin-junit:build UP-TO-DATE
> Task :eclipsePlugin-test:unzipPdeTool UP-TO-DATE
> Task :test-harness-core:compileJava UP-TO-DATE
> Task :test-harness:compileJava UP-TO-DATE
> Task :eclipsePlugin-test:compileJava UP-TO-DATE
> Task :eclipsePlugin-test:processResources UP-TO-DATE
> Task :eclipsePlugin-test:classes UP-TO-DATE
> Task :eclipsePlugin-test:jar UP-TO-DATE
> Task :eclipsePlugin-test:sourcesJar UP-TO-DATE
> Task :eclipsePlugin-test:assemble UP-TO-DATE
> Task :eclipsePlugin-test:checkstyleMain UP-TO-DATE
> Task :eclipsePlugin-test:compileTestJava NO-SOURCE
> Task :eclipsePlugin-test:processTestResources NO-SOURCE
> Task :eclipsePlugin-test:testClasses UP-TO-DATE
> Task :eclipsePlugin-test:checkstyleTest NO-SOURCE
> Task :eclipsePlugin-test:spotbugsMain UP-TO-DATE
> Task :eclipsePlugin-test:spotbugsTest NO-SOURCE
> Task :test-harness:processResources NO-SOURCE
> Task :test-harness:classes UP-TO-DATE
> Task :test-harness:jar UP-TO-DATE
> Task :test-harness-core:processResources NO-SOURCE
> Task :test-harness-core:classes UP-TO-DATE
> Task :test-harness-core:jar UP-TO-DATE
> Task :eclipsePlugin-test:test NO-SOURCE
> Task :eclipsePlugin-test:check UP-TO-DATE
> Task :eclipsePlugin-test:build UP-TO-DATE
> Task :spotbugs:scripts UP-TO-DATE
> Task :spotbugs-ant:compileJava UP-TO-DATE
> Task :spotbugs-ant:processResources UP-TO-DATE
> Task :spotbugs-ant:classes UP-TO-DATE
> Task :spotbugs-ant:jar UP-TO-DATE
> Task :spotbugs:distTar UP-TO-DATE
> Task :spotbugs:distZip UP-TO-DATE
> Task :spotbugs:assembleDist UP-TO-DATE
> Task :spotbugs:distSrcZip UP-TO-DATE
> Task :spotbugs:javadoc UP-TO-DATE
> Task :spotbugs:javadocJar UP-TO-DATE
> Task :spotbugs:sourcesJar UP-TO-DATE
> Task :spotbugs:assemble UP-TO-DATE
> Task :spotbugs:checkstyleGui UP-TO-DATE
> Task :spotbugs:checkstyleMain UP-TO-DATE
> Task :spotbugs:compileTestJava NO-SOURCE
> Task :spotbugs:processTestResources NO-SOURCE
> Task :spotbugs:testClasses UP-TO-DATE
> Task :spotbugs:checkstyleTest NO-SOURCE
> Task :spotbugs:spotbugsGui UP-TO-DATE
> Task :spotbugs:spotbugsMain UP-TO-DATE
> Task :spotbugs:spotbugsTest NO-SOURCE
> Task :spotbugs:test NO-SOURCE
> Task :spotbugs:jacocoTestReport SKIPPED
> Task :spotbugs:check UP-TO-DATE
> Task :spotbugs:build UP-TO-DATE
> Task :spotbugs-annotations:javadoc UP-TO-DATE
> Task :spotbugs-annotations:javadocJar UP-TO-DATE
> Task :spotbugs-annotations:sourcesJar UP-TO-DATE
> Task :spotbugs-annotations:assemble UP-TO-DATE
> Task :spotbugs-annotations:checkstyleMain UP-TO-DATE
> Task :spotbugs-annotations:compileTestJava NO-SOURCE
> Task :spotbugs-annotations:processTestResources NO-SOURCE
> Task :spotbugs-annotations:testClasses UP-TO-DATE
> Task :spotbugs-annotations:checkstyleTest NO-SOURCE
> Task :spotbugs-annotations:spotbugsMain UP-TO-DATE
> Task :spotbugs-annotations:spotbugsTest NO-SOURCE
> Task :spotbugs-annotations:test NO-SOURCE
> Task :spotbugs-annotations:check UP-TO-DATE
> Task :spotbugs-annotations:build UP-TO-DATE
> Task :spotbugs-ant:javadoc UP-TO-DATE
> Task :spotbugs-ant:javadocJar UP-TO-DATE
> Task :spotbugs-ant:sourcesJar UP-TO-DATE
> Task :spotbugs-ant:assemble UP-TO-DATE
> Task :spotbugs-ant:checkstyleMain UP-TO-DATE
> Task :spotbugs-ant:compileTestJava UP-TO-DATE
> Task :spotbugs-ant:processTestResources UP-TO-DATE
> Task :spotbugs-ant:testClasses UP-TO-DATE
> Task :spotbugs-ant:checkstyleTest UP-TO-DATE
> Task :spotbugs-ant:spotbugsMain UP-TO-DATE
> Task :spotbugs-ant:spotbugsTest UP-TO-DATE
> Task :spotbugs-ant:test UP-TO-DATE
> Task :spotbugs-ant:jacocoTestReport SKIPPED
> Task :spotbugs-ant:check UP-TO-DATE
> Task :spotbugs-ant:build UP-TO-DATE
> Task :spotbugsTestCases:compileJava UP-TO-DATE
> Task :spotbugsTestCases:compileGroovy UP-TO-DATE
> Task :test-harness-jupiter:compileJava UP-TO-DATE
> Task :spotbugs-tests:compileJava NO-SOURCE
> Task :spotbugs-tests:processResources NO-SOURCE
> Task :spotbugs-tests:classes UP-TO-DATE
> Task :spotbugs-tests:jar UP-TO-DATE
> Task :spotbugs-tests:sourcesJar UP-TO-DATE
> Task :spotbugs-tests:assemble UP-TO-DATE
> Task :spotbugs-tests:checkstyleMain NO-SOURCE
> Task :spotbugs-tests:compileTestJava UP-TO-DATE
> Task :spotbugs-tests:processTestResources NO-SOURCE
> Task :spotbugs-tests:testClasses UP-TO-DATE
> Task :spotbugs-tests:checkstyleTest UP-TO-DATE
> Task :spotbugs-tests:spotbugsMain NO-SOURCE
> Task :spotbugs-tests:spotbugsTest UP-TO-DATE
> Task :spotbugsTestCases:classesJava11 UP-TO-DATE
> Task :spotbugsTestCases:classesJava8 UP-TO-DATE
> Task :spotbugsTestCases:processResources NO-SOURCE
> Task :spotbugsTestCases:classes UP-TO-DATE
> Task :spotbugsTestCases:jar UP-TO-DATE
> Task :test-harness-jupiter:processResources UP-TO-DATE
> Task :test-harness-jupiter:classes UP-TO-DATE
> Task :test-harness-jupiter:jar UP-TO-DATE
> Task :spotbugs-tests:unstableTest UP-TO-DATE
> Task :spotbugsTestCases:assemble UP-TO-DATE
> Task :spotbugsTestCases:spotbugsMain UP-TO-DATE
> Task :spotbugsTestCases:compileTestJava NO-SOURCE
> Task :spotbugsTestCases:compileTestGroovy NO-SOURCE
> Task :spotbugsTestCases:processTestResources NO-SOURCE
> Task :spotbugsTestCases:testClasses UP-TO-DATE
> Task :spotbugsTestCases:spotbugsTest NO-SOURCE
> Task :spotbugsTestCases:test NO-SOURCE
> Task :spotbugsTestCases:check UP-TO-DATE
> Task :spotbugsTestCases:build UP-TO-DATE
> Task :spotbugs-tests:test UP-TO-DATE
> Task :spotbugs-tests:jacocoTestReport UP-TO-DATE
> Task :spotbugs-tests:check UP-TO-DATE
> Task :spotbugs-tests:build UP-TO-DATE
> Task :test-harness:javadoc UP-TO-DATE
> Task :test-harness:javadocJar UP-TO-DATE
> Task :test-harness:sourcesJar UP-TO-DATE
> Task :test-harness:assemble UP-TO-DATE
> Task :test-harness:checkstyleMain UP-TO-DATE
> Task :test-harness:compileTestJava NO-SOURCE
> Task :test-harness:processTestResources NO-SOURCE
> Task :test-harness:testClasses UP-TO-DATE
> Task :test-harness:checkstyleTest NO-SOURCE
> Task :test-harness:spotbugsMain UP-TO-DATE
> Task :test-harness:spotbugsTest NO-SOURCE
> Task :test-harness:test NO-SOURCE
> Task :test-harness:check UP-TO-DATE
> Task :test-harness:build UP-TO-DATE
> Task :test-harness-core:javadoc UP-TO-DATE
> Task :test-harness-core:javadocJar UP-TO-DATE
> Task :test-harness-core:sourcesJar UP-TO-DATE
> Task :test-harness-core:assemble UP-TO-DATE
> Task :test-harness-core:checkstyleMain UP-TO-DATE
> Task :test-harness-core:compileTestJava NO-SOURCE
> Task :test-harness-core:processTestResources NO-SOURCE
> Task :test-harness-core:testClasses UP-TO-DATE
> Task :test-harness-core:checkstyleTest NO-SOURCE
> Task :test-harness-core:spotbugsMain UP-TO-DATE
> Task :test-harness-core:spotbugsTest NO-SOURCE
> Task :test-harness-core:test NO-SOURCE
> Task :test-harness-core:check UP-TO-DATE
> Task :test-harness-core:build UP-TO-DATE
> Task :test-harness-jupiter:javadoc UP-TO-DATE
> Task :test-harness-jupiter:javadocJar UP-TO-DATE
> Task :test-harness-jupiter:sourcesJar UP-TO-DATE
> Task :test-harness-jupiter:assemble UP-TO-DATE
> Task :test-harness-jupiter:checkstyleMain UP-TO-DATE
> Task :test-harness-jupiter:compileTestJava UP-TO-DATE
> Task :test-harness-jupiter:processTestResources NO-SOURCE
> Task :test-harness-jupiter:testClasses UP-TO-DATE
> Task :test-harness-jupiter:checkstyleTest UP-TO-DATE
> Task :test-harness-jupiter:spotbugsMain UP-TO-DATE
> Task :test-harness-jupiter:spotbugsTest UP-TO-DATE
> Task :test-harness-jupiter:test UP-TO-DATE
> Task :test-harness-jupiter:jacocoTestReport UP-TO-DATE
> Task :test-harness-jupiter:check UP-TO-DATE
> Task :test-harness-jupiter:build UP-TO-DATE
> Task :spotbugs:unzipDist UP-TO-DATE
> Task :spotbugs:smokeTest

[Incubating] Problems report is available at: file:///Users/nrayburn/Documents/github/spotbugs/spotbugs/build/reports/problems/problems-report.html

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.13/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 52s
155 actionable tasks: 24 executed, 131 up-to-date

Publishing build scan...
https://gradle.com/s/faulj4qw73saq


</pre>
</details>

Fixes #3099.