### PR TITLE
Make the Gradle build parallel

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 org.gradle.jvmargs=-XX:+HeapDumpOnOutOfMemoryError -Xmx1G --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+org.gradle.parallel=true


### PR DESCRIPTION
The Gradle build is currently sequential so, for instance, the bug samples from `spotbugs-TestCases` aren't compiled until the core `spotbugs` module is.
By turning parallel on the various modules can be built concurrently, which is a bit faster.

Note that the main bottleneck is running all the tests and this part is still sequential (we're only running one unit test at time). When trying to run tests in parallel I occasionally saw some failures, so parallel tests are not enabled here.