### PR TITLE
Ignore non-interpreted text in `DateFormatStringChecker`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Widen main method recognition according to [JEP 445](https://openjdk.org/jeps/445). ([#3371](https://github.com/spotbugs/spotbugs/pull/3371))
 - Do not report `US_USELESS_SUPPRESSION_ON_METHOD` on generated methods ([#3350](https://github.com/spotbugs/spotbugs/issues/3350))
 - Rewrite some member in `ResourceValueFrame.java` to Enum ([#2061](https://github.com/spotbugs/spotbugs/issues/2061))
+- Ignore non-interpreted text when looking for `FS_BAD_DATE_FORMAT_FLAG_COMBO` ([#3387](https://github.com/spotbugs/spotbugs/issues/3387))
 
 ## 4.9.3 - 2025-03-14
 ### Added

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/DateFormatStringCheckerTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/DateFormatStringCheckerTest.java
@@ -1,0 +1,37 @@
+/**
+ *
+ */
+package edu.umd.cs.findbugs.detect;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+/**
+ * @author gtoison
+ */
+public class DateFormatStringCheckerTest {
+
+    private final DateFormatStringChecker checker = new DateFormatStringChecker(null);
+
+    @ParameterizedTest
+    @MethodSource("testCases")
+    void removeNonInterpretedText(String expected, String source) {
+        assertEquals(expected, checker.removeNonInterpretedText(source));
+    }
+
+    static Stream<Arguments> testCases() {
+        return Arrays.asList(
+                Arguments.of("dd/MM/yyyy", "dd/MM/yyyy"),
+                Arguments.of("ddMMyyyy", "ddMMyyyy"),
+                Arguments.of("d MMMM yyyy à HHmm", "d MMMM yyyy à HH'h'mm"),
+                Arguments.of("ddMMyyyy ", "ddMMyyyy 'non interpreted text'"),
+                Arguments.of("HH", "HH''"),
+                Arguments.of("HH", "HH'o''clock'")).stream();
+    }
+}

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3387Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3387Test.java
@@ -1,0 +1,14 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class Issue3387Test extends AbstractIntegrationTest {
+
+    @Test
+    void testSuppression() {
+        performAnalysis("ghIssues/Issue3387.class");
+
+        assertBugInClassCount("FS_BAD_DATE_FORMAT_FLAG_COMBO", "ghIssues.Issue3387", 0);
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DateFormatStringChecker.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DateFormatStringChecker.java
@@ -139,6 +139,8 @@ public class DateFormatStringChecker extends OpcodeStackDetector {
      * @return {@code true} if given string matches any bad combination.
      */
     private boolean runDateFormatRuleVerify(String dateFormat) {
+        String interpretedDateFormat = removeNonInterpretedText(dateFormat);
+
         return Stream.of(
                 // when "h" or "K" flags found, make sure that it ALSO CONTAINS "a" or "B"
                 new Rule(Arrays.asList("a", "B"), null, true, Arrays.asList("h", "K")),
@@ -168,6 +170,25 @@ public class DateFormatStringChecker extends OpcodeStackDetector {
 
                 // year and year-of-era cannot be used together
                 new Rule(Collections.singletonList("u"), null, false, Collections.singletonList("y")),
-                new Rule(Collections.singletonList("y"), null, false, Collections.singletonList("u"))).anyMatch(rule -> rule.verify(dateFormat));
+                new Rule(Collections.singletonList("y"), null, false, Collections.singletonList("u"))).anyMatch(rule -> rule.verify(
+                        interpretedDateFormat));
+    }
+
+    protected String removeNonInterpretedText(String dateFormat) {
+        int length = dateFormat.length();
+        boolean inQuote = false;
+        StringBuilder builder = new StringBuilder();
+
+        for (int i = 0; i < length; i++) {
+            char c = dateFormat.charAt(i);
+
+            if (c == '\'') {
+                inQuote = !inQuote;
+            } else if (!inQuote) {
+                builder.append(c);
+            }
+        }
+
+        return builder.toString();
     }
 }

--- a/spotbugsTestCases/src/java/ghIssues/Issue3387.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3387.java
@@ -1,0 +1,14 @@
+package ghIssues;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+
+public class Issue3387 {
+
+    public String testDateFormat() {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("d MMMM yyyy à HH'h'mm", Locale.FRENCH);
+        return ZonedDateTime.now(ZoneId.systemDefault()).format(formatter);
+    }
+}


### PR DESCRIPTION
As noted in #3387 the non interpreted text should be ignored when looking for `FS_BAD_DATE_FORMAT_FLAG_COMBO`