### PR TITLE
Do not report `RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT` with Mockito doAnswer() and doReturn()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Rewrite some member in `ResourceValueFrame.java` to Enum ([#2061](https://github.com/spotbugs/spotbugs/issues/2061))
 - Ignore non-interpreted text when looking for `FS_BAD_DATE_FORMAT_FLAG_COMBO` ([#3387](https://github.com/spotbugs/spotbugs/issues/3387))
 - Fix IllegalArgumentException thrown from `FindNoSideEffectMethods` detector ([#3320](https://github.com/spotbugs/spotbugs/issues/3320))
+- Do not report `RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT` when part of a Mockito `doAnswer()` or `doReturn()` call ([#3334](https://github.com/spotbugs/spotbugs/issues/3334))
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Rewrite some member in `ResourceValueFrame.java` to Enum ([#2061](https://github.com/spotbugs/spotbugs/issues/2061))
 - Ignore non-interpreted text when looking for `FS_BAD_DATE_FORMAT_FLAG_COMBO` ([#3387](https://github.com/spotbugs/spotbugs/issues/3387))
 - Fix IllegalArgumentException thrown from `FindNoSideEffectMethods` detector ([#3320](https://github.com/spotbugs/spotbugs/issues/3320))
-- Do not report `RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT` when part of a Mockito `doAnswer()` or `doReturn()` call ([#3334](https://github.com/spotbugs/spotbugs/issues/3334))
+- Do not report `RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT` when part of a Mockito `doAnswer()`, `doCallRealMethod()`, `doNothing()`, `doThrow()` or `doReturn()` call ([#3334](https://github.com/spotbugs/spotbugs/issues/3334))
 
 ### Added
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MethodReturnCheck.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MethodReturnCheck.java
@@ -18,7 +18,9 @@
  */
 package edu.umd.cs.findbugs.detect;
 
+import java.util.Arrays;
 import java.util.BitSet;
+import java.util.List;
 
 import edu.umd.cs.findbugs.ba.*;
 import edu.umd.cs.findbugs.classfile.MethodDescriptor;
@@ -65,6 +67,14 @@ public class MethodReturnCheck extends OpcodeStackDetector implements UseAnnotat
         INVOKE_OPCODE_SET.set(Const.INVOKESTATIC);
         INVOKE_OPCODE_SET.set(Const.INVOKEVIRTUAL);
     }
+
+    private static final List<String> MOCKITO_VOID_STUBBING_METHODS = Arrays.asList(
+            "doAnswer",
+            "doCallRealMethod",
+            "doNothing",
+            "doReturn",
+            "doThrow",
+            "verify");
 
     boolean previousOpcodeWasNEW;
 
@@ -237,11 +247,9 @@ public class MethodReturnCheck extends OpcodeStackDetector implements UseAnnotat
     }
 
     private boolean isCallMockitoInvocation(XMethod method) {
-        String methodName = method.getName();
-
         return method.isStatic()
                 && "org.mockito.Mockito".equals(method.getClassName())
-                && ("verify".equals(methodName) || "doAnswer".equals(methodName) || "doReturn".equals(methodName));
+                && MOCKITO_VOID_STUBBING_METHODS.contains(method.getName());
     }
 
     /**

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MethodReturnCheck.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MethodReturnCheck.java
@@ -18,9 +18,8 @@
  */
 package edu.umd.cs.findbugs.detect;
 
-import java.util.Arrays;
 import java.util.BitSet;
-import java.util.List;
+import java.util.Set;
 
 import edu.umd.cs.findbugs.ba.*;
 import edu.umd.cs.findbugs.classfile.MethodDescriptor;
@@ -68,7 +67,7 @@ public class MethodReturnCheck extends OpcodeStackDetector implements UseAnnotat
         INVOKE_OPCODE_SET.set(Const.INVOKEVIRTUAL);
     }
 
-    private static final List<String> MOCKITO_VOID_STUBBING_METHODS = Arrays.asList(
+    private static final Set<String> MOCKITO_VOID_STUBBING_METHODS = Set.of(
             "doAnswer",
             "doCallRealMethod",
             "doNothing",

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MethodReturnCheck.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MethodReturnCheck.java
@@ -207,7 +207,7 @@ public class MethodReturnCheck extends OpcodeStackDetector implements UseAnnotat
             callPC = getPC();
             callSeen = XFactory.createReferencedXMethod(this);
             state = State.SAW_INVOKE;
-            sawMockitoInvoke |= isCallMockitoVerifyInvocation(callSeen);
+            sawMockitoInvoke |= isCallMockitoInvocation(callSeen);
             if (DEBUG) {
                 System.out.println("  invoking " + callSeen);
             }
@@ -236,8 +236,12 @@ public class MethodReturnCheck extends OpcodeStackDetector implements UseAnnotat
 
     }
 
-    private boolean isCallMockitoVerifyInvocation(XMethod method) {
-        return method.isStatic() && "verify".equals(method.getName()) && "org.mockito.Mockito".equals(method.getClassName());
+    private boolean isCallMockitoInvocation(XMethod method) {
+        String methodName = method.getName();
+
+        return method.isStatic()
+                && "org.mockito.Mockito".equals(method.getClassName())
+                && ("verify".equals(methodName) || "doAnswer".equals(methodName) || "doReturn".equals(methodName));
     }
 
     /**

--- a/spotbugsTestCases/src/java/ghIssues/Issue872.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue872.java
@@ -49,8 +49,8 @@ public class Issue872 {
 	void doAnswerMockito() {
 		Value spy = Mockito.spy(Value.class);
 		Mockito.doAnswer(invocation -> {
-		      return "foo";
-		    }
+				return "foo";
+			}
 		).when(spy).checkMe();
 	}
 	
@@ -58,6 +58,24 @@ public class Issue872 {
 	void doReturnMockito() {
 		Value receiver = Mockito.mock(Value.class);
 		Mockito.doReturn("foo").when(receiver).checkMe();
+	}
+	
+	// compliant
+	void doCallRealMethodMockito() {
+		Value receiver = Mockito.mock(Value.class);
+		Mockito.doCallRealMethod().when(receiver).checkMe();
+	}
+	
+	// compliant
+	void doNothingMockito() {
+		Value receiver = Mockito.mock(Value.class);
+		Mockito.doNothing().when(receiver).checkMe();
+	}
+	
+	// compliant
+	void doThrowMockito() {
+		Value receiver = Mockito.mock(Value.class);
+		Mockito.doThrow(Exception.class).when(receiver).checkMe();
 	}
 	
 	public static class Value {

--- a/spotbugsTestCases/src/java/ghIssues/Issue872.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue872.java
@@ -45,6 +45,21 @@ public class Issue872 {
 		Mockito.verify(checked, Mockito.times(4)).noSideEffect();
 	}
 	
+	// compliant
+	void doAnswerMockito() {
+		Value spy = Mockito.spy(Value.class);
+		Mockito.doAnswer(invocation -> {
+		      return "foo";
+		    }
+		).when(spy).checkMe();
+	}
+	
+	// compliant
+	void doReturnMockito() {
+		Value receiver = Mockito.mock(Value.class);
+		Mockito.doReturn("foo").when(receiver).checkMe();
+	}
+	
 	public static class Value {
 		@CheckReturnValue
 		public String checkMe() {


### PR DESCRIPTION
Followup to #2550 and fix for #3334