### PR TITLE
Fix gradle buildDir/task deprecations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ allprojects {
 }
 
 // https://discuss.gradle.org/t/merge-jacoco-coverage-reports-for-multiproject-setups/12100/6
-task jacocoRootReport(type: JacocoReport) {
+tasks.register("jacocoRootReport", JacocoReport.class) {
   description = 'Merge all coverage reports before submit to SonarQube'
   def reportTasks = project.getTasksByName("jacocoTestReport", true).minus(rootProject.jacocoTestReport)
   dependsOn reportTasks

--- a/eclipsePlugin/build.gradle
+++ b/eclipsePlugin/build.gradle
@@ -115,8 +115,10 @@ def copyLibsForEclipse = tasks.register('copyLibsForEclipse', Copy) {
     into "lib"
 }
 
+def resolvedBuildDir = project.layout.buildDirectory.asFile.get()
+
 def distSrcZip = tasks.register('distSrcZip', Exec) {
-  def out = "${buildDir}/distributions/${eclipsePluginId}_${project.version}-source.zip"
+  def out = "${resolvedBuildDir}/distributions/${eclipsePluginId}_${project.version}-source.zip"
   outputs.file out
   commandLine 'git', 'archive', '-o', out, 'HEAD'
 }
@@ -248,7 +250,7 @@ def distZip = tasks.register('distZip', Zip) {
 }
 
 def testPluginJar = tasks.register('testPluginJar') {
-  def jarFile = "$buildDir/site/eclipse/plugins/${eclipsePluginId}_${project.version}.jar"
+  def jarFile = "${resolvedBuildDir}/site/eclipse/plugins/${eclipsePluginId}_${project.version}.jar"
   inputs.file jarFile
   doLast {
     def spotbugsJar = zipTree(jarFile)
@@ -498,9 +500,9 @@ def generateP2Metadata = tasks.register('generateP2Metadata', Exec) {
   dependsOn confirmEclipse, pluginJar, featureJar, siteXml, siteHtml
   commandLine "${eclipseExecutable}", '-nosplash',
     '-application', 'org.eclipse.equinox.p2.publisher.UpdateSitePublisher',
-    '-metadataRepository', "file:${buildDir}/site/eclipse",
-    '-artifactRepository', "file:${buildDir}/site/eclipse",
-    '-source', "${buildDir}/site/eclipse",
+    '-metadataRepository', "file:${resolvedBuildDir}/site/eclipse",
+    '-artifactRepository', "file:${resolvedBuildDir}/site/eclipse",
+    '-source', "${resolvedBuildDir}/site/eclipse",
     '-vm', "${System.getProperty('java.home')}/bin"
 }
 
@@ -515,9 +517,9 @@ def generateCandidateP2Metadata = tasks.register('generateCandidateP2Metadata', 
   dependsOn confirmEclipse, pluginCandidateJar, featureCandidateJar, siteCandidateXml, siteCandidateHtml
   commandLine "${eclipseExecutable}", '-nosplash',
     '-application', 'org.eclipse.equinox.p2.publisher.UpdateSitePublisher',
-    '-metadataRepository', "file:${buildDir}/site/eclipse-candidate",
-    '-artifactRepository', "file:${buildDir}/site/eclipse-candidate",
-    '-source', "${buildDir}/site/eclipse-candidate",
+    '-metadataRepository', "file:${resolvedBuildDir}/site/eclipse-candidate",
+    '-artifactRepository', "file:${resolvedBuildDir}/site/eclipse-candidate",
+    '-source', "${resolvedBuildDir}/site/eclipse-candidate",
     '-vm', "${System.getProperty('java.home')}/bin"
 }
 
@@ -532,9 +534,9 @@ def generateP2MetadataDaily = tasks.register('generateP2MetadataDaily', Exec) {
   dependsOn confirmEclipse, pluginDailyJar, featureDailyJar, siteDailyXml, siteDailyHtml
   commandLine "${eclipseExecutable}", '-nosplash',
     '-application', 'org.eclipse.equinox.p2.publisher.UpdateSitePublisher',
-    '-metadataRepository', "file:${buildDir}/site/eclipse-daily",
-    '-artifactRepository', "file:${buildDir}/site/eclipse-daily",
-    '-source', "${buildDir}/site/eclipse-daily",
+    '-metadataRepository', "file:${resolvedBuildDir}/site/eclipse-daily",
+    '-artifactRepository', "file:${resolvedBuildDir}/site/eclipse-daily",
+    '-source', "${resolvedBuildDir}/site/eclipse-daily",
     '-vm', "${System.getProperty('java.home')}/bin"
 }
 
@@ -549,9 +551,9 @@ def generateP2MetadataStableLatest = tasks.register('generateP2MetadataStableLat
   dependsOn confirmEclipse, pluginStableLatestJar, featureStableLatestJar, siteStableLatestXml, siteStableLatestHtml
   commandLine "${eclipseExecutable}", '-nosplash',
     '-application', 'org.eclipse.equinox.p2.publisher.UpdateSitePublisher',
-    '-metadataRepository', "file:${buildDir}/site/eclipse-stable-latest",
-    '-artifactRepository', "file:${buildDir}/site/eclipse-stable-latest",
-    '-source', "${buildDir}/site/eclipse-stable-latest",
+    '-metadataRepository', "file:${resolvedBuildDir}/site/eclipse-stable-latest",
+    '-artifactRepository', "file:${resolvedBuildDir}/site/eclipse-stable-latest",
+    '-source', "${resolvedBuildDir}/site/eclipse-stable-latest",
     '-vm', "${System.getProperty('java.home')}/bin"
 }
 

--- a/gradle/sonar.gradle
+++ b/gradle/sonar.gradle
@@ -6,7 +6,9 @@ sonar {
         property 'sonar.organization', 'spotbugs'
         property 'sonar.projectKey', 'com.github.spotbugs.spotbugs'
         property 'sonar.projectName', 'SpotBugs'
-        property 'sonar.coverage.jacoco.xmlReportPaths', "${buildDir}/reports/jacoco/jacocoRootReport/jacocoRootReport.xml"
+
+        def resolvedBuildDir = project.layout.buildDirectory.asFile.get()
+        property 'sonar.coverage.jacoco.xmlReportPaths', "${resolvedBuildDir}/reports/jacoco/jacocoRootReport/jacocoRootReport.xml"
     }
 }
 

--- a/spotbugs-tests/build.gradle
+++ b/spotbugs-tests/build.gradle
@@ -45,7 +45,7 @@ tasks.named('jacocoTestReport', JacocoReport).configure {
 
 // Tests below fail if executed with other tests
 // So we run them before all other tests are executed
-task unstableTest(type: Test) {
+tasks.register("unstableTest", Test.class) {
   useJUnitPlatform()
   filter {
     includeTestsMatching "PlaceholderTest"

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -298,8 +298,10 @@ tasks.named('jar') {
   dependsOn tasks.named('updateManifest')
 }
 
+def resolvedBuildDir = project.layout.buildDirectory.asFile.get()
+
 def distSrcZip = tasks.register('distSrcZip', Exec) {
-  def out = "${buildDir}/distributions/spotbugs-${project.version}-source.zip"
+  def out = "${resolvedBuildDir}/distributions/spotbugs-${project.version}-source.zip"
   outputs.file out
   commandLine 'git', 'archive', '-o', out,
     '--prefix', "spotbugs-${project.version}/", 'HEAD'
@@ -318,7 +320,7 @@ tasks.named('assemble') {
 def unzipDist = tasks.register('unzipDist', Copy) {
   dependsOn distZip
   from distZip.map { zipTree(it.outputs.files.singleFile) }
-  into file("$buildDir/smoketest/")
+  into file("${resolvedBuildDir}/smoketest/")
   // Remove prefix
   eachFile { details ->
     details.path = details.path - "spotbugs-${project.version}"
@@ -330,13 +332,13 @@ def smokeTest = tasks.register('smokeTest') {
   dependsOn unzipDist, project(':spotbugs-ant').tasks.named('jar')
   doLast {
     ant.taskdef(name:'spotbugs', classname:'edu.umd.cs.findbugs.anttask.FindBugsTask', classpath:project(':spotbugs-ant').jar.outputs.files.asPath)
-    ant.spotbugs(home:"$buildDir/smoketest/", output:'xml:withMessages',
+    ant.spotbugs(home:"${resolvedBuildDir}/smoketest/", output:'xml:withMessages',
               jvmargs:'-ea -Xmx1200m',
               excludeFilter:'findbugsExclude.xml',
               projectName:'spotbugs',
               maxRank:'20',
               timeout:'1800000',
-              outputFile:"${buildDir}/smoketest/findbugscheckAll.xml") {
+              outputFile:"${resolvedBuildDir}/smoketest/findbugscheckAll.xml") {
       sourcePath(path:'src/main/java:src/gui/main:src/tools')
       'class'(location:project.tasks['compileJava'].destinationDirectory.get().asFile)
       configurations.compileClasspath.each { File file -> auxClasspath(path:file.path) }


### PR DESCRIPTION
Replaced usages of `project.buildDir` and made the registration of `unstableTest` and `jacocoRootReport` lazy. Both previous behaviours were deprecated and will be removed in Gradle 9.