### PR TITLE
Fix FPs in `SharedVariableAtomicityDetector`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Fix IllegalArgumentException thrown from `FindNoSideEffectMethods` detector ([#3320](https://github.com/spotbugs/spotbugs/issues/3320))
 - Do not report `RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT` when part of a Mockito `doAnswer()`, `doCallRealMethod()`, `doNothing()`, `doThrow()` or `doReturn()` call ([#3334](https://github.com/spotbugs/spotbugs/issues/3334))
 - Fix `CT_CONSTRUCTOR_THROW` false positive with public and private constructors in specific order of methods ([#3417](https://github.com/spotbugs/spotbugs/issues/3417))
+- Fix `AT_NONATOMIC_OPERATIONS_ON_SHARED_VARIABLE`, `AT_NONATOMIC_64BIT_PRIMITIVE` and `AT_STALE_THREAD_WRITE_OF_PRIMITIVE` FP when the relevant code is in private method, which is only called with proper synchronization ([#3428](https://github.com/spotbugs/spotbugs/issues/3428)) 
 
 ### Added
 - Added the unnecessary annotation to the `US_USELESS_SUPPRESSION_ON_*` messages ([#3395](https://github.com/spotbugs/spotbugs/issues/3395))

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/SharedVariableAtomicityDetectorTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/SharedVariableAtomicityDetectorTest.java
@@ -90,6 +90,15 @@ class SharedVariableAtomicityDetectorTest extends AbstractIntegrationTest {
     }
 
     @Test
+    void noBugWhenIssue3428() {
+        performAnalysis("multithreaded/primitivewrite/Issue3428.class");
+        assertBugTypeCount(PRIMITIVE_BUG, 0);
+        assertBugTypeCount(WRITE_64BIT_BUG, 0);
+        assertBugTypeCount(OPS_BUG, 0);
+    }
+
+
+    @Test
     void noBugAtomicField() {
         performAnalysis("multithreaded/primitivewrite/AtomicField.class");
         assertBugTypeCount(PRIMITIVE_BUG, 0);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SharedVariableAtomicityDetector.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SharedVariableAtomicityDetector.java
@@ -197,7 +197,8 @@ public class SharedVariableAtomicityDetector extends OpcodeStackDetector {
             }
         } else if (seen == Const.PUTFIELD || seen == Const.PUTSTATIC) {
             XField field = getXFieldOperand();
-            if (field != null && !field.isFinal() && !field.isSynthetic() && field.getClassDescriptor().equals(method.getClassDescriptor())) {
+            if (field != null && !field.isFinal() && !field.isSynthetic() && field.getClassDescriptor().equals(method.getClassDescriptor())
+                    && hasNonSyncedNonPrivateCallToMethod(method, new HashSet<>())) {
                 boolean fieldReadInOtherMethod = mapContainsFieldWithOtherMethod(field, method, readFieldsByMethods);
                 if (fieldReadInOtherMethod) {
                     if (!relevantFields.isEmpty() && relevantFields.contains(field) && isPrimitiveOrItsBoxingType(field.getSignature())) {

--- a/spotbugsTestCases/src/java/multithreaded/primitivewrite/Issue3428.java
+++ b/spotbugsTestCases/src/java/multithreaded/primitivewrite/Issue3428.java
@@ -1,0 +1,40 @@
+package multithreaded.primitivewrite;
+
+public class Issue3428 {
+    private long directCounter;
+    private long indirectCounter;
+    private long finallyCounter;
+
+    private void increaseFinallyCounter() {
+        try {
+            // do something
+        } finally {
+            finallyCounter++;
+        }
+    }
+
+    private void increaseIndirectCounter() {
+        indirectCounter++;
+    }
+
+    public synchronized void directCounterIncreaseSynchronized() {
+        directCounter++;
+    }
+
+    public synchronized void indirectCounterIncreaseSynchronized() {
+        increaseIndirectCounter();
+    }
+
+    public synchronized void finallyCounterIncreaseSynchronized() {
+        increaseFinallyCounter();
+    }
+
+    protected void toStringAppendFields(final StringBuilder builder) {
+        builder.append("IndirectCounter =");
+        builder.append(indirectCounter);
+        builder.append(", DirectCounter =");
+        builder.append(directCounter);
+        builder.append(", FinallyCounter =");
+        builder.append(finallyCounter);
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/spotbugs/spotbugs/issues/3428. The testcase is minimized from [SoftReferenceObjectPool](https://github.com/apache/commons-pool/blob/5d41a5185a301e3d135a0b611e5cbc283a367654/src/main/java/org/apache/commons/pool3/impl/SoftReferenceObjectPool.java) class's `destroyCount` field and its usages, which is mentioned at the issue.
The cause of the issue was that the check for the methods visibility and the functions calling the method was only done for the reads/other usages of the relevant field, but not for the method which modifies the field.

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [X] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
