### PR TITLE
Fix `AT_NONATOMIC_OPERATIONS_ON_SHARED_VARIABLE` FP with no compound ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Fix IllegalArgumentException thrown from `FindNoSideEffectMethods` detector ([#3320](https://github.com/spotbugs/spotbugs/issues/3320))
 - Do not report `RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT` when part of a Mockito `doAnswer()`, `doCallRealMethod()`, `doNothing()`, `doThrow()` or `doReturn()` call ([#3334](https://github.com/spotbugs/spotbugs/issues/3334))
 - Fix `CT_CONSTRUCTOR_THROW` false positive with public and private constructors in specific order of methods ([#3417](https://github.com/spotbugs/spotbugs/issues/3417))
-- Fix `AT_NONATOMIC_OPERATIONS_ON_SHARED_VARIABLE`, `AT_NONATOMIC_64BIT_PRIMITIVE` and `AT_STALE_THREAD_WRITE_OF_PRIMITIVE` FP when the relevant code is in private method, which is only called with proper synchronization ([#3428](https://github.com/spotbugs/spotbugs/issues/3428)) 
+- Fix `AT_NONATOMIC_OPERATIONS_ON_SHARED_VARIABLE`, `AT_NONATOMIC_64BIT_PRIMITIVE` and `AT_STALE_THREAD_WRITE_OF_PRIMITIVE` FP when the relevant code is in private method, which is only called with proper synchronization ([#3428](https://github.com/spotbugs/spotbugs/issues/3428))
+- Fix `AT_NONATOMIC_OPERATIONS_ON_SHARED_VARIABLE` FP when there was no compound operation ([#3363](https://github.com/spotbugs/spotbugs/issues/3363))
 
 ### Added
 - Added the unnecessary annotation to the `US_USELESS_SUPPRESSION_ON_*` messages ([#3395](https://github.com/spotbugs/spotbugs/issues/3395))

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/SharedVariableAtomicityDetectorTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/SharedVariableAtomicityDetectorTest.java
@@ -278,6 +278,14 @@ class SharedVariableAtomicityDetectorTest extends AbstractIntegrationTest {
         assertBugTypeCount(OPS_BUG, 0);
     }
 
+    @Test
+    void noBugNoCompoundOp() {
+        performAnalysis("multithreaded/compoundoperation/NoCompoundOp.class");
+        assertBugTypeCount(PRIMITIVE_BUG, 0);
+        assertBugTypeCount(WRITE_64BIT_BUG, 0);
+        assertBugTypeCount(OPS_BUG, 0);
+    }
+
     // --num
     @Test
     void bugForCompoundPreDecrementation() {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SharedVariableAtomicityDetector.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SharedVariableAtomicityDetector.java
@@ -204,7 +204,8 @@ public class SharedVariableAtomicityDetector extends OpcodeStackDetector {
                     && hasNonSyncedNonPrivateCallToMethod(method, new HashSet<>())) {
                 boolean fieldReadInOtherMethod = mapContainsFieldWithOtherMethod(field, method, readFieldsByMethods);
                 if (fieldReadInOtherMethod) {
-                    if (hadOperation && !relevantFields.isEmpty() && relevantFields.contains(field) && isPrimitiveOrItsBoxingType(field.getSignature())) {
+                    if (hadOperation && !relevantFields.isEmpty() && relevantFields.contains(field)
+                            && isPrimitiveOrItsBoxingType(field.getSignature())) {
                         bugAccumulator.accumulateBug(
                                 new BugInstance(this, "AT_NONATOMIC_OPERATIONS_ON_SHARED_VARIABLE", NORMAL_PRIORITY)
                                         .addClass(this)

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SharedVariableAtomicityDetector.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SharedVariableAtomicityDetector.java
@@ -47,6 +47,7 @@ public class SharedVariableAtomicityDetector extends OpcodeStackDetector {
     private CFG currentCFG;
     private LockDataflow currentLockDataFlow;
     private boolean isFirstVisit = true;
+    private boolean hadOperation = false;
     private final Map<XMethod, Set<XField>> readFieldsByMethods = new HashMap<>();
     private final Set<XField> relevantFields = new HashSet<>();
     private final Map<XMethod, Set<XMethod>> nonSyncedMethodCallsByCallingMethods = new HashMap<>();
@@ -109,6 +110,7 @@ public class SharedVariableAtomicityDetector extends OpcodeStackDetector {
     public void visit(Method method) {
         try {
             relevantFields.clear();
+            hadOperation = false;
             currentMethod = method;
             currentLockDataFlow = getClassContext().getLockDataflow(currentMethod);
             currentCFG = getClassContext().getCFG(currentMethod);
@@ -122,6 +124,7 @@ public class SharedVariableAtomicityDetector extends OpcodeStackDetector {
         bugAccumulator.reportAccumulatedBugs();
         relevantFields.clear();
         readFieldsByMethods.clear();
+        hadOperation = false;
         nonSyncedMethodCallsByCallingMethods.clear();
     }
 
@@ -201,7 +204,7 @@ public class SharedVariableAtomicityDetector extends OpcodeStackDetector {
                     && hasNonSyncedNonPrivateCallToMethod(method, new HashSet<>())) {
                 boolean fieldReadInOtherMethod = mapContainsFieldWithOtherMethod(field, method, readFieldsByMethods);
                 if (fieldReadInOtherMethod) {
-                    if (!relevantFields.isEmpty() && relevantFields.contains(field) && isPrimitiveOrItsBoxingType(field.getSignature())) {
+                    if (hadOperation && !relevantFields.isEmpty() && relevantFields.contains(field) && isPrimitiveOrItsBoxingType(field.getSignature())) {
                         bugAccumulator.accumulateBug(
                                 new BugInstance(this, "AT_NONATOMIC_OPERATIONS_ON_SHARED_VARIABLE", NORMAL_PRIORITY)
                                         .addClass(this)
@@ -223,10 +226,14 @@ public class SharedVariableAtomicityDetector extends OpcodeStackDetector {
             relevantFields.clear();
         } else {
             short opcode = (short) seen;
-            // if the opcode is something different then it is not the calculation of the assigned value
-            if (!readOpCodes.contains(opcode) && !pushOpCodes.contains(opcode) && !operationOpCodes.contains(opcode)
-                    && !methodCallOpCodes.contains(opcode)) {
+            if (operationOpCodes.contains(opcode)) {
+                if (!relevantFields.isEmpty()) {
+                    hadOperation = true;
+                }
+            } else if (!readOpCodes.contains(opcode) && !pushOpCodes.contains(opcode) && !methodCallOpCodes.contains(opcode)) {
+                // if the opcode is something different then it is not the calculation of the assigned value
                 relevantFields.clear();
+                hadOperation = false;
             }
         }
     }

--- a/spotbugsTestCases/src/java/multithreaded/compoundoperation/NoCompoundOp.java
+++ b/spotbugsTestCases/src/java/multithreaded/compoundoperation/NoCompoundOp.java
@@ -1,0 +1,30 @@
+package multithreaded.compoundoperation;
+
+/**
+* @see <a href="https://github.com/spotbugs/spotbugs/issues/3363">GitHub issue #3363</a>
+*/
+public class NoCompoundOp {
+
+    private volatile boolean hasCalled = false;
+
+    public void test1() {
+        assertEquals(false, hasCalled);
+        // do something that changes the flag
+        hasCalled = false; // AT_NONATOMIC_OPERATIONS_ON_SHARED_VARIABLE
+    }
+
+    public void test2() {
+        assertEquals(false, hasCalled);
+        // do something that changes the flag
+        hasCalled = false; // AT_NONATOMIC_OPERATIONS_ON_SHARED_VARIABLE
+    }
+
+    public void snapshot() {
+        NoCompoundOp p = new NoCompoundOp();
+        p.hasCalled = hasCalled; // AT_NONATOMIC_OPERATIONS_ON_SHARED_VARIABLE
+        System.out.println(p);
+    }
+
+    public static void assertEquals(Object expected, Object actual) {
+    }
+}


### PR DESCRIPTION
This PR fixes #3363, the `AT_NONATOMIC_OPERATIONS_ON_SHARED_VARIABLE` false positive hit where there was no compound operation.
During the fix, I ran into some other false positive and false negative hits for this bug, but I will raise separate PRs for those when the fix is ready.

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
