### PR TITLE
Fix `AT_NONATOMIC_OPERATIONS_ON_SHARED_VARIABLE` fp with fields of inner local vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Do not report `RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT` when part of a Mockito `doAnswer()`, `doCallRealMethod()`, `doNothing()`, `doThrow()` or `doReturn()` call ([#3334](https://github.com/spotbugs/spotbugs/issues/3334))
 - Fix `CT_CONSTRUCTOR_THROW` false positive with public and private constructors in specific order of methods ([#3417](https://github.com/spotbugs/spotbugs/issues/3417))
 - Fix `AT_NONATOMIC_OPERATIONS_ON_SHARED_VARIABLE`, `AT_NONATOMIC_64BIT_PRIMITIVE` and `AT_STALE_THREAD_WRITE_OF_PRIMITIVE` FP when the relevant code is in private method, which is only called with proper synchronization ([#3428](https://github.com/spotbugs/spotbugs/issues/3428)) 
+- Fix `AT_NONATOMIC_OPERATIONS_ON_SHARED_VARIABLE` when field of a local variable is set. ([#3459](https://github.com/spotbugs/spotbugs/pull/3459))
 
 ### Added
 - Added the unnecessary annotation to the `US_USELESS_SUPPRESSION_ON_*` messages ([#3395](https://github.com/spotbugs/spotbugs/issues/3395))

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/SharedVariableAtomicityDetectorTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/SharedVariableAtomicityDetectorTest.java
@@ -278,6 +278,15 @@ class SharedVariableAtomicityDetectorTest extends AbstractIntegrationTest {
         assertBugTypeCount(OPS_BUG, 0);
     }
 
+    @Test
+    void noBugInnerLocalVarFields() {
+        // Inner local vars
+        performAnalysis("multithreaded/compoundoperation/InnerLocalVarFields.class");
+        assertBugTypeCount(PRIMITIVE_BUG, 0);
+        assertBugTypeCount(WRITE_64BIT_BUG, 0);
+        assertBugTypeCount(OPS_BUG, 0);
+    }
+
     // --num
     @Test
     void bugForCompoundPreDecrementation() {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SharedVariableAtomicityDetector.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SharedVariableAtomicityDetector.java
@@ -197,7 +197,9 @@ public class SharedVariableAtomicityDetector extends OpcodeStackDetector {
             }
         } else if (seen == Const.PUTFIELD || seen == Const.PUTSTATIC) {
             XField field = getXFieldOperand();
-            if (field != null && !field.isFinal() && !field.isSynthetic() && field.getClassDescriptor().equals(method.getClassDescriptor())
+            if (field != null && !field.isFinal() && !field.isSynthetic()
+                    && (seen == Const.PUTSTATIC || stack.getStackItem(1).getRegisterNumber() == 0)
+                    && field.getClassDescriptor().equals(method.getClassDescriptor())
                     && hasNonSyncedNonPrivateCallToMethod(method, new HashSet<>())) {
                 boolean fieldReadInOtherMethod = mapContainsFieldWithOtherMethod(field, method, readFieldsByMethods);
                 if (fieldReadInOtherMethod) {

--- a/spotbugsTestCases/src/java/multithreaded/compoundoperation/InnerLocalVarFields.java
+++ b/spotbugsTestCases/src/java/multithreaded/compoundoperation/InnerLocalVarFields.java
@@ -1,0 +1,19 @@
+package multithreaded.compoundoperation;
+
+/**
+* @see <a href="https://github.com/spotbugs/spotbugs/issues/3363">GitHub issue #3363</a>
+*/
+public class InnerLocalVarFields {
+    private volatile int number = 1;
+
+    public int getNumber() {
+        return number;
+    }
+
+    public void snapshot() {
+        InnerLocalVarFields p = new InnerLocalVarFields();
+        p.number = number + 1; // AT_NONATOMIC_OPERATIONS_ON_SHARED_VARIABLE
+        number = 2;
+        System.out.println(p);
+    }
+}


### PR DESCRIPTION
With slightly modifying the example at https://github.com/spotbugs/spotbugs/issues/3363, I stumbled upon this false positive.
This does not fix that issue, only the third hit in snapshot. The proper fix for that issue is at https://github.com/spotbugs/spotbugs/pull/3446.

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [X] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
