### PR TITLE
Fix test failures on Java 24

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2040Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2040Test.java
@@ -15,7 +15,22 @@ class Issue2040Test extends AbstractIntegrationTest {
                 "ghIssues/issue2040/Caller.class");
 
         assertBugTypeCount("THROWS_METHOD_THROWS_RUNTIMEEXCEPTION", 3);
-        assertBugInMethodAtLine("THROWS_METHOD_THROWS_RUNTIMEEXCEPTION", "Derived", "lambda$lambda2$1", 36);
+        String runtimeExceptionLambdaName;
+        if (Runtime.version().feature() >= 24) {
+            // The enumeration of lambdas changed slightly in Java 24, it appears to now count per-method rather than per-class.
+            // The pre-24 enumeration was
+            // lambda$lambda$0
+            // lambda$lambda2$1
+            // lambda$lambda3$2
+            // It is now
+            // lambda$lambda$0
+            // lambda$lambda2$0
+            // lambda$lambda3$0
+            runtimeExceptionLambdaName = "lambda$lambda2$0";
+        } else {
+            runtimeExceptionLambdaName = "lambda$lambda2$1";
+        }
+        assertBugInMethodAtLine("THROWS_METHOD_THROWS_RUNTIMEEXCEPTION", "Derived", runtimeExceptionLambdaName, 36);
         assertBugInMethodAtLine("THROWS_METHOD_THROWS_RUNTIMEEXCEPTION", "Derived", "runtimeExThrownFromCatch", 97);
         assertBugInMethodAtLine("THROWS_METHOD_THROWS_RUNTIMEEXCEPTION", "Derived", "runtimeExceptionThrowingMethod", 45);
 


### PR DESCRIPTION
Issue2040Test fails because it asserts on the index of a lambda. That indexing has changed slightly in Java 24, so the name of the lambda is different. Added code to adjust the assertion based on the JDK the test is running on.
