### PR TITLE
`TestASM` crashes with constant field with bad naming convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Do not report `RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT` when part of a BDDMockito call ([#3441](https://github.com/spotbugs/spotbugs/issues/3441))
 - Fix `AT_NONATOMIC_OPERATIONS_ON_SHARED_VARIABLE` when field of a local variable is set. ([#3459](https://github.com/spotbugs/spotbugs/pull/3459))
 - Fix `AT_NONATOMIC_OPERATIONS_ON_SHARED_VARIABLE` FP when there was no compound operation ([#3363](https://github.com/spotbugs/spotbugs/issues/3363))
+- Fix `NM_FIELD_NAMING_CONVENTION` crash in the TestASM detector ([#3489](https://github.com/spotbugs/spotbugs/pull/3489))
 
 ### Added
 - Added the unnecessary annotation to the `US_USELESS_SUPPRESSION_ON_*` messages ([#3395](https://github.com/spotbugs/spotbugs/issues/3395))

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FieldNamingConventionTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FieldNamingConventionTest.java
@@ -1,0 +1,13 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class FieldNamingConventionTest extends AbstractIntegrationTest {
+
+    @Test
+    void testIssue() {
+        performAnalysis("badNaming/FieldNamingConvention.class");
+        assertBugTypeCount("NM_FIELD_NAMING_CONVENTION", 1);
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/BugInstance.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/BugInstance.java
@@ -1125,7 +1125,7 @@ public class BugInstance implements Comparable<BugInstance>, XMLWriteable, Clone
      * Add a field annotation.
      *
      * @param className
-     *            name of the class containing the field
+     *            the dotted name of the class containing the field
      * @param fieldName
      *            the name of the field
      * @param fieldSig
@@ -1135,7 +1135,7 @@ public class BugInstance implements Comparable<BugInstance>, XMLWriteable, Clone
      * @return this object
      */
     @Nonnull
-    public BugInstance addField(String className, String fieldName, String fieldSig, boolean isStatic) {
+    public BugInstance addField(@DottedClassName String className, String fieldName, String fieldSig, boolean isStatic) {
         addField(new FieldAnnotation(className, fieldName, fieldSig, isStatic));
         return this;
     }
@@ -1144,7 +1144,7 @@ public class BugInstance implements Comparable<BugInstance>, XMLWriteable, Clone
      * Add a field annotation.
      *
      * @param className
-     *            name of the class containing the field
+     *            the dotted name of the class containing the field
      * @param fieldName
      *            the name of the field
      * @param fieldSig
@@ -1154,7 +1154,7 @@ public class BugInstance implements Comparable<BugInstance>, XMLWriteable, Clone
      * @return this object
      */
     @Nonnull
-    public BugInstance addField(String className, String fieldName, String fieldSig, int accessFlags) {
+    public BugInstance addField(@DottedClassName String className, String fieldName, String fieldSig, int accessFlags) {
         addField(new FieldAnnotation(className, fieldName, fieldSig, accessFlags));
         return this;
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/CheckRelaxingNullnessAnnotation.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/CheckRelaxingNullnessAnnotation.java
@@ -54,9 +54,7 @@ import edu.umd.cs.findbugs.ba.NullnessAnnotation.Parser;
 import edu.umd.cs.findbugs.ba.SignatureParser;
 import edu.umd.cs.findbugs.ba.XClass;
 import edu.umd.cs.findbugs.ba.XMethod;
-import edu.umd.cs.findbugs.classfile.CheckedAnalysisException;
 import edu.umd.cs.findbugs.classfile.ClassDescriptor;
-import edu.umd.cs.findbugs.classfile.Global;
 import edu.umd.cs.findbugs.classfile.MethodDescriptor;
 import edu.umd.cs.findbugs.classfile.analysis.AnnotationValue;
 import edu.umd.cs.findbugs.classfile.engine.asm.FindBugsASM;
@@ -76,31 +74,8 @@ import edu.umd.cs.findbugs.util.ClassName;
  */
 public class CheckRelaxingNullnessAnnotation extends ClassNodeDetector {
 
-    XClass xclass;
-
     public CheckRelaxingNullnessAnnotation(BugReporter bugReporter) {
         super(bugReporter);
-    }
-
-    @Override
-    public void visitClass(ClassDescriptor classDescriptor) throws CheckedAnalysisException {
-        xclass = getClassInfo(classDescriptor);
-        if (xclass != null) {
-            super.visitClass(classDescriptor);
-        }
-    }
-
-    @CheckForNull
-    XClass getClassInfo(ClassDescriptor classDescr) {
-        if (classDescr == null) {
-            return null;
-        }
-        try {
-            return Global.getAnalysisCache().getClassAnalysis(XClass.class, classDescr);
-        } catch (CheckedAnalysisException e) {
-            bugReporter.reportMissingClass(classDescr);
-            return null;
-        }
     }
 
     @Override

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/TestASM.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/TestASM.java
@@ -32,6 +32,7 @@ import edu.umd.cs.findbugs.MethodAnnotation;
 import edu.umd.cs.findbugs.Priorities;
 import edu.umd.cs.findbugs.asm.AbstractFBMethodVisitor;
 import edu.umd.cs.findbugs.asm.ClassNodeDetector;
+import edu.umd.cs.findbugs.internalAnnotations.DottedClassName;
 
 /**
  * Sample detector, using ASM
@@ -81,8 +82,10 @@ public class TestASM extends ClassNodeDetector {
     public FieldVisitor visitField(int access, String name, String desc, String signature, Object value) {
         if ((access & Opcodes.ACC_STATIC) != 0 && (access & Opcodes.ACC_FINAL) != 0 && (access & Opcodes.ACC_PUBLIC) != 0
                 && !name.equals(name.toUpperCase())) {
+            @DottedClassName
+            String className = xclass.getClassDescriptor().getDottedClassName();
             bugReporter.reportBug(new BugInstance(this, "NM_FIELD_NAMING_CONVENTION", Priorities.LOW_PRIORITY).addClass(this)
-                    .addField(this.name, name, desc, access));
+                    .addField(className, name, desc, access));
         }
         return null;
     }

--- a/spotbugsTestCases/src/java/badNaming/FieldNamingConvention.java
+++ b/spotbugsTestCases/src/java/badNaming/FieldNamingConvention.java
@@ -1,0 +1,6 @@
+package badNaming;
+
+public class FieldNamingConvention {
+	// Expect NM_FIELD_NAMING_CONVENTION here:
+	public static final int constant = 42;
+}


### PR DESCRIPTION
While investigating #3483 I ran into a crash of the `TestASM` detector.
It is disabled by default so most probably nobody runs it, except when running integration tests because we enable all detectors.