### PR TITLE
Improve missing class error reporting

### DIFF
--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/FindBugs2.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/FindBugs2.java
@@ -995,7 +995,7 @@ public class FindBugs2 implements IFindBugsEngine, AutoCloseable {
                     XClass info = Global.getAnalysisCache().getClassAnalysis(XClass.class, desc);
                     factory.intern(info);
                 } catch (CheckedAnalysisException | RuntimeException e) {
-                    AnalysisContext.logError("Couldn't get class info for " + desc, e);
+                    AnalysisContext.currentAnalysisContext().getLookupFailureCallback().reportMissingClass(desc, e);
                     badClasses.add(desc);
                 }
             }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/FindBugs2.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/FindBugs2.java
@@ -994,7 +994,7 @@ public class FindBugs2 implements IFindBugsEngine, AutoCloseable {
                 try {
                     XClass info = Global.getAnalysisCache().getClassAnalysis(XClass.class, desc);
                     factory.intern(info);
-                } catch (CheckedAnalysisException | RuntimeException e) {
+                } catch (CheckedAnalysisException e) {
                     AnalysisContext.currentAnalysisContext().getLookupFailureCallback().reportMissingClass(desc, e);
                     badClasses.add(desc);
                 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/asm/ClassNodeDetector.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/asm/ClassNodeDetector.java
@@ -78,7 +78,7 @@ public abstract class ClassNodeDetector extends ClassNode implements Detector2 {
         try {
             return Global.getAnalysisCache().getClassAnalysis(XClass.class, classDescr);
         } catch (CheckedAnalysisException e) {
-            bugReporter.reportMissingClass(classDescr);
+            bugReporter.reportMissingClass(classDescr, e);
             return null;
         }
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/ClassContext.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/ClassContext.java
@@ -117,10 +117,13 @@ public class ClassContext {
         this.jclass = jclass;
         this.analysisContext = analysisContext;
         this.methodAnalysisObjectMap = new HashMap<>();
+
+        ClassDescriptor classDescriptor = DescriptorFactory.createClassDescriptor(jclass);
+
         try {
-            classInfo = (ClassInfo) Global.getAnalysisCache().getClassAnalysis(XClass.class,
-                    DescriptorFactory.createClassDescriptor(jclass));
+            classInfo = (ClassInfo) Global.getAnalysisCache().getClassAnalysis(XClass.class, classDescriptor);
         } catch (CheckedAnalysisException e) {
+            analysisContext.getLookupFailureCallback().reportMissingClass(classDescriptor, e);
             throw new AssertionError("No ClassInfo for " + jclass);
         }
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/FieldSummary.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/FieldSummary.java
@@ -93,6 +93,7 @@ public class FieldSummary {
                 }
             }
         } catch (CheckedAnalysisException e) {
+            AnalysisContext.currentAnalysisContext().getLookupFailureCallback().reportMissingClass(c, e);
             return false;
         }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/TypeQualifierValue.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/TypeQualifierValue.java
@@ -36,7 +36,6 @@ import javax.annotation.meta.When;
 
 import edu.umd.cs.findbugs.SystemProperties;
 import edu.umd.cs.findbugs.ba.AnalysisContext;
-import edu.umd.cs.findbugs.ba.MissingClassException;
 import edu.umd.cs.findbugs.ba.XClass;
 import edu.umd.cs.findbugs.ba.XMethod;
 import edu.umd.cs.findbugs.classfile.CheckedAnalysisException;
@@ -124,11 +123,10 @@ public class TypeQualifierValue<A extends Annotation> {
                     break;
                 }
             }
-        } catch (MissingClassException e) {
-            AnalysisContext.currentAnalysisContext().getLookupFailureCallback().reportMissingClass(e.getClassNotFoundException());
         } catch (CheckedAnalysisException e) {
-            AnalysisContext.logError("Error looking up annotation class " + typeQualifier.toDottedClassName(), e);
+            AnalysisContext.currentAnalysisContext().getLookupFailureCallback().reportMissingClass(typeQualifier, e);
         }
+
         this.isStrict = isStrict1;
         this.isExclusive = isExclusive1;
         this.isExhaustive = isExhaustive1;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/IErrorLogger.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/IErrorLogger.java
@@ -47,14 +47,14 @@ public interface IErrorLogger {
      *
      * @param classDescriptor
      *            ClassDescriptor of a missing class
-     * @param exception
-     *            The exception thrown when trying to get the class
+     * @param throwable
+     *            The throwable thrown when trying to get the class
      */
-    public default void reportMissingClass(ClassDescriptor classDescriptor, CheckedAnalysisException exception) {
-        if (exception instanceof MissingClassException) {
+    public default void reportMissingClass(ClassDescriptor classDescriptor, Throwable throwable) {
+        if (throwable instanceof MissingClassException) {
             reportMissingClass(classDescriptor);
         } else {
-            logError("Could not find class " + classDescriptor.getDottedClassName(), exception);
+            logError("Could not find class " + classDescriptor.getDottedClassName(), throwable);
         }
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/IErrorLogger.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/IErrorLogger.java
@@ -47,14 +47,14 @@ public interface IErrorLogger {
      *
      * @param classDescriptor
      *            ClassDescriptor of a missing class
-     * @param throwable
-     *            The throwable thrown when trying to get the class
+     * @param exception
+     *            The exception thrown when trying to get the class
      */
-    public default void reportMissingClass(ClassDescriptor classDescriptor, Throwable throwable) {
-        if (throwable instanceof MissingClassException) {
+    public default void reportMissingClass(ClassDescriptor classDescriptor, CheckedAnalysisException exception) {
+        if (exception instanceof MissingClassException) {
             reportMissingClass(classDescriptor);
         } else {
-            logError("Could not find class " + classDescriptor.getDottedClassName(), throwable);
+            logError("Error looking up class " + classDescriptor.getDottedClassName(), exception);
         }
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/IErrorLogger.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/IErrorLogger.java
@@ -43,6 +43,22 @@ public interface IErrorLogger {
     public void reportMissingClass(ClassDescriptor classDescriptor);
 
     /**
+     * Called to report a class lookup failure.
+     *
+     * @param classDescriptor
+     *            ClassDescriptor of a missing class
+     * @param exception
+     *            The exception thrown when trying to get the class
+     */
+    public default void reportMissingClass(ClassDescriptor classDescriptor, CheckedAnalysisException exception) {
+        if (exception instanceof MissingClassException) {
+            reportMissingClass(classDescriptor);
+        } else {
+            logError("Could not find class " + classDescriptor.getDottedClassName(), exception);
+        }
+    }
+
+    /**
      * Log an error that occurs while performing analysis.
      *
      * @param message

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ExplicitSerialization.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ExplicitSerialization.java
@@ -92,7 +92,7 @@ public class ExplicitSerialization extends OpcodeStackDetector implements NonRep
                 }
                 unreadFields.strongEvidenceForIntendedSerialization(c);
             } catch (CheckedAnalysisException e) {
-                bugReporter.logError("Error looking up xClass of " + c, e);
+                bugReporter.reportMissingClass(c, e);
             }
 
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindMaskedFields.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindMaskedFields.java
@@ -105,6 +105,7 @@ public class FindMaskedFields extends BytecodeScanningDetector {
             try {
                 c = Global.getAnalysisCache().getClassAnalysis(XClass.class, s);
             } catch (CheckedAnalysisException e) {
+                bugReporter.reportMissingClass(s, e);
                 break;
             }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNoSideEffectMethods.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNoSideEffectMethods.java
@@ -353,6 +353,7 @@ public class FindNoSideEffectMethods extends OpcodeStackDetector implements NonR
                         sawCall(new MethodCall(matchingMethod.getMethodDescriptor(), TARGET_THIS), false);
                     }
                 } catch (CheckedAnalysisException e) {
+                    AnalysisContext.currentAnalysisContext().getLookupFailureCallback().reportMissingClass(subtype, e);
                 }
             }
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InvalidJUnitTest.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InvalidJUnitTest.java
@@ -101,6 +101,7 @@ public class InvalidJUnitTest extends BytecodeScanningDetector {
             }
             return isJunit3TestCase(sClass);
         } catch (CheckedAnalysisException e) {
+            bugReporter.reportMissingClass(sDesc, e);
             return false;
         }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/Naming.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/Naming.java
@@ -337,7 +337,7 @@ public class Naming extends PreorderVisitor implements Detector {
      *            class descriptor we want to check
      * @return true iff the descriptor ultimately inherits from Exception
      */
-    private static boolean mightInheritFromException(ClassDescriptor d) {
+    private boolean mightInheritFromException(ClassDescriptor d) {
         while (d != null) {
             try {
                 if ("java.lang.Exception".equals(d.getDottedClassName())) {
@@ -346,6 +346,7 @@ public class Naming extends PreorderVisitor implements Detector {
                 XClass classNameAndInfo = Global.getAnalysisCache().getClassAnalysis(XClass.class, d);
                 d = classNameAndInfo.getSuperclassDescriptor();
             } catch (CheckedAnalysisException e) {
+            	bugReporter.reportMissingClass(d, e);
                 return true; // don't know
             }
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/Naming.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/Naming.java
@@ -346,7 +346,7 @@ public class Naming extends PreorderVisitor implements Detector {
                 XClass classNameAndInfo = Global.getAnalysisCache().getClassAnalysis(XClass.class, d);
                 d = classNameAndInfo.getSuperclassDescriptor();
             } catch (CheckedAnalysisException e) {
-            	bugReporter.reportMissingClass(d, e);
+                bugReporter.reportMissingClass(d, e);
                 return true; // don't know
             }
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/OverridingEqualsNotSymmetrical.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/OverridingEqualsNotSymmetrical.java
@@ -391,6 +391,7 @@ public class OverridingEqualsNotSymmetrical extends OpcodeStackDetector implemen
                                         try {
                                             Global.getAnalysisCache().getClassAnalysis(XClass.class, c);
                                         } catch (CheckedAnalysisException e) {
+                                            bugReporter.reportMissingClass(c, e);
                                             continue;
                                         }
                                         XMethod m = Hierarchy2.findMethod(c, "equals", "(Ljava/lang/Object;)Z", false);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ResolveAllReferences.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ResolveAllReferences.java
@@ -31,7 +31,6 @@ import edu.umd.cs.findbugs.ba.ch.Subtypes2;
 import edu.umd.cs.findbugs.classfile.CheckedAnalysisException;
 import edu.umd.cs.findbugs.classfile.Global;
 import edu.umd.cs.findbugs.classfile.IAnalysisCache;
-import edu.umd.cs.findbugs.classfile.MissingClassException;
 import edu.umd.cs.findbugs.util.ClassName;
 import edu.umd.cs.findbugs.util.NestedAccessUtil;
 import edu.umd.cs.findbugs.visitclass.PreorderVisitor;
@@ -61,10 +60,8 @@ public class ResolveAllReferences extends PreorderVisitor implements Detector {
                 try {
                     JavaClass jclass = analysisCache.getClassAnalysis(JavaClass.class, c.getClassDescriptor());
                     addAllDefinitions(jclass);
-                } catch (MissingClassException e) {
-                    bugReporter.reportMissingClass(e.getClassDescriptor());
                 } catch (CheckedAnalysisException e) {
-                    bugReporter.logError("Could not find class " + c.getClassDescriptor().toDottedClassName(), e);
+                    bugReporter.reportMissingClass(c.getClassDescriptor(), e);
                 }
             }
             // System.out.println("Done Computing: " +


### PR DESCRIPTION
`analysisCache.getClassAnalysis(JavaClass.class, ...)` throws `CheckedAnalysisException` which could be a `MissingClassException`. Added a reporting method so we don't need to use a try/multi catch block