### PR TITLE
Consider JUnit setUp() methods when looking for uninitialized fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Fix `AT_NONATOMIC_OPERATIONS_ON_SHARED_VARIABLE` when field of a local variable is set. ([#3459](https://github.com/spotbugs/spotbugs/pull/3459))
 - Fix `AT_NONATOMIC_OPERATIONS_ON_SHARED_VARIABLE` FP when there was no compound operation ([#3363](https://github.com/spotbugs/spotbugs/issues/3363))
 - Fix `NM_FIELD_NAMING_CONVENTION` crash in the TestASM detector ([#3489](https://github.com/spotbugs/spotbugs/pull/3489))
+- Do not report `UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR` for fields initialized in JUnit 3/4 `setUp()` method. ([#3169](https://github.com/spotbugs/spotbugs/issues/3169))
 
 ### Added
 - Added the unnecessary annotation to the `US_USELESS_SUPPRESSION_ON_*` messages ([#3395](https://github.com/spotbugs/spotbugs/issues/3395))

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3169Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3169Test.java
@@ -1,0 +1,14 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class Issue3169Test extends AbstractIntegrationTest {
+
+    @Test
+    void testIssue() {
+        performAnalysis("ghIssues/Issue3169.class");
+
+        assertNoBugType("UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR");
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InvalidJUnitTest.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InvalidJUnitTest.java
@@ -81,7 +81,7 @@ public class InvalidJUnitTest extends BytecodeScanningDetector {
 
     }
 
-    private boolean isJunit3TestCase(XClass jClass) throws ClassNotFoundException {
+    public static boolean isJunit3TestCase(XClass jClass) throws ClassNotFoundException {
         ClassDescriptor sDesc = jClass.getSuperclassDescriptor();
         if (sDesc == null) {
             return false;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UnreadFields.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UnreadFields.java
@@ -858,6 +858,14 @@ public class UnreadFields extends OpcodeStackDetector {
             }
         }
 
+        try {
+            if ("setUp".equals(getMethodName()) && InvalidJUnitTest.isJunit3TestCase(getXClass())) {
+                return true;
+            }
+        } catch (ClassNotFoundException e) {
+            bugReporter.reportMissingClass(e);
+        }
+
         return false;
     }
 

--- a/spotbugsTestCases/src/java/ghIssues/Issue3169.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3169.java
@@ -1,0 +1,21 @@
+package ghIssues;
+
+import junit.framework.TestCase;
+
+public class Issue3169 extends TestCase {
+	private String x;
+	private int y;
+	
+	public Issue3169() {
+		y = 12;
+	}
+
+	@Override
+	protected void setUp() throws Exception {
+		x = "42";
+	}
+	
+	public int doStuff() {
+		return x.length() * y;
+	}
+}


### PR DESCRIPTION
JUnit 3/4 has the constructor-like `junit.framework.TestCase.setUp()` method for fields initialization.
This should fix #3169 