### PR TITLE
Let `UnreadFields` consider all suppress annotations as "known"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Fix `AT_NONATOMIC_OPERATIONS_ON_SHARED_VARIABLE` when field of a local variable is set. ([#3459](https://github.com/spotbugs/spotbugs/pull/3459))
 - Fix `AT_NONATOMIC_OPERATIONS_ON_SHARED_VARIABLE` FP when there was no compound operation ([#3363](https://github.com/spotbugs/spotbugs/issues/3363))
 - Fix `NM_FIELD_NAMING_CONVENTION` crash in the TestASM detector ([#3489](https://github.com/spotbugs/spotbugs/pull/3489))
+- Fix `US_USELESS_SUPPRESSION_ON_FIELD`/`UUF_UNUSED_FIELD` false positive ([#3496](https://github.com/spotbugs/spotbugs/pull/3496))
 
 ### Added
 - Added the unnecessary annotation to the `US_USELESS_SUPPRESSION_ON_*` messages ([#3395](https://github.com/spotbugs/spotbugs/issues/3395))

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/WarningSuppressorTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/WarningSuppressorTest.java
@@ -34,6 +34,15 @@ class WarningSuppressorTest extends AbstractIntegrationTest {
         assertBugInMethod("US_USELESS_SUPPRESSION_ON_METHOD", "suppress.SuppressedBugs", "nonSuppressedNpeRegex");
     }
 
+    @Test
+    void customSuppressAnnotationTest() {
+        performAnalysis("suppress/custom/CustomSuppressedBugs.class", "suppress/custom/SuppressFBWarnings.class");
+
+        assertMethodBugsCount("suppressedNpePrefix", 0);
+
+        assertMethodBugsCount("suppressedNpeExact", 0);
+    }
+
     private void assertMethodBugsCount(String methodName, int expectedCount) {
         BugInstanceMatcher matcher = new BugInstanceMatcherBuilder().inMethod(methodName).build();
         assertThat(getBugCollection(), containsExactly(expectedCount, matcher));

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/WarningSuppressorTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/WarningSuppressorTest.java
@@ -35,12 +35,37 @@ class WarningSuppressorTest extends AbstractIntegrationTest {
     }
 
     @Test
-    void customSuppressAnnotationTest() {
+    void customSuppressAnnotationMethodTest() {
         performAnalysis("suppress/custom/CustomSuppressedBugs.class", "suppress/custom/SuppressFBWarnings.class");
 
         assertMethodBugsCount("suppressedNpePrefix", 0);
 
         assertMethodBugsCount("suppressedNpeExact", 0);
+
+        assertNoBugType("US_USELESS_SUPPRESSION_ON_FIELD");
+    }
+
+    @Test
+    void customSuppressAnnotationFieldTest() {
+        performAnalysis("suppress/custom/ExampleWithUnusedFields.class", "suppress/custom/SuppressFBWarnings.class");
+
+        // Field with an useless suppression
+        assertBugAtField("US_USELESS_SUPPRESSION_ON_FIELD", "suppress.custom.ExampleWithUnusedFields", "uselessSuppression");
+        assertBugAtField("UUF_UNUSED_FIELD", "suppress.custom.ExampleWithUnusedFields", "uselessSuppression");
+
+        // Field with an unknown annotation and an useless annotation
+        assertBugAtField("US_USELESS_SUPPRESSION_ON_FIELD", "suppress.custom.ExampleWithUnusedFields", "injectedAndUselessSuppression");
+
+        // unused field
+        assertBugAtField("UUF_UNUSED_FIELD", "suppress.custom.ExampleWithUnusedFields", "unused");
+
+        // unused field with suppress annotation: no bug expected here
+        assertNoBugAtField("UUF_UNUSED_FIELD", "suppress.custom.ExampleWithUnusedFields", "unusedSuppressed");
+        assertNoBugAtField("US_USELESS_SUPPRESSION_ON_FIELD", "suppress.custom.ExampleWithUnusedFields", "unusedSuppressed");
+
+        // Check the bug counts for this class
+        assertBugInClassCount("US_USELESS_SUPPRESSION_ON_FIELD", "suppress.custom.ExampleWithUnusedFields", 2);
+        assertBugInClassCount("UUF_UNUSED_FIELD", "suppress.custom.ExampleWithUnusedFields", 2);
     }
 
     private void assertMethodBugsCount(String methodName, int expectedCount) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/NoteSuppressedWarnings.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/NoteSuppressedWarnings.java
@@ -100,7 +100,7 @@ public class NoteSuppressedWarnings extends AnnotationVisitor implements Detecto
         }
     }
 
-    public boolean isSuppressWarnings(String annotationClass) {
+    public static boolean isSuppressWarnings(String annotationClass) {
         return annotationClass.endsWith("SuppressWarnings")
                 || annotationClass.endsWith("SuppressFBWarnings");
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UnreadFields.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UnreadFields.java
@@ -335,7 +335,9 @@ public class UnreadFields extends OpcodeStackDetector {
         if (isInjectionAttribute(annotationClass)) {
             data.containerFields.add(XFactory.createXField(this));
         }
-        if (!annotationClass.startsWith("edu.umd.cs.findbugs") && !annotationClass.startsWith("javax.lang")) {
+        if (!annotationClass.startsWith("edu.umd.cs.findbugs")
+                && !annotationClass.startsWith("javax.lang")
+                && !NoteSuppressedWarnings.isSuppressWarnings(annotationClass)) {
             data.unknownAnnotation.add(XFactory.createXField(this), annotationClass);
         }
 

--- a/spotbugsTestCases/src/java/suppress/custom/CustomSuppressedBugs.java
+++ b/spotbugsTestCases/src/java/suppress/custom/CustomSuppressedBugs.java
@@ -1,0 +1,17 @@
+package suppress.custom;
+
+public class CustomSuppressedBugs {
+	@SuppressFBWarnings(value = "NP")
+	public int suppressedNpePrefix() {
+		// NP_ALWAYS_NULL and NP_LOAD_OF_KNOWN_NULL_VALUE
+		String x = null;
+		return x.length();
+	}
+	
+	@SuppressFBWarnings(value = {"NP_ALWAYS_NULL", "NP_LOAD_OF_KNOWN_NULL_VALUE"})
+	public int suppressedNpeExact() {
+		// NP_ALWAYS_NULL and NP_LOAD_OF_KNOWN_NULL_VALUE
+		String x = null;
+		return x.length();
+	}
+}

--- a/spotbugsTestCases/src/java/suppress/custom/ExampleWithUnusedFields.java
+++ b/spotbugsTestCases/src/java/suppress/custom/ExampleWithUnusedFields.java
@@ -1,0 +1,20 @@
+package suppress.custom;
+
+import javax.inject.Inject;
+
+public class ExampleWithUnusedFields {
+    @SuppressFBWarnings("XYZ") // Expecting US_USELESS_SUPPRESSION_ON_FIELD and UUF_UNUSED_FIELD here
+    private String uselessSuppression;
+
+    @Inject
+    private String injected; // No bug expected here because there's an annotation
+
+    @SuppressFBWarnings("XYZ") // Expecting US_USELESS_SUPPRESSION_ON_FIELD here
+    @Inject
+    private String injectedAndUselessSuppression;
+
+    private String unused; // Expecting UUF_UNUSED_FIELD
+
+    @SuppressFBWarnings("UUF_UNUSED_FIELD")
+    private String unusedSuppressed;
+}

--- a/spotbugsTestCases/src/java/suppress/custom/SuppressFBWarnings.java
+++ b/spotbugsTestCases/src/java/suppress/custom/SuppressFBWarnings.java
@@ -1,0 +1,16 @@
+package suppress.custom;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A custom SuppressFBWarnings annotation lacking the matchType
+ */
+@Target({ ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.FIELD, ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SuppressFBWarnings {
+    String[] value();
+    String justification() default "";
+}


### PR DESCRIPTION
Currently `UnreadFields` checks for some known annotations and does `annotationClass.startsWith("edu.umd.cs.findbugs")` to sort out `@SuppressFBWarning`. Fields annotated with "unknown" annotations are assumed to be used.

When a field was annotated with a custom suppression annotation (e.g. `@my.custom.SuppressFBWarning("...")`) the field was considered used, therefore no bug was reported and in the end the annotation was flagged with `US_USELESS_SUPPRESSION_ON_FIELD`

The solution is to use the same method to check if an annotation is a suppression.

This should fix #3492 