### PR TITLE
Make the osgi manifest of the annotations jar Java 8 compatible

### DIFF
--- a/spotbugs-annotations/build.gradle
+++ b/spotbugs-annotations/build.gradle
@@ -23,7 +23,7 @@ def manifestSpec = java.manifest {
                'Bundle-SymbolicName': 'spotbugs-annotations',
                'Bundle-Version': project.version.replace('-', '.'),
                'Export-Package': 'edu.umd.cs.findbugs.annotations',
-               'Bundle-RequiredExecutionEnvironment': 'JavaSE-11',
+               'Bundle-RequiredExecutionEnvironment': 'JavaSE-1.8',
                'Bundle-ManifestVersion': '2'
 }
 
@@ -41,7 +41,7 @@ def jar = tasks.named('jar', Jar) {
                'Bundle-SymbolicName': 'spotbugs-annotations',
                'Bundle-Version': project.version.replace('-', '.'),
                'Export-Package': 'edu.umd.cs.findbugs.annotations',
-               'Bundle-RequiredExecutionEnvironment': 'JavaSE-11',
+               'Bundle-RequiredExecutionEnvironment': 'JavaSE-1.8',
                'Bundle-ManifestVersion': '2'
   }
 }


### PR DESCRIPTION
As discussed in #3498 we can revert the annotations jar to java 8 compatibility