### PR TITLE
[gha] Disable gpg signing on *nix for time being and change release tto run from windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,18 +59,19 @@ jobs:
           cp -r /Volumes/Eclipse/Eclipse.app /Applications/
           hdiutil detach /Volumes/Eclipse
           echo "eclipseRoot.dir=/Applications/Eclipse.app" | tee eclipsePlugin/local.properties
-      - name: Pre-build setup
-        if: matrix.os != 'windows-latest'
-        run: |
-          echo "keystorepass=${KEYSTORE_PASS}" >> gradle.properties
-          git fetch --no-tags https://$GITHUB_TOKEN@github.com/spotbugs/spotbugs.git +refs/heads/master:refs/remotes/origin/master
-          if [ "$GPG_SECRET_PASSPHRASE" != "" ]; then
-            gpg --quiet --batch --yes --decrypt --passphrase="$GPG_SECRET_PASSPHRASE" --output spotbugs.jks .github/workflows/spotbugs.jks.gpg;
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GPG_SECRET_PASSPHRASE: ${{ secrets.GPG_SECRET_PASSPHRASE }}
-          KEYSTORE_PASS: ${{ secrets.KEYSTORE_PASS }}
+      # Disable gpg signing on *nix for time being until we get new keys established, checks will be on windows only for now
+      #- name: Pre-build setup
+      #  if: matrix.os != 'windows-latest'
+      #  run: |
+      #    echo "keystorepass=${KEYSTORE_PASS}" >> gradle.properties
+      #    git fetch --no-tags https://$GITHUB_TOKEN@github.com/spotbugs/spotbugs.git +refs/heads/master:refs/remotes/origin/master
+      #    if [ "$GPG_SECRET_PASSPHRASE" != "" ]; then
+      #      gpg --quiet --batch --yes --decrypt --passphrase="$GPG_SECRET_PASSPHRASE" --output spotbugs.jks .github/workflows/spotbugs.jks.gpg;
+      #    fi
+      #  env:
+      #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #    GPG_SECRET_PASSPHRASE: ${{ secrets.GPG_SECRET_PASSPHRASE }}
+      #    KEYSTORE_PASS: ${{ secrets.KEYSTORE_PASS }}
       - name: Pre-build setup Windows
         if: matrix.os == 'windows-latest'
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       contents: write # to push pages branch (peaceiris/actions-gh-pages)
 
     if: github.repository_owner == 'spotbugs'
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
There is nothing directly wrong with the various keys involved here.  However, the gpg key was generated from windows and seems to contain windows line endings.  Therefore it does not work on *nix.  So this just simply changes it.  Confirmation it was fine was done on the archetype project successfully.  It is still known the underlying keystore used for eclipse is expired and needs replaced or turned off.  The intent for time being is to see if this causes eclipse to release again at least as its not been releasing for some time.  Once that is confirmed, likely will just move to release and come back to the issues later.