### PR TITLE
Synchronize Eclipse and TextUICommandLine execution to use same options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Do not report `UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR` for fields initialized in JUnit 3/4 `setUp()` method. ([#3169](https://github.com/spotbugs/spotbugs/issues/3169))
 - Fix `US_USELESS_SUPPRESSION_ON_FIELD`/`UUF_UNUSED_FIELD` false positive ([#3496](https://github.com/spotbugs/spotbugs/pull/3496))
 - Make the osgi manifest of the annotations jar Java 8 compatible  ([#3498](https://github.com/spotbugs/spotbugs/pull/3498)) ([#3500](https://github.com/spotbugs/spotbugs/pull/3500))
+- `TextUICommandLine` supports all options encoded in Eclipse preferences file ([#3520](https://github.com/spotbugs/spotbugs/issues/3520))
 
 ### Added
 - Added the unnecessary annotation to the `US_USELESS_SUPPRESSION_ON_*` messages ([#3395](https://github.com/spotbugs/spotbugs/issues/3395))

--- a/eclipsePlugin/src/de/tobject/findbugs/builder/FindBugsWorker.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/builder/FindBugsWorker.java
@@ -206,7 +206,7 @@ public class FindBugsWorker {
 
         // configure extended preferences
         findBugs.setAnalysisFeatureSettings(userPrefs.getAnalysisFeatureSettings());
-        findBugs.setMergeSimilarWarnings(false);
+        findBugs.setMergeSimilarWarnings(userPrefs.getMergeSimilarWarnings());
 
         if (cacheClassData) {
             FindBugs2Eclipse.checkClassPathChanges(findBugs.getProject().getAuxClasspathEntryList(), project);

--- a/eclipsePlugin/src/de/tobject/findbugs/messages.properties
+++ b/eclipsePlugin/src/de/tobject/findbugs/messages.properties
@@ -18,6 +18,7 @@ property.detectorsTab=Detector configuration
 property.filterFilesTab=Filter files
 property.categoriesGroup=Reported (visible) bug categories
 property.reportConfigurationTab=Reporter Configuration
+property.mergeSimilarWarnings=Merge similar warnings
 
 property.tabgeneral=General
 property.tabextended=Extended

--- a/eclipsePlugin/src/de/tobject/findbugs/properties/ReportConfigurationTab.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/properties/ReportConfigurationTab.java
@@ -84,6 +84,7 @@ public class ReportConfigurationTab extends Composite {
 
     private MarkerSeverity initialOfConcernRank;
 
+    private final Button mergeSimilarWarnings;
 
     public ReportConfigurationTab(TabFolder parent, FindbugsPropertyPage page, int style) {
         super(parent, style);
@@ -97,6 +98,18 @@ public class ReportConfigurationTab extends Composite {
 
         Composite rankAndPrioGroup = new Composite(this, SWT.NONE);
         rankAndPrioGroup.setLayout(new GridLayout(2, false));
+
+        mergeSimilarWarnings = new Button(rankAndPrioGroup, SWT.CHECK);
+        mergeSimilarWarnings.setText(getMessage("property.mergeSimilarWarnings"));
+        mergeSimilarWarnings.setLayoutData(new GridData(SWT.BEGINNING, SWT.CENTER, false, false, 2, 1));
+        mergeSimilarWarnings.setSelection(getCurrentProps().getMergeSimilarWarnings());
+        mergeSimilarWarnings.addSelectionListener(new SelectionAdapter() {
+            @Override
+            public void widgetSelected(SelectionEvent event) {
+                boolean merge = mergeSimilarWarnings.getSelection();
+                getCurrentProps().setMergeSimilarWarnings(merge);
+            }
+        });
 
         createRankGroup(rankAndPrioGroup);
         createPriorityGroup(rankAndPrioGroup);
@@ -353,6 +366,7 @@ public class ReportConfigurationTab extends Composite {
             checkBox.setSelection(filterSettings.containsCategory((String) checkBox.getData()));
         }
         syncSelectedCategories();
+        mergeSimilarWarnings.setSelection(prefs.getMergeSimilarWarnings());
     }
 
     protected List<Button> getChkEnableBugCategoryList() {


### PR DESCRIPTION
`TextUICommandLine` supports now all options encoded in Eclipse preferences file, and Eclipse doesn't hard code analysis options.

Fixes https://github.com/spotbugs/spotbugs/issues/3520