### PR TITLE
[gha] Move git for previous tag to use powershell and better git logic

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Get previous tag for the change log
         id: previousTag
         run: |
-          name=$(git --no-pager tag --sort=creatordate --merged ${{ github.ref_name }} | tail -2 | head -1)
+          name=$(git for-each-ref --merged=${{ github.ref_name }} --sort=creatordate --format='%(refname:short)' refs/tags | Select-Object -Last 2 | Select-Object -First 1)
           echo "previousTag: $name"
           echo "previousTag=$name" >> $GITHUB_ENV
 


### PR DESCRIPTION
The original is not very precise, drops to using system level tail/head that isn't on windows, this should be pure git and while still uses that should not delegate to the platform.