### PR TITLE
Fix rest of annotatons jar to remain at java 8

### DIFF
--- a/spotbugs-annotations/build.gradle
+++ b/spotbugs-annotations/build.gradle
@@ -8,9 +8,9 @@ tasks.named('compileJava', JavaCompile).configure {
 
 eclipse {
   jdt {
-    sourceCompatibility = 11
-    targetCompatibility = 11
-    javaRuntimeName = "JavaSE-11"
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
+    javaRuntimeName = "JavaSE-1.8"
   }
 }
 

--- a/spotbugs-annotations/build.gradle
+++ b/spotbugs-annotations/build.gradle
@@ -8,8 +8,8 @@ tasks.named('compileJava', JavaCompile).configure {
 
 eclipse {
   jdt {
-    sourceCompatibility = 1.8
-    targetCompatibility = 1.8
+    sourceCompatibility = 8
+    targetCompatibility = 8
     javaRuntimeName = "JavaSE-1.8"
   }
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/JavaVersion.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/JavaVersion.java
@@ -46,11 +46,6 @@ public class JavaVersion {
     }
 
     /**
-     * StaticConstant for Java 1.5 (Tiger).
-     */
-    public static final JavaVersion JAVA_1_5 = new JavaVersion(1, 5);
-
-    /**
      * Constructor.
      *
      * @param versionString


### PR DESCRIPTION
While meta data and osgi data updated, the item was still compiled to java 11, fixes this.  Did not add change log since this was already documented to be fixed and we had not yet released.

I also removed legacy static for java 5 that isn't used.