### PR TITLE
Migrate to central publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,9 +128,12 @@ createReleaseBody.configure {
 }
 
 nexusPublishing {
-    repositories {
-        sonatype()
+  repositories {
+    sonatype {
+      nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+      snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
     }
+  }
 }
 
 apply from: "$rootDir/gradle/sonar.gradle"

--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -4,6 +4,12 @@ apply plugin: 'signing'
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT") && /* for Eclipse plugin */ !version.contains("-SNAPSHOT.")
 
 publishing {
+  repositories {
+    maven {
+      name = 'ossrh-staging-api'
+      url = "https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/"
+      }
+  }
   publications {
     maven(MavenPublication) {
       from components.java


### PR DESCRIPTION
old hosting shut down 6/30/2025.  This moves it over.  There is no official plugin so the overrides are required.