### PR TITLE
Dead store fix when switch case contains loops

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3530Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3530Test.java
@@ -1,0 +1,18 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class Issue3530Test extends AbstractIntegrationTest {
+
+    @Test
+    void testFallthrough() {
+        performAnalysis("ghIssues/Issue3530.class");
+
+        assertBugInMethod("SF_DEAD_STORE_DUE_TO_SWITCH_FALLTHROUGH", "ghIssues.Issue3530", "switchForLoop");
+        assertBugInMethod("SF_SWITCH_FALLTHROUGH", "ghIssues.Issue3530", "switchForLoop");
+
+        assertBugInMethod("SF_DEAD_STORE_DUE_TO_SWITCH_FALLTHROUGH_TO_THROW", "ghIssues.Issue3530", "switchWhileLoop");
+        assertBugInMethod("SF_SWITCH_FALLTHROUGH", "ghIssues.Issue3530", "switchWhileLoop");
+    }
+}

--- a/spotbugsTestCases/src/java/ghIssues/Issue3530.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3530.java
@@ -1,0 +1,41 @@
+package ghIssues;
+
+public class Issue3530 {
+
+	// Issue 3530
+    public String switchForLoop(int value) {
+        String valueType = null;
+        switch (value % 2) {
+            case 0:
+                valueType = "even";        // this falls through and is over-written by valueType = "odd";
+                for (int i = 0; i < 5; i++) {
+                    System.out.println("Nice even value: " + i);
+                }
+            case 1:
+                valueType = "odd";
+                break;
+            default:
+                valueType = "invalid number";
+        }
+        return valueType;
+    }
+    
+    // Issue 3449
+    public int switchWhileLoop(int input) {
+        int i = 0;
+        int result = 0;
+        switch (input) {
+            case 1:
+                result = 10;
+                while (i < input) {
+                    System.out.println(i);
+                    i++;
+                }
+            case 2:
+                throw new IllegalArgumentException("Invalid input");
+            default:
+                result = input * 2;
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
When looking for dead stores due to switch fall through SpotBugs currently gives up when a switch case contains a branch instruction (such as a `break`).
We only care for breaks, because they target an instruction outside of the current case. For other instructions (such as the `goto` of a loop) we are remaining inside the current case.

This should fix #3530 and #3449