### PR TITLE
Disable the SpotBugs analysis on sample code to speed up the build

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/AbstractIntegrationTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/AbstractIntegrationTest.java
@@ -129,7 +129,7 @@ public abstract class AbstractIntegrationTest {
             throw new UncheckedIOException(e);
         }
 
-        final Path dependencies = getFindbugsTestCases().resolve("build/spotbugs/auxclasspath/spotbugsMain");
+        final Path dependencies = getFindbugsTestCases().resolve("build/runtime-classpath.txt");
         try {
             final List<String> lines = Files.readAllLines(dependencies);
             for (String line : lines) {

--- a/spotbugsTestCases/build.gradle
+++ b/spotbugsTestCases/build.gradle
@@ -40,6 +40,25 @@ dependencies {
   implementation 'org.mockito:mockito-core:5.18.0'
 }
 
+// spotbugs takes a long time to analyse the module but we don't need that
+project.tasks.getByName('spotbugsMain').enabled = false
+
+// generate a file with the list of runtime dependencies
+tasks.register('exportClasspath') {
+  def File dependenciesFile = new File('spotbugsTestCases/build/runtime-classpath.txt')
+  
+  doLast {
+    dependenciesFile.delete()
+    dependenciesFile.getParentFile().mkdirs();
+    
+    project.configurations.getByName('runtimeClasspath').resolvedConfiguration.resolvedArtifacts.each {
+      dependenciesFile << it.file
+      dependenciesFile << '\n'
+    }
+  }
+  println dependenciesFile
+}
+
 tasks.withType(JavaCompile).configureEach {
   options.compilerArgs << '-Xlint:none'
   options.encoding = 'UTF-8'
@@ -105,14 +124,11 @@ tasks.named('classes').configure {
   } else {
     println "skip tests for Java 21 features"
   }
+  dependsOn exportClasspath
 }
 
 sonar {
   // this project should not be analyzed with sonarqube
   // as it is test data, not real code
   skipProject true
-}
-
-spotbugs {
-  ignoreFailures = true
 }


### PR DESCRIPTION
The current build includes the analysis (through the SpotBugs gradle plugin) of the test cases, this poses several problems:
- The analysis of the sample code takes a long time
- It is on the critical path so it slows down the overall build
- It runs with an older version of SpotBugs, so it occasionally crashes when a new sample was added and the sample was reproducing a crash.
- 
The analysis produces a 'spotbugsMain' file containing all the dependencies and this is used in the integration test, replace that by a custom gradle task.