### PR TITLE
Remove the broken changelog update task

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,24 +31,6 @@ jobs:
           echo "previousTag: $name"
           echo "previousTag=$name" >> $GITHUB_ENV
 
-      - name: Update CHANGELOG
-        id: changelog
-        uses: requarks/changelog-action@v1
-        with:
-          token: ${{ github.token }}
-          toTag: ${{ env.previousTag }}
-          fromTag: ${{ github.ref_name }}
-          writeToFile: true
-        continue-on-error: true
-
-      - name: Commit CHANGELOG.md
-        if: (github.ref_type == 'tag') && (github.event.base_ref == 'refs/heads/master')
-        uses: stefanzweifel/git-auto-commit-action@v6
-        with:
-          branch: ${{ github.base_ref}}
-          commit_message: 'docs: update CHANGELOG.md for ${{ github.ref_name }}'
-          file_pattern: CHANGELOG.md
-
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
The changelog automation never really worked and currently fails with "Must provide either input tag OR (fromTag and toTag). None were provided!".
Remove this unused task to reduce the clutter