### PR TITLE
Consider fields when looking for side effects in assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - `TextUICommandLine` supports all options encoded in Eclipse preferences file ([#3520](https://github.com/spotbugs/spotbugs/issues/3520))
 - Unnecessary suppressions fix for records headers ([#3471](https://github.com/spotbugs/spotbugs/issues/3471))
 - Dead store fix when switch case contains loops  ([#3530](https://github.com/spotbugs/spotbugs/issues/3530))  ([#3449](https://github.com/spotbugs/spotbugs/issues/3449))
--  Consider PUTFIELD and PUTSTATIC when looking for side effects ([#3463](https://github.com/spotbugs/spotbugs/issues/3463))
+-  Consider PUTFIELD and PUTSTATIC when looking for assertions with side effects ([#3463](https://github.com/spotbugs/spotbugs/issues/3463))
 
 ### Added
 - Added the unnecessary annotation to the `US_USELESS_SUPPRESSION_ON_*` messages ([#3395](https://github.com/spotbugs/spotbugs/issues/3395))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - `TextUICommandLine` supports all options encoded in Eclipse preferences file ([#3520](https://github.com/spotbugs/spotbugs/issues/3520))
 - Unnecessary suppressions fix for records headers ([#3471](https://github.com/spotbugs/spotbugs/issues/3471))
 - Dead store fix when switch case contains loops  ([#3530](https://github.com/spotbugs/spotbugs/issues/3530))  ([#3449](https://github.com/spotbugs/spotbugs/issues/3449))
+-  Consider PUTFIELD and PUTSTATIC when looking for side effects ([#3463](https://github.com/spotbugs/spotbugs/issues/3463))
 
 ### Added
 - Added the unnecessary annotation to the `US_USELESS_SUPPRESSION_ON_*` messages ([#3395](https://github.com/spotbugs/spotbugs/issues/3395))

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3463Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3463Test.java
@@ -1,0 +1,15 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class Issue3463Test extends AbstractIntegrationTest {
+
+    @Test
+    void testIssue() {
+        performAnalysis("ghIssues/Issue3463.class");
+
+        assertBugInMethod("ASE_ASSERTION_WITH_SIDE_EFFECT", "ghIssues/Issue3463", "testField");
+        assertBugInMethod("ASE_ASSERTION_WITH_SIDE_EFFECT", "ghIssues/Issue3463", "testStaticField");
+    }
+}

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3463Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3463Test.java
@@ -9,7 +9,7 @@ class Issue3463Test extends AbstractIntegrationTest {
     void testIssue() {
         performAnalysis("ghIssues/Issue3463.class");
 
-        assertBugInMethod("ASE_ASSERTION_WITH_SIDE_EFFECT", "ghIssues/Issue3463", "testField");
-        assertBugInMethod("ASE_ASSERTION_WITH_SIDE_EFFECT", "ghIssues/Issue3463", "testStaticField");
+        assertBugInMethod("ASE_ASSERTION_WITH_SIDE_EFFECT", "ghIssues.Issue3463", "testField");
+        assertBugInMethod("ASE_ASSERTION_WITH_SIDE_EFFECT", "ghIssues.Issue3463", "testStaticField");
     }
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindAssertionsWithSideEffects.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindAssertionsWithSideEffects.java
@@ -53,7 +53,9 @@ public class FindAssertionsWithSideEffects extends AbstractAssertDetector {
                 seen == Const.ISTORE_0 ||
                 seen == Const.ISTORE_1 ||
                 seen == Const.ISTORE_2 ||
-                seen == Const.ISTORE_3;
+                seen == Const.ISTORE_3 ||
+                seen == Const.PUTFIELD ||
+                seen == Const.PUTSTATIC;
     }
 
     /**

--- a/spotbugsTestCases/src/java/ghIssues/Issue3463.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3463.java
@@ -1,0 +1,19 @@
+package ghIssues;
+
+public class Issue3463 {
+	private static int staticCounter;
+	
+	private int counter;
+	
+	public int testField() {
+		// Expecting ASE_ASSERTION_WITH_SIDE_EFFECT here
+		assert ++counter > 0;
+		return counter;
+	}
+	
+	public static int testStaticField() {
+		// Expecting ASE_ASSERTION_WITH_SIDE_EFFECT here
+		assert ++staticCounter > 0;
+		return staticCounter;
+	}
+}


### PR DESCRIPTION
As reported in #3463 the instance fields and static fields were not considered, this should fix #3463