### PR TITLE
Detect equals() unconditionally returning true or false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Unnecessary suppressions fix for records headers ([#3471](https://github.com/spotbugs/spotbugs/issues/3471))
 - Dead store fix when switch case contains loops  ([#3530](https://github.com/spotbugs/spotbugs/issues/3530))  ([#3449](https://github.com/spotbugs/spotbugs/issues/3449))
 -  Consider PUTFIELD and PUTSTATIC when looking for assertions with side effects ([#3463](https://github.com/spotbugs/spotbugs/issues/3463))
+- Detect cases when equals() unconditionally returns true or false ([#3528](https://github.com/spotbugs/spotbugs/issues/3528))
 
 ### Added
 - Added the unnecessary annotation to the `US_USELESS_SUPPRESSION_ON_*` messages ([#3395](https://github.com/spotbugs/spotbugs/issues/3395))

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3528Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3528Test.java
@@ -1,0 +1,14 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+
+class Issue3528Test extends AbstractIntegrationTest {
+    @Test
+    void testEquals() {
+        performAnalysis("ghIssues/Issue3528.class");
+
+        assertBugTypeCount("EQ_ALWAYS_TRUE", 1);
+    }
+}

--- a/spotbugsTestCases/src/java/ghIssues/Issue3528.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3528.java
@@ -1,0 +1,15 @@
+package ghIssues;
+
+public class Issue3528 {
+	@Override
+	public int hashCode() {
+		return 42;
+	}
+	
+	@Override
+	public boolean equals(Object obj) {
+	    boolean checkEqual = (obj instanceof Issue3528);
+	    System.out.println(checkEqual);
+	    return true; // expecting EQ_ALWAYS_TRUE here
+	}
+}


### PR DESCRIPTION
As noted in #3528 the detection of equals() always returning true or false only works if the `return` is the very first instruction.

Extend the detector to also consider cases when there was no branch prior to that `return`

This should fix #3528 