### PR TITLE
Do not report `IT_NO_SUCH_ELEMENT` when `hasNext()` returns true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Dead store fix when switch case contains loops  ([#3530](https://github.com/spotbugs/spotbugs/issues/3530))  ([#3449](https://github.com/spotbugs/spotbugs/issues/3449))
 -  Consider PUTFIELD and PUTSTATIC when looking for assertions with side effects ([#3463](https://github.com/spotbugs/spotbugs/issues/3463))
 - Detect cases when equals() unconditionally returns true or false ([#3528](https://github.com/spotbugs/spotbugs/issues/3528))
-
+- Do not report that an Iterator does not throw `NoSuchElementException` when `hasNext()` returns true ([#3501](https://github.com/spotbugs/spotbugs/issues/3501))
 ### Added
 - Added the unnecessary annotation to the `US_USELESS_SUPPRESSION_ON_*` messages ([#3395](https://github.com/spotbugs/spotbugs/issues/3395))
 - Multi-threaded code checks can be skipped with `@NotThreadSafe` ([#3390](https://github.com/spotbugs/spotbugs/issues/3390))

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3501Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3501Test.java
@@ -1,0 +1,14 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+
+class Issue3501Test extends AbstractIntegrationTest {
+    @Test
+    void testEquals() {
+        performAnalysis("ghIssues/Issue3501.class");
+
+        assertBugTypeCount("IT_NO_SUCH_ELEMENT", 0);
+    }
+}

--- a/spotbugsTestCases/src/java/ghIssues/Issue3501.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3501.java
@@ -1,0 +1,21 @@
+package ghIssues;
+
+import java.util.Iterator;
+
+public class Issue3501<T> implements Iterator<T> {
+    private final T value;
+
+    private Issue3501(T value) {
+        this.value = value;
+    }
+
+    @Override
+    public boolean hasNext() {
+        return true;
+    }
+
+    @Override
+    public T next() {
+        return value;
+    }
+}


### PR DESCRIPTION
Check for the case when `Iterator.hasNext()` returns true unconditionally, then it is OK for next() to omit throwing `NoSuchElementException`

This should fix #3501