### PR TITLE
Detect random value cast to int when stored in temporary variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 -  Consider PUTFIELD and PUTSTATIC when looking for assertions with side effects ([#3463](https://github.com/spotbugs/spotbugs/issues/3463))
 - Detect cases when equals() unconditionally returns true or false ([#3528](https://github.com/spotbugs/spotbugs/issues/3528))
 - Do not report that an Iterator does not throw `NoSuchElementException` when `hasNext()` returns true ([#3501](https://github.com/spotbugs/spotbugs/issues/3501))
+- Detect random value cast to int when stored in temporary variable ([#3461](https://github.com/spotbugs/spotbugs/issues/3461))
+
 ### Added
 - Added the unnecessary annotation to the `US_USELESS_SUPPRESSION_ON_*` messages ([#3395](https://github.com/spotbugs/spotbugs/issues/3395))
 - Multi-threaded code checks can be skipped with `@NotThreadSafe` ([#3390](https://github.com/spotbugs/spotbugs/issues/3390))

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3461Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3461Test.java
@@ -1,0 +1,14 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class Issue3461Test extends AbstractIntegrationTest {
+
+    @Test
+    void testRandomValue() {
+        performAnalysis("ghIssues/Issue3461.class");
+
+        assertBugTypeCount("RV_01_TO_INT", 1);
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DumbMethods.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DumbMethods.java
@@ -555,7 +555,10 @@ public class DumbMethods extends OpcodeStackDetector {
 
     private int sinceBufferedInputStreamReady;
 
-    private int randomNextIntState;
+    private RandomNextIntState randomNextIntState;
+
+    // The register where we stored the result of random.nextValue()
+    private int randomNextIntRegister;
 
     private boolean checkForBitIorofSignedByte;
 
@@ -642,7 +645,7 @@ public class DumbMethods extends OpcodeStackDetector {
         }
         primitiveObjCtorSeen = null;
         ctorSeen = false;
-        randomNextIntState = 0;
+        randomNextIntState = RandomNextIntState.START;
         checkForBitIorofSignedByte = false;
         sinceBufferedInputStreamReady = 100000;
         sawCheckForNonNegativeSignedByte = -1000;
@@ -1154,51 +1157,65 @@ public class DumbMethods extends OpcodeStackDetector {
             // System.out.println(randomNextIntState + " " + Const.getOpcodeName(seen)
             // + " " + getMethodName());
             switch (randomNextIntState) {
-            case 0:
+            case START:
                 if (seen == Const.INVOKEVIRTUAL && CLASS_NAME_RANDOM.equals(getClassConstantOperand())
                         && ("nextDouble".equals(getNameConstantOperand()) || "nextFloat".equals(getNameConstantOperand())
                                 || "nextLong".equals(getNameConstantOperand()))
                         || seen == Const.INVOKESTATIC && ClassName.isMathClass(getClassConstantOperand())
                                 && "random".equals(getNameConstantOperand())) {
-                    randomNextIntState = 1;
+                    randomNextIntState = RandomNextIntState.INVOKED;
                 }
                 break;
-            case 1:
+            case INVOKED:
                 if (seen == Const.D2I || seen == Const.F2I || seen == Const.L2I) {
                     accumulator.accumulateBug(new BugInstance(this, "RV_01_TO_INT", HIGH_PRIORITY).addClassAndMethod(this), this);
-                    randomNextIntState = 0;
+                    randomNextIntState = RandomNextIntState.START;
                 } else if (seen == Const.DMUL) {
-                    randomNextIntState = 4;
+                    randomNextIntState = RandomNextIntState.REPORT;
                 } else if (seen == Const.LDC2_W && getConstantRefOperand() instanceof ConstantDouble
                         && ((ConstantDouble) getConstantRefOperand()).getBytes() == Integer.MIN_VALUE) {
-                    randomNextIntState = 0;
+                    randomNextIntState = RandomNextIntState.START;
+                } else if (seen == Const.DSTORE_0 || seen == Const.DSTORE_1 || seen == Const.DSTORE_2 || seen == Const.DSTORE_3
+                        || seen == Const.DSTORE) {
+                    randomNextIntRegister = getRegisterOperand();
+                    randomNextIntState = RandomNextIntState.STORED;
                 } else {
-                    randomNextIntState = 2;
+                    randomNextIntState = RandomNextIntState.CAST_TO_DOUBLE;
                 }
 
                 break;
-            case 2:
+            case STORED:
+                if ((seen == Const.DLOAD_0 || seen == Const.DLOAD_1 || seen == Const.DLOAD_2 || seen == Const.DLOAD_3 || seen == Const.DLOAD)
+                        && randomNextIntRegister == getRegisterOperand()) {
+                    randomNextIntState = RandomNextIntState.INVOKED;
+                } else {
+                    // We only track the value when we store it in a variable and load it immediately afterwards
+                    // When something else happens we give up and reset the state to START
+                    randomNextIntState = RandomNextIntState.START;
+                }
+                break;
+            case CAST_TO_DOUBLE:
                 if (seen == Const.I2D) {
-                    randomNextIntState = 3;
+                    randomNextIntState = RandomNextIntState.MULTIPLY;
                 } else if (seen == Const.DMUL) {
-                    randomNextIntState = 4;
+                    randomNextIntState = RandomNextIntState.REPORT;
                 } else {
-                    randomNextIntState = 0;
+                    randomNextIntState = RandomNextIntState.START;
                 }
                 break;
-            case 3:
+            case MULTIPLY:
                 if (seen == Const.DMUL) {
-                    randomNextIntState = 4;
+                    randomNextIntState = RandomNextIntState.REPORT;
                 } else {
-                    randomNextIntState = 0;
+                    randomNextIntState = RandomNextIntState.START;
                 }
                 break;
-            case 4:
+            case REPORT:
                 if (seen == Const.D2I) {
                     accumulator.accumulateBug(
                             new BugInstance(this, "DM_NEXTINT_VIA_NEXTDOUBLE", NORMAL_PRIORITY).addClassAndMethod(this), this);
                 }
-                randomNextIntState = 0;
+                randomNextIntState = RandomNextIntState.START;
                 break;
             default:
                 throw new IllegalStateException();
@@ -1574,5 +1591,15 @@ public class DumbMethods extends OpcodeStackDetector {
         gcInvocationBugReport = null;
 
         exceptionTable = null;
+    }
+
+    private enum RandomNextIntState {
+        START,
+        STORED,
+        LOADED,
+        INVOKED,
+        CAST_TO_DOUBLE,
+        MULTIPLY,
+        REPORT,
     }
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DumbMethods.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DumbMethods.java
@@ -1180,7 +1180,7 @@ public class DumbMethods extends OpcodeStackDetector {
                     randomNextIntRegister = getRegisterOperand();
                     randomNextIntState = RandomNextIntState.STORED;
                 } else {
-                    randomNextIntState = RandomNextIntState.CAST_TO_DOUBLE;
+                    randomNextIntState = RandomNextIntState.OTHER;
                 }
 
                 break;
@@ -1194,16 +1194,16 @@ public class DumbMethods extends OpcodeStackDetector {
                     randomNextIntState = RandomNextIntState.START;
                 }
                 break;
-            case CAST_TO_DOUBLE:
+            case OTHER:
                 if (seen == Const.I2D) {
-                    randomNextIntState = RandomNextIntState.MULTIPLY;
+                    randomNextIntState = RandomNextIntState.CAST_TO_DOUBLE;
                 } else if (seen == Const.DMUL) {
                     randomNextIntState = RandomNextIntState.REPORT;
                 } else {
                     randomNextIntState = RandomNextIntState.START;
                 }
                 break;
-            case MULTIPLY:
+            case CAST_TO_DOUBLE:
                 if (seen == Const.DMUL) {
                     randomNextIntState = RandomNextIntState.REPORT;
                 } else {
@@ -1598,8 +1598,8 @@ public class DumbMethods extends OpcodeStackDetector {
         STORED,
         LOADED,
         INVOKED,
+        OTHER,
         CAST_TO_DOUBLE,
-        MULTIPLY,
         REPORT,
     }
 }

--- a/spotbugsTestCases/src/java/ghIssues/Issue3461.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3461.java
@@ -1,0 +1,14 @@
+package ghIssues;
+
+import java.util.Random;
+
+public class Issue3461 {
+	private Random random = new Random();
+
+	public int showBug() {
+		double randomValue = random.nextDouble();
+		int coercedValue = (int) randomValue;
+		
+		return coercedValue;
+	}
+}


### PR DESCRIPTION
Currently a random double value cast to int is not reported as a bug when stored in a temporary variable.
I have added a state to the detector for that case and replaced the int-based switch by an enum for clarity.

This should fix #3461