### PR TITLE
`SA_FIELD_SELF_ASSIGNMENT` false positive fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Do not report that an Iterator does not throw `NoSuchElementException` when `hasNext()` returns true ([#3501](https://github.com/spotbugs/spotbugs/issues/3501))
 - Detect random value cast to int when stored in temporary variable ([#3461](https://github.com/spotbugs/spotbugs/issues/3461))
 - Look for interfaces default methods when searching uncalled private methods ([#1988](https://github.com/spotbugs/spotbugs/issues/1988))
+- Fixed field self assignment false positive ([#2258](https://github.com/spotbugs/spotbugs/issues/2258))
 
 ### Added
 - Added the unnecessary annotation to the `US_USELESS_SUPPRESSION_ON_*` messages ([#3395](https://github.com/spotbugs/spotbugs/issues/3395))

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2258Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2258Test.java
@@ -1,0 +1,14 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class Issue2258Test extends AbstractIntegrationTest {
+
+    @Test
+    void testIssue() {
+        performAnalysis("ghIssues/Issue2258.class");
+
+        assertBugTypeCount("SA_FIELD_SELF_ASSIGNMENT", 0);
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindFieldSelfAssignment.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindFieldSelfAssignment.java
@@ -29,7 +29,6 @@ import edu.umd.cs.findbugs.BugInstance;
 import edu.umd.cs.findbugs.BugReporter;
 import edu.umd.cs.findbugs.LocalVariableAnnotation;
 import edu.umd.cs.findbugs.OpcodeStack;
-import edu.umd.cs.findbugs.OpcodeStack.CustomUserValue;
 import edu.umd.cs.findbugs.OpcodeStack.Item;
 import edu.umd.cs.findbugs.Priorities;
 import edu.umd.cs.findbugs.StatelessDetector;
@@ -37,7 +36,6 @@ import edu.umd.cs.findbugs.SystemProperties;
 import edu.umd.cs.findbugs.ba.XField;
 import edu.umd.cs.findbugs.bcel.OpcodeStackDetector;
 
-@CustomUserValue
 public class FindFieldSelfAssignment extends OpcodeStackDetector implements StatelessDetector {
     private final BugReporter bugReporter;
 

--- a/spotbugsTestCases/src/java/ghIssues/Issue2258.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue2258.java
@@ -1,0 +1,24 @@
+package ghIssues;
+
+public class Issue2258 {
+	private boolean isHole;
+	private Issue2258 next;
+	
+	public void fixHoleLinkage() {
+		Issue2258 orfl = next;
+		
+		while (orfl != null && (orfl.isHole == isHole)) {
+			orfl = orfl.next;
+		}
+		
+		next = orfl;
+	}
+	
+	public void setNext(Issue2258 next) {
+		this.next = next;
+	}
+	
+	public void setHole(boolean isHole) {
+		this.isHole = isHole;
+	}
+}


### PR DESCRIPTION
The `CustomUserValue` annotation disables the "iterative stack analysis" and this results in a false positive in the test case of this PR.
Apparently removing the annotation is compatible with still using "user values" on the stack items

This should fix #2258 