### PR TITLE
Added `DMI_MISLEADING_SUBSTRING` for calling `subString(0)` on a StringBuffer/StringBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - New bug type `CWO_CLOSED_WITHOUT_OPENED` for locks that might be released without even being acquired. (See [SEI CERT rule LCK08-J](https://wiki.sei.cmu.edu/confluence/display/java/LCK08-J.+Ensure+actively+held+locks+are+released+on+exceptional+conditions)) ([#2055](https://github.com/spotbugs/spotbugs/pull/2055))
   - Breaking change: changed values and new items in `ResourceValueFrame`.
 - Inline access method for method. ([#3481](https://github.com/spotbugs/spotbugs/issues/3481))
+- Added `DMI_MISLEADING_SUBSTRING` for calling `subString(0)` on a StringBuffer/StringBuilder ([#1928](https://github.com/spotbugs/spotbugs/issues/1928))
 
 ## 4.9.3 - 2025-03-14
 ### Added

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1928Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1928Test.java
@@ -1,0 +1,17 @@
+package edu.umd.cs.findbugs.detect;
+
+
+import org.junit.jupiter.api.Test;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+
+class Issue1928Test extends AbstractIntegrationTest {
+    @Test
+    void testIssue() {
+        performAnalysis("ghIssues/Issue1928.class");
+
+        assertBugInMethod("DMI_MISLEADING_SUBSTRING", "ghIssues.Issue1928", "builder");
+        assertBugInMethod("DMI_MISLEADING_SUBSTRING", "ghIssues.Issue1928", "buffer");
+        assertBugInMethod("DMI_USELESS_SUBSTRING", "ghIssues.Issue1928", "simpleString");
+    }
+}

--- a/spotbugs/etc/findbugs.xml
+++ b/spotbugs/etc/findbugs.xml
@@ -418,7 +418,7 @@
                     disabled="false" reports="NP_LOAD_OF_KNOWN_NULL_VALUE"/>
           <Detector class="edu.umd.cs.findbugs.detect.DumbMethodInvocations" speed="fast"
                     disabled="false"
-                    reports="DMI_EMPTY_DB_PASSWORD,DMI_CONSTANT_DB_PASSWORD,DMI_USELESS_SUBSTRING,DMI_HARDCODED_ABSOLUTE_FILENAME"/>
+                    reports="DMI_EMPTY_DB_PASSWORD,DMI_CONSTANT_DB_PASSWORD,DMI_USELESS_SUBSTRING,DMI_MISLEADING_SUBSTRING,DMI_HARDCODED_ABSOLUTE_FILENAME"/>
           <Detector class="edu.umd.cs.findbugs.detect.URLProblems" speed="fast"
                     reports="DMI_BLOCKING_METHODS_ON_URL,DMI_COLLECTION_OF_URLS"/>
           <Detector class="edu.umd.cs.findbugs.detect.CovariantArrayAssignment" speed="fast" disabled="true"
@@ -1235,6 +1235,7 @@
           <BugPattern abbrev="DMI" type="DMI_HARDCODED_ABSOLUTE_FILENAME" category="STYLE"/>
           <BugPattern abbrev="DMI" type="DMI_BAD_MONTH" category="CORRECTNESS"/>
           <BugPattern abbrev="DMI" type="DMI_USELESS_SUBSTRING" category="STYLE"/>
+          <BugPattern abbrev="DMI" type="DMI_MISLEADING_SUBSTRING" category="STYLE"/>
           <BugPattern abbrev="DMI" type="DMI_CALLING_NEXT_FROM_HASNEXT" category="CORRECTNESS"/>
           <BugPattern abbrev="ST" type="ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD" category="STYLE"/>
           <BugPattern abbrev="SWL" type="SWL_SLEEP_WITH_LOCK_HELD" category="MT_CORRECTNESS" cweid="667"/>

--- a/spotbugs/etc/messages.xml
+++ b/spotbugs/etc/messages.xml
@@ -8230,6 +8230,17 @@ This code invokes substring(0) on a String, which returns the original value.
 ]]>
     </Details>
   </BugPattern>
+  <BugPattern type="DMI_MISLEADING_SUBSTRING">
+    <ShortDescription>Invocation of substring(0), which returns the same as toString()</ShortDescription>
+    <LongDescription>{1} invokes substring(0), which might be misleading because it returns the entire String</LongDescription>
+    <Details>
+<![CDATA[
+<p>
+This code invokes substring(0) on a StringBuffer or a StringBuilder, which returns the same as toString().
+</p>
+]]>
+    </Details>
+  </BugPattern>
   <BugPattern type="DMI_CALLING_NEXT_FROM_HASNEXT">
     <ShortDescription>hasNext method invokes next</ShortDescription>
     <LongDescription>{1} invokes {2.givenClass}</LongDescription>

--- a/spotbugs/etc/messages_fr.xml
+++ b/spotbugs/etc/messages_fr.xml
@@ -3235,6 +3235,15 @@ double value2 =  x / (double) y;
 ]]>
   </Details>
  </BugPattern>
+ <BugPattern type="DMI_MISLEADING_SUBSTRING">
+  <ShortDescription>Appel de substring(0) qui retourne la même valeur que toString()</ShortDescription>
+  <LongDescription>{1} appelle substring(0), ce qui peut être clarifié en appelant toString()</LongDescription>
+  <Details>
+<![CDATA[
+<p>Ce code appelle <code>substring(0)</code> sur un StringBuffer ou StringBuilder, ce qui renvoit la même valeur que toString().</p>
+]]>
+  </Details>
+ </BugPattern>
  <BugPattern type="DMI_CALLING_NEXT_FROM_HASNEXT">
   <ShortDescription>Méthode hasNext() appelant next()</ShortDescription>
   <LongDescription>{1} appelle {3}</LongDescription>

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DumbMethodInvocations.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DumbMethodInvocations.java
@@ -34,6 +34,10 @@ import edu.umd.cs.findbugs.detect.BuildStringPassthruGraph.StringPassthruDatabas
 public class DumbMethodInvocations implements Detector {
     private static final MethodDescriptor STRING_SUBSTRING =
             new MethodDescriptor("java/lang/String", "substring", "(I)Ljava/lang/String;");
+    private static final MethodDescriptor STRINGBUILDER_SUBSTRING =
+            new MethodDescriptor("java/lang/StringBuilder", "substring", "(I)Ljava/lang/String;");
+    private static final MethodDescriptor STRINGBUFFER_SUBSTRING =
+            new MethodDescriptor("java/lang/StringBuffer", "substring", "(I)Ljava/lang/String;");
 
 
     private final BugReporter bugReporter;
@@ -120,7 +124,9 @@ public class DumbMethodInvocations implements Detector {
                 }
             }
 
-            if (md.equals(STRING_SUBSTRING)) {
+            if (md.equals(STRING_SUBSTRING)
+                    || md.equals(STRINGBUILDER_SUBSTRING)
+                    || md.equals(STRINGBUFFER_SUBSTRING)) {
 
                 Constant operandValue = frame.getTopValue();
                 if (!operandValue.isConstantInteger()) {
@@ -128,7 +134,12 @@ public class DumbMethodInvocations implements Detector {
                 }
                 int v = operandValue.getConstantInt();
                 if (v == 0) {
-                    bugAccumulator.accumulateBug(new BugInstance(this, "DMI_USELESS_SUBSTRING", NORMAL_PRIORITY)
+                    String bugType = "DMI_USELESS_SUBSTRING";
+                    if (md.equals(STRINGBUILDER_SUBSTRING) || md.equals(STRINGBUFFER_SUBSTRING)) {
+                        bugType = "DMI_MISLEADING_SUBSTRING";
+                    }
+
+                    bugAccumulator.accumulateBug(new BugInstance(this, bugType, NORMAL_PRIORITY)
                             .addClassAndMethod(methodGen, sourceFile), classContext, methodGen, sourceFile, location);
                 }
 

--- a/spotbugsTestCases/src/java/ghIssues/Issue1928.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue1928.java
@@ -1,0 +1,24 @@
+package ghIssues;
+
+public class Issue1928 {
+
+	public String builder() {
+		StringBuilder builder = new StringBuilder();
+		builder.append("x");
+		
+		return builder.substring(0);
+	}
+
+	public String buffer() {
+		StringBuffer buffer = new StringBuffer();
+		buffer.append("x");
+		
+		return buffer.substring(0);
+	}
+
+	public String simpleString() {
+		String value = "x";
+		
+		return value.substring(0);
+	}
+}


### PR DESCRIPTION
As noted in #1928 on might expect to get `DMI_USELESS_SUBSTRING` on a StringBuilder or StringBuffer when calling `subString(0)`.
That call isn't as useless as String.subString(0), because it converts the builder/buffer to String, so it seemed to me that "useless" was not the best word for that case and I've added a new bug code.

This should fix #1928