### PR TITLE
Fix `NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE` with `Objects.requireNonNull`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Look for interfaces default methods when searching uncalled private methods ([#1988](https://github.com/spotbugs/spotbugs/issues/1988))
 - Fixed field self assignment false positive ([#2258](https://github.com/spotbugs/spotbugs/issues/2258))
 - Fixed `DMI_INVOKING_TOSTRING_ON_ARRAY` on newer JDK ([#1147](https://github.com/spotbugs/spotbugs/issues/1147))
+- Fix `NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE` false positive with `Objects.requireNonNull` ([#2965](https://github.com/spotbugs/spotbugs/issues/2965))
 
 ### Added
 - Added the unnecessary annotation to the `US_USELESS_SUPPRESSION_ON_*` messages ([#3395](https://github.com/spotbugs/spotbugs/issues/3395))

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/npe/IsNullValueTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/npe/IsNullValueTest.java
@@ -7,6 +7,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+import edu.umd.cs.findbugs.ba.NullnessAnnotation;
+import edu.umd.cs.findbugs.ba.XMethod;
+import org.mockito.Mockito;
+
 class IsNullValueTest {
 
     @Test
@@ -65,5 +69,18 @@ class IsNullValueTest {
         IsNullValue nsp_e = IsNullValue.merge(checkedNull_e, unknown);
         assertTrue(nsp_e.isNullOnSomePath());
         assertTrue(nsp_e.isException());
+    }
+
+    @Test
+    void testMergeCheckForNull() {
+        XMethod method = Mockito.mock(XMethod.class);
+
+        IsNullValue checkedNull_e = IsNullValue.checkedNullValue().toExceptionValue();
+        IsNullValue checkForNull = IsNullValue.nullOnSimplePathValue().markInformationAsComingFromReturnValueOfMethod(method,
+                NullnessAnnotation.CHECK_FOR_NULL);
+        IsNullValue merged = IsNullValue.merge(checkedNull_e, checkForNull);
+
+        assertTrue(merged.isNullOnSomePath());
+        assertTrue(merged.isCheckForNull());
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1778Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1778Test.java
@@ -1,0 +1,14 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class Issue1778Test extends AbstractIntegrationTest {
+
+    @Test
+    void testIssue() {
+        performAnalysis("ghIssues/Issue1778.class");
+        
+        assertBugTypeCount("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", 0);
+    }
+}

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1778Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1778Test.java
@@ -8,7 +8,7 @@ class Issue1778Test extends AbstractIntegrationTest {
     @Test
     void testIssue() {
         performAnalysis("ghIssues/Issue1778.class");
-        
+
         assertBugTypeCount("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", 0);
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2965Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2965Test.java
@@ -1,0 +1,23 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class Issue2965Test extends AbstractIntegrationTest {
+
+    @Test
+    void testIssue() {
+        performAnalysis("ghIssues/Issue2965.class");
+
+        assertNoBugInMethod("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", "ghIssues.Issue2965", "checkForNullRequireNonNull");
+        assertNoBugInMethod("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", "ghIssues.Issue2965", "checkForNullRequireNonNullWithMessage");
+        assertNoBugInMethod("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", "ghIssues.Issue2965", "checkForNullRequireNonNullWithMessageMultiLine");
+        assertNoBugInMethod("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", "ghIssues.Issue2965", "checkForNullRequireNonNullWithMessageSupplier");
+        assertNoBugInMethod("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", "ghIssues.Issue2965", "conditionalCheckForNull");
+
+        assertBugTypeCount("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", 0);
+
+        // Check that we can still detect a load of null
+        assertBugInMethod("NP_LOAD_OF_KNOWN_NULL_VALUE", "ghIssues.Issue2965", "nullRequireNonNull");
+    }
+}

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2965Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2965Test.java
@@ -15,9 +15,11 @@ class Issue2965Test extends AbstractIntegrationTest {
         assertNoBugInMethod("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", "ghIssues.Issue2965", "checkForNullRequireNonNullWithMessageSupplier");
         assertNoBugInMethod("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", "ghIssues.Issue2965", "conditionalCheckForNull");
 
-        assertBugTypeCount("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", 0);
-
         // Check that we can still detect a load of null
         assertBugInMethod("NP_LOAD_OF_KNOWN_NULL_VALUE", "ghIssues.Issue2965", "nullRequireNonNull");
+        assertBugInMethod("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", "ghIssues.Issue2965", "requireNonNullDereference");
+
+        assertBugTypeCount("NP_LOAD_OF_KNOWN_NULL_VALUE", 1);
+        assertBugTypeCount("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", 1);
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2965Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2965Test.java
@@ -14,6 +14,8 @@ class Issue2965Test extends AbstractIntegrationTest {
         assertNoBugInMethod("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", "ghIssues.Issue2965", "checkForNullRequireNonNullWithMessageMultiLine");
         assertNoBugInMethod("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", "ghIssues.Issue2965", "checkForNullRequireNonNullWithMessageSupplier");
         assertNoBugInMethod("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", "ghIssues.Issue2965", "conditionalCheckForNull");
+        assertNoBugInMethod("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", "ghIssues.Issue2965", "springNullableRequireNonNull");
+        assertNoBugInMethod("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", "ghIssues.Issue2965", "checkForNullRequireNonNullChainedCall");
 
         // Check that we can still detect a load of null
         assertBugInMethod("NP_LOAD_OF_KNOWN_NULL_VALUE", "ghIssues.Issue2965", "nullRequireNonNull");

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue782Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue782Test.java
@@ -13,6 +13,6 @@ class Issue782Test extends AbstractIntegrationTest {
 
         assertBugTypeCount("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", 1);
 
-        assertBugAtLine("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", 27);
+        assertBugAtLine("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", 28);
     }
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/IsNullValue.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/IsNullValue.java
@@ -22,8 +22,10 @@ package edu.umd.cs.findbugs.ba.npe;
 import javax.annotation.Nonnull;
 
 import edu.umd.cs.findbugs.SystemProperties;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.ba.Debug;
 import edu.umd.cs.findbugs.ba.Location;
+import edu.umd.cs.findbugs.ba.NullnessAnnotation;
 import edu.umd.cs.findbugs.ba.XFactory;
 import edu.umd.cs.findbugs.ba.XField;
 import edu.umd.cs.findbugs.ba.XMethod;
@@ -95,7 +97,15 @@ public class IsNullValue implements IsNullValueAnalysisFeatures, Debug {
     /** Value is (potentially) null because of a value returned from readline. */
     private static final int READLINE_VAL = (16 << FLAG_SHIFT) | RETURN_VAL;
 
-    private static final int FLAG_MASK = EXCEPTION | PARAM | RETURN_VAL | FIELD_VAL | READLINE_VAL;
+    /** Value is (potentially) null because it was returned from a {@link CheckForNull} method . */
+    private static final int CHECK_FOR_NULL_VAL = (32 << FLAG_SHIFT) | RETURN_VAL;
+
+    private static final int FLAG_MASK = EXCEPTION
+            | PARAM
+            | RETURN_VAL
+            | FIELD_VAL
+            | READLINE_VAL
+            | CHECK_FOR_NULL_VAL;
 
     private static final int[][] mergeMatrix = {
         // NULL, CHECKED_NULL, NN, CHECKED_NN, NO_KABOOM_NN, NSP,
@@ -212,6 +222,13 @@ public class IsNullValue implements IsNullValueAnalysisFeatures, Debug {
         return hasFlag(READLINE_VAL);
     }
 
+    /**
+     * @return <code>true</code> if that was returned from a {@link CheckForNull} method
+     */
+    public boolean isCheckForNull() {
+        return hasFlag(CHECK_FOR_NULL_VAL);
+    }
+
     public boolean isFieldValue() {
         return hasFlag(FIELD_VAL);
     }
@@ -258,10 +275,10 @@ public class IsNullValue implements IsNullValueAnalysisFeatures, Debug {
      * Convert to a value known because it was returned from a method in a
      * method property database.
      *
-     * @param methodInvoked
-     *            TODO
+     * @param methodInvoked The invoked method
+     * @param methodNullnessAnnotation The {@link NullnessAnnotation} of the invoked method
      */
-    public IsNullValue markInformationAsComingFromReturnValueOfMethod(XMethod methodInvoked) {
+    public IsNullValue markInformationAsComingFromReturnValueOfMethod(XMethod methodInvoked, NullnessAnnotation methodNullnessAnnotation) {
         FieldDescriptor fieldDescriptor = methodInvoked.getAccessMethodForField();
         if (fieldDescriptor != null) {
             XField f = XFactory.getExactXField(fieldDescriptor);
@@ -271,7 +288,10 @@ public class IsNullValue implements IsNullValueAnalysisFeatures, Debug {
         int flag = RETURN_VAL;
         if ("readLine".equals(methodInvoked.getName()) && "()Ljava/lang/String;".equals(methodInvoked.getSignature())) {
             flag = READLINE_VAL;
+        } else if (methodNullnessAnnotation == NullnessAnnotation.CHECK_FOR_NULL) {
+            flag = CHECK_FOR_NULL_VAL;
         }
+
         if (getBaseKind() == NO_KABOOM_NN) {
             return new IsNullValue(kind | flag, locationOfKaBoom);
         }
@@ -415,6 +435,10 @@ public class IsNullValue implements IsNullValueAnalysisFeatures, Debug {
         if ((!(a.isNullOnSomePath() || a.isDefinitelyNull()) && b.isException())
                 || (!(b.isNullOnSomePath() || b.isDefinitelyNull()) && a.isException())) {
             combinedFlags |= EXCEPTION;
+        }
+
+        if (a.isCheckForNull() || b.isCheckForNull()) {
+            combinedFlags |= CHECK_FOR_NULL_VAL;
         }
 
         // Left hand value should be >=, since it is used

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/IsNullValueFrameModelingVisitor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/IsNullValueFrameModelingVisitor.java
@@ -265,7 +265,8 @@ public class IsNullValueFrameModelingVisitor extends AbstractFrameModelingVisito
                 System.out.println("Null value returned from " + calledMethod);
             }
             pushValue = IsNullValue.nullOnSimplePathValue().markInformationAsComingFromReturnValueOfMethod(
-                    calledMethod);
+                    calledMethod,
+                    annotation);
         } else if (annotation == NullnessAnnotation.NULLABLE) {
             pushValue = IsNullValue.nonReportingNotNullValue();
         } else if (annotation == NullnessAnnotation.NONNULL
@@ -274,7 +275,9 @@ public class IsNullValueFrameModelingVisitor extends AbstractFrameModelingVisito
             if (IsNullValueAnalysis.DEBUG) {
                 System.out.println("NonNull value return from " + calledMethod);
             }
-            pushValue = IsNullValue.nonNullValue().markInformationAsComingFromReturnValueOfMethod(calledMethod);
+            pushValue = IsNullValue.nonNullValue().markInformationAsComingFromReturnValueOfMethod(
+                    calledMethod,
+                    annotation);
 
         } else {
             pushValue = IsNullValue.nonReportingNotNullValue();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/NullValueUnconditionalDeref.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/NullValueUnconditionalDeref.java
@@ -18,6 +18,8 @@ public class NullValueUnconditionalDeref {
 
     private boolean alwaysReadlineValue;
 
+    private boolean alwaysCheckForNullMethodReturn;
+
     private final Set<Location> derefLocationSet;
 
     public NullValueUnconditionalDeref() {
@@ -25,6 +27,7 @@ public class NullValueUnconditionalDeref {
         this.alwaysMethodReturnValue = true;
         this.alwaysFieldValue = true;
         this.alwaysReadlineValue = true;
+        this.alwaysCheckForNullMethodReturn = true;
         this.derefLocationSet = new HashSet<>();
     }
 
@@ -45,6 +48,10 @@ public class NullValueUnconditionalDeref {
         if (!isNullValue.isReadlineValue()) {
             alwaysReadlineValue = false;
         }
+        if (!isNullValue.isCheckForNull()) {
+            alwaysCheckForNullMethodReturn = false;
+        }
+
         derefLocationSet.addAll(unconditionalDerefLocationSet);
     }
 
@@ -81,5 +88,9 @@ public class NullValueUnconditionalDeref {
      */
     public boolean isFieldValue() {
         return alwaysFieldValue;
+    }
+
+    public boolean isAlwaysCheckForNullMethodReturn() {
+        return alwaysCheckForNullMethodReturn;
     }
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNullDeref.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNullDeref.java
@@ -1408,6 +1408,10 @@ public class FindNullDeref implements Detector, UseAnnotationDatabase, NullDeref
         if (deref.isMethodReturnValue()) {
             if (deref.isReadlineValue()) {
                 bugType = "NP_DEREFERENCE_OF_READLINE_VALUE";
+            } else if (deref.isAlwaysCheckForNullMethodReturn()
+                    && deref.getDerefLocationSet().stream().allMatch(this::callToAssertionMethod)) {
+                // The value was the return of a CheckForNull annotated-method and the code is deliberately asserting its nullness
+                return;
             } else {
                 bugType = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE";
             }

--- a/spotbugsTestCases/src/java/ghIssues/Issue1778.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue1778.java
@@ -1,0 +1,22 @@
+package ghIssues;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+
+public class Issue1778 {
+	@CheckForNull
+	public static Function<String, String> get() {
+		return k -> "nope";
+	}
+	
+	public static String getMapping(String value) {
+		Objects.requireNonNull(value);
+		
+		Function<String, String> f = get();
+		Objects.requireNonNull(f);
+		
+		return f.apply(value);
+	}
+}

--- a/spotbugsTestCases/src/java/ghIssues/Issue2965.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue2965.java
@@ -1,0 +1,59 @@
+package ghIssues;
+
+import java.util.Objects;
+import java.util.function.Supplier;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nullable;
+
+public class Issue2965 {
+
+  public void checkForNullRequireNonNull() {
+    final String foo = getString("foo");
+    // Getting an NPE here is the point of requireNonNull(), we should not report NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE
+    Objects.requireNonNull(foo);
+  }
+
+  public void checkForNullRequireNonNullWithMessage() {
+    final String bar = getString("bar");
+    // Getting an NPE here is the point of requireNonNull(), we should not report NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE
+    Objects.requireNonNull(bar, "Bar must not be null");
+  }
+
+  public void checkForNullRequireNonNullWithMessageMultiLine() {
+    final String bar = getString("bar");
+    // Getting an NPE here is the point of requireNonNull(), we should not report NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE
+    Objects.requireNonNull(
+    		bar, 
+    		"Bar must not be null");
+  }
+
+  public void checkForNullRequireNonNullWithMessageSupplier() {
+    final Supplier<String> supplier = ()-> "Baz must not be null";
+    final String baz = getString("baz");
+    // Getting an NPE here is the point of requireNonNull(), we should not report NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE
+    Objects.requireNonNull(baz, supplier);
+  }
+
+  public void conditionalCheckForNull(boolean flag) {
+    String foo = getString("foo");
+    if (flag)  {
+      foo = "x";
+    }
+
+    Objects.requireNonNull(
+      foo,
+            () -> "missing value"
+    );
+  }
+
+  @CheckForNull
+  private String getString(@Nullable final String text) {
+    return text == null ? null : text;
+  }
+
+  public void nullRequireNonNull() {
+    final String foo = null;
+    Objects.requireNonNull(foo); // NP_LOAD_OF_KNOWN_NULL_VALUE
+  }
+}

--- a/spotbugsTestCases/src/java/ghIssues/Issue2965.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue2965.java
@@ -56,4 +56,9 @@ public class Issue2965 {
     final String foo = null;
     Objects.requireNonNull(foo); // NP_LOAD_OF_KNOWN_NULL_VALUE
   }
+  
+  public String requireNonNullDereference() {
+    final String foo = getString("foo");
+    return foo.trim(); // NP_LOAD_OF_KNOWN_NULL_VALUE
+  }
 }

--- a/spotbugsTestCases/src/java/ghIssues/Issue2965.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue2965.java
@@ -61,4 +61,28 @@ public class Issue2965 {
     final String foo = getString("foo");
     return foo.trim(); // NP_LOAD_OF_KNOWN_NULL_VALUE
   }
+  
+
+  // From: https://github.com/spotbugs/spotbugs/issues/2965#issuecomment-2456118599
+  public String springNullableRequireNonNull() {
+    String nullableResult = callNullableMethod();
+    nullableResult = Objects.requireNonNull(nullableResult);
+
+    return nullableResult;
+  }
+
+  @Nullable
+  private String callNullableMethod() {
+    return "x";
+  }
+  
+  // From https://github.com/spotbugs/spotbugs/issues/2965#issuecomment-2787946295
+  public String checkForNullRequireNonNullChainedCall() {
+    return Objects.requireNonNull(getValue()).toString();
+  }
+  
+  @CheckForNull
+  private Issue2965 getValue() {
+    return null;
+  }
 }

--- a/spotbugsTestCases/src/java/ghIssues/Issue782.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue782.java
@@ -1,14 +1,15 @@
 package ghIssues;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static java.util.Objects.requireNonNull;
-
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-
+import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 import javax.annotation.meta.TypeQualifierNickname;
 import javax.annotation.meta.When;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.Objects;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 /**
  * False negatives and positives of NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE.
@@ -55,6 +56,46 @@ public class Issue782 {
         System.out.println(c.toString());
     }
 
+    public void multiArgMultiLineUsingNullableWorks() {
+        Object result = Objects.requireNonNull(
+                get2(), // seems to work with method returns @Nullable, not sure this is being validated possibly
+                "This fails when the return type is string");
+        System.out.println(result.toString());
+    }
+
+    public void singleArgMultiLineUsingCheckForNullWorks() {
+        Object result = Objects.requireNonNull(
+                methodUsingCheckForNull()); // seems okay on new line if using the single arg variant
+        System.out.println(result.toString());
+    }
+
+    public void multiArgWithJustMessageOnNewLineCheckForNullWorks() {
+        Object result = Objects.requireNonNull(methodUsingCheckForNull(),
+                "This fails when the return type is string");
+        System.out.println(result.toString());
+    }
+
+    /**
+     * Main difference here is arguments are on a new line + using multi-arg variant,
+     * see {@link #multiArgWithJustMessageOnNewLineCheckForNullWorks()} which works with the main difference
+     * being the first param is not on a new line
+     */
+    public void multiArgWithArgumentsOnNewLineFails() {
+        Object result = Objects.requireNonNull(
+                methodUsingCheckForNull(), "This fails when the return type is string");
+        System.out.println(result.toString());
+    }
+
+    /**
+     * Pretty much the same as {@link #multiArgWithArgumentsOnNewLineFails()} but each argument is on a new line
+     */
+    public void multiArgMultiLineUsingCheckForNullFails() {
+        Object result = Objects.requireNonNull(
+                methodUsingCheckForNull(), // doesn't like if the method uses @CheckForNull
+                "This fails when the return type is string");
+        System.out.println(result.toString());
+    }
+
     @MyNullable
     public Object get() {
         return null;
@@ -64,10 +105,15 @@ public class Issue782 {
     public Object get2() {
         return null;
     }
-    
+
     @TypeQualifierNickname
     @javax.annotation.Nonnull(when = When.MAYBE)
     @Retention(RetentionPolicy.CLASS)
     public @interface MyNullable {
+    }
+
+    @CheckForNull
+    private Object methodUsingCheckForNull() {
+        return null;
     }
 }


### PR DESCRIPTION
When a method is annotated with `CheckForNull` checking the nullness with `Objects.requireNonNull` might result in an NPE, but that's the point of the assertion.

In order to correctly track down values returned from such method this PR hads a new flag to the `IsNullValue` used in the nullness analysis.
When a value with that flag is used in an assertion method (such as `Objects.requireNonNull`) we do not want to report `NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE`

This should fix the following issues:
- #782
- #1778
- #2277
- #2965

I'll add a changelog entry once the PR sent earlier is merged in