### PR TITLE
Add back `DetectorToDetector2Adapter.getDetectorClassName()`

### DIFF
--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/DetectorToDetector2Adapter.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/DetectorToDetector2Adapter.java
@@ -78,4 +78,9 @@ public class DetectorToDetector2Adapter implements Detector2 {
             profiler.end(detector.getClass());
         }
     }
+
+    @Override
+    public String getDetectorClassName() {
+        return detector.getClass().getName();
+    }
 }


### PR DESCRIPTION
The method was removed by mistake in #3352; it is in fact not redundant and should return the class name of the delegate.