### PR TITLE
reenable `RegressionIdeas20110722Test`

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/RegressionIdeas20110722Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/RegressionIdeas20110722Test.java
@@ -1,13 +1,11 @@
 package edu.umd.cs.findbugs.detect;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 class RegressionIdeas20110722Test extends AbstractIntegrationTest {
 
     // Problems in null checks, see https://github.com/spotbugs/spotbugs/issues/2890
-    @Disabled
     @Test
     void testArgumentAssertions() {
         performAnalysis("bugIdeas/Ideas_2011_07_22.class");


### PR DESCRIPTION
It looks like `RegressionIdeas20110722Test` works again since guava was updated from 33.4.0 to 3.3.4.5 (https://github.com/spotbugs/spotbugs/pull/3361).
See the changes between these two guava versions here: https://github.com/google/guava/compare/v33.4.0...v33.4.5
The reason is most likely the migration from `javax.annotation.CheckForNull` annotation to Checker Framework's `@Nullable` ( https://github.com/google/guava/commit/d997ad9367c1369fca227605be4713c52b235e49 ), which then was again migrated to JSpecify's `@Nullable` ( https://github.com/google/guava/commit/2cc8c5eddb587db3ac12dacdd5563e79a4681ec4 ).
The test was originally disabled in https://github.com/spotbugs/spotbugs/pull/2840 and the problem documented in https://github.com/spotbugs/spotbugs/issues/2890. So this PR closes https://github.com/spotbugs/spotbugs/issues/2890.

This is only only changes test code, so I haven't added a changelog entry.