### PR TITLE
Fixed `DMI_INVOKING_TOSTRING_ON_ARRAY` on newer JDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
   - Breaking change: changed values and new items in `ResourceValueFrame`.
 - Inline access method for method. ([#3481](https://github.com/spotbugs/spotbugs/issues/3481))
 - Added `DMI_MISLEADING_SUBSTRING` for calling `subString(0)` on a StringBuffer/StringBuilder ([#1928](https://github.com/spotbugs/spotbugs/issues/1928))
+- Fixed `DMI_INVOKING_TOSTRING_ON_ARRAY` on newer JDK ([#1147](https://github.com/spotbugs/spotbugs/issues/1147))
 
 ## 4.9.3 - 2025-03-14
 ### Added

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1147Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1147Test.java
@@ -1,0 +1,14 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class Issue1147Test extends AbstractIntegrationTest {
+
+    @Test
+    void testIssue() {
+        performAnalysis("ghIssues/Issue1147.class");
+
+        assertBugTypeCount("DMI_INVOKING_TOSTRING_ON_ARRAY", 1);
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindPuzzlers.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindPuzzlers.java
@@ -495,7 +495,7 @@ public class FindPuzzlers extends OpcodeStackDetector {
         }
 
         // Java Puzzlers, chapter 3, puzzle 12
-        if (seen == Const.INVOKEVIRTUAL
+        if ((seen == Const.INVOKEVIRTUAL
                 && stack.getStackDepth() > 0
                 && ("toString".equals(getNameConstantOperand()) && "()Ljava/lang/String;".equals(getSigConstantOperand())
                         || "append".equals(getNameConstantOperand())
@@ -505,7 +505,11 @@ public class FindPuzzlers extends OpcodeStackDetector {
                                 && "(Ljava/lang/Object;)Ljava/lang/StringBuffer;".equals(getSigConstantOperand())
                                 && "java/lang/StringBuffer".equals(getClassConstantOperand()) || ("print".equals(getNameConstantOperand())
                                         || "println".equals(getNameConstantOperand()))
-                                        && "(Ljava/lang/Object;)V".equals(getSigConstantOperand()))) {
+                                        && "(Ljava/lang/Object;)V".equals(getSigConstantOperand())))
+                || (seen == Const.INVOKESTATIC
+                        && stack.getStackDepth() > 0
+                        && "valueOf".equals(getNameConstantOperand())
+                        && "(Ljava/lang/Object;)Ljava/lang/String;".equals(getSigConstantOperand()))) {
             OpcodeStack.Item item = stack.getStackItem(0);
             String signature = item.getSignature();
             if (signature != null && signature.startsWith("[")) {

--- a/spotbugsTestCases/src/java/ghIssues/Issue1147.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue1147.java
@@ -1,0 +1,9 @@
+package ghIssues;
+
+public class Issue1147 {
+
+	// Test for issues 1147 and 1874
+	public String append(Integer[] array) {
+		return "x" + array;
+	}
+}


### PR DESCRIPTION
Detect the `String.valueOf(array)` call during string concatenation.

This should fix #1147 