### PR TITLE
Use bcel snapshot to get bcel 6.11 that supports Java 25 (#3564)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Detect random value cast to int when stored in temporary variable ([#3461](https://github.com/spotbugs/spotbugs/issues/3461))
 - Look for interfaces default methods when searching uncalled private methods ([#1988](https://github.com/spotbugs/spotbugs/issues/1988))
 - Fixed field self assignment false positive ([#2258](https://github.com/spotbugs/spotbugs/issues/2258))
+- Fixed `DMI_INVOKING_TOSTRING_ON_ARRAY` on newer JDK ([#1147](https://github.com/spotbugs/spotbugs/issues/1147))
 
 ### Added
 - Added the unnecessary annotation to the `US_USELESS_SUPPRESSION_ON_*` messages ([#3395](https://github.com/spotbugs/spotbugs/issues/3395))
@@ -44,7 +45,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
   - Breaking change: changed values and new items in `ResourceValueFrame`.
 - Inline access method for method. ([#3481](https://github.com/spotbugs/spotbugs/issues/3481))
 - Added `DMI_MISLEADING_SUBSTRING` for calling `subString(0)` on a StringBuffer/StringBuilder ([#1928](https://github.com/spotbugs/spotbugs/issues/1928))
-- Fixed `DMI_INVOKING_TOSTRING_ON_ARRAY` on newer JDK ([#1147](https://github.com/spotbugs/spotbugs/issues/1147))
+- Added Java 25 support ([#3564](https://github.com/spotbugs/spotbugs/issues/3564))
 
 ## 4.9.3 - 2025-03-14
 ### Added

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,9 @@ subprojects {
 allprojects {
   repositories {
     mavenCentral()
+    maven {
+      url = uri("https://repository.apache.org/content/repositories/snapshots/")
+    }
   }
   dependencies {
     def junitVersion = '5.13.4'

--- a/eclipsePlugin/build.gradle
+++ b/eclipsePlugin/build.gradle
@@ -90,7 +90,7 @@ dependencies {
 }
 
 tasks.named('clean', Delete).configure {
-    delete "lib", "build"
+    delete "lib", "build", "META-INF/MANIFEST.MF", "build.properties"
 }
 
 // This disables hundreds of javadoc warnings on missing tags etc, see #340

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -65,7 +65,7 @@ dependencies {
   api libs.asm.commons
   api libs.asm.tree
   api libs.asm.util
-  api 'org.apache.bcel:bcel:6.10.0'
+  api 'org.apache.bcel:bcel:6.11.0-20250706.125103-7'
   api 'com.github.stephenc.jcip:jcip-annotations:1.0-1'
   api('org.dom4j:dom4j:2.2.0') {
     // exclude transitive dependencies to keep compatible with dom4j 2.1.1
@@ -99,7 +99,7 @@ dependencies {
 }
 
 clean {
-  delete ".libs"
+  delete ".libs", "META-INF/MANIFEST.MF"
 }
 
 project(':spotbugs-annotations') {


### PR DESCRIPTION
- Allows spotbugs to analyze Java 25 compiled code
- Also fixed "clean" task to pick up latest versions of libraries in manifests

Fixes https://github.com/spotbugs/spotbugs/issues/3564

