### PR TITLE
Disable Eclipse plugin signing to fix plugin build & release process

### DIFF
--- a/eclipsePlugin/build.gradle
+++ b/eclipsePlugin/build.gradle
@@ -463,6 +463,9 @@ ext.signJar = { File dir ->
   if (keystorepass.isEmpty()) {
     print 'to sign eclipse plugins, set "keystorepass" project property'
     return
+  } else {
+    print 'Signing of Eclipse plugins is disabled now, see https://github.com/spotbugs/spotbugs/issues/3406'
+    return;
   }
 
   dir.traverse(type: FILES, nameFilter: ~/.*\.jar$/) {


### PR DESCRIPTION
Originally plugin signing introduced in
f45d1917d8683b7ed10dbb581edd36a6a7c04a7e, now the key is expired and it doesn't make sense to sign with expired key.

Not signed plugins are not nice (warning is shown on installation in Eclipse) but same warning is shown if the key is not valid anymore and the installation is still possible.

See https://github.com/spotbugs/spotbugs/issues/3406