### PR TITLE
Map subclass with `@CheckForNull` raises bugs on all `Map.get()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Look for interfaces default methods when searching uncalled private methods ([#1988](https://github.com/spotbugs/spotbugs/issues/1988))
 - Fixed field self assignment false positive ([#2258](https://github.com/spotbugs/spotbugs/issues/2258))
 - Fixed `DMI_INVOKING_TOSTRING_ON_ARRAY` on newer JDK ([#1147](https://github.com/spotbugs/spotbugs/issues/1147))
-- Fix `NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE` false positive with `Objects.requireNonNull` ([#2965](https://github.com/spotbugs/spotbugs/issues/2965))
+- Fix `NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE` false positive with `Objects.requireNonNull` ([#2965](https://github.com/spotbugs/spotbugs/issues/2965)) ([#3573](https://github.com/spotbugs/spotbugs/issues/3573))
 - Track inner classes access methods to correctly report the bugs ([#2029](https://github.com/spotbugs/spotbugs/issues/2029))
 - `SF_SWITCH_NO_DEFAULT` false positive fix ([#1148](https://github.com/spotbugs/spotbugs/issues/1148)) ([#3572](https://github.com/spotbugs/spotbugs/issues/3572))
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/npe/IsNullValueTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/npe/IsNullValueTest.java
@@ -81,6 +81,6 @@ class IsNullValueTest {
         IsNullValue merged = IsNullValue.merge(checkedNull_e, checkForNull);
 
         assertTrue(merged.isNullOnSomePath());
-        assertTrue(merged.isCheckForNull());
+        assertFalse(merged.isCheckForNull());
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3573Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3573Test.java
@@ -1,0 +1,16 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+
+import org.junit.jupiter.api.Test;
+
+class Issue3573Test extends AbstractIntegrationTest {
+
+    @Test
+    void testIssue() {
+        performAnalysis("ghIssues/Issue3573.class",
+                "ghIssues/Issue3573$HashBiDictionnary.class");
+
+        assertBugTypeCount("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", 0);
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/IsNullValue.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/IsNullValue.java
@@ -437,10 +437,6 @@ public class IsNullValue implements IsNullValueAnalysisFeatures, Debug {
             combinedFlags |= EXCEPTION;
         }
 
-        if (a.isCheckForNull() || b.isCheckForNull()) {
-            combinedFlags |= CHECK_FOR_NULL_VAL;
-        }
-
         // Left hand value should be >=, since it is used
         // as the first dimension of the matrix to index.
         if (aKind < bKind) {

--- a/spotbugsTestCases/src/java/ghIssues/Issue3573.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3573.java
@@ -1,0 +1,26 @@
+package ghIssues;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.annotation.CheckForNull;
+
+public class Issue3573 {
+	public boolean doSomethingCompletelyDifferent(Map<String, String> map) {
+		boolean b = true;
+		if(map.get("") != null) {
+			b = map.get("").contains("42"); // NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE warning here
+		}
+		return b;
+	}
+	
+	public static class HashBiDictionnary<K, V> extends HashMap<K, V> {
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		@CheckForNull
+		public V get(Object key) {
+			return super.get(key);
+		}
+	}
+}


### PR DESCRIPTION
See #3573 
Guava's `HashBiMap` is annotated with `@CheckForNull` and implements `Map`.
Potentially all `Map.get()` are from a `HashBiMap` so they would need to be checked for nullness