### PR TITLE
build: GHA Updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,8 @@ jobs:
         run: |
           curl --continue-at - --create-dirs --location 'https://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops4/R-${{ env.eclipse-version }}-${{ env.eclipse-date }}/eclipse-SDK-${{ env.eclipse-version }}-macosx-cocoa-aarch64.dmg&mirror_id=1' --output eclipse-sdk/eclipse.dmg
           hdiutil attach eclipse-sdk/eclipse.dmg
-          cp --recursive /Volumes/Eclipse/Eclipse.app /Applications/
+          # Mac uses BSD cp which doesn't have --recursive therefore -R is required
+          cp -R /Volumes/Eclipse/Eclipse.app /Applications/
           hdiutil detach /Volumes/Eclipse
           echo "eclipseRoot.dir=/Applications/Eclipse.app" | tee eclipsePlugin/local.properties
       # Disable gpg signing on *nix for time being until we get new keys established, checks will be on windows only for now

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,15 +59,9 @@ jobs:
           cp -r /Volumes/Eclipse/Eclipse.app /Applications/
           hdiutil detach /Volumes/Eclipse
           echo "eclipseRoot.dir=/Applications/Eclipse.app" | tee eclipsePlugin/local.properties
-      # Disable gpg signing on *nix for time being until we get new keys established
-      #- name: Pre-build setup
-      #  if: github.repository_owner == 'spotbugs' && matrix.os != 'windows-latest'
-      #  run: gpg --quiet --batch --yes --decrypt --passphrase="$GPG_SECRET_PASSPHRASE" --output spotbugs.jks .github/workflows/spotbugs.jks.gpg;
-      #  env:
-      #    GPG_SECRET_PASSPHRASE: ${{ secrets.GPG_SECRET_PASSPHRASE }}
       # Disable gpg signing on windows for time being until we get new keys established
-      #- name: Pre-build setup Windows
-      #  if: github.repository_owner == 'spotbugs' && matrix.os == 'windows-latest'
+      #- name: Pre-build setup
+      #  if: github.repository_owner == 'spotbugs'
       #  run: gpg --quiet --batch --yes --decrypt --passphrase="$GPG_SECRET_PASSPHRASE" --output spotbugs.jks .github/workflows/spotbugs.jks.gpg;
       #  env:
       #    GPG_SECRET_PASSPHRASE: ${{ secrets.GPG_SECRET_PASSPHRASE }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,14 +84,12 @@ jobs:
       - name: Build with Sonar JDK ${{ matrix.java }}, ${{ matrix.os }}
         # https://community.sonarsource.com/t/sonarcloud-now-not-updating-github-pr-and-checks/6595/17
         if: matrix.java == '21'
-        run: |
-          ./gradlew spotlessCheck build smoketest ${SONAR_LOGIN:+sonar} --no-daemon "-Dsonar.token=$SONAR_LOGIN" --scan
+        run: ./gradlew spotlessCheck build smoketest ${SONAR_LOGIN:+sonar} --no-daemon "-Dsonar.token=$SONAR_LOGIN" --scan
         env:
           SONAR_LOGIN: ${{ secrets.SONAR_LOGIN }}
       - name: Build JDK ${{ matrix.java }}, ${{ matrix.os }}
         # https://community.sonarsource.com/t/sonarcloud-now-not-updating-github-pr-and-checks/6595/17
         if: matrix.java != '21'
-        run: |
-          ./gradlew spotlessCheck build smoketest --no-daemon --scan
+        run: ./gradlew spotlessCheck build smoketest --no-daemon --scan
         env:
           SONAR_LOGIN: ${{ secrets.SONAR_LOGIN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,9 +63,7 @@ jobs:
       #  if: github.repository_owner == 'spotbugs' && matrix.os != 'windows-latest'
       #  run: |
       #    git fetch --no-tags https://$GITHUB_TOKEN@github.com/spotbugs/spotbugs.git +refs/heads/master:refs/remotes/origin/master
-      #    if [ "$GPG_SECRET_PASSPHRASE" != "" ]; then
-      #      gpg --quiet --batch --yes --decrypt --passphrase="$GPG_SECRET_PASSPHRASE" --output spotbugs.jks .github/workflows/spotbugs.jks.gpg;
-      #    fi
+      #    gpg --quiet --batch --yes --decrypt --passphrase="$GPG_SECRET_PASSPHRASE" --output spotbugs.jks .github/workflows/spotbugs.jks.gpg;
       #  env:
       #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       #    GPG_SECRET_PASSPHRASE: ${{ secrets.GPG_SECRET_PASSPHRASE }}
@@ -74,9 +72,7 @@ jobs:
         if: github.repository_owner == 'spotbugs' && matrix.os == 'windows-latest'
         run: |
           git fetch --no-tags https://$GITHUB_TOKEN@github.com/spotbugs/spotbugs.git +refs/heads/master:refs/remotes/origin/master
-          if ( "$GPG_SECRET_PASSPHRASE" -ne "" ) {
-            gpg --quiet --batch --yes --decrypt --passphrase="$GPG_SECRET_PASSPHRASE" --output spotbugs.jks .github/workflows/spotbugs.jks.gpg;
-          }
+          gpg --quiet --batch --yes --decrypt --passphrase="$GPG_SECRET_PASSPHRASE" --output spotbugs.jks .github/workflows/spotbugs.jks.gpg;
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_SECRET_PASSPHRASE: ${{ secrets.GPG_SECRET_PASSPHRASE }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           curl --continue-at - --create-dirs --location 'https://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops4/R-${{ env.eclipse-version }}-${{ env.eclipse-date }}/eclipse-SDK-${{ env.eclipse-version }}-macosx-cocoa-aarch64.dmg&mirror_id=1' --output eclipse-sdk/eclipse.dmg
           hdiutil attach eclipse-sdk/eclipse.dmg
-          cp -r /Volumes/Eclipse/Eclipse.app /Applications/
+          cp --recursive /Volumes/Eclipse/Eclipse.app /Applications/
           hdiutil detach /Volumes/Eclipse
           echo "eclipseRoot.dir=/Applications/Eclipse.app" | tee eclipsePlugin/local.properties
       # Disable gpg signing on *nix for time being until we get new keys established, checks will be on windows only for now

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,19 +62,13 @@ jobs:
       # Disable gpg signing on *nix for time being until we get new keys established, checks will be on windows only for now
       #- name: Pre-build setup
       #  if: github.repository_owner == 'spotbugs' && matrix.os != 'windows-latest'
-      #  run: |
-      #    git fetch --no-tags https://$GITHUB_TOKEN@github.com/spotbugs/spotbugs.git +refs/heads/master:refs/remotes/origin/master
-      #    gpg --quiet --batch --yes --decrypt --passphrase="$GPG_SECRET_PASSPHRASE" --output spotbugs.jks .github/workflows/spotbugs.jks.gpg;
+      #  run: gpg --quiet --batch --yes --decrypt --passphrase="$GPG_SECRET_PASSPHRASE" --output spotbugs.jks .github/workflows/spotbugs.jks.gpg;
       #  env:
-      #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       #    GPG_SECRET_PASSPHRASE: ${{ secrets.GPG_SECRET_PASSPHRASE }}
       - name: Pre-build setup Windows
         if: github.repository_owner == 'spotbugs' && matrix.os == 'windows-latest'
-        run: |
-          git fetch --no-tags https://$GITHUB_TOKEN@github.com/spotbugs/spotbugs.git +refs/heads/master:refs/remotes/origin/master
-          gpg --quiet --batch --yes --decrypt --passphrase="$GPG_SECRET_PASSPHRASE" --output spotbugs.jks .github/workflows/spotbugs.jks.gpg;
+        run: gpg --quiet --batch --yes --decrypt --passphrase="$GPG_SECRET_PASSPHRASE" --output spotbugs.jks .github/workflows/spotbugs.jks.gpg;
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_SECRET_PASSPHRASE: ${{ secrets.GPG_SECRET_PASSPHRASE }}
       - name: Build with Sonar JDK ${{ matrix.java }}, ${{ matrix.os }}
         # https://community.sonarsource.com/t/sonarcloud-now-not-updating-github-pr-and-checks/6595/17

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
           echo "eclipseRoot.dir=/Applications/Eclipse.app" | tee eclipsePlugin/local.properties
       # Disable gpg signing on *nix for time being until we get new keys established, checks will be on windows only for now
       #- name: Pre-build setup
-      #  if: matrix.os != 'windows-latest'
+      #  if: github.repository_owner == 'spotbugs' && matrix.os != 'windows-latest'
       #  run: |
       #    git fetch --no-tags https://$GITHUB_TOKEN@github.com/spotbugs/spotbugs.git +refs/heads/master:refs/remotes/origin/master
       #    if [ "$GPG_SECRET_PASSPHRASE" != "" ]; then
@@ -71,7 +71,7 @@ jobs:
       #    GPG_SECRET_PASSPHRASE: ${{ secrets.GPG_SECRET_PASSPHRASE }}
       #    ORG_GRADLE_PROJECT_keystorepass: ${{ secrets.KEYSTORE_PASS }}
       - name: Pre-build setup Windows
-        if: matrix.os == 'windows-latest'
+        if: github.repository_owner == 'spotbugs' && matrix.os == 'windows-latest'
         run: |
           git fetch --no-tags https://$GITHUB_TOKEN@github.com/spotbugs/spotbugs.git +refs/heads/master:refs/remotes/origin/master
           if ( "$GPG_SECRET_PASSPHRASE" -ne "" ) {

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
           cp -r /Volumes/Eclipse/Eclipse.app /Applications/
           hdiutil detach /Volumes/Eclipse
           echo "eclipseRoot.dir=/Applications/Eclipse.app" | tee eclipsePlugin/local.properties
-      # Disable gpg signing on windows for time being until we get new keys established
+      # Disable gpg signing for time being until we get new keys established
       #- name: Pre-build setup
       #  if: github.repository_owner == 'spotbugs'
       #  run: gpg --quiet --batch --yes --decrypt --passphrase="$GPG_SECRET_PASSPHRASE" --output spotbugs.jks .github/workflows/spotbugs.jks.gpg;

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
           curl --continue-at - --create-dirs --location 'https://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops4/R-${{ env.eclipse-version }}-${{ env.eclipse-date }}/eclipse-SDK-${{ env.eclipse-version }}-macosx-cocoa-aarch64.dmg&mirror_id=1' --output eclipse-sdk/eclipse.dmg
           hdiutil attach eclipse-sdk/eclipse.dmg
           # Mac uses BSD cp which doesn't have --recursive therefore -R is required
-          cp -R /Volumes/Eclipse/Eclipse.app /Applications/
+          cp -r /Volumes/Eclipse/Eclipse.app /Applications/
           hdiutil detach /Volumes/Eclipse
           echo "eclipseRoot.dir=/Applications/Eclipse.app" | tee eclipsePlugin/local.properties
       # Disable gpg signing on *nix for time being until we get new keys established, checks will be on windows only for now

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
           cp -r /Volumes/Eclipse/Eclipse.app /Applications/
           hdiutil detach /Volumes/Eclipse
           echo "eclipseRoot.dir=/Applications/Eclipse.app" | tee eclipsePlugin/local.properties
-      # Disable gpg signing for time being until we get new keys established
+      # Disable gpg decryption of certificate for time being until we get new keys established
       #- name: Pre-build setup
       #  if: github.repository_owner == 'spotbugs'
       #  run: gpg --quiet --batch --yes --decrypt --passphrase="$GPG_SECRET_PASSPHRASE" --output spotbugs.jks .github/workflows/spotbugs.jks.gpg;

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,17 +59,18 @@ jobs:
           cp -r /Volumes/Eclipse/Eclipse.app /Applications/
           hdiutil detach /Volumes/Eclipse
           echo "eclipseRoot.dir=/Applications/Eclipse.app" | tee eclipsePlugin/local.properties
-      # Disable gpg signing on *nix for time being until we get new keys established, checks will be on windows only for now
+      # Disable gpg signing on *nix for time being until we get new keys established
       #- name: Pre-build setup
       #  if: github.repository_owner == 'spotbugs' && matrix.os != 'windows-latest'
       #  run: gpg --quiet --batch --yes --decrypt --passphrase="$GPG_SECRET_PASSPHRASE" --output spotbugs.jks .github/workflows/spotbugs.jks.gpg;
       #  env:
       #    GPG_SECRET_PASSPHRASE: ${{ secrets.GPG_SECRET_PASSPHRASE }}
-      - name: Pre-build setup Windows
-        if: github.repository_owner == 'spotbugs' && matrix.os == 'windows-latest'
-        run: gpg --quiet --batch --yes --decrypt --passphrase="$GPG_SECRET_PASSPHRASE" --output spotbugs.jks .github/workflows/spotbugs.jks.gpg;
-        env:
-          GPG_SECRET_PASSPHRASE: ${{ secrets.GPG_SECRET_PASSPHRASE }}
+      # Disable gpg signing on windows for time being until we get new keys established
+      #- name: Pre-build setup Windows
+      #  if: github.repository_owner == 'spotbugs' && matrix.os == 'windows-latest'
+      #  run: gpg --quiet --batch --yes --decrypt --passphrase="$GPG_SECRET_PASSPHRASE" --output spotbugs.jks .github/workflows/spotbugs.jks.gpg;
+      #  env:
+      #    GPG_SECRET_PASSPHRASE: ${{ secrets.GPG_SECRET_PASSPHRASE }}
       - name: Build with Sonar JDK ${{ matrix.java }}, ${{ matrix.os }}
         # https://community.sonarsource.com/t/sonarcloud-now-not-updating-github-pr-and-checks/6595/17
         if: matrix.java == '21'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,6 @@ jobs:
       #  env:
       #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       #    GPG_SECRET_PASSPHRASE: ${{ secrets.GPG_SECRET_PASSPHRASE }}
-      #    ORG_GRADLE_PROJECT_keystorepass: ${{ secrets.KEYSTORE_PASS }}
       - name: Pre-build setup Windows
         if: github.repository_owner == 'spotbugs' && matrix.os == 'windows-latest'
         run: |
@@ -77,16 +76,17 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_SECRET_PASSPHRASE: ${{ secrets.GPG_SECRET_PASSPHRASE }}
-          ORG_GRADLE_PROJECT_keystorepass: ${{ secrets.KEYSTORE_PASS }}
       - name: Build with Sonar JDK ${{ matrix.java }}, ${{ matrix.os }}
         # https://community.sonarsource.com/t/sonarcloud-now-not-updating-github-pr-and-checks/6595/17
         if: matrix.java == '21'
         run: ./gradlew spotlessCheck build smoketest ${SONAR_LOGIN:+sonar} --no-daemon "-Dsonar.token=$SONAR_LOGIN" --scan
         env:
           SONAR_LOGIN: ${{ secrets.SONAR_LOGIN }}
+          ORG_GRADLE_PROJECT_keystorepass: ${{ secrets.KEYSTORE_PASS }}
       - name: Build JDK ${{ matrix.java }}, ${{ matrix.os }}
         # https://community.sonarsource.com/t/sonarcloud-now-not-updating-github-pr-and-checks/6595/17
         if: matrix.java != '21'
         run: ./gradlew spotlessCheck build smoketest --no-daemon --scan
         env:
           SONAR_LOGIN: ${{ secrets.SONAR_LOGIN }}
+          ORG_GRADLE_PROJECT_keystorepass: ${{ secrets.KEYSTORE_PASS }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: build
+name: Build
 on: [push, pull_request]
 
 permissions:
@@ -35,7 +35,6 @@ jobs:
         with:
           path: eclipse-sdk
           key: eclipse-sdk-${{ matrix.os }}-${{ env.eclipse-version }}-${{ env.eclipse-date }}
-
       - name: Download Eclipse on Ubuntu
         if: matrix.os == 'ubuntu-latest'
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: release
+name: Release
 on:
   push:
     branches:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,8 @@ jobs:
       - name: Build on tag
         if: (github.ref_type == 'tag') && (github.event.base_ref == 'refs/heads/master')
         run: |
-          gpg --quiet --batch --yes --decrypt --passphrase="$GPG_SECRET_PASSPHRASE" --output spotbugs.jks .github/workflows/spotbugs.jks.gpg
+          # Disable gpg signing on *nix for time being until we get new keys established
+          # gpg --quiet --batch --yes --decrypt --passphrase="$GPG_SECRET_PASSPHRASE" --output spotbugs.jks .github/workflows/spotbugs.jks.gpg
           ./gradlew assemble publishToSonatype closeAndReleaseSonatypeStagingRepository createReleaseBody --no-daemon
         env:
           GPG_SECRET_PASSPHRASE: ${{ secrets.GPG_SECRET_PASSPHRASE }}
@@ -61,7 +62,8 @@ jobs:
       - name: Build otherwise
         if: ${{ !((github.ref_type == 'tag') && (github.event.base_ref == 'refs/heads/master')) }}
         run: |
-          gpg --quiet --batch --yes --decrypt --passphrase="$GPG_SECRET_PASSPHRASE" --output spotbugs.jks .github/workflows/spotbugs.jks.gpg
+          # Disable gpg signing on *nix for time being until we get new keys established
+          # gpg --quiet --batch --yes --decrypt --passphrase="$GPG_SECRET_PASSPHRASE" --output spotbugs.jks .github/workflows/spotbugs.jks.gpg
           ./gradlew assemble publishToSonatype createReleaseBody --no-daemon
         env:
           GPG_SECRET_PASSPHRASE: ${{ secrets.GPG_SECRET_PASSPHRASE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Build on tag
         if: (github.ref_type == 'tag') && (github.event.base_ref == 'refs/heads/master')
         run: |
-          # Disable gpg signing on *nix for time being until we get new keys established
+          # Disable gpg signing for time being until we get new keys established
           # gpg --quiet --batch --yes --decrypt --passphrase="$GPG_SECRET_PASSPHRASE" --output spotbugs.jks .github/workflows/spotbugs.jks.gpg
           ./gradlew assemble publishToSonatype closeAndReleaseSonatypeStagingRepository createReleaseBody --no-daemon
         env:
@@ -62,7 +62,7 @@ jobs:
       - name: Build otherwise
         if: ${{ !((github.ref_type == 'tag') && (github.event.base_ref == 'refs/heads/master')) }}
         run: |
-          # Disable gpg signing on *nix for time being until we get new keys established
+          # Disable gpg signing on for time being until we get new keys established
           # gpg --quiet --batch --yes --decrypt --passphrase="$GPG_SECRET_PASSPHRASE" --output spotbugs.jks .github/workflows/spotbugs.jks.gpg
           ./gradlew assemble publishToSonatype createReleaseBody --no-daemon
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Build on tag
         if: (github.ref_type == 'tag') && (github.event.base_ref == 'refs/heads/master')
         run: |
-          # Disable gpg signing for time being until we get new keys established
+          # Disable gpg decryption of certificate for time being until we get new keys established
           # gpg --quiet --batch --yes --decrypt --passphrase="$GPG_SECRET_PASSPHRASE" --output spotbugs.jks .github/workflows/spotbugs.jks.gpg
           ./gradlew assemble publishToSonatype closeAndReleaseSonatypeStagingRepository createReleaseBody --no-daemon
         env:
@@ -62,7 +62,7 @@ jobs:
       - name: Build otherwise
         if: ${{ !((github.ref_type == 'tag') && (github.event.base_ref == 'refs/heads/master')) }}
         run: |
-          # Disable gpg signing on for time being until we get new keys established
+          # Disable gpg decryption of certificate on for time being until we get new keys established
           # gpg --quiet --batch --yes --decrypt --passphrase="$GPG_SECRET_PASSPHRASE" --output spotbugs.jks .github/workflows/spotbugs.jks.gpg
           ./gradlew assemble publishToSonatype createReleaseBody --no-daemon
         env:

--- a/.github/workflows/ticket-management.yml
+++ b/.github/workflows/ticket-management.yml
@@ -1,4 +1,4 @@
-name: 'Automated ticket management'
+name: Ticket Management
 on:
   schedule:
     # Run the check every day.


### PR DESCRIPTION
- adjust action names
- Add note to macos as to why we use -R instead of --location
- Do not run gpg on forks, only spotbugs
- No longer check if gpg key exists, its only on spotbugs, it exists
- Don't use line continuation for runs if only one line