### PR TITLE
build: Remove patch on dom4j as fixed with version 2.2.0

### DIFF
--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -72,17 +72,7 @@ dependencies {
   api libs.asm.util
   api 'org.apache.bcel:bcel:6.10.0'
   api 'com.github.stephenc.jcip:jcip-annotations:1.0-1'
-  api('org.dom4j:dom4j:2.2.0') {
-    // exclude transitive dependencies to keep compatible with dom4j 2.1.1
-    // https://github.com/dom4j/dom4j/issues/85
-    // https://docs.gradle.org/current/userguide/dependency_downgrade_and_exclude.html#sec:excluding-transitive-deps
-    exclude group: 'jaxen',            module: 'jaxen'
-    exclude group: 'javax.xml.stream', module: 'stax-api'
-    exclude group: 'net.java.dev.msv', module: 'xsdlib'
-    exclude group: 'javax.xml.bind',   module: 'jaxb-api'
-    exclude group: 'pull-parser',      module: 'pull-parser'
-    exclude group: 'xpp3',             module: 'xpp3'
-  }
+  api('org.dom4j:dom4j:2.2.0')
   constraints {
     logBinding('org.apache.logging.log4j:log4j-core') {
       version {


### PR DESCRIPTION
further is now incorrect as underlying libs changed

See original issue https://github.com/dom4j/dom4j/issues/85

Fixed in June, stax-api isn't part of it any longer and jaxb-api is now jakarta bind api.  Given this is fixed correctly we don't need to exclude anything any longer as original pom setup was restored.