### PR TITLE
Fix for an exception thrown when a record method has `@SuppressFBWarnings`

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3622Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3622Test.java
@@ -1,0 +1,18 @@
+package edu.umd.cs.findbugs.detect;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnJre;
+import org.junit.jupiter.api.condition.JRE;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+
+class Issue3622Test extends AbstractIntegrationTest {
+
+    @Test
+    @DisabledOnJre({ JRE.JAVA_8, JRE.JAVA_11 })
+    void testRecordsSuppressions() {
+        performAnalysis("../java17/Issue3622.class");
+
+        assertBugTypeCount("EQ_ALWAYS_TRUE", 0);
+    }
+}

--- a/spotbugsTestCases/src/java17/Issue3622.java
+++ b/spotbugsTestCases/src/java17/Issue3622.java
@@ -1,0 +1,9 @@
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+public record Issue3622(int x) {
+	@Override
+	@SuppressFBWarnings
+	public final boolean equals(Object x) {
+		return true;
+	}
+}


### PR DESCRIPTION
This was caused by #3535
The PR should fix #3622