### PR TITLE
build: generaly handle javadocs in similar way to reduce noise

### DIFF
--- a/eclipsePlugin-test/build.gradle
+++ b/eclipsePlugin-test/build.gradle
@@ -33,12 +33,14 @@ dependencies {
 // This disables hundreds of javadoc warnings on missing tags etc, see #340
 javadoc {
   doFirst {
-    // This is supposed to enable everything except "missing" but doesn't work with gradle
-    // See https://docs.oracle.com/en/java/javase/11/tools/javadoc.html
-    options.addBooleanOption('Xdoclint:all,-missing', true)
+    options.with {
+      // This is supposed to enable everything except "missing" but doesn't work with gradle
+      // See https://docs.oracle.com/en/java/javase/11/tools/javadoc.html
+      addBooleanOption('Xdoclint:all,-missing', true)
 
-    // TODO remove command and warning below if the doclint can be properly configured
-    options.addStringOption('Xmaxwarns', '3')
+      // TODO remove command and warning below if the doclint can be properly configured
+      addStringOption('Xmaxwarns', '3')
+    }
   }
   doLast {
     logger.warn('Javadoc: too many warnings, only first 3 are shown, see #340!')

--- a/eclipsePlugin/build.gradle
+++ b/eclipsePlugin/build.gradle
@@ -109,12 +109,14 @@ tasks.named('clean', Delete).configure {
 
 // This disables hundreds of javadoc warnings on missing tags etc, see #340
 tasks.named('javadoc', Javadoc).configure {
-  // This is supposed to enable everything except "missing" but doesn't work with gradle
-  // See https://docs.oracle.com/en/java/javase/11/tools/javadoc.html
-  options.addBooleanOption('Xdoclint:all,-missing', true)
+  options.with {
+    // This is supposed to enable everything except "missing" but doesn't work with gradle
+    // See https://docs.oracle.com/en/java/javase/11/tools/javadoc.html
+    addBooleanOption('Xdoclint:all,-missing', true)
 
-  // TODO remove command and warning below if the doclint can be properly configured
-  options.addStringOption('Xmaxwarns', '3')
+    // TODO remove command and warning below if the doclint can be properly configured
+    addStringOption('Xmaxwarns', '3')
+  }
 
   doLast {
     logger.warn('Javadoc: too many warnings, only first 3 are shown, see #340!')

--- a/spotbugs-annotations/build.gradle
+++ b/spotbugs-annotations/build.gradle
@@ -48,15 +48,21 @@ TaskProvider<Jar> jar = tasks.named('jar', Jar) {
   }
 }
 
+// This disables hundreds of javadoc warnings on missing tags etc, see #340
 tasks.named('javadoc', Javadoc).configure {
   options.with {
     memberLevel = JavadocMemberLevel.PUBLIC
     docTitle = 'SpotBugs Annotation Documentation'
   }
   doFirst {
-    // This is supposed to enable everything except "missing" but doesn't work with gradle
-    // See https://docs.oracle.com/en/java/javase/11/tools/javadoc.html
-    options.addBooleanOption('Xdoclint:all,-missing', true)
+    options.with {
+      // This is supposed to enable everything except "missing" but doesn't work with gradle
+      // See https://docs.oracle.com/en/java/javase/11/tools/javadoc.html
+      addBooleanOption('Xdoclint:all,-missing', true)
+
+      // TODO remove command and warning below if the doclint can be properly configured
+      addStringOption('Xmaxwarns', '3')
+    }
   }
   doLast {
     logger.warn('Javadoc: "missing" warnings are disabled, see #340!')

--- a/spotbugs-ant/build.gradle
+++ b/spotbugs-ant/build.gradle
@@ -13,8 +13,16 @@ dependencies {
   testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
+// This disables hundreds of javadoc warnings on missing tags etc, see #340
 tasks.named('javadoc', Javadoc).configure {
   options.with {
+    // This is supposed to enable everything except "missing" but doesn't work with gradle
+    // See https://docs.oracle.com/en/java/javase/11/tools/javadoc.html
+    addBooleanOption('Xdoclint:all,-missing', true)
+
+    // TODO remove command and warning below if the doclint can be properly configured
+    addStringOption('Xmaxwarns', '3')
+
     memberLevel = JavadocMemberLevel.PUBLIC
     docTitle = 'SpotBugs Ant Task Documentation'
   }

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -254,12 +254,14 @@ TaskProvider<Copy> scripts = tasks.register('scripts', Copy) {
 // This disables hundreds of javadoc warnings on missing tags etc, see #340
 javadoc {
   doFirst {
-    // This is supposed to enable everything except "missing" but doesn't work with gradle
-    // See https://docs.oracle.com/en/java/javase/11/tools/javadoc.html
-    options.addBooleanOption('Xdoclint:all,-missing', true)
+    options.with {
+      // This is supposed to enable everything except "missing" but doesn't work with gradle
+      // See https://docs.oracle.com/en/java/javase/11/tools/javadoc.html
+      addBooleanOption('Xdoclint:all,-missing', true)
 
-    // TODO remove command and warning below if the doclint can be properly configured
-    options.addStringOption('Xmaxwarns', '3')
+      // TODO remove command and warning below if the doclint can be properly configured
+      addStringOption('Xmaxwarns', '3')
+    }
   }
   doLast {
     logger.warn('Javadoc: too many warnings, only first 3 are shown, see #340!')

--- a/spotbugsTestCases/build.gradle
+++ b/spotbugsTestCases/build.gradle
@@ -81,12 +81,14 @@ tasks.withType(JavaCompile).configureEach { JavaCompile compileTask ->
 
 // This disables hundreds of javadoc warnings on missing tags etc, see #340
 tasks.named('javadoc', Javadoc).configure { Javadoc javadocTask ->
-  // This is supposed to enable everything except "missing" but doesn't work with gradle
-  // See https://docs.oracle.com/en/java/javase/11/tools/javadoc.html
-  options.addBooleanOption('Xdoclint:all,-missing', true)
+  options.with {
+    // This is supposed to enable everything except "missing" but doesn't work with gradle
+    // See https://docs.oracle.com/en/java/javase/11/tools/javadoc.html
+    addBooleanOption('Xdoclint:all,-missing', true)
 
-  // TODO remove command and warning below if the doclint can be properly configured
-  options.addStringOption('Xmaxwarns', '3')
+    // TODO remove command and warning below if the doclint can be properly configured
+    addStringOption('Xmaxwarns', '3')
+  }
   doLast {
     logger.warn('Javadoc: too many warnings, only first 3 are shown, see #340!')
   }


### PR DESCRIPTION
This doesn't correct all warnings to console but does reduce some noise and ensures where overridden like this they all just do the same.  Javadoc issues are smaller in test areas and probably should just be fixed for what remains.