### PR TITLE
rewrite SwitchFallthrough tests with AbstractIntegrationTest instead of deprecated annotations

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/SwitchFallThroughTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/SwitchFallThroughTest.java
@@ -1,0 +1,67 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class SwitchFallThroughTest extends AbstractIntegrationTest {
+    @Test
+    void testBug2539590() {
+        performAnalysis("sfBugs/Bug2539590.class");
+
+        assertBugInMethod("SF_SWITCH_NO_DEFAULT", "Bug2539590", "noFallthroughMethodNoDefault");
+        assertNoBugInMethod("SF_SWITCH_NO_DEFAULT", "Bug2539590", "noFallthroughMethod");
+        assertNoBugInMethod("SF_SWITCH_NO_DEFAULT", "Bug2539590", "noFallthroughMethod2");
+
+        assertBugInMethod("SF_SWITCH_NO_DEFAULT", "Bug2539590", "fallthroughMethodNoDefault");
+        assertNoBugInMethod("SF_SWITCH_FALLTHROUGH", "Bug2539590", "fallthroughMethodNoDefault");
+
+        // assertNoBugInMethod("SF_SWITCH_NO_DEFAULT", "Bug2539590", "fallthroughMethod"); // desire, false positive
+        // assertBugInMethod("SF_SWITCH_FALLTHROUGH", "Bug2539590", "fallthroughMethod"); // desire, false negative
+
+        assertBugInMethod("SF_SWITCH_FALLTHROUGH", "Bug2539590", "fallthroughMethod2");
+
+        assertNoBugInMethod("SF_SWITCH_FALLTHROUGH", "Bug2539590", "fallthroughMethod3");
+
+        assertBugInMethod("SF_DEAD_STORE_DUE_TO_SWITCH_FALLTHROUGH", "Bug2539590", "fallthroughMethodNoDefaultClobber");
+        assertBugInMethod("SF_SWITCH_NO_DEFAULT", "Bug2539590", "fallthroughMethodNoDefaultClobber");
+
+        assertBugInMethod("SF_DEAD_STORE_DUE_TO_SWITCH_FALLTHROUGH", "Bug2539590", "fallthroughMethodClobber");
+        // SF_SWITCH_NO_DEFAULT fp in fallthroughMethodClobber, without any break/continue in the switch-case
+        // the presence of the default case doesn't make a difference in the bytecode
+
+        assertBugInMethod("SF_DEAD_STORE_DUE_TO_SWITCH_FALLTHROUGH_TO_THROW", "Bug2539590", "fallthroughMethodToss");
+        assertNoBugInMethod("SF_SWITCH_NO_DEFAULT", "Bug2539590", "fallthroughMethodToss");
+
+        assertBugTypeCountBetween("SF_SWITCH_FALLTHROUGH", 1, 2);
+        assertBugTypeCountBetween("SF_SWITCH_NO_DEFAULT", 3, 5);
+        assertBugTypeCount("SF_DEAD_STORE_DUE_TO_SWITCH_FALLTHROUGH", 2);
+        assertBugTypeCount("SF_DEAD_STORE_DUE_TO_SWITCH_FALLTHROUGH_TO_THROW", 1);
+    }
+
+    @Test
+    void testBug1172() {
+        performAnalysis("sfBugsNew/Bug1172.class");
+
+        assertBugInMethod("SF_SWITCH_FALLTHROUGH", "Bug1172", "testFallThrough");
+        // assertNoBugInMethod("SF_SWITCH_FALLTHROUGH", "Bug1172", "testFallThroughGood"); // desire, false negative
+
+        assertBugTypeCountBetween("SF_SWITCH_FALLTHROUGH", 1, 2);
+        assertNoBugType("SF_SWITCH_NO_DEFAULT");
+        assertNoBugType("SF_DEAD_STORE_DUE_TO_SWITCH_FALLTHROUGH");
+        assertNoBugType("SF_DEAD_STORE_DUE_TO_SWITCH_FALLTHROUGH_TO_THROW");
+    }
+
+    @Test
+    void testBug1249() {
+        performAnalysis("sfBugsNew/Bug1249.class");
+
+        assertBugInMethod("SF_SWITCH_FALLTHROUGH", "Bug1249", "foo1");
+        // assertNoBugInMethod("SF_SWITCH_FALLTHROUGH", "Bug1249", "foo2"); // desire, false negative
+        // assertNoBugInMethod("SF_SWITCH_FALLTHROUGH", "Bug1249", "foo3"); // desire, false negative
+
+        assertBugTypeCountBetween("SF_SWITCH_FALLTHROUGH", 1, 3);
+        assertNoBugType("SF_SWITCH_NO_DEFAULT");
+        assertNoBugType("SF_DEAD_STORE_DUE_TO_SWITCH_FALLTHROUGH");
+        assertNoBugType("SF_DEAD_STORE_DUE_TO_SWITCH_FALLTHROUGH_TO_THROW");
+    }
+}

--- a/spotbugsTestCases/src/java/sfBugs/Bug2539590.java
+++ b/spotbugsTestCases/src/java/sfBugs/Bug2539590.java
@@ -14,12 +14,9 @@ package sfBugs;
 
 import edu.umd.cs.findbugs.annotations.DesireNoWarning;
 import edu.umd.cs.findbugs.annotations.DesireWarning;
-import edu.umd.cs.findbugs.annotations.ExpectWarning;
-import edu.umd.cs.findbugs.annotations.NoWarning;
 
 public class Bug2539590 {
 
-    @ExpectWarning("SF_SWITCH_NO_DEFAULT")
     public static void noFallthroughMethodNoDefault(int which) {
         switch (which) {
         case 0:
@@ -28,7 +25,6 @@ public class Bug2539590 {
         }
     }
 
-    @DesireNoWarning("SF_SWITCH_NO_DEFAULT")
     public static void noFallthroughMethod(int which) {
         switch (which) {
         case 0:
@@ -38,7 +34,6 @@ public class Bug2539590 {
         }
     }
 
-    @NoWarning("SF_SWITCH_NO_DEFAULT")
     public static void noFallthroughMethod2(int which) {
         switch (which) {
         case 0:
@@ -57,8 +52,6 @@ public class Bug2539590 {
      * \ sfBugs.Bug2539590.fallthroughMethod(int) where one case falls \ through
      * to the next case At Bug2539590.java:[lines 33-35]
      */
-    @NoWarning("SF_SWITCH_FALLTHROUGH")
-    @ExpectWarning("SF_SWITCH_NO_DEFAULT")
     public static void fallthroughMethodNoDefault(int which) {
         switch (which) {
         case 0:
@@ -77,7 +70,6 @@ public class Bug2539590 {
         }
     }
 
-    @ExpectWarning("SF_SWITCH_FALLTHROUGH")
     public static void fallthroughMethod2(int which) {
         switch (which) {
         case 0:
@@ -90,7 +82,6 @@ public class Bug2539590 {
         }
     }
 
-    @NoWarning("SF_SWITCH_FALLTHROUGH")
     public static void fallthroughMethod3(int which) {
         switch (which) {
         case 0:
@@ -102,7 +93,6 @@ public class Bug2539590 {
         }
     }
 
-    @ExpectWarning("SF_DEAD_STORE_DUE_TO_SWITCH_FALLTHROUGH,SF_SWITCH_NO_DEFAULT")
     public static int fallthroughMethodNoDefaultClobber(int which) {
         int result = 0;
         switch (which) {
@@ -114,7 +104,8 @@ public class Bug2539590 {
         return result;
     }
 
-    @ExpectWarning("SF_DEAD_STORE_DUE_TO_SWITCH_FALLTHROUGH")
+    // there is an SF_SWITCH_NO_DEFAULT fp here, but if there is no goto in the switch,
+    // the bytecode is the same as if the content of the default case would be after the switch without a default case
     public static int fallthroughMethodClobber(int which) {
         int result = 0;
         switch (which) {
@@ -127,8 +118,6 @@ public class Bug2539590 {
         return result;
     }
 
-    @ExpectWarning("SF_DEAD_STORE_DUE_TO_SWITCH_FALLTHROUGH_TO_THROW")
-    @NoWarning("SF_SWITCH_NO_DEFAULT")
     public static int fallthroughMethodToss(int which) {
         int result;
         switch (which) {

--- a/spotbugsTestCases/src/java/sfBugsNew/Bug1172.java
+++ b/spotbugsTestCases/src/java/sfBugsNew/Bug1172.java
@@ -1,12 +1,8 @@
 package sfBugsNew;
 
 import edu.umd.cs.findbugs.annotations.DesireNoWarning;
-import edu.umd.cs.findbugs.annotations.ExpectWarning;
 
 public class Bug1172 {
-
-
-    @ExpectWarning("SF_SWITCH_FALLTHROUGH")
     public int testFallThrough(int x) {
         switch (x) {
         case 0:
@@ -34,5 +30,4 @@ public class Bug1172 {
         }
         return 0;
     }
-
 }

--- a/spotbugsTestCases/src/java/sfBugsNew/Bug1249.java
+++ b/spotbugsTestCases/src/java/sfBugsNew/Bug1249.java
@@ -1,11 +1,8 @@
 package sfBugsNew;
 
 import edu.umd.cs.findbugs.annotations.DesireNoWarning;
-import edu.umd.cs.findbugs.annotations.ExpectWarning;
 
 public class Bug1249 {
-
-    @ExpectWarning("SF_SWITCH_FALLTHROUGH")
     void foo1(int x) {
 
         switch (x) {


### PR DESCRIPTION
Rewrite the tests of `SwitchFallthrough` to inherit from `AbstractIntegrationTest` instead of using the deprecated `@[Expect|No]Warning` and `@Desire[No]Warning` annotations. There are a few cases where the current behavior of SpotBugs contradicts to the desire annotation. In these cases desire annotations are kept.
This PR doesn't cause any change in the functionality, so I haven't added a changelog entry.
