### PR TITLE
`CWO_CLOSED_WITHOUT_OPENED` false positive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 ### Fixed
 - Fix for an error when a record method has the `@SuppressFBWarnings` annotation ([#3622](https://github.com/spotbugs/spotbugs/pull/3622))
 - Fix `SF_SWITCH_FALLTHROUGH` false positive when continuing a loop ([#3617](https://github.com/spotbugs/spotbugs/issues/3617))
+- `CWO_CLOSED_WITHOUT_OPENED` false positive ([#3616](https://github.com/spotbugs/spotbugs/issues/3616))
 
 ## 4.9.4 - 2025-08-07
 ### Changed

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3616Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3616Test.java
@@ -1,0 +1,14 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class Issue3616Test extends AbstractIntegrationTest {
+
+    @Test
+    void testIssue() {
+        performAnalysis("ghIssues/Issue3616.class");
+
+        assertBugTypeCount("CWO_CLOSED_WITHOUT_OPENED", 0);
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/ResourceValueAnalysis.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/ResourceValueAnalysis.java
@@ -106,7 +106,7 @@ public class ResourceValueAnalysis<Resource> extends FrameDataflowAnalysis<Resou
                 // If status is OPEN, downgrade to OPEN_ON_EXCEPTION_PATH
                 tmpFact = modifyFrame(fact, null);
                 tmpFact.setStatus(ResourceValueFrame.State.OPEN_ON_EXCEPTION_PATH);
-            } else {
+            } else if (fact.getStatus() != ResourceValueFrame.State.CLOSED) {
                 tmpFact = modifyFrame(fact, null);
                 tmpFact.setStatus(ResourceValueFrame.State.NOT_OPEN_ON_EXCEPTION_PATH);
             }

--- a/spotbugsTestCases/src/java/ghIssues/Issue3616.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3616.java
@@ -1,0 +1,22 @@
+package ghIssues;
+
+import java.util.concurrent.locks.ReentrantLock;
+
+public class Issue3616 {
+	private final ReentrantLock evictionLock = new ReentrantLock();
+	
+	public void performCleanUp(boolean flag) {
+		evictionLock.lock();
+		try {
+			maintenance(flag);
+		} finally {
+			evictionLock.unlock();
+		}
+	}
+
+	public void maintenance(boolean flag) {
+		if (flag) {
+			throw new IllegalStateException();
+		}
+	}
+}


### PR DESCRIPTION
During the CFG analysis there's an exception edge where the resource was closed, so it shouldn't transition to "not opened"