### PR TITLE
unstableTest - set testClassesDirs and classpath

### DIFF
--- a/spotbugs-tests/build.gradle
+++ b/spotbugs-tests/build.gradle
@@ -43,6 +43,8 @@ tasks.named('jacocoTestReport', JacocoReport).configure {
 // Tests below fail if executed with other tests
 // So we run them before all other tests are executed
 tasks.register('unstableTest', Test.class) {
+  testClassesDirs = testing.suites.test.sources.output.classesDirs
+  classpath = testing.suites.test.sources.runtimeClasspath
   useJUnitPlatform()
   filter {
     includeTestsMatching 'PlaceholderTest'


### PR DESCRIPTION
Gradle 9 deprecated the default classpath usage for custom Test tasks ( see https://docs.gradle.org/8.14.3/userguide/upgrading_version_8.html#test_task_default_classpath ). Because of this `:spotbugs-tests:unstableTest` task become `NO-SOURCE` since https://github.com/spotbugs/spotbugs/pull/3571 was merged.
I couldn't find other custom tests in the project, which may need this setting.
This PR only makes some minor fixes in the gradle config of unstabletest, so I don't think it needs a changelog entry.