### PR TITLE
test: setup/teardown MutableClassesTest to remove unstableTests

### DIFF
--- a/spotbugs-tests/build.gradle
+++ b/spotbugs-tests/build.gradle
@@ -34,36 +34,13 @@ tasks.named('compileJava', JavaCompile).configure {
 }
 
 tasks.named('jacocoTestReport', JacocoReport).configure {
-  dependsOn('unstableTest')
   additionalSourceDirs.setFrom files(project(':spotbugs').sourceSets.main.java.srcDirs)
   additionalClassDirs.setFrom files(project(':spotbugs').sourceSets.main.output.classesDirs)
-  executionData.setFrom files(layout.buildDirectory.file('jacoco/unstableTest.exec'), layout.buildDirectory.file('jacoco/test.exec'))
-}
-
-// Tests below fail if executed with other tests
-// So we run them before all other tests are executed
-tasks.register('unstableTest', Test.class) {
-  testClassesDirs = testing.suites.test.sources.output.classesDirs
-  classpath = testing.suites.test.sources.runtimeClasspath
-  useJUnitPlatform()
-  filter {
-    includeTestsMatching 'PlaceholderTest'
-    includeTestsMatching 'MutableClassesTest'
-  }
-  testLogging {
-    events 'passed', 'skipped', 'failed'
-  }
 }
 
 test {
-  dependsOn ':spotbugsTestCases:build', 'unstableTest'
   useJUnitPlatform()
-  filter {
-    excludeTestsMatching 'PlaceholderTest'
-    excludeTestsMatching 'MutableClassesTest'
-  }
 }
-
 
 spotbugs {
   ignoreFailures = true

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/util/MutableClassesTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/util/MutableClassesTest.java
@@ -2,10 +2,19 @@ package edu.umd.cs.findbugs.util;
 
 import javax.annotation.concurrent.Immutable;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnJre;
 import org.junit.jupiter.api.condition.JRE;
+
+import edu.umd.cs.findbugs.FindBugs2;
+import edu.umd.cs.findbugs.PrintingBugReporter;
+import edu.umd.cs.findbugs.classfile.Global;
+import edu.umd.cs.findbugs.classfile.IAnalysisCache;
+import edu.umd.cs.findbugs.classfile.impl.ClassFactory;
+import edu.umd.cs.findbugs.classfile.impl.ClassPathImpl;
 
 @Immutable
 class Annotated {
@@ -21,7 +30,18 @@ class Annotated {
     }
 }
 
-class MutableClassesTest {
+class MutableClassesTest {    
+	@BeforeEach
+	void setUp() {
+		IAnalysisCache analysisCache = ClassFactory.instance().createAnalysisCache(new ClassPathImpl(), new PrintingBugReporter());
+		Global.setAnalysisCacheForCurrentThread(analysisCache);
+		FindBugs2.registerBuiltInAnalysisEngines(analysisCache);
+	}
+
+    @AfterEach
+    void teardown() {
+        Global.removeAnalysisCacheForCurrentThread();
+    }
 
     @Test
     void testKnownMutable() {


### PR DESCRIPTION
When running a unit test as a gradle test the `unstableTests` is also executed with its two tests, which takes a few seconds; this makes iterating slower.
This also requires to merge the jacoco execs reports.

The `unstableTests` task was introduced because `MutableClassesTest` failed when running as part of the gradle build, this should fix the root problem.