### PR TITLE
Fix missing classes needed for analyses for Tests

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindRefComparisonTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindRefComparisonTest.java
@@ -52,7 +52,8 @@ class FindRefComparisonTest extends AbstractIntegrationTest {
         setPriorityAdjustment(-1); // raise priority
         SystemProperties.setProperty("findbugs.refcomp.reportAll", "false");
 
-        performAnalysis("RefComparisons.class");
+        performAnalysis("RefComparisons.class", "RefComparisons$MyEnum.class", "RefComparisons$MyClass2.class",
+                "RefComparisons$MyClass1.class", "RefComparisons$MyClass3.class");
         assertBugTypeCount("RC_REF_COMPARISON", 1);
         assertBugInMethodAtLineWithConfidence("RC_REF_COMPARISON", "RefComparisons", "integerBadComparison", 5, Confidence.HIGH);
     }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1148Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1148Test.java
@@ -3,11 +3,24 @@ package edu.umd.cs.findbugs.detect;
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 
 class Issue1148Test extends AbstractIntegrationTest {
 
     @Test
-    void testIssue() {
+    @EnabledForJreRange(max = JRE.JAVA_20)
+    void testIssueUnderJava21() {
+        // Under JDK 21 there is an additional class in the bytecode generated from the switch
+        performAnalysis("ghIssues/Issue1148.class",
+                "ghIssues/Issue1148$UsageType.class", "ghIssues/Issue1148$1.class");
+
+        assertBugInMethodCount("SF_SWITCH_NO_DEFAULT", "ghIssues.Issue1148", "addData", 0);
+    }
+
+    @Test
+    @EnabledForJreRange(min = JRE.JAVA_21)
+    void testIssueJava21() {
         performAnalysis("ghIssues/Issue1148.class",
                 "ghIssues/Issue1148$UsageType.class");
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3396Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3396Test.java
@@ -7,7 +7,7 @@ class Issue3396Test extends AbstractIntegrationTest {
 
     @Test
     void testClassLevelSuppression() {
-        performAnalysis("ghIssues/issue3396/Issue3396.class");
+        performAnalysis("ghIssues/issue3396/Issue3396.class", "ghIssues/issue3396/Generated.class");
 
         assertBugInClassCount("US_USELESS_SUPPRESSION_ON_CLASS", "ghIssues.issue3396.Issue3396", 0);
         assertBugInClassCount("US_USELESS_SUPPRESSION_ON_FIELD", "ghIssues.issue3396.Issue3396", 0);
@@ -17,7 +17,7 @@ class Issue3396Test extends AbstractIntegrationTest {
 
     @Test
     void testPackageLevelSuppression() {
-        performAnalysis("ghIssues/issue3396/package-info.class");
+        performAnalysis("ghIssues/issue3396/package-info.class", "ghIssues/issue3396/Generated.class");
 
         assertBugInClassCount("US_USELESS_SUPPRESSION_ON_PACKAGE", "ghIssues.issue3396.Issue3396", 0);
     }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3572Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3572Test.java
@@ -2,12 +2,25 @@ package edu.umd.cs.findbugs.detect;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
 import org.junit.jupiter.api.Test;
-
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 
 class Issue3572Test extends AbstractIntegrationTest {
 
     @Test
-    void testIssue() {
+    @EnabledForJreRange(max = JRE.JAVA_20)
+    void testIssueUnderJava21() {
+        // Under JDK 21 there is an additional class in the bytecode generated from the switch
+        performAnalysis("ghIssues/Issue3572.class",
+                "ghIssues/Issue3572$MyEnum.class", "ghIssues/Issue3572$1.class");
+
+        assertBugInMethodCount("SF_SWITCH_NO_DEFAULT", "ghIssues.Issue3572", "withSwitchDefault", 0);
+        assertBugInMethodCount("SF_SWITCH_NO_DEFAULT", "ghIssues.Issue3572", "missingSwitchDefault", 1);
+    }
+
+    @Test
+    @EnabledForJreRange(min = JRE.JAVA_21)
+    void testIssueJava21() {
         performAnalysis("ghIssues/Issue3572.class",
                 "ghIssues/Issue3572$MyEnum.class");
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/nullness/AndroidNullabilityTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/nullness/AndroidNullabilityTest.java
@@ -26,21 +26,24 @@ class AndroidNullabilityTest {
     @Test
     void objectForNonNullParam_isOk(SpotBugsRunner spotbugs) {
         BugCollection bugCollection = spotbugs.performAnalysis(
-                Paths.get("../spotbugsTestCases/build/classes/java/main/androidAnnotations/ObjectForNonNullParam.class"));
+                Paths.get("../spotbugsTestCases/build/classes/java/main/androidAnnotations/ObjectForNonNullParam.class"),
+                Paths.get("../spotbugsTestCases/build/classes/java/main/android/support/annotation/NonNull.class"));
         assertThat(bugCollection, emptyIterable());
     }
 
     @Test
     void objectForNonNullParam2_isOk(SpotBugsRunner spotbugs) {
         BugCollection bugCollection = spotbugs.performAnalysis(
-                Paths.get("../spotbugsTestCases/build/classes/java/main/androidAnnotations/ObjectForNonNullParam2.class"));
+                Paths.get("../spotbugsTestCases/build/classes/java/main/androidAnnotations/ObjectForNonNullParam2.class"),
+                Paths.get("../spotbugsTestCases/build/classes/java/main/androidx/annotation/NonNull.class"));
         assertThat(bugCollection, emptyIterable());
     }
 
     @Test
     void nullForNonNullParam_isDetected(SpotBugsRunner spotbugs) {
         BugCollection bugCollection = spotbugs.performAnalysis(
-                Paths.get("../spotbugsTestCases/build/classes/java/main/androidAnnotations/NullForNonNullParam.class"));
+                Paths.get("../spotbugsTestCases/build/classes/java/main/androidAnnotations/NullForNonNullParam.class"),
+                Paths.get("../spotbugsTestCases/build/classes/java/main/android/support/annotation/NonNull.class"));
 
         assertThat(bugCollection, containsExactly(1, bug("NP_NONNULL_PARAM_VIOLATION")));
     }
@@ -48,7 +51,8 @@ class AndroidNullabilityTest {
     @Test
     void nullForNonNullParam2_isDetected(SpotBugsRunner spotbugs) {
         BugCollection bugCollection = spotbugs.performAnalysis(
-                Paths.get("../spotbugsTestCases/build/classes/java/main/androidAnnotations/NullForNonNullParam2.class"));
+                Paths.get("../spotbugsTestCases/build/classes/java/main/androidAnnotations/NullForNonNullParam2.class"),
+                Paths.get("../spotbugsTestCases/build/classes/java/main/androidx/annotation/NonNull.class"));
 
         assertThat(bugCollection, containsExactly(1, bug("NP_NONNULL_PARAM_VIOLATION")));
     }
@@ -56,21 +60,24 @@ class AndroidNullabilityTest {
     @Test
     void checkedNullableReturn_isOk(SpotBugsRunner spotbugs) {
         BugCollection bugCollection = spotbugs.performAnalysis(
-                Paths.get("../spotbugsTestCases/build/classes/java/main/androidAnnotations/CheckedNullableReturn.class"));
+                Paths.get("../spotbugsTestCases/build/classes/java/main/androidAnnotations/CheckedNullableReturn.class"),
+                Paths.get("../spotbugsTestCases/build/classes/java/main/android/support/annotation/Nullable.class"));
         assertThat(bugCollection, emptyIterable());
     }
 
     @Test
     void checkedNullableReturn2_isOk(SpotBugsRunner spotbugs) {
         BugCollection bugCollection = spotbugs.performAnalysis(
-                Paths.get("../spotbugsTestCases/build/classes/java/main/androidAnnotations/CheckedNullableReturn2.class"));
+                Paths.get("../spotbugsTestCases/build/classes/java/main/androidAnnotations/CheckedNullableReturn2.class"),
+                Paths.get("../spotbugsTestCases/build/classes/java/main/androidx/annotation/Nullable.class"));
         assertThat(bugCollection, emptyIterable());
     }
 
     @Test
     void uncheckedNullableReturn_isDetected(SpotBugsRunner spotbugs) {
         BugCollection bugCollection = spotbugs.performAnalysis(
-                Paths.get("../spotbugsTestCases/build/classes/java/main/androidAnnotations/UncheckedNullableReturn.class"));
+                Paths.get("../spotbugsTestCases/build/classes/java/main/androidAnnotations/UncheckedNullableReturn.class"),
+                Paths.get("../spotbugsTestCases/build/classes/java/main/android/support/annotation/Nullable.class"));
 
         assertThat(bugCollection, containsExactly(1, bug("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")));
     }
@@ -78,7 +85,8 @@ class AndroidNullabilityTest {
     @Test
     void uncheckedNullableReturn2_isDetected(SpotBugsRunner spotbugs) {
         BugCollection bugCollection = spotbugs.performAnalysis(
-                Paths.get("../spotbugsTestCases/build/classes/java/main/androidAnnotations/UncheckedNullableReturn2.class"));
+                Paths.get("../spotbugsTestCases/build/classes/java/main/androidAnnotations/UncheckedNullableReturn2.class"),
+                Paths.get("../spotbugsTestCases/build/classes/java/main/androidx/annotation/Nullable.class"));
 
         assertThat(bugCollection, containsExactly(1, bug("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")));
     }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/nullness/AvroNullabilityTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/nullness/AvroNullabilityTest.java
@@ -25,14 +25,16 @@ class AvroNullabilityTest {
     @Test
     void checkedAvroNullableReturn_isOk(SpotBugsRunner spotbugs) {
         BugCollection bugCollection = spotbugs.performAnalysis(
-                Paths.get("../spotbugsTestCases/build/classes/java/main/CheckedAvroNullableReturn.class"));
+                Paths.get("../spotbugsTestCases/build/classes/java/main/CheckedAvroNullableReturn.class"),
+                Paths.get("../spotbugsTestCases/build/classes/java/main/org/apache/avro/reflect/Nullable.class"));
         assertThat(bugCollection, emptyIterable());
     }
 
     @Test
     void uncheckedAvroNullableReturn_isDetected(SpotBugsRunner spotbugs) {
         BugCollection bugCollection = spotbugs.performAnalysis(
-                Paths.get("../spotbugsTestCases/build/classes/java/main/UncheckedAvroNullableReturn.class"));
+                Paths.get("../spotbugsTestCases/build/classes/java/main/UncheckedAvroNullableReturn.class"),
+                Paths.get("../spotbugsTestCases/build/classes/java/main/org/apache/avro/reflect/Nullable.class"));
 
         assertThat(bugCollection, containsExactly(1, bug()));
     }

--- a/spotbugsTestCases/src/java/multithreaded/primitivewrite/SynchronizedBlockDoubleFromOtherMethod.java
+++ b/spotbugsTestCases/src/java/multithreaded/primitivewrite/SynchronizedBlockDoubleFromOtherMethod.java
@@ -18,7 +18,7 @@ public class SynchronizedBlockDoubleFromOtherMethod {
     }
 
     public void anotherSyncPrint() {
-        synchronized (SynchronizedBlockDouble.class) {
+        synchronized (SynchronizedBlockDoubleFromOtherMethod.class) {
             printValue();
         }
     }


### PR DESCRIPTION
Several tests were emitting the `The following classes needed for analyses were missing:` message to the standard error, even though it doesn't appear in the log when running the tests from gradle, and this does not make the tests fail, but this masks some problems.


The following tests are still missing some classes:
- [Issue1771Test](https://github.com/spotbugs/spotbugs/blob/master/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1771Test.java) misses java.util.Collections$EmptyNavigableMap, java.util.Collections$EmptyNavigableSet;
   - It may be because this tests needs Java 11.
- [Issue2759Test](https://github.com/spotbugs/spotbugs/blob/master/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2759Test.java), [Issue2864Test](https://github.com/spotbugs/spotbugs/blob/master/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2864Test.java), [Issue3059Test](https://github.com/spotbugs/spotbugs/blob/master/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3059Test.java), [Issue3094Test](https://github.com/spotbugs/spotbugs/blob/master/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3094Test.java), [Issue3350Test](https://github.com/spotbugs/spotbugs/blob/master/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3350Test.java) and [LombokWithTest](https://github.com/spotbugs/spotbugs/blob/master/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/LombokWithTest.java) miss several classes, but these are read from classSample class files with several outside dependencies. IMO we shouldn't add all of those dependencies, and it's okay like this.
- [ClassPathBuilderTest.nestedTraversalEnabled](https://github.com/spotbugs/spotbugs/blob/master/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/classfile/impl/ClassPathBuilderTest.java#L29) misses MethodsCallOrder$SimpleTest, foo.Foo, com.bla.Parent, edu.umd.cs.findbugs.annotations.Confidence, edu.umd.cs.findbugs.annotations.CheckReturnValue, edu.umd.cs.findbugs.annotations.ExpectWarning, com.foo.Foo, org.jacoco.agent.rt.internal_43a39aa.Offline, MethodsCallOrder,  com.bla.Parent$Child, com.bla.Parent$Child$1, MethodsCallOrder$ShortcutPathTest,  edu.umd.cs.findbugs.annotations.DesireWarning.
  - A jar is analyzed, most likely it does not contain these classes, so IMO it's acceptable.
- [FindReturnRefTest.testFindReturnRefTestNegativeChecks](https://github.com/spotbugs/spotbugs/blob/master/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindReturnRefTest.java#L11), because the `PreferenceTreeNode` inner class in `FindReturnRefNegativeTest` was not added to the analysis in the test in https://github.com/spotbugs/spotbugs/pull/3284. With it, the test fails because there is an unexpected hit, I'll do it in a separate PR, the detector may need to be modified. (The original issue is about not throwing an NPE, not about an bug hit.)
- [WarningSuppressorTest.testIssue](https://github.com/spotbugs/spotbugs/blob/master/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/WarningSuppressorTest.java#L14), [Issue1254Test](https://github.com/spotbugs/spotbugs/blob/master/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue1254Test.java) miss some classes as well, but only when running with all tests, not when running them individually.
- [DetectorsTest.testAllRegressionFilesJavac](https://github.com/spotbugs/spotbugs/blob/master/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/DetectorsTest.java#L100) misses org.apiguardian.api.API$Status, org.apiguardian.api.API, javax.annotation.PreDestroy, javax.annotation.PostConstruct, and also when running with all tests additionally misses some.UnknownClass, org.example.Bar.
   - I think it's because of other classes
- [Issue574Test.testRegisterExtensionAnnotation](https://github.com/spotbugs/spotbugs/blob/master/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue574Test.java#L39) misses org.apiguardian.api.API, org.apiguardian.api.API$Status.
   - This annotation is on the parent of the analyzed class, which is coming from Junit Jupiter. I'm not sure about this one.

I haven't added a changelog entry, since I only modified test or sample code, and I don't think it's necessary for this type of change.
