### PR TITLE
chore: Move to NIO for file handling

### DIFF
--- a/spotbugs/src/gui/main/edu/umd/cs/findbugs/gui2/MainFrameComponentFactory.java
+++ b/spotbugs/src/gui/main/edu/umd/cs/findbugs/gui2/MainFrameComponentFactory.java
@@ -15,7 +15,6 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.Serializable;
 import java.net.MalformedURLException;
@@ -309,8 +308,6 @@ public class MainFrameComponentFactory implements Serializable {
     private boolean sourceCodeExists(@Nonnull SourceLineAnnotation note) {
         try {
             mainFrame.getProject().getSourceFinder().findSourceFile(note);
-        } catch (FileNotFoundException e) {
-            return false;
         } catch (IOException e) {
             return false;
         }

--- a/spotbugs/src/gui/main/edu/umd/cs/findbugs/gui2/MainFrameLoadSaveHelper.java
+++ b/spotbugs/src/gui/main/edu/umd/cs/findbugs/gui2/MainFrameLoadSaveHelper.java
@@ -2,10 +2,10 @@ package edu.umd.cs.findbugs.gui2;
 
 import java.awt.EventQueue;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.Serializable;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
@@ -230,7 +230,7 @@ public class MainFrameLoadSaveHelper implements Serializable {
 
             Filter suppressionFilter = mainFrame.getProject().getSuppressionFilter();
             try {
-                suppressionFilter.writeEnabledMatchersAsXML(new FileOutputStream(f));
+                suppressionFilter.writeEnabledMatchersAsXML(Files.newOutputStream(f.toPath()));
             } catch (IOException e) {
                 JOptionPane.showMessageDialog(mainFrame,
                         L10N.getLocalString("dlg.saving_error_lbl", "An error occurred in saving."));
@@ -439,7 +439,7 @@ public class MainFrameLoadSaveHelper implements Serializable {
         Future<Object> waiter = mainFrame.getBackgroundExecutor().submit(() -> {
             HTMLBugReporter reporter = new HTMLBugReporter(mainFrame.getProject(), "default.xsl");
             reporter.setIsRelaxed(true);
-            reporter.setOutputStream(UTF8.printStream(new FileOutputStream(f)));
+            reporter.setOutputStream(UTF8.printStream(Files.newOutputStream(f.toPath())));
             for (BugInstance bug : mainFrame.getBugCollection().getCollection()) {
                 try {
                     if (mainFrame.getViewFilter().show(bug)) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/AddMessages.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/AddMessages.java
@@ -20,7 +20,8 @@
 package edu.umd.cs.findbugs;
 
 import java.io.BufferedOutputStream;
-import java.io.FileOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
@@ -188,7 +189,7 @@ public class AddMessages {
         AddMessages addMessages = new AddMessages(inputCollection, document);
         addMessages.execute();
 
-        XMLWriter writer = new XMLWriter(new BufferedOutputStream(new FileOutputStream(outputFile)),
+        XMLWriter writer = new XMLWriter(new BufferedOutputStream(Files.newOutputStream(Path.of(outputFile))),
                 OutputFormat.createPrettyPrint());
         writer.write(document);
         writer.close();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/FindBugs2.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/FindBugs2.java
@@ -19,8 +19,9 @@
 
 package edu.umd.cs.findbugs;
 
-import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -893,7 +894,7 @@ public class FindBugs2 implements IFindBugsEngine, AutoCloseable {
         // If needed, load SourceInfoMap
         if (sourceInfoFileName != null) {
             SourceInfoMap sourceInfoMap = analysisContext.getSourceInfoMap();
-            sourceInfoMap.read(new FileInputStream(sourceInfoFileName));
+            sourceInfoMap.read(Files.newInputStream(Path.of(sourceInfoFileName)));
         }
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/HTMLBugReporter.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/HTMLBugReporter.java
@@ -20,10 +20,11 @@
 package edu.umd.cs.findbugs;
 
 import java.io.BufferedInputStream;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
@@ -102,7 +103,7 @@ public class HTMLBugReporter extends BugCollectionBugReporter {
             assert true; // ignore it
         }
         try {
-            return new BufferedInputStream(new FileInputStream(stylesheet));
+            return new BufferedInputStream(Files.newInputStream(Path.of(stylesheet)));
         } catch (Exception fnfe) {
             assert true; // ignore it
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/PrintingBugReporter.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/PrintingBugReporter.java
@@ -20,8 +20,9 @@
 package edu.umd.cs.findbugs;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.StringTokenizer;
@@ -166,7 +167,7 @@ public class PrintingBugReporter extends TextUIBugReporter {
         }
 
         if (argCount < args.length) {
-            reporter.setOutputStream(UTF8.printStream(new FileOutputStream(args[argCount++]), true));
+            reporter.setOutputStream(UTF8.printStream(Files.newOutputStream(Path.of(args[argCount++])), true));
         }
         boolean bugsReported = false;
         RuntimeException storedException = null;
@@ -232,7 +233,7 @@ public class PrintingBugReporter extends TextUIBugReporter {
         }
 
         if (argCount < args.length) {
-            reporter.setOutputStream(UTF8.printStream(new FileOutputStream(args[argCount++]), true));
+            reporter.setOutputStream(UTF8.printStream(Files.newOutputStream(Path.of(args[argCount++])), true));
         }
 
         reporter.finish();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/Project.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/Project.java
@@ -31,8 +31,6 @@ import static java.util.Objects.requireNonNull;
 
 import java.io.BufferedInputStream;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -40,6 +38,7 @@ import java.io.PrintWriter;
 import java.io.Reader;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -691,7 +690,7 @@ public class Project implements XMLWriteable, AutoCloseable {
         @SuppressWarnings("resource") // will be closed by caller
         Project project = new Project();
 
-        try (InputStream in = new BufferedInputStream(new FileInputStream(f))) {
+        try (InputStream in = new BufferedInputStream(Files.newInputStream(f.toPath()))) {
             String tag = Util.getXMLType(in);
             SAXBugCollectionHandler handler;
             if ("Project".equals(tag)) {
@@ -730,7 +729,7 @@ public class Project implements XMLWriteable, AutoCloseable {
     }
 
     public void writeXML(File f, @CheckForNull BugCollection bugCollection) throws IOException {
-        OutputStream out = new FileOutputStream(f);
+        OutputStream out = Files.newOutputStream(f.toPath());
         XMLOutput xmlOutput = new OutputStreamXMLOutput(out);
         try {
             writeXML(xmlOutput, f, bugCollection);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/PropertyBundle.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/PropertyBundle.java
@@ -29,7 +29,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import edu.umd.cs.findbugs.ba.AnalysisContext;
-import edu.umd.cs.findbugs.io.IO;
 
 /**
  * @author pugh
@@ -105,14 +104,10 @@ public class PropertyBundle {
         if (url == null) {
             return;
         }
-        InputStream in = null;
-        try {
-            in = url.openStream();
+        try (InputStream in = url.openStream()) {
             properties.load(in);
         } catch (IOException e) {
             AnalysisContext.logError("Unable to load properties from " + url, e);
-        } finally {
-            IO.close(in);
         }
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/SortedBugCollection.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/SortedBugCollection.java
@@ -23,8 +23,6 @@ import java.awt.GraphicsEnvironment;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -33,6 +31,8 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -402,7 +402,7 @@ public class SortedBugCollection implements BugCollection {
      */
     @Override
     public void writeXML(String fileName) throws IOException {
-        OutputStream out = new FileOutputStream(fileName);
+        OutputStream out = Files.newOutputStream(Path.of(fileName));
         if (fileName.endsWith(".gz")) {
             out = new GZIPOutputStream(out);
         }
@@ -416,7 +416,7 @@ public class SortedBugCollection implements BugCollection {
      *            the file to write to
      */
     public void writeXML(File file) throws IOException {
-        OutputStream out = new FileOutputStream(file);
+        OutputStream out = Files.newOutputStream(file.toPath());
         if (file.getName().endsWith(".gz")) {
             out = new GZIPOutputStream(out);
         }
@@ -1254,7 +1254,7 @@ public class SortedBugCollection implements BugCollection {
         if (length > Integer.MAX_VALUE) {
             throw new IllegalArgumentException("File " + f + " is too big at " + length + " bytes");
         }
-        InputStream in = new FileInputStream(f);
+        InputStream in = Files.newInputStream(f.toPath());
         return wrapGzip(progressMonitoredInputStream(in, (int) length, msg), f);
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/SystemProperties.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/SystemProperties.java
@@ -19,11 +19,13 @@
 
 package edu.umd.cs.findbugs;
 
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.IllegalFormatException;
 import java.util.Properties;
 import java.util.regex.Matcher;
@@ -31,7 +33,6 @@ import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
 import edu.umd.cs.findbugs.ba.AnalysisContext;
-import edu.umd.cs.findbugs.io.IO;
 
 /**
  * @author pugh
@@ -66,15 +67,11 @@ public class SystemProperties {
         OS_NAME = osName;
         loadPropertiesFromConfigFile();
         if (getBoolean("findbugs.dumpProperties")) {
-            FileOutputStream out = null;
-            try {
-                out = new FileOutputStream("/tmp/outProperties.txt");
+            try (OutputStream out = Files.newOutputStream(Path.of("/tmp/outProperties.txt"))) {
                 System.getProperties().store(out, "System properties dump");
                 properties.store(out, "SpotBugs properties dump");
             } catch (IOException e) {
                 assert true;
-            } finally {
-                IO.close(out);
             }
         }
     }
@@ -116,14 +113,10 @@ public class SystemProperties {
         if (url == null) {
             return;
         }
-        InputStream in = null;
-        try {
-            in = url.openStream();
+        try (InputStream in = url.openStream()) {
             properties.load(in);
         } catch (IOException e) {
             AnalysisContext.logError("Unable to load properties from " + url, e);
-        } finally {
-            IO.close(in);
         }
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/TextUICommandLine.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/TextUICommandLine.java
@@ -22,8 +22,6 @@ package edu.umd.cs.findbugs;
 import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
@@ -463,7 +461,7 @@ public class TextUICommandLine extends FindBugsCommandLine {
 
             try {
                 @WillCloseWhenClosed
-                OutputStream oStream = new BufferedOutputStream(new FileOutputStream(outputFile));
+                OutputStream oStream = new BufferedOutputStream(Files.newOutputStream(outputFile.toPath()));
                 if (fileName.endsWith(".gz")) {
                     oStream = new GZIPOutputStream(oStream);
                 }
@@ -616,7 +614,7 @@ public class TextUICommandLine extends FindBugsCommandLine {
             project.addSourceDirs(sourceDirs);
         } else if (USER_PREFS.equals(option)) {
             UserPreferences prefs = UserPreferences.createDefaultUserPreferences();
-            prefs.read(new FileInputStream(argument));
+            prefs.read(Files.newInputStream(Path.of(argument)));
             project.setConfiguration(prefs);
         } else {
             super.handleOptionWithArgument(option, argument);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/CFGPrinter.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/CFGPrinter.java
@@ -125,7 +125,7 @@ public class CFGPrinter {
     // String methodName = SystemProperties.getProperty("cfg.method");
     // PrintStream out = System.err;
     // if (argv.length == 2)
-    // out = UTF8.printStream(new FileOutputStream(argv[1]));
+    // out = UTF8.printStream(Files.newOutputStream(Path.of(argv[1])));
     // for (Method method : methods) {
     // MethodGen methodGen = classContext.getMethodGen(method);
     // if (methodGen == null)

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/FileSourceFileDataSource.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/FileSourceFileDataSource.java
@@ -21,10 +21,10 @@ package edu.umd.cs.findbugs.ba;
 
 import java.io.BufferedInputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.nio.file.Files;
 
 /**
  * Data source for source files which are stored in the filesystem.
@@ -40,7 +40,7 @@ public class FileSourceFileDataSource implements SourceFileDataSource {
 
     @Override
     public InputStream open() throws IOException {
-        return new BufferedInputStream(new FileInputStream(fileName));
+        return new BufferedInputStream(Files.newInputStream(java.nio.file.Path.of(fileName)));
     }
 
     @Override

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/SourceFinder.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/SourceFinder.java
@@ -22,8 +22,6 @@ package edu.umd.cs.findbugs.ba;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -33,6 +31,7 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
+import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -272,7 +271,7 @@ public class SourceFinder implements AutoCloseable {
         file.deleteOnExit();
         final BlockingSourceRepository r = new BlockingSourceRepository();
         Util.runInDameonThread(() -> {
-            try (InputStream in = open(url); OutputStream out = new FileOutputStream(file);) {
+            try (InputStream in = open(url); OutputStream out = Files.newOutputStream(file.toPath())) {
                 IO.copy(in, out);
                 r.setBase(new ZipSourceRepository(new ZipFile(file)));
             } catch (IOException e) {
@@ -531,7 +530,7 @@ public class SourceFinder implements AutoCloseable {
         String sourceRepositories = repositoryList.stream()
                 .map(Object::toString)
                 .collect(Collectors.joining(", "));
-        throw new FileNotFoundException("Can't find source file " + fileName + " (source repositories="
+        throw new IOException("Can't find source file " + fileName + " (source repositories="
                 + sourceRepositories + ")");
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/URLClassPath.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/URLClassPath.java
@@ -21,11 +21,11 @@ package edu.umd.cs.findbugs.ba;
 
 import java.io.BufferedInputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -163,7 +163,7 @@ public class URLClassPath implements AutoCloseable, Serializable {
             if (!file.exists()) {
                 return null;
             }
-            return new BufferedInputStream(new FileInputStream(file));
+            return new BufferedInputStream(Files.newInputStream(file.toPath()));
         }
 
         /*

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/ZipSourceFileDataSource.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/ZipSourceFileDataSource.java
@@ -19,7 +19,6 @@
 
 package edu.umd.cs.findbugs.ba;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -49,7 +48,7 @@ public class ZipSourceFileDataSource implements SourceFileDataSource {
     @Override
     public InputStream open() throws IOException {
         if (zipEntry == null) {
-            throw new FileNotFoundException("No zip entry for " + entryName);
+            throw new IOException("No zip entry for " + entryName);
         }
         return zipFile.getInputStream(zipEntry);
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/interproc/PropertyDatabase.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/interproc/PropertyDatabase.java
@@ -21,14 +21,14 @@ package edu.umd.cs.findbugs.ba.interproc;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -123,7 +123,7 @@ public abstract class PropertyDatabase<KeyType extends FieldOrMethodDescriptor, 
      * @throws PropertyDatabaseFormatException
      */
     public void readFromFile(String fileName) throws IOException, PropertyDatabaseFormatException {
-        read(new FileInputStream(fileName));
+        read(Files.newInputStream(Path.of(fileName)));
     }
 
     /**
@@ -164,7 +164,7 @@ public abstract class PropertyDatabase<KeyType extends FieldOrMethodDescriptor, 
      * @throws IOException
      */
     public void writeToFile(String fileName) throws IOException {
-        write(new FileOutputStream(fileName));
+        write(Files.newOutputStream(Path.of(fileName)));
     }
 
     // @SuppressWarnings("unchecked")

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/charsets/SourceCharset.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/charsets/SourceCharset.java
@@ -22,7 +22,6 @@ package edu.umd.cs.findbugs.charsets;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -30,6 +29,8 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.Writer;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 /**
  * @author pugh
@@ -43,7 +44,7 @@ public class SourceCharset {
     }
 
     public static Writer fileWriter(File fileName) throws IOException {
-        return new OutputStreamWriter(new FileOutputStream(fileName), charset);
+        return new OutputStreamWriter(Files.newOutputStream(fileName.toPath()), Charset.defaultCharset());
     }
 
     public static PrintWriter printWriter(File fileName) throws IOException {
@@ -51,7 +52,7 @@ public class SourceCharset {
     }
 
     public static Writer fileWriter(String fileName) throws IOException {
-        return new OutputStreamWriter(new FileOutputStream(fileName), charset);
+        return new OutputStreamWriter(Files.newOutputStream(Path.of(fileName)), Charset.defaultCharset());
     }
 
     public static PrintWriter printWriter(String fileName) throws IOException {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/charsets/UTF8.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/charsets/UTF8.java
@@ -22,8 +22,6 @@ package edu.umd.cs.findbugs.charsets;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -35,6 +33,8 @@ import java.io.Reader;
 import java.io.UnsupportedEncodingException;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import javax.annotation.WillCloseWhenClosed;
 
@@ -65,7 +65,7 @@ public class UTF8 {
     }
 
     public static Writer fileWriter(File fileName) throws IOException {
-        return new OutputStreamWriter(new FileOutputStream(fileName), StandardCharsets.UTF_8);
+        return new OutputStreamWriter(Files.newOutputStream(fileName.toPath()), StandardCharsets.UTF_8);
     }
 
     public static BufferedWriter bufferedWriter(File fileName) throws IOException {
@@ -86,7 +86,7 @@ public class UTF8 {
     }
 
     public static Writer fileWriter(String fileName) throws IOException {
-        return new OutputStreamWriter(new FileOutputStream(fileName), StandardCharsets.UTF_8);
+        return new OutputStreamWriter(Files.newOutputStream(Path.of(fileName)), StandardCharsets.UTF_8);
     }
 
     public static BufferedWriter bufferedWriter(String fileName) throws IOException {
@@ -94,11 +94,11 @@ public class UTF8 {
     }
 
     public static Reader fileReader(String fileName) throws IOException {
-        return reader(new FileInputStream(fileName));
+        return reader(Files.newInputStream(Path.of(fileName)));
     }
 
     public static Reader fileReader(File fileName) throws IOException {
-        return reader(new FileInputStream(fileName));
+        return reader(Files.newInputStream(fileName.toPath()));
     }
 
     public static PrintWriter printWriter(String fileName) throws IOException {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/charsets/UserTextFile.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/charsets/UserTextFile.java
@@ -21,7 +21,6 @@ package edu.umd.cs.findbugs.charsets;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -30,6 +29,8 @@ import java.io.PrintWriter;
 import java.io.Reader;
 import java.io.Writer;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import javax.annotation.WillCloseWhenClosed;
 
@@ -45,7 +46,7 @@ public class UserTextFile {
     }
 
     public static Writer fileWriter(String fileName) throws IOException {
-        return new OutputStreamWriter(new FileOutputStream(fileName), charset);
+        return new OutputStreamWriter(Files.newOutputStream(Path.of(fileName)), Charset.defaultCharset());
     }
 
     public static PrintWriter printWriter(String fileName) throws IOException {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/ClassPathBuilder.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/ClassPathBuilder.java
@@ -22,7 +22,6 @@ package edu.umd.cs.findbugs.classfile.impl;
 import java.io.DataInputStream;
 import java.io.File;
 import java.io.FileFilter;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -638,15 +637,7 @@ public class ClassPathBuilder implements IClassPathBuilder {
                 scanJarManifestForClassPathEntries(workList, discoveredCodeBase.getCodeBase());
             } catch (IOException e) {
                 if (item.isAppCodeBase() || item.getHowDiscovered() == ICodeBase.Discovered.SPECIFIED) {
-                    if (e instanceof FileNotFoundException) {
-                        if (item.isAppCodeBase()) {
-                            errorLogger.logError("File from project not found: " + item.getCodeBaseLocator(), e);
-                        } else {
-                            errorLogger.logError("File from auxiliary classpath not found: " + item.getCodeBaseLocator(), e);
-                        }
-                    } else {
-                        errorLogger.logError("Cannot open codebase " + item.getCodeBaseLocator(), e);
-                    }
+                    errorLogger.logError("Cannot open codebase " + item.getCodeBaseLocator(), e);
                 }
             } catch (ResourceNotFoundException e) {
                 if (item.getHowDiscovered() == ICodeBase.Discovered.SPECIFIED) {
@@ -759,9 +750,7 @@ public class ClassPathBuilder implements IClassPathBuilder {
         }
 
         // Try to read the manifest
-        InputStream in = null;
-        try {
-            in = manifestEntry.openResource();
+        try (InputStream in = manifestEntry.openResource()) {
             Manifest manifest = new Manifest(in);
 
             Attributes mainAttrs = manifest.getMainAttributes();
@@ -779,10 +768,6 @@ public class ClassPathBuilder implements IClassPathBuilder {
                     // added to the aux classpath, not the application.
                     addToWorkList(workList, new WorkListItem(relativeCodeBaseLocator, false, ICodeBase.Discovered.IN_JAR_MANIFEST));
                 }
-            }
-        } finally {
-            if (in != null) {
-                IO.close(in);
             }
         }
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/DirectoryCodeBase.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/DirectoryCodeBase.java
@@ -19,7 +19,11 @@
 
 package edu.umd.cs.findbugs.classfile.impl;
 
-import java.io.*;
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.Iterator;
 import java.util.LinkedList;
 
@@ -151,7 +155,7 @@ public class DirectoryCodeBase extends AbstractScannableCodeBase {
 
     InputStream openFile(String resourceName) throws IOException {
         File path = getFullPathOfResource(resourceName);
-        return new BufferedInputStream(new FileInputStream(path));
+        return new BufferedInputStream(Files.newInputStream(path.toPath()));
     }
 
     /**

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/NestedZipFileCodeBase.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/NestedZipFileCodeBase.java
@@ -21,10 +21,10 @@ package edu.umd.cs.findbugs.classfile.impl;
 
 import java.io.BufferedOutputStream;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Files;
 
 import edu.umd.cs.findbugs.ba.AnalysisContext;
 import edu.umd.cs.findbugs.classfile.ICodeBase;
@@ -77,7 +77,7 @@ public class NestedZipFileCodeBase extends AbstractScannableCodeBase {
                 throw new ResourceNotFoundException(resourceName);
             }
             inputStream = resource.openResource();
-            outputStream = new BufferedOutputStream(new FileOutputStream(tempFile));
+            outputStream = new BufferedOutputStream(Files.newOutputStream(tempFile.toPath()));
             IO.copy(inputStream, outputStream);
             outputStream.flush();
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/ZipFileCodeBase.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/ZipFileCodeBase.java
@@ -21,8 +21,8 @@ package edu.umd.cs.findbugs.classfile.impl;
 
 import java.io.DataInputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Enumeration;
 import java.util.NoSuchElementException;
 import java.util.zip.ZipEntry;
@@ -78,7 +78,7 @@ public class ZipFileCodeBase extends AbstractScannableCodeBase {
                 throw ioException;
             }
             int magicBytes;
-            try (DataInputStream in = new DataInputStream(new FileInputStream(file))) {
+            try (DataInputStream in = new DataInputStream(Files.newInputStream(file.toPath()))) {
                 magicBytes = in.readInt();
             } catch (IOException e3) {
                 throw new IOException(String.format("Unable read first 4 bytes of zip file %s of %d bytes", file, file.length()));

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/ZipInputStreamCodeBase.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/ZipInputStreamCodeBase.java
@@ -21,8 +21,8 @@ package edu.umd.cs.findbugs.classfile.impl;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.HashSet;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -62,7 +62,7 @@ public class ZipInputStreamCodeBase extends AbstractScannableCodeBase {
 
         this.file = file;
         setLastModifiedTime(file.lastModified());
-        try (ZipInputStream zis = new ZipInputStream(new FileInputStream(file))) {
+        try (ZipInputStream zis = new ZipInputStream(Files.newInputStream(file.toPath()))) {
             ZipEntry ze;
 
             if (DEBUG) {
@@ -111,7 +111,7 @@ public class ZipInputStreamCodeBase extends AbstractScannableCodeBase {
             if (z != null) {
                 return z;
             }
-            try (ZipInputStream zis = new ZipInputStream(new FileInputStream(file))) {
+            try (ZipInputStream zis = new ZipInputStream(Files.newInputStream(file.toPath()))) {
                 ZipEntry ze;
 
                 boolean found = false;
@@ -162,7 +162,7 @@ public class ZipInputStreamCodeBase extends AbstractScannableCodeBase {
 
         MyIterator() {
             try {
-                zis = new ZipInputStream(new FileInputStream(file));
+                zis = new ZipInputStream(Files.newInputStream(file.toPath()));
                 ze = zis.getNextEntry();
             } catch (IOException e) {
                 throw new RuntimeException(e);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/config/CommandLine.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/config/CommandLine.java
@@ -20,11 +20,13 @@
 package edu.umd.cs.findbugs.config;
 
 import java.io.BufferedReader;
-import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -189,7 +191,7 @@ public abstract class CommandLine {
                 continue;
             }
 
-            try (FileInputStream stream = new FileInputStream(arg.substring(1));
+            try (InputStream stream = Files.newInputStream(Path.of(arg.substring(1)));
                     BufferedReader reader = UTF8.bufferedReader(stream)) {
                 addCommandLineOptions(expandedOptionsList, reader, ignoreComments, ignoreBlankLines);
             }
@@ -294,11 +296,11 @@ public abstract class CommandLine {
      *         entire command line was parsed
      * @throws HelpRequestedException
      */
-    public int parse(String argv[]) throws IOException, HelpRequestedException {
+    public int parse(String[] argv) throws IOException, HelpRequestedException {
         return parse(argv, false);
     }
 
-    private int parse(String argv[], boolean dryRun) throws IOException, HelpRequestedException {
+    private int parse(String[] argv, boolean dryRun) throws IOException, HelpRequestedException {
         int arg = 0;
 
         while (arg < argv.length) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/config/UserPreferences.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/config/UserPreferences.java
@@ -29,8 +29,6 @@ package edu.umd.cs.findbugs.config;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -166,7 +164,7 @@ public class UserPreferences implements Cloneable {
             return;
         }
         try {
-            read(new FileInputStream(prefFile));
+            read(Files.newInputStream(prefFile.toPath()));
         } catch (IOException e) {
             // Ignore - just use default preferences
         }
@@ -266,7 +264,7 @@ public class UserPreferences implements Cloneable {
     public void write() {
         try {
             File prefFile = new File(SystemProperties.getProperty("user.home"), PREF_FILE_NAME);
-            write(new FileOutputStream(prefFile));
+            write(Files.newOutputStream(prefFile.toPath()));
         } catch (IOException e) {
             if (FindBugs.DEBUG) {
                 e.printStackTrace(); // Ignore

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/filter/Filter.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/filter/Filter.java
@@ -207,8 +207,8 @@ public class Filter extends OrMatcher {
      */
     private void parse(String fileName) throws IOException, SAXException, ParserConfigurationException {
         Path path = FileSystems.getDefault().getPath(fileName);
-        InputStream fileInputStream = Files.newInputStream(path);
-        parse(fileName, fileInputStream);
+        InputStream inputStream = Files.newInputStream(path);
+        parse(fileName, inputStream);
     }
 
     /**

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/io/IO.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/io/IO.java
@@ -192,25 +192,6 @@ public class IO {
     }
 
     /**
-     * Close given InputStream, ignoring any resulting exception.
-     *
-     * @param inputStream
-     *            the InputStream to close; may be null (in which case nothing
-     *            happens)
-     */
-    public static void close(@CheckForNull InputStream inputStream) {
-        if (inputStream == null) {
-            return;
-        }
-
-        try {
-            inputStream.close();
-        } catch (IOException e) {
-            // Ignore
-        }
-    }
-
-    /**
      * Close given OutputStream, ignoring any resulting exception.
      *
      * @param outputStream

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/Util.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/Util.java
@@ -22,14 +22,13 @@ package edu.umd.cs.findbugs.util;
 import java.io.BufferedReader;
 import java.io.Closeable;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Reader;
 import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
@@ -132,20 +131,20 @@ public class Util {
         return UTF8.reader(in);
     }
 
-    public static Reader getFileReader(String filename) throws FileNotFoundException {
-        return getReader(new FileInputStream(filename));
+    public static Reader getFileReader(String filename) throws IOException {
+        return getReader(Files.newInputStream(Path.of(filename)));
     }
 
-    public static Reader getFileReader(File filename) throws FileNotFoundException {
-        return getReader(new FileInputStream(filename));
+    public static Reader getFileReader(File filename) throws IOException {
+        return getReader(Files.newInputStream(filename.toPath()));
     }
 
     public static Writer getWriter(@WillCloseWhenClosed OutputStream out) {
         return UTF8.writer(out);
     }
 
-    public static Writer getFileWriter(String filename) throws FileNotFoundException {
-        return getWriter(new FileOutputStream(filename));
+    public static Writer getFileWriter(String filename) throws IOException {
+        return getWriter(Files.newOutputStream(Path.of(filename)));
     }
 
     public static void closeSilently(@WillClose InputStream in) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/Churn.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/Churn.java
@@ -19,8 +19,9 @@
 
 package edu.umd.cs.findbugs.workflow;
 
-import java.io.FileOutputStream;
 import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
@@ -234,7 +235,7 @@ public class Churn {
         PrintStream out = System.out;
         try {
             if (argCount < args.length) {
-                out = UTF8.printStream(new FileOutputStream(args[argCount++]), true);
+                out = UTF8.printStream(Files.newOutputStream(Path.of(args[argCount++])), true);
             }
             churn.dump(out);
         } finally {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/CopyBuggySource.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/CopyBuggySource.java
@@ -18,10 +18,10 @@
 package edu.umd.cs.findbugs.workflow;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Files;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.zip.DeflaterOutputStream;
@@ -112,10 +112,10 @@ public class CopyBuggySource {
         case DIR:
             break;
         case ZIP:
-            zOut = new ZipOutputStream(new FileOutputStream(src));
+            zOut = new ZipOutputStream(Files.newOutputStream(src.toPath()));
             break;
         case Z0P_GZ:
-            zOut = new ZipOutputStream(new DeflaterOutputStream(new FileOutputStream(src)));
+            zOut = new ZipOutputStream(new DeflaterOutputStream(Files.newOutputStream(src.toPath())));
             zOut.setLevel(0);
             break;
         }
@@ -224,7 +224,7 @@ public class CopyBuggySource {
                 return null;
             }
 
-            return new FileOutputStream(dstFile);
+            return Files.newOutputStream(dstFile.toPath());
         } else {
             ZipEntry e = new ZipEntry(fullName);
             e.setTime(lastModifiedTime);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/MineBugHistory.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/MineBugHistory.java
@@ -19,8 +19,9 @@
 
 package edu.umd.cs.findbugs.workflow;
 
-import java.io.FileOutputStream;
 import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashMap;
@@ -474,7 +475,7 @@ public class MineBugHistory {
 
         try {
             if (argCount < args.length) {
-                out = UTF8.printStream(new FileOutputStream(args[argCount++]), true);
+                out = UTF8.printStream(Files.newOutputStream(Path.of(args[argCount++])), true);
             }
             mineBugHistory.dump(out);
         } finally {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/RejarClassesForAnalysis.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/RejarClassesForAnalysis.java
@@ -22,11 +22,10 @@ package edu.umd.cs.findbugs.workflow;
 import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -575,9 +574,9 @@ public class RejarClassesForAnalysis {
         System.out.println("All done");
     }
 
-    private ZipOutputStream createZipFile(String fileName) throws FileNotFoundException {
+    private ZipOutputStream createZipFile(String fileName) throws IOException {
         File newFile = new File(commandLine.outputDir, fileName);
-        return new ZipOutputStream(new BufferedOutputStream(new FileOutputStream(newFile)));
+        return new ZipOutputStream(new BufferedOutputStream(Files.newOutputStream(newFile.toPath())));
     }
 
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/UnionResults.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/UnionResults.java
@@ -20,10 +20,11 @@
 package edu.umd.cs.findbugs.workflow;
 
 import java.io.BufferedReader;
-import java.io.FileInputStream;
 import java.io.InputStreamReader;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -174,7 +175,7 @@ public class UnionResults {
 
     private static List<String> readWrappedArguments(String fileName) throws IOException {
         List<String> wrappedArguments = new ArrayList<>();
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(fileName), StandardCharsets.UTF_8))) {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(Files.newInputStream(Path.of(fileName)), StandardCharsets.UTF_8))) {
             String next;
             while ((next = reader.readLine()) != null) {
                 wrappedArguments.add(next);

--- a/spotbugs/src/tools/edu/umd/cs/findbugs/tools/ComparePerfomance.java
+++ b/spotbugs/src/tools/edu/umd/cs/findbugs/tools/ComparePerfomance.java
@@ -20,7 +20,6 @@
 package edu.umd.cs.findbugs.tools;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
@@ -67,8 +66,7 @@ public class ComparePerfomance {
         SAXReader reader = new SAXReader();
 
         String fName = f.getName();
-        InputStream in = new FileInputStream(f);
-        try {
+        try (InputStream in = Files.newInputStream(f.toPath())) {
             if (fName.endsWith(".gz")) {
                 in = new GZIPInputStream(in);
             }
@@ -87,8 +85,6 @@ public class ComparePerfomance {
                 putStats(name, i, totalMilliseconds);
                 //            System.out.printf("%6d %10d %s%n", invocations, totalMilliseconds, simpleName);
             }
-        } finally {
-            in.close();
         }
     }
 

--- a/spotbugs/src/tools/edu/umd/cs/findbugs/tools/FilterAndCombineBitfieldPropertyDatabase.java
+++ b/spotbugs/src/tools/edu/umd/cs/findbugs/tools/FilterAndCombineBitfieldPropertyDatabase.java
@@ -1,10 +1,10 @@
 package edu.umd.cs.findbugs.tools;
 
 import java.io.BufferedReader;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -15,7 +15,6 @@ import java.util.regex.Pattern;
 import javax.annotation.WillClose;
 
 import edu.umd.cs.findbugs.internalAnnotations.DottedClassName;
-import edu.umd.cs.findbugs.util.Util;
 
 /*
  * FindBugs - Find Bugs in Java programs
@@ -56,7 +55,7 @@ public class FilterAndCombineBitfieldPropertyDatabase {
             process(System.in, properties, accessFlags);
         } else {
             for (String f : args) {
-                process(new FileInputStream(f), properties, accessFlags);
+                process(Files.newInputStream(Path.of(f)), properties, accessFlags);
             }
         }
 
@@ -100,14 +99,12 @@ public class FilterAndCombineBitfieldPropertyDatabase {
 
     /**
      * @param inSource
-     * @throws UnsupportedEncodingException
      * @throws IOException
      */
     private static void process(@WillClose InputStream inSource, Map<String, Integer> properties, Map<String, Integer> accessFlags)
-            throws UnsupportedEncodingException, IOException {
-        BufferedReader in = new BufferedReader(Util.getReader(inSource));
+            throws IOException {
         Pattern p = Pattern.compile("^(([^,]+),.+),([0-9]+)\\|([0-9]+)$");
-        try {
+        try (BufferedReader in = new BufferedReader(Util.getReader(inSource))) {
             while (true) {
                 String s = in.readLine();
                 if (s == null) {
@@ -133,8 +130,6 @@ public class FilterAndCombineBitfieldPropertyDatabase {
                 }
 
             }
-        } finally {
-            Util.closeSilently(in);
         }
     }
 

--- a/spotbugs/src/tools/edu/umd/cs/findbugs/tools/FilterPropertyDatabase.java
+++ b/spotbugs/src/tools/edu/umd/cs/findbugs/tools/FilterPropertyDatabase.java
@@ -1,17 +1,16 @@
 package edu.umd.cs.findbugs.tools;
 
 import java.io.BufferedReader;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.annotation.WillClose;
 
 import edu.umd.cs.findbugs.tools.FilterAndCombineBitfieldPropertyDatabase.Status;
-import edu.umd.cs.findbugs.util.Util;
 
 /*
  * FindBugs - Find Bugs in Java programs
@@ -47,7 +46,7 @@ public class FilterPropertyDatabase {
     public static void main(String[] args) throws IOException {
         InputStream inSource = System.in;
         if (args.length > 0) {
-            inSource = new FileInputStream(args[0]);
+            inSource = Files.newInputStream(Path.of(args[0]));
         }
         process(inSource);
 
@@ -55,13 +54,10 @@ public class FilterPropertyDatabase {
 
     /**
      * @param inSource
-     * @throws UnsupportedEncodingException
      * @throws IOException
      */
-    private static void process(@WillClose InputStream inSource) throws UnsupportedEncodingException, IOException {
-        BufferedReader in = null;
-        try {
-            in = new BufferedReader(Util.getReader(inSource));
+    private static void process(@WillClose InputStream inSource) throws IOException {
+        try (BufferedReader in = new BufferedReader(Util.getReader(inSource))) {
 
             Pattern p = Pattern.compile("^(([^,]+),.+),([0-9]+)\\|(.+)$");
 
@@ -84,8 +80,6 @@ public class FilterPropertyDatabase {
                 }
 
             }
-        } finally {
-            Util.closeSilently(in);
         }
     }
 


### PR DESCRIPTION
I have not added a change log for this change.

These are considered obsolete

- FileNotFoundException
- FileInputStream
- FileOutputStream

Replaced all with modern NIO type.  For file not found exception, its just a io exception without need for separate named exception.