### PR TITLE
Use modifiers in correct order

### DIFF
--- a/docs/locale/ja/LC_MESSAGES/bugDescriptions.po
+++ b/docs/locale/ja/LC_MESSAGES/bugDescriptions.po
@@ -4615,7 +4615,7 @@ msgstr ""
 #: ../../generated/bugDescriptionList.inc:4572
 msgid ""
 "<p>\n"
-" A final static field that is\n"
+" A static final field that is\n"
 "defined in an interface references a mutable\n"
 "   object such as an array or hashtable.\n"
 "   This mutable object could\n"
@@ -4692,7 +4692,7 @@ msgstr ""
 
 #: ../../generated/bugDescriptionList.inc:4662
 msgid ""
-"<p>A final static field references a Hashtable\n"
+"<p>A static final field references a Hashtable\n"
 "  and can be accessed by malicious code or\n"
 "       by accident from another package.\n"
 "  This code can freely modify the contents of the Hashtable.</p>"
@@ -4704,7 +4704,7 @@ msgstr ""
 
 #: ../../generated/bugDescriptionList.inc:4677
 msgid ""
-"<p> A final static field references an array\n"
+"<p> A static final field references an array\n"
 "   and can be accessed by malicious code or\n"
 "        by accident from another package.\n"
 "   This code can freely modify the contents of the array.</p>"
@@ -4716,7 +4716,7 @@ msgstr ""
 
 #: ../../generated/bugDescriptionList.inc:4692
 msgid ""
-"<p>A mutable collection instance is assigned to a final static field,\n"
+"<p>A mutable collection instance is assigned to a static final field,\n"
 "  thus can be changed by malicious code or by accident from another "
 "package.\n"
 "  Consider wrapping this field into "
@@ -4732,7 +4732,7 @@ msgstr ""
 
 #: ../../generated/bugDescriptionList.inc:4707
 msgid ""
-"<p>A mutable collection instance is assigned to a final static field,\n"
+"<p>A mutable collection instance is assigned to a static final field,\n"
 "  thus can be changed by malicious code or by accident from another "
 "package.\n"
 "  The field could be made package protected to avoid this vulnerability.\n"

--- a/docs/locale/pt_BR/LC_MESSAGES/bugDescriptions.po
+++ b/docs/locale/pt_BR/LC_MESSAGES/bugDescriptions.po
@@ -4913,7 +4913,7 @@ msgstr ""
 #: ../../generated/bugDescriptionList.inc:4572
 msgid ""
 "<p>\n"
-" A final static field that is\n"
+" A static final field that is\n"
 "defined in an interface references a mutable\n"
 "   object such as an array or hashtable.\n"
 "   This mutable object could\n"
@@ -4990,7 +4990,7 @@ msgstr ""
 
 #: ../../generated/bugDescriptionList.inc:4662
 msgid ""
-"<p>A final static field references a Hashtable\n"
+"<p>A static final field references a Hashtable\n"
 "  and can be accessed by malicious code or\n"
 "       by accident from another package.\n"
 "  This code can freely modify the contents of the Hashtable.</p>"
@@ -5002,7 +5002,7 @@ msgstr ""
 
 #: ../../generated/bugDescriptionList.inc:4677
 msgid ""
-"<p> A final static field references an array\n"
+"<p> A static final field references an array\n"
 "   and can be accessed by malicious code or\n"
 "        by accident from another package.\n"
 "   This code can freely modify the contents of the array.</p>"
@@ -5014,7 +5014,7 @@ msgstr ""
 
 #: ../../generated/bugDescriptionList.inc:4692
 msgid ""
-"<p>A mutable collection instance is assigned to a final static field,\n"
+"<p>A mutable collection instance is assigned to a static final field,\n"
 "  thus can be changed by malicious code or by accident from another "
 "package.\n"
 "  Consider wrapping this field into "
@@ -5030,7 +5030,7 @@ msgstr ""
 
 #: ../../generated/bugDescriptionList.inc:4707
 msgid ""
-"<p>A mutable collection instance is assigned to a final static field,\n"
+"<p>A mutable collection instance is assigned to a static final field,\n"
 "  thus can be changed by malicious code or by accident from another "
 "package.\n"
 "  The field could be made package protected to avoid this vulnerability.\n"

--- a/eclipsePlugin-test/quickfixOutput/MakeFieldStaticResolutionExample.java
+++ b/eclipsePlugin-test/quickfixOutput/MakeFieldStaticResolutionExample.java
@@ -1,3 +1,3 @@
 public class MakeFieldStaticResolutionExample {
-    final static String GREETING = "Hello World";
+    static final String GREETING = "Hello World";
 }

--- a/eclipsePlugin/src/de/tobject/findbugs/properties/PathsProvider.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/properties/PathsProvider.java
@@ -156,7 +156,7 @@ abstract class PathsProvider extends SelectionAdapter implements IStructuredCont
         return dialog;
     }
 
-    abstract protected void configureDialog(FileDialog dialog);
+    protected abstract void configureDialog(FileDialog dialog);
 
     protected String openFileDialog(FileDialog dialog) {
         return dialog.open();
@@ -231,7 +231,7 @@ abstract class PathsProvider extends SelectionAdapter implements IStructuredCont
         viewer.refresh(true);
     }
 
-    abstract protected IStatus validate();
+    protected abstract IStatus validate();
 
     public void remove(IPathElement holder) {
         paths.remove(holder);

--- a/eclipsePlugin/src/edu/umd/cs/findbugs/plugin/eclipse/quickfix/BugResolution.java
+++ b/eclipsePlugin/src/edu/umd/cs/findbugs/plugin/eclipse/quickfix/BugResolution.java
@@ -64,7 +64,7 @@ import edu.umd.cs.findbugs.plugin.eclipse.quickfix.exception.BugResolutionExcept
  */
 public abstract class BugResolution extends WorkbenchMarkerResolution {
 
-    static private final String MISSING_BUG_INSTANCE = "This bug is no longer in the system. "
+    private static final String MISSING_BUG_INSTANCE = "This bug is no longer in the system. "
             + "The bugs somehow got out of sync with the memory representation. "
             + "Try running SpotBugs again. If that does not work, check the error log.";
 

--- a/spotbugs/etc/messages.xml
+++ b/spotbugs/etc/messages.xml
@@ -4345,7 +4345,7 @@ threads may be synchronizing on different objects.</p>
     <Details>
 <![CDATA[
 <p>
- A final static field that is
+ A static final field that is
 defined in an interface references a mutable
    object such as an array or hashtable.
    This mutable object could
@@ -4425,7 +4425,7 @@ could be changed by malicious code or
     <LongDescription>{1} is a mutable Hashtable</LongDescription>
     <Details>
 <![CDATA[
- <p>A final static field references a Hashtable
+ <p>A static final field references a Hashtable
    and can be accessed by malicious code or
         by accident from another package.
    This code can freely modify the contents of the Hashtable.</p>
@@ -4437,7 +4437,7 @@ could be changed by malicious code or
     <LongDescription>{1} is a mutable collection</LongDescription>
     <Details>
 <![CDATA[
- <p>A mutable collection instance is assigned to a final static field,
+ <p>A mutable collection instance is assigned to a static final field,
    thus can be changed by malicious code or by accident from another package.
    Consider wrapping this field into Collections.unmodifiableSet/List/Map/etc.
    to avoid this vulnerability.</p>
@@ -4449,7 +4449,7 @@ could be changed by malicious code or
     <LongDescription>{1} is a mutable collection which should be package protected</LongDescription>
     <Details>
 <![CDATA[
- <p>A mutable collection instance is assigned to a final static field,
+ <p>A mutable collection instance is assigned to a static final field,
    thus can be changed by malicious code or by accident from another package.
    The field could be made package protected to avoid this vulnerability.
    Alternatively you may wrap this field into Collections.unmodifiableSet/List/Map/etc.
@@ -4462,7 +4462,7 @@ could be changed by malicious code or
     <LongDescription>{1} is a mutable array</LongDescription>
     <Details>
 <![CDATA[
-<p> A final static field references an array
+<p> A static final field references an array
    and can be accessed by malicious code or
         by accident from another package.
    This code can freely modify the contents of the array.</p>

--- a/spotbugs/etc/messages_fr.xml
+++ b/spotbugs/etc/messages_fr.xml
@@ -1688,7 +1688,7 @@ synchronized() {}
   <LongDescription>{1} devrait être sorti de l'interface et mis en package protected</LongDescription>
   <Details>
 <![CDATA[
-<p>Un champ final static défini dans une interface référence un objet modifiable tel qu'un tableau ou une table de hachage. Cet objet pourrait être modifié par accident ou par du code sournois d'un autre paquetage. Pour résoudre cela et éviter cette vulnérabilité, le champ doit être intégré dans une classe et sa visibilité modifiée en package protected.</p>
+<p>Un champ static final défini dans une interface référence un objet modifiable tel qu'un tableau ou une table de hachage. Cet objet pourrait être modifié par accident ou par du code sournois d'un autre paquetage. Pour résoudre cela et éviter cette vulnérabilité, le champ doit être intégré dans une classe et sa visibilité modifiée en package protected.</p>
 ]]>
   </Details>
  </BugPattern>
@@ -1734,7 +1734,7 @@ Cependant l'initialisation du champ comporte plusieurs écriture, ce qui requier
   <LongDescription>{1} une Hashtable modifiable</LongDescription>
   <Details>
 <![CDATA[
-<p>Le champ est une référence final static à une <code>Hashtable</code> et peut-être modifié par accident ou par du code malveillant d'un autre paquetage. Ce code peut librement modifier le contenu de la <code>Hashtable</code>.</p>
+<p>Le champ est une référence static final à une <code>Hashtable</code> et peut-être modifié par accident ou par du code malveillant d'un autre paquetage. Ce code peut librement modifier le contenu de la <code>Hashtable</code>.</p>
 ]]>
   </Details>
  </BugPattern>
@@ -1743,7 +1743,7 @@ Cependant l'initialisation du champ comporte plusieurs écriture, ce qui requier
   <LongDescription>{1} est un tableau modifiable</LongDescription>
   <Details>
 <![CDATA[
-<p>Le champ est une référence final static à un tableau et peut-être modifié par accident ou par du code malveillant d'un autre paquetage. Ce code peut librement modifier le contenu du tableau.</p>
+<p>Le champ est une référence static final à un tableau et peut-être modifié par accident ou par du code malveillant d'un autre paquetage. Ce code peut librement modifier le contenu du tableau.</p>
 ]]>
   </Details>
  </BugPattern>

--- a/spotbugs/src/gui/main/edu/umd/cs/findbugs/gui2/MainFrame.java
+++ b/spotbugs/src/gui/main/edu/umd/cs/findbugs/gui2/MainFrame.java
@@ -81,7 +81,7 @@ public class MainFrame extends FBFrame implements LogSync {
 
     public static final String TITLE_START_TXT = "SpotBugs";
 
-    private final static String WINDOW_MODIFIED = "windowModified";
+    private static final String WINDOW_MODIFIED = "windowModified";
 
     public static final boolean USE_WINDOWS_LAF = false;
 

--- a/spotbugs/src/gui/main/edu/umd/cs/findbugs/sourceViewer/JavaScanner.java
+++ b/spotbugs/src/gui/main/edu/umd/cs/findbugs/sourceViewer/JavaScanner.java
@@ -25,22 +25,22 @@ import java.util.HashSet;
 import edu.umd.cs.findbugs.internalAnnotations.StaticConstant;
 
 public class JavaScanner {
-    public final static int NORMAL_TEXT = 0;
+    public static final int NORMAL_TEXT = 0;
 
-    public final static int COMMENT = 1;
+    public static final int COMMENT = 1;
 
-    public final static int JAVADOC = 2;
+    public static final int JAVADOC = 2;
 
-    public final static int KEYWORD = 3;
+    public static final int KEYWORD = 3;
 
-    public final static int QUOTE = 4;
+    public static final int QUOTE = 4;
 
-    public final static int EOF = -1;
+    public static final int EOF = -1;
 
     @StaticConstant
-    private final static HashSet<String> KEYWORDS = new HashSet<>();
+    private static final HashSet<String> KEYWORDS = new HashSet<>();
 
-    private final static int MAX_KEYWORD_LENGTH;
+    private static final int MAX_KEYWORD_LENGTH;
 
     static {
         String[] keywordList = new String[] { "abstract", "assert", "boolean", "break", "byte", "case", "catch", "char", "class",

--- a/spotbugs/src/gui/main/edu/umd/cs/findbugs/sourceViewer/JavaSourceDocument.java
+++ b/spotbugs/src/gui/main/edu/umd/cs/findbugs/sourceViewer/JavaSourceDocument.java
@@ -55,7 +55,7 @@ public class JavaSourceDocument {
 
     static Font sourceFont = new Font("Monospaced", Font.PLAIN, (int) Driver.getFontSize());
 
-    final static Color HIGHLIGHT_COLOR = new Color(1f, 1f, .3f);
+    static final Color HIGHLIGHT_COLOR = new Color(1f, 1f, .3f);
 
     TabSet TAB_SET;
     static {

--- a/spotbugs/src/gui/main/edu/umd/cs/findbugs/sourceViewer/NumberedParagraphView.java
+++ b/spotbugs/src/gui/main/edu/umd/cs/findbugs/sourceViewer/NumberedParagraphView.java
@@ -35,7 +35,7 @@ import edu.umd.cs.findbugs.gui2.Driver;
 // Code inspired by http://www.developer.com/java/other/article.php/3318421
 
 class NumberedParagraphView extends ParagraphView {
-    public final static int NUMBERS_WIDTH = (int) Driver.getFontSize() * 3 + 9;
+    public static final int NUMBERS_WIDTH = (int) Driver.getFontSize() * 3 + 9;
 
     HighlightInformation highlight;
 

--- a/spotbugs/src/gui/main/edu/umd/cs/findbugs/workflow/MergeSummarizeAndView.java
+++ b/spotbugs/src/gui/main/edu/umd/cs/findbugs/workflow/MergeSummarizeAndView.java
@@ -138,7 +138,7 @@ public class MergeSummarizeAndView {
         // detector plugins
     }
 
-    static public SortedBugCollection union(SortedBugCollection origCollection, SortedBugCollection newCollection) {
+    public static SortedBugCollection union(SortedBugCollection origCollection, SortedBugCollection newCollection) {
 
         SortedBugCollection result = origCollection.duplicate();
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/ClassContext.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/ClassContext.java
@@ -461,7 +461,7 @@ public class ClassContext {
     }
 
     @Nonnull
-    static public Set<Integer> getLoopExitBranches(Method method, MethodGen methodGen) {
+    public static Set<Integer> getLoopExitBranches(Method method, MethodGen methodGen) {
 
         XMethod xmethod = XFactory.createXMethod(methodGen);
         if (cachedLoopExits().containsKey(xmethod)) {

--- a/spotbugs/src/patches/bcel.diff
+++ b/spotbugs/src/patches/bcel.diff
@@ -306,8 +306,8 @@ Index: /Users/pugh/Documents/eclipse/workspace/jakarta-bcel-5.2/src/java/org/apa
 +    private static int hits = 0;
 +    private static int skipped = 0;
 +    private static int created = 0;
-+    final static boolean BCEL_STATISTICS = Boolean.getBoolean("bcel.statistics");
-+    final static boolean BCEL_DONT_CACHE = Boolean.getBoolean("bcel.dontCache");
++    static final boolean BCEL_STATISTICS = Boolean.getBoolean("bcel.statistics");
++    static final boolean BCEL_DONT_CACHE = Boolean.getBoolean("bcel.dontCache");
 +    
 +    static {
 +        if (BCEL_STATISTICS)

--- a/spotbugs/src/tools/edu/umd/cs/findbugs/tools/FilterAndCombineBitfieldPropertyDatabase.java
+++ b/spotbugs/src/tools/edu/umd/cs/findbugs/tools/FilterAndCombineBitfieldPropertyDatabase.java
@@ -41,7 +41,7 @@ import edu.umd.cs.findbugs.internalAnnotations.DottedClassName;
  */
 public class FilterAndCombineBitfieldPropertyDatabase {
 
-    final static int FLAGS = Const.ACC_PROTECTED | Const.ACC_PUBLIC;
+    static final int FLAGS = Const.ACC_PROTECTED | Const.ACC_PUBLIC;
 
     /**
      * @param args

--- a/spotbugs/src/tools/edu/umd/cs/findbugs/tools/FilterPropertyDatabase.java
+++ b/spotbugs/src/tools/edu/umd/cs/findbugs/tools/FilterPropertyDatabase.java
@@ -37,7 +37,7 @@ import edu.umd.cs.findbugs.tools.FilterAndCombineBitfieldPropertyDatabase.Status
  */
 public class FilterPropertyDatabase {
 
-    final static int FLAGS = Const.ACC_PROTECTED | Const.ACC_PUBLIC;
+    static final int FLAGS = Const.ACC_PROTECTED | Const.ACC_PUBLIC;
 
     /**
      * @param args

--- a/spotbugsTestCases/src/java/DontBeMalicious.java
+++ b/spotbugsTestCases/src/java/DontBeMalicious.java
@@ -6,7 +6,7 @@ import java.util.HashMap;
 
 public class DontBeMalicious {
 
-    final static HashMap myMap = new HashMap();
+    static final HashMap myMap = new HashMap();
 
     /**
      * @param args

--- a/spotbugsTestCases/src/java/Doublecheck.java
+++ b/spotbugsTestCases/src/java/Doublecheck.java
@@ -1,17 +1,17 @@
 public class Doublecheck {
-    static private Object o;
+    private static Object o;
 
-    static private volatile Object v;
+    private static volatile Object v;
 
-    static private String s;
+    private static String s;
 
-    static private int i;
+    private static int i;
 
-    static private long j;
+    private static long j;
 
-    static private Object lock = new Object();
+    private static Object lock = new Object();
 
-    static public Object standardDoubleCheck() {
+    public static Object standardDoubleCheck() {
         if (o == null) {
             synchronized (lock) {
                 if (o == null)
@@ -21,7 +21,7 @@ public class Doublecheck {
         return o;
     }
 
-    static public Object volatileDoubleCheck() {
+    public static Object volatileDoubleCheck() {
         if (v == null) {
             synchronized (lock) {
                 if (v == null)
@@ -31,7 +31,7 @@ public class Doublecheck {
         return o;
     }
 
-    static public String stringDoubleCheck() {
+    public static String stringDoubleCheck() {
         if (s == null) {
             synchronized (lock) {
                 if (s == null)
@@ -41,7 +41,7 @@ public class Doublecheck {
         return s;
     }
 
-    static public int intDoubleCheck() {
+    public static int intDoubleCheck() {
         if (i == 0) {
             synchronized (lock) {
                 if (i == 0)
@@ -51,7 +51,7 @@ public class Doublecheck {
         return i;
     }
 
-    static public long longDoubleCheck() {
+    public static long longDoubleCheck() {
         if (j == 0) {
             synchronized (lock) {
                 if (j == 0)

--- a/spotbugsTestCases/src/java/DumbMethods.java
+++ b/spotbugsTestCases/src/java/DumbMethods.java
@@ -2,11 +2,11 @@ import java.util.Collection;
 
 class DumbMethods {
 
-    static public String getStringOfString(String s) {
+    public static String getStringOfString(String s) {
         return s.toString();
     }
 
-    static public boolean isCollection(Object o) {
+    public static boolean isCollection(Object o) {
         return ((o != null) && (o instanceof Collection));
     }
 }

--- a/spotbugsTestCases/src/java/ExternalizableTest.java
+++ b/spotbugsTestCases/src/java/ExternalizableTest.java
@@ -22,7 +22,7 @@ public class ExternalizableTest implements Externalizable {
     public void writeExternal(ObjectOutput out) {
     }
 
-    static public void main(String args[]) throws Exception {
+    public static void main(String args[]) throws Exception {
         ByteArrayOutputStream pout = new ByteArrayOutputStream();
         ObjectOutputStream oout = new ObjectOutputStream(pout);
         oout.writeObject(new ExternalizableTest(42));

--- a/spotbugsTestCases/src/java/ExternalizableTest2.java
+++ b/spotbugsTestCases/src/java/ExternalizableTest2.java
@@ -35,7 +35,7 @@ public class ExternalizableTest2 implements Externalizable {
         }
     }
 
-    static public void main(String args[]) throws Exception {
+    public static void main(String args[]) throws Exception {
         ByteArrayOutputStream pout = new ByteArrayOutputStream();
         ObjectOutputStream oout = new ObjectOutputStream(pout);
         oout.writeObject(new ExternalizableTest2a(42));

--- a/spotbugsTestCases/src/java/MutableMan.java
+++ b/spotbugsTestCases/src/java/MutableMan.java
@@ -1,6 +1,6 @@
 
 public class MutableMan {
-    static public int[] y = new int[1];
+    public static int[] y = new int[1];
 
     final int[] x = new int[1];
 

--- a/spotbugsTestCases/src/java/MutableStatic.java
+++ b/spotbugsTestCases/src/java/MutableStatic.java
@@ -15,25 +15,25 @@ import edu.umd.cs.findbugs.annotations.NoWarning;
 public class MutableStatic {
 
     @ExpectWarning("MS_MUTABLE_COLLECTION_PKGPROTECT")
-    static public final Hashtable h = new Hashtable();
+    public static final Hashtable h = new Hashtable();
 
     @ExpectWarning("MS_MUTABLE_COLLECTION_PKGPROTECT")
-    static public final Map h2 = new Hashtable();
+    public static final Map h2 = new Hashtable();
 
     @ExpectWarning("MS_PKGPROTECT")
-    static public final int[] data = new int[5];
+    public static final int[] data = new int[5];
 
     @ExpectWarning("MS_FINAL_PKGPROTECT")
-    static public int[] data2 = new int[5];
+    public static int[] data2 = new int[5];
 
     @ExpectWarning("MS_SHOULD_BE_FINAL")
-    static public Point p = new Point();
+    public static Point p = new Point();
 
     @NoWarning("MS_MUTABLE_COLLECTION_PKGPROTECT")
-    static public final List EMPTY_LIST = Arrays.asList();
+    public static final List EMPTY_LIST = Arrays.asList();
 
     @ExpectWarning("MS_MUTABLE_COLLECTION_PKGPROTECT")
-    static public final List LIST = Arrays.asList("a");
+    public static final List LIST = Arrays.asList("a");
 
     @NoWarning("MS_MUTABLE_COLLECTION_PKGPROTECT")
     static protected final List PROPER_LIST = Collections.unmodifiableList(Arrays.asList("a"));
@@ -45,13 +45,13 @@ public class MutableStatic {
     static protected final List ARRAY_LIST = new ArrayList(Arrays.asList("a"));
 
     @ExpectWarning("MS_MUTABLE_COLLECTION_PKGPROTECT")
-    static public final Set SET = new HashSet(Arrays.asList("a"));
+    public static final Set SET = new HashSet(Arrays.asList("a"));
 
     @NoWarning("MS_MUTABLE_COLLECTION_PKGPROTECT")
-    static public final Set PROPER_SET = Collections.unmodifiableSet(new HashSet(Arrays.asList("a")));
+    public static final Set PROPER_SET = Collections.unmodifiableSet(new HashSet(Arrays.asList("a")));
 
     @ExpectWarning("MS_MUTABLE_COLLECTION_PKGPROTECT")
-    static public final Map MAP = new HashMap();
+    public static final Map MAP = new HashMap();
 
     static {
         MAP.put("a", "b");
@@ -59,13 +59,13 @@ public class MutableStatic {
     }
 
     @ExpectWarning("MS_MUTABLE_COLLECTION_PKGPROTECT")
-    static public final Map MAP_ANONYMOUS = new HashMap() {{
+    public static final Map MAP_ANONYMOUS = new HashMap() {{
         put("a", "b");
         put("c", "d");
     }};
 
     @NoWarning("MS_MUTABLE_COLLECTION_PKGPROTECT")
-    static public final Map PROPER_MAP_ANONYMOUS = Collections.unmodifiableMap(new HashMap() {{
+    public static final Map PROPER_MAP_ANONYMOUS = Collections.unmodifiableMap(new HashMap() {{
         put("a", "b");
         put("c", "d");
     }});

--- a/spotbugsTestCases/src/java/PublicAttributesTest.java
+++ b/spotbugsTestCases/src/java/PublicAttributesTest.java
@@ -20,7 +20,7 @@ public class PublicAttributesTest {
     public final Map<Integer, String> hm = new HashMap<Integer, String>();
 
     // Mutable static fields are already detected by MS. No PA warning expected.
-    public final static Map<Integer, String> SHM = new HashMap<Integer, String>();
+    public static final Map<Integer, String> SHM = new HashMap<Integer, String>();
 
     // This field is not written, but only read. No PA warning expected.
     public final Set<String> hs = new HashSet<String>();

--- a/spotbugsTestCases/src/java/Serializable2.java
+++ b/spotbugsTestCases/src/java/Serializable2.java
@@ -29,7 +29,7 @@ class Serializable2 {
         });
     }
 
-    static public void main(String args[]) throws Exception {
+    public static void main(String args[]) throws Exception {
         ByteArrayOutputStream pout = new ByteArrayOutputStream();
         ObjectOutputStream oout = new ObjectOutputStream(pout);
         oout.writeObject(new Inner());

--- a/spotbugsTestCases/src/java/UncallableMethodOfAnonymousClass.java
+++ b/spotbugsTestCases/src/java/UncallableMethodOfAnonymousClass.java
@@ -3,7 +3,7 @@ import java.util.Comparator;
 import edu.umd.cs.findbugs.annotations.NoWarning;
 
 public class UncallableMethodOfAnonymousClass {
-    private final static Comparator COMPARATOR = new Comparator() {
+    private static final Comparator COMPARATOR = new Comparator() {
         @Override
         public int compare(Object o1, Object o2) {
             int result = o1.hashCode() - o2.hashCode();

--- a/spotbugsTestCases/src/java/UncallableMethodOfAnonymousClass2.java
+++ b/spotbugsTestCases/src/java/UncallableMethodOfAnonymousClass2.java
@@ -3,7 +3,7 @@ import java.util.TreeMap;
 
 public class UncallableMethodOfAnonymousClass2 {
 
-    private final static Comparator COMPARATOR = new Comparator() {
+    private static final Comparator COMPARATOR = new Comparator() {
         @Override
         public int compare(Object o1, Object o2) {
             int result = o1.hashCode() - o2.hashCode();

--- a/spotbugsTestCases/src/java/UncalledPrivateMethod.java
+++ b/spotbugsTestCases/src/java/UncalledPrivateMethod.java
@@ -3,7 +3,7 @@ import edu.umd.cs.findbugs.annotations.ExpectWarning;
 public class UncalledPrivateMethod {
     // Interesting tidbit:
     // Sun's javac makes class initializer methods "default static",
-    // while jikes makes them "private final static", which could
+    // while jikes makes them "private static final", which could
     // lead to spurious warnings.
     private static final Object myObject = new Object();
 

--- a/spotbugsTestCases/src/java/bugIdeas/Ideas_2009_02_24.java
+++ b/spotbugsTestCases/src/java/bugIdeas/Ideas_2009_02_24.java
@@ -8,7 +8,7 @@ public class Ideas_2009_02_24 {
 
     public static final int ZERO = 0;
 
-    final static List<String> NAMES = Arrays.asList(new String[] { "John", "Bill", "Sue", "Sarah" });
+    static final List<String> NAMES = Arrays.asList(new String[] { "John", "Bill", "Sue", "Sarah" });
 
     public static void main(String args[]) {
         falsePositive();

--- a/spotbugsTestCases/src/java/bugIdeas/Ideas_2009_08_27.java
+++ b/spotbugsTestCases/src/java/bugIdeas/Ideas_2009_08_27.java
@@ -9,7 +9,7 @@ public class Ideas_2009_08_27 {
     // return System.getProperty("foo");
     // }
     //
-    // static public void checkDereferenceInsideCatchException() {
+    // public static void checkDereferenceInsideCatchException() {
     //
     // try {
     // foo().hashCode();
@@ -18,7 +18,7 @@ public class Ideas_2009_08_27 {
     // }
     // }
     //
-    // static public void checkDereferenceInsideCatchRuntimeException() {
+    // public static void checkDereferenceInsideCatchRuntimeException() {
     //
     // try {
     // foo().hashCode();
@@ -27,7 +27,7 @@ public class Ideas_2009_08_27 {
     // }
     // }
     //
-    // static public void checkDereferenceInsideCatchNullPointerException() {
+    // public static void checkDereferenceInsideCatchNullPointerException() {
     //
     // try {
     // foo().hashCode();
@@ -36,20 +36,20 @@ public class Ideas_2009_08_27 {
     // }
     // }
 
-    static public <K, V> int sumValueHashes(Map<K, V> m) {
+    public static <K, V> int sumValueHashes(Map<K, V> m) {
         int sum = 0;
         for (K k : m.keySet())
             sum += m.get(k).hashCode();
         return sum;
     }
 
-    static public <K, V> int getValueHash1(Map<K, V> m, K k) {
+    public static <K, V> int getValueHash1(Map<K, V> m, K k) {
         if (m.containsKey(k))
             return m.get(k).hashCode();
         return 0;
     }
 
-    static public <K, V> int getValueHash2(Map<K, V> m, K k) {
+    public static <K, V> int getValueHash2(Map<K, V> m, K k) {
         if (m.get(k) != null)
             return m.get(k).hashCode();
         return 0;

--- a/spotbugsTestCases/src/java/bugIdeas/Ideas_2010_10_11.java
+++ b/spotbugsTestCases/src/java/bugIdeas/Ideas_2010_10_11.java
@@ -10,8 +10,8 @@ import edu.umd.cs.findbugs.annotations.ExpectWarning;
 
 public class Ideas_2010_10_11 {
 
-    final static Integer FOO = 1;
-    final static Integer BAR = 2;
+    static final Integer FOO = 1;
+    static final Integer BAR = 2;
 
     Integer state = FOO;
 

--- a/spotbugsTestCases/src/java/bugIdeas/Ideas_2012_10_18.java
+++ b/spotbugsTestCases/src/java/bugIdeas/Ideas_2012_10_18.java
@@ -5,8 +5,8 @@ import edu.umd.cs.findbugs.annotations.NoWarning;
 
 public class Ideas_2012_10_18 {
 
-    final static int DEFAULT_PORT = 80;
-    final static Integer DEFAULT_BOXED_PORT = 80;
+    static final int DEFAULT_PORT = 80;
+    static final Integer DEFAULT_BOXED_PORT = 80;
 
     Integer port;
     int p;

--- a/spotbugsTestCases/src/java/bugPatterns/BC_IMPOSSIBLE_INSTANCEOF.java
+++ b/spotbugsTestCases/src/java/bugPatterns/BC_IMPOSSIBLE_INSTANCEOF.java
@@ -8,7 +8,7 @@ public class BC_IMPOSSIBLE_INSTANCEOF {
     // seen in edu.umd.cs.findbugs.ba.IncompatibleTypes
 
     @ExpectWarning("BC_IMPOSSIBLE_INSTANCEOF")
-    static public @Nonnull
+    public static @Nonnull
     boolean getPriorityForAssumingCompatible(Type expectedType, Type actualType, boolean pointerEquality) {
         if (expectedType.equals(actualType))
             return true;

--- a/spotbugsTestCases/src/java/foundOnTheWeb/SynchronizationOnSharedBuiltinConstant.java
+++ b/spotbugsTestCases/src/java/foundOnTheWeb/SynchronizationOnSharedBuiltinConstant.java
@@ -8,7 +8,7 @@ package foundOnTheWeb;
  *
  * <pre>
  * class Foo {
- *     static private final String LOCK = &quot;LOCK&quot;;
+ *     private static final String LOCK = &quot;LOCK&quot;;
  *
  *     void someMethod() {
  *     synchronized(LOCK) {
@@ -38,7 +38,7 @@ package foundOnTheWeb;
  *
  */
 public class SynchronizationOnSharedBuiltinConstant {
-    static private final String LOCK = "LOCK";
+    private static final String LOCK = "LOCK";
 
     void someMethod() {
         synchronized (LOCK) {

--- a/spotbugsTestCases/src/java/jsr305/validation/SlashedClassName.java
+++ b/spotbugsTestCases/src/java/jsr305/validation/SlashedClassName.java
@@ -42,13 +42,13 @@ public @interface SlashedClassName {
     When when() default When.ALWAYS;
 
     static class Checker implements TypeQualifierValidator<SlashedClassName> {
-        final static String simpleName = "(\\p{javaJavaIdentifierStart}(\\p{javaJavaIdentifierPart}|\\$)*)";
+        static final String simpleName = "(\\p{javaJavaIdentifierStart}(\\p{javaJavaIdentifierPart}|\\$)*)";
 
-        final static String slashedClassName = simpleName + "(/" + simpleName + ")*";
+        static final String slashedClassName = simpleName + "(/" + simpleName + ")*";
 
-        final static Pattern simplePattern = Pattern.compile(simpleName);
+        static final Pattern simplePattern = Pattern.compile(simpleName);
 
-        final static Pattern pattern = Pattern.compile(slashedClassName);
+        static final Pattern pattern = Pattern.compile(slashedClassName);
 
         @Override
         public When forConstantValue(SlashedClassName annotation, Object value) {

--- a/spotbugsTestCases/src/java/messWithMe/Insecure.java
+++ b/spotbugsTestCases/src/java/messWithMe/Insecure.java
@@ -2,6 +2,6 @@ package messWithMe;
 
 public interface Insecure {
 
-    final static int[] CreditCardNumbers = new int[5];
+    static final int[] CreditCardNumbers = new int[5];
 
 }

--- a/spotbugsTestCases/src/java/messWithMe/Secure.java
+++ b/spotbugsTestCases/src/java/messWithMe/Secure.java
@@ -1,6 +1,6 @@
 package messWithMe;
 
 interface Secure {// Or is it?
-    final static long[] CreditCardNumbers = { 12848392, 12842642, 12384623, 192369, 1203789 };
+    static final long[] CreditCardNumbers = { 12848392, 12842642, 12384623, 192369, 1203789 };
     //
 }

--- a/spotbugsTestCases/src/java/publicIdentifiers/GoodPublicIdentifiersFieldNames.java
+++ b/spotbugsTestCases/src/java/publicIdentifiers/GoodPublicIdentifiersFieldNames.java
@@ -1,7 +1,7 @@
 package publicIdentifiers;
 
 public class GoodPublicIdentifiersFieldNames {
-    private final static String myStringValue = "String";
+    private static final String myStringValue = "String";
     public Integer myIntValue = 8;
 
     public void myMethod() {

--- a/spotbugsTestCases/src/java/publicIdentifiers/ShadowedPublicIdentifiersFieldNames.java
+++ b/spotbugsTestCases/src/java/publicIdentifiers/ShadowedPublicIdentifiersFieldNames.java
@@ -1,7 +1,7 @@
 package publicIdentifiers;
 
 public class ShadowedPublicIdentifiersFieldNames {
-    private final static String String = "String";
+    private static final String String = "String";
     public Integer Integer = 4;
 
     public void myMethod() {

--- a/spotbugsTestCases/src/java/sfBugs/Bug1487083.java
+++ b/spotbugsTestCases/src/java/sfBugs/Bug1487083.java
@@ -6,7 +6,7 @@ import edu.umd.cs.findbugs.annotations.NoWarning;
 public class Bug1487083 {
     @NoWarning("MS_SHOULD_BE_FINAL")
     @ExpectWarning("MS_SHOULD_BE_REFACTORED_TO_BE_FINAL")
-    static public int falsePos;
+    public static int falsePos;
 
     static {
         try {

--- a/spotbugsTestCases/src/java/sfBugs/Bug1723940.java
+++ b/spotbugsTestCases/src/java/sfBugs/Bug1723940.java
@@ -8,7 +8,7 @@ public class Bug1723940 {
         return child;
     }
 
-    static public void doX(Bug1723940 o) {
+    public static void doX(Bug1723940 o) {
         o.hashCode();
         while (o != null) {
             o = o.getChild();

--- a/spotbugsTestCases/src/java/sfBugs/Bug1941804.java
+++ b/spotbugsTestCases/src/java/sfBugs/Bug1941804.java
@@ -5,7 +5,7 @@ public class Bug1941804 {
 
     private String nsLOCK = "LOCK";
 
-    private final static String fLOCK = "LOCK";
+    private static final String fLOCK = "LOCK";
 
     private final String fnsLOCK = "LOCK";
 

--- a/spotbugsTestCases/src/java/sfBugs/Bug2311502.java
+++ b/spotbugsTestCases/src/java/sfBugs/Bug2311502.java
@@ -23,7 +23,7 @@ public class Bug2311502 {
     /**
      * Should flag code as unsafe.
      */
-    static public class NonNullFalseNegative {
+    public static class NonNullFalseNegative {
 
         @CheckForNull
         private Object junkField;
@@ -42,7 +42,7 @@ public class Bug2311502 {
 
     }
 
-    static public @ReturnValuesAreNonnullByDefault
+    public static @ReturnValuesAreNonnullByDefault
     class NPNonNullReturnViolationBug {
 
         @CheckForNull

--- a/spotbugsTestCases/src/java/sfBugs/Bug3343304.java
+++ b/spotbugsTestCases/src/java/sfBugs/Bug3343304.java
@@ -10,8 +10,8 @@ public final class Bug3343304 {
         new FindBugs().getResult();
     }
 
-    static private abstract class Abstract {
-        abstract protected void parseLine();
+    private static abstract class Abstract {
+        protected abstract void parseLine();
 
         public void getResult() {
             parseLine();
@@ -21,7 +21,7 @@ public final class Bug3343304 {
         }
     }
 
-    static private final class FindBugs extends Abstract {
+    private static final class FindBugs extends Abstract {
         private @CheckForNull
         Map<Integer, String> metrics = null;
 

--- a/spotbugsTestCases/src/java/sfBugs/Bug3584224.java
+++ b/spotbugsTestCases/src/java/sfBugs/Bug3584224.java
@@ -13,9 +13,9 @@ import edu.umd.cs.findbugs.annotations.NoWarning;
 @NoWarning("OBL_UNSATISFIED_OBLIGATION_EXCEPTION_EDGE")
 public class Bug3584224 {
 
-    final static String PROPERTIES_FILENAME = "properies.txt";
+    static final String PROPERTIES_FILENAME = "properies.txt";
 
-    final static Logger LOGGER = Logger.getLogger(Bug3584224.class.getSimpleName());
+    static final Logger LOGGER = Logger.getLogger(Bug3584224.class.getSimpleName());
 
     public Properties test(Properties props, InputStream stream) {
         try {

--- a/spotbugsTestCases/src/java/sfBugsNew/Bug1244.java
+++ b/spotbugsTestCases/src/java/sfBugsNew/Bug1244.java
@@ -30,7 +30,7 @@ public class Bug1244 {
         return true;
     }
 
-   static public class Wrong {
+   public static class Wrong {
         private final int a;
 
         public Wrong(int a) {


### PR DESCRIPTION
includes documentation to follow the same naming conventions.