### PR TITLE
Use bcel snapshot to get bcel 6.11 that supports Java 25 (#3569) (#3569)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ### Added
 - Add 'java.nio.file.Path.of' to known types for path traversal checks ([#3699](https://github.com/spotbugs/spotbugs/pull/3699))
+- Added Java 25 support ([#3569](https://github.com/spotbugs/spotbugs/issues/3569))
 
 ### Cleanup
 - S1481: Unused local variables should be removed ([#3654](https://github.com/spotbugs/spotbugs/pull/3654))

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,9 @@ subprojects {
 allprojects {
   repositories {
     mavenCentral()
+    maven {
+      url = uri("https://repository.apache.org/content/repositories/snapshots/")
+    }
   }
   dependencies {
     String junitVersion = '5.13.4'

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -70,7 +70,7 @@ dependencies {
   api libs.asm.commons
   api libs.asm.tree
   api libs.asm.util
-  api 'org.apache.bcel:bcel:6.10.0'
+  api 'org.apache.bcel:bcel:6.11.0-20250916.141220-9'
   api 'com.github.stephenc.jcip:jcip-annotations:1.0-1'
   api('org.dom4j:dom4j:2.2.0')
   constraints {


### PR DESCRIPTION
- Allows spotbugs to analyze Java 25 compiled code

See original commit 4eeaf79fcec33a6aaafd5652471a687a4ef63bf1 that was reverted via 86e943b6fa372578219987e2d78ecfb6d9d95e96.

