### PR TITLE
Fix exception throw when singleton implementing Cloneable has no clone() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased - 2025-??-??
+### Fixed
+- Fix exception throw when singleton implementing Cloneable has no clone() method ([#3727](https://github.com/spotbugs/spotbugs/issues/3727)) 
 
 ## 4.9.6 - 2025-09-16
 ### Fixed

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/MultipleInstantiationsOfSingletonsTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/MultipleInstantiationsOfSingletonsTest.java
@@ -1,5 +1,6 @@
 package edu.umd.cs.findbugs.detect;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
 import org.junit.jupiter.api.condition.DisabledOnJre;
@@ -78,6 +79,22 @@ class MultipleInstantiationsOfSingletonsTest extends AbstractIntegrationTest {
         assertNoBugType("SING_SINGLETON_IMPLEMENTS_CLONE_METHOD");
         assertNoBugType("SING_SINGLETON_IMPLEMENTS_SERIALIZABLE");
         assertNoBugType("SING_SINGLETON_GETTER_NOT_SYNCHRONIZED");
+    }
+
+    @Test
+    void cloneableSingletonWithoutCloneMethodTest() {
+        // See https://github.com/spotbugs/spotbugs/issues/3727
+        Assertions.assertDoesNotThrow(() -> {
+            performAnalysis("singletons/CloneableSingletonWithoutCloneMethod.class");
+            assertBugTypeCount("SING_SINGLETON_IMPLEMENTS_CLONEABLE", 1);
+            assertBugInClass("SING_SINGLETON_IMPLEMENTS_CLONEABLE", "CloneableSingletonWithoutCloneMethod");
+
+            assertNoBugType("SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR");
+            assertNoBugType("SING_SINGLETON_INDIRECTLY_IMPLEMENTS_CLONEABLE");
+            assertNoBugType("SING_SINGLETON_IMPLEMENTS_CLONE_METHOD");
+            assertNoBugType("SING_SINGLETON_IMPLEMENTS_SERIALIZABLE");
+            assertNoBugType("SING_SINGLETON_GETTER_NOT_SYNCHRONIZED");
+        });
     }
 
     @Test

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MultipleInstantiationsOfSingletons.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MultipleInstantiationsOfSingletons.java
@@ -250,8 +250,11 @@ public class MultipleInstantiationsOfSingletons extends OpcodeStackDetector {
         if (!cloneOnlyThrowsCloneNotSupportedException) { // no or not only CloneNotSupportedException
             if (isCloneable) {
                 if (implementsCloneableDirectly) { // directly
-                    bugReporter.reportBug(new BugInstance(this, "SING_SINGLETON_IMPLEMENTS_CLONEABLE", NORMAL_PRIORITY).addClass(this)
-                            .addMethod(cloneMethod));
+                    BugInstance bi = new BugInstance(this, "SING_SINGLETON_IMPLEMENTS_CLONEABLE", NORMAL_PRIORITY).addClass(this);
+                    if (cloneMethod != null) {
+                        bi.addMethod(cloneMethod);
+                    }
+                    bugReporter.reportBug(bi);
                 } else { // indirectly
                     bugReporter.reportBug(new BugInstance(this, "SING_SINGLETON_INDIRECTLY_IMPLEMENTS_CLONEABLE", NORMAL_PRIORITY).addClass(this));
                 }

--- a/spotbugsTestCases/src/java/singletons/CloneableSingletonWithoutCloneMethod.java
+++ b/spotbugsTestCases/src/java/singletons/CloneableSingletonWithoutCloneMethod.java
@@ -1,0 +1,18 @@
+package singletons;
+
+/**
+ * @see <a href="https://github.com/spotbugs/spotbugs/issues/3727">GitHub issue #3727</a>
+  */
+public class CloneableSingletonWithoutCloneMethod implements Cloneable {
+    private static CloneableSingletonWithoutCloneMethod instance;
+
+    private CloneableSingletonWithoutCloneMethod() {
+    }
+
+    public static synchronized CloneableSingletonWithoutCloneMethod getInstance() {
+      if (instance == null) {
+        instance = new CloneableSingletonWithoutCloneMethod();
+      }
+      return instance;
+    }
+}


### PR DESCRIPTION
Fixes #3727 .
Looked at the other bugs reported by the relevant detector, all others had null checks for the data added to the BugInstances.

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
