### PR TITLE
Always read latest preferences state from the disk on build in Eclipse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ## Unreleased - 2025-??-??
 ### Fixed
+- Fix Eclipse not always using latest preferences file state ([#3740](https://github.com/spotbugs/spotbugs/issues/3740)) 
 - Fix exception throw when singleton implementing Cloneable has no clone() method ([#3727](https://github.com/spotbugs/spotbugs/issues/3727)) 
 
 ## 4.9.6 - 2025-09-16

--- a/eclipsePlugin/src/de/tobject/findbugs/FindbugsPlugin.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/FindbugsPlugin.java
@@ -710,7 +710,6 @@ public class FindbugsPlugin extends AbstractUIPlugin {
             return;
         }
 
-        UserPreferences prefs = getUserPreferences(project);
         bugCollection = new SortedBugCollection();
         bugCollection.getProject().setGuiCallback(new EclipseGuiCallback(project));
 

--- a/eclipsePlugin/src/de/tobject/findbugs/builder/FindBugsBuilder.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/builder/FindBugsBuilder.java
@@ -138,6 +138,12 @@ public class FindBugsBuilder extends IncrementalProjectBuilder {
             if (configChanged) {
                 files = new ArrayList<>();
                 files.add(new WorkItem(project));
+                // Clear previously saved user preferences
+                try {
+                    project.setSessionProperty(FindbugsPlugin.SESSION_PROPERTY_USERPREFS, null);
+                } catch (CoreException e) {
+                    FindbugsPlugin.getDefault().logException(e, "Failed to clear user preferences in session");
+                }
             } else {
                 files = ResourceUtils.collectIncremental(resourceDelta);
                 if (files.size() == 1) {
@@ -192,7 +198,7 @@ public class FindBugsBuilder extends IncrementalProjectBuilder {
         }
     }
 
-    private boolean isConfigUnchanged(IResourceDelta resourceDelta) {
+    private static boolean isConfigUnchanged(IResourceDelta resourceDelta) {
         return resourceDelta != null && resourceDelta.findMember(new Path(".project")) == null
                 && resourceDelta.findMember(new Path(".classpath")) == null
                 && resourceDelta.findMember(FindbugsPlugin.DEPRECATED_PREFS_PATH) == null


### PR DESCRIPTION
For the rest of the code it isn't that important (and constant reading can affect performance), but every analysis execution should make sure it is working with up-to-date settings.

Additionally removed unneeded call to getUserPreferences() from readBugCollectionAndProject(), it was not needed anymore after one of the previous code changes.

Fixes https://github.com/spotbugs/spotbugs/issues/3740
