### PR TITLE
Don't modify DetectorFactory state during analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Fix exception throw when singleton implementing Cloneable has no clone() method ([#3727](https://github.com/spotbugs/spotbugs/issues/3727)) 
 - Fix for missing -adjustPriority parameter in Eclipse preferences ([#3687](https://github.com/spotbugs/spotbugs/issues/3687))
 - Documentation of -adjustPriority parameter
+- Functionality from DetectorFactory setEnabledButNonReporting(), getPriorityAdjustment() methods and BugInstance.adjustForDetector() is deprecated and moved to PriorityAdjuster ([#3753](https://github.com/spotbugs/spotbugs/issues/3753))
 
 ### Changed
 - Support for fully qualified class names for detectors in -adjustPriority parameter

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/AbstractBugReporter.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/AbstractBugReporter.java
@@ -171,6 +171,7 @@ public abstract class AbstractBugReporter implements BugReporter {
      *
      * @param priorityAdjuster the priority adjuster
      */
+    @Override
     public void setPriorityAdjuster(PriorityAdjuster priorityAdjuster) {
         this.priorityAdjuster = priorityAdjuster;
     }
@@ -434,4 +435,9 @@ public abstract class AbstractBugReporter implements BugReporter {
      *            the name of the class
      */
     public abstract void reportMissingClass(String string);
+
+    @Override
+    public PriorityAdjuster getPriorityAdjuster() {
+        return priorityAdjuster;
+    }
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/BugInstance.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/BugInstance.java
@@ -19,18 +19,30 @@
 
 package edu.umd.cs.findbugs;
 
-import java.nio.charset.StandardCharsets;
-import java.util.*;
-import java.util.stream.Collectors;
-
 import static java.util.Objects.requireNonNull;
 
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
@@ -51,6 +63,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import edu.umd.cs.findbugs.ba.AccessMethodDatabase;
+import edu.umd.cs.findbugs.ba.AccessMethodDatabase.AccessMethodLocation;
 import edu.umd.cs.findbugs.ba.AnalysisContext;
 import edu.umd.cs.findbugs.ba.CFGBuilderException;
 import edu.umd.cs.findbugs.ba.ClassContext;
@@ -63,7 +76,6 @@ import edu.umd.cs.findbugs.ba.OpcodeStackScanner.UnreachableCodeException;
 import edu.umd.cs.findbugs.ba.XFactory;
 import edu.umd.cs.findbugs.ba.XField;
 import edu.umd.cs.findbugs.ba.XMethod;
-import edu.umd.cs.findbugs.ba.AccessMethodDatabase.AccessMethodLocation;
 import edu.umd.cs.findbugs.ba.bcp.FieldVariable;
 import edu.umd.cs.findbugs.ba.vna.ValueNumberSourceInfo;
 import edu.umd.cs.findbugs.bytecode.MemberUtils;
@@ -243,29 +255,22 @@ public class BugInstance implements Comparable<BugInstance>, XMLWriteable, Clone
     public BugInstance(Detector detector, String type, int priority) {
         this(type, priority);
         if (detector != null) {
-            // Adjust priority if required
             String detectorName = detector.getClass().getName();
-            adjustForDetector(detectorName);
+            rememberDetectorFactory(detectorName);
         }
 
+    }
+
+    @Deprecated(forRemoval = true)
+    public void adjustForDetector(String detectorName) {
+        rememberDetectorFactory(detectorName);
     }
 
     /**
      * @param detectorName
      */
-    public void adjustForDetector(String detectorName) {
-        DetectorFactory factory = DetectorFactoryCollection.instance().getFactoryByClassName(detectorName);
-        detectorFactory = factory;
-        if (factory != null) {
-            this.priority += factory.getPriorityAdjustment();
-            boundPriority();
-            BugPattern bugPattern = getBugPattern();
-            if (SystemProperties.ASSERTIONS_ENABLED && !"EXPERIMENTAL".equals(bugPattern.getCategory())
-                    && !factory.getReportedBugPatterns().contains(bugPattern)) {
-                AnalysisContext.logError(factory.getShortName() + " doesn't note that it reports "
-                        + bugPattern + " in category " + bugPattern.getCategory());
-            }
-        }
+    public void rememberDetectorFactory(String detectorName) {
+        detectorFactory = DetectorFactoryCollection.instance().getFactoryByClassName(detectorName);
     }
 
     /**
@@ -283,9 +288,8 @@ public class BugInstance implements Comparable<BugInstance>, XMLWriteable, Clone
         this(type, priority);
 
         if (detector != null) {
-            // Adjust priority if required
             String detectorName = detector.getDetectorClassName();
-            adjustForDetector(detectorName);
+            rememberDetectorFactory(detectorName);
         }
 
     }
@@ -393,7 +397,7 @@ public class BugInstance implements Comparable<BugInstance>, XMLWriteable, Clone
         priority = boundedPriority(p);
     }
 
-    private int boundedPriority(int p) {
+    public static int boundedPriority(int p) {
         return Math.max(Priorities.HIGH_PRIORITY, Math.min(Priorities.IGNORE_PRIORITY, p));
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/BugReporter.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/BugReporter.java
@@ -108,4 +108,12 @@ public interface BugReporter extends RepositoryLookupFailureCallback, IClassObse
      */
     @CheckForNull
     BugCollection getBugCollection();
+
+    /**
+     * @return the PriorityAdjuster set for this BugReporter, or null if none was set
+     */
+    @CheckForNull
+    default PriorityAdjuster getPriorityAdjuster() {
+        return null;
+    }
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/DetectorFactory.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/DetectorFactory.java
@@ -73,8 +73,6 @@ public class DetectorFactory {
 
     private String detailHTML;
 
-    private boolean enabledButNonReporting;
-
     private boolean hidden;
 
     static class ReflectionDetectorCreator {
@@ -293,19 +291,12 @@ public class DetectorFactory {
         return defEnabled;
     }
 
+    @Deprecated(forRemoval = true)
     public void setEnabledButNonReporting(boolean notReporting) {
-        this.enabledButNonReporting = notReporting;
     }
 
-    /**
-     * Get the priority adjustment for the detector produced by this factory.
-     *
-     * @return the priority adjustment
-     */
+    @Deprecated(forRemoval = true)
     public int getPriorityAdjustment() {
-        if (enabledButNonReporting) {
-            return 100;
-        }
         return 0;
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/DetectorFactoryChooser.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/DetectorFactoryChooser.java
@@ -19,6 +19,9 @@
 
 package edu.umd.cs.findbugs;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.plan.ExecutionPlan;
+
 /**
  * Predicate for choosing DetectorFactory objects.
  *
@@ -41,4 +44,16 @@ public interface DetectorFactoryChooser {
      * @param factory
      */
     void enable(DetectorFactory factory);
+
+    /**
+     * Check whether the given factory was enabled by {@link ExecutionPlan#build()}
+     *
+     * @param factory
+     *            the DetectorFactory to check, not null
+     * @return returns true by default
+     * @see ExecutionPlan#build()
+     */
+    default boolean wasFactoryEnabled(@NonNull DetectorFactory factory) {
+        return true;
+    }
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/FindBugs2.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/FindBugs2.java
@@ -942,7 +942,6 @@ public class FindBugs2 implements IFindBugsEngine, AutoCloseable {
             @Override
             public void enable(DetectorFactory factory) {
                 forcedEnabled.add(factory);
-                factory.setEnabledButNonReporting(true);
             }
 
         };
@@ -977,6 +976,11 @@ public class FindBugs2 implements IFindBugsEngine, AutoCloseable {
     private void analyzeApplication() throws InterruptedException {
         int passCount = 0;
         Profiler profiler = bugReporter.getProjectStats().getProfiler();
+        PriorityAdjuster priorityAdjuster = bugReporter.getPriorityAdjuster();
+        if (priorityAdjuster != null) {
+            priorityAdjuster.setFactoryChooser(executionPlan.getFactoryChooser());
+        }
+
         profiler.start(this.getClass());
         AnalysisContext.currentXFactory().canonicalizeAll();
         try {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/plan/ExecutionPlan.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/plan/ExecutionPlan.java
@@ -19,7 +19,16 @@
 
 package edu.umd.cs.findbugs.plan;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import edu.umd.cs.findbugs.Detector;
 import edu.umd.cs.findbugs.DetectorFactory;
@@ -28,6 +37,7 @@ import edu.umd.cs.findbugs.DetectorFactoryCollection;
 import edu.umd.cs.findbugs.FindBugs2;
 import edu.umd.cs.findbugs.Plugin;
 import edu.umd.cs.findbugs.SystemProperties;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.graph.DepthFirstSearch;
 import edu.umd.cs.findbugs.internalAnnotations.DottedClassName;
 
@@ -137,10 +147,6 @@ public class ExecutionPlan {
      * Detectors within those passes.
      */
     public void build() throws OrderingConstraintException {
-
-        for (DetectorFactory detectorFactory : factoryMap.values()) {
-            detectorFactory.setEnabledButNonReporting(false);
-        }
 
         ArrayList<DetectorOrderingConstraint> allConstraints = new ArrayList<>(
                 interPassConstraintList.size() + intraPassConstraintList.size());
@@ -521,5 +527,13 @@ public class ExecutionPlan {
 
         System.out.println(execPlan.getNumPasses() + " passes in plan");
         execPlan.print();
+    }
+
+    /**
+     * @return Returns the factoryChooser used during analysis.
+     */
+    @NonNull
+    public DetectorFactoryChooser getFactoryChooser() {
+        return factoryChooser;
     }
 }


### PR DESCRIPTION
SpotBugs creates new `ExecutionPlan` for analysis, however each `ExecutionPlan` uses same `DetectorFactory` instances created from static `Plugin.getDetectorFactories()` context and the state of the instances could be modified during analysis, affecting analysis results.

`DetectorFactory` state relied on `enabledButNonReporting` flag and could lead to unpredictable analysis results for multiple SpotBugs analysis tasks running in parallel.

If one thread would call `factory.getPriorityAdjustment()` while creating a `BugInstance`, other could change this priority by calling `setEnabledButNonReporting()` from `ExecutionPlan.build()`.

The first problem was that `ExecutionPlan.build()` unconditionally sets `factory.setEnabledButNonReporting(false)` at very beginning, which alone could affect other execution results.

Later on, `ExecutionPlan.build()` changed factory state depending on the results of `DetectorFactoryChooser.choose()`. `DetectorFactoryChooser`is created in `FindBugs2.createExecutionPlan()`, which is based on `FindBugs.isDetectorEnabled()` result which depends on `UserPreferences`. Again, this could lead to unexpected results if the settings used were different.

Removed `getPriorityAdjustment()` and `setEnabledButNonReporting()` from `DetectorFactory`, `adjustForDetector()` from `BugInstance` and moved the related functionality to the `PriorityAdjuster.adjustForDetector()`.

Fixes https://github.com/spotbugs/spotbugs/issues/3753

