### PR TITLE
Unconditionally initialize PriorityAdjuster for AbstractBugReporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased - 2025-??-??
+### Fixed
+- Maven plugin reporting issue if -adjustPriority is not set ([#3774](https://github.com/spotbugs/spotbugs/issues/3774)) 
 
 ## 4.9.7 - 2025-10-14
 ### Fixed

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/AbstractBugReporter.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/AbstractBugReporter.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.CheckForNull;
@@ -144,6 +145,8 @@ public abstract class AbstractBugReporter implements BugReporter {
         // bug 2815983: no bugs are reported anymore
         // there is no info which value should be default, so using the max
         rankThreshold = BugRanker.VISIBLE_RANK_MAX;
+        // using by default empty settings
+        priorityAdjuster = new PriorityAdjuster(Map.of());
     }
 
     @Override

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/TextUICommandLine.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/TextUICommandLine.java
@@ -662,8 +662,10 @@ public class TextUICommandLine extends FindBugsCommandLine {
             throw new IllegalStateException("No bug reporter configured");
         }
 
-        for (TextUIBugReporter reporter : reporters) {
-            reporter.setPriorityAdjuster(priorityAdjuster);
+        if (priorityAdjuster != null) {
+            for (TextUIBugReporter reporter : reporters) {
+                reporter.setPriorityAdjuster(priorityAdjuster);
+            }
         }
 
         ConfigurableBugReporter textuiBugReporter = reporters.size() == 1 ? reporters.get(0) : new BugReportDispatcher(reporters);


### PR DESCRIPTION
After commit f03df3d019fba0c42cf3c604231104f2ca164f70 `PriorityAdjuster` is also used to disable/enable factories (by raising their reporting priority) which was implemented as a "static global" feature of `DetectorFactory` before.

However, this requires that we *always* initialize `PriorityAdjuster` in `AbstractBugReporter`, independently if `-adjustPriority` is used or not.

Fixes https://github.com/spotbugs/spotbugs/issues/3774