### PR TITLE
Fix priority adjustment code

### DIFF
--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/DelegatingBugReporter.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/DelegatingBugReporter.java
@@ -65,6 +65,11 @@ public class DelegatingBugReporter implements BugReporter {
     }
 
     @Override
+    public PriorityAdjuster getPriorityAdjuster() {
+        return delegate.getPriorityAdjuster();
+    }
+
+    @Override
     public void observeClass(ClassDescriptor classDescriptor) {
         delegate.observeClass(classDescriptor);
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/DetectorFactoryChooser.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/DetectorFactoryChooser.java
@@ -38,22 +38,23 @@ public interface DetectorFactoryChooser {
     boolean choose(DetectorFactory factory);
 
     /**
-     * Enable the factory due to ordering constraints with other enabled
-     * detectors
+     * <b>Forcibly</b> enable the factory due to ordering constraints with other enabled detectors, if the factory would
+     * not otherwise be chosen by {@link #choose(DetectorFactory)}.
      *
      * @param factory
      */
     void enable(DetectorFactory factory);
 
     /**
-     * Check whether the given factory was enabled by {@link ExecutionPlan#build()}
+     * Check whether the given factory was <b>forcibly</b> enabled via {@link #enable(DetectorFactory)} by
+     * {@link ExecutionPlan#build()}
      *
      * @param factory
      *            the DetectorFactory to check, not null
-     * @return returns true by default
+     * @return returns false by default
      * @see ExecutionPlan#build()
      */
-    default boolean wasFactoryEnabled(@NonNull DetectorFactory factory) {
-        return true;
+    default boolean wasForciblyEnabled(@NonNull DetectorFactory factory) {
+        return false;
     }
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/FindBugs2.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/FindBugs2.java
@@ -944,6 +944,11 @@ public class FindBugs2 implements IFindBugsEngine, AutoCloseable {
                 forcedEnabled.add(factory);
             }
 
+            @Override
+            public boolean wasForciblyEnabled(DetectorFactory factory) {
+                return forcedEnabled.contains(factory);
+            }
+
         };
         executionPlan.setDetectorFactoryChooser(detectorFactoryChooser);
 


### PR DESCRIPTION
Various fixes for changes from f03df3d019fba0c42cf3c604231104f2ca164f70 and 1ac9f30a6dc2d123b3ae28e8fa49efe6f0ac7d2b

- `getPriorityAdjuster()` must be implemented by `DelegatingBugReporter`
- `wasFactoryEnabled()` must be implemented by `DetectorFactoryChooser` instance created from `Findbugs2`
- `PriorityAdjuster.checkTarget()` should use `factory.getFullName()` not `factory.getClass().getName()` which is same for all factories
- `PriorityAdjuster.adjustPriority()` should use `factory.getFullName()` and should always call `adjustForDetector()`
- Improved javadoc on `DetectorFactoryChooser` and renamed `wasFactoryEnabled()` to `wasForciblyEnabled()` to clarify the intent
- `DetectorFactoryChooser.wasForciblyEnabled()` and `PriorityAdjuster.adjustForDetector()` logic was inverted

Fixes https://github.com/spotbugs/spotbugs/issues/3774

