### PR TITLE
Fix SonarCloud coverage issue

### DIFF
--- a/gradle/sonar.gradle
+++ b/gradle/sonar.gradle
@@ -7,7 +7,7 @@ sonar {
     property 'sonar.projectKey', 'com.github.spotbugs.spotbugs'
     property 'sonar.projectName', 'SpotBugs'
 
-    property 'sonar.coverage.jacoco.xmlReportPaths', "${project.layout.buildDirectory}/reports/jacoco/jacocoRootReport/jacocoRootReport.xml"
+    property 'sonar.coverage.jacoco.xmlReportPaths', "${project.layout.buildDirectory.asFile.get().absolutePath}/reports/jacoco/jacocoRootReport/jacocoRootReport.xml"
   }
 }
 


### PR DESCRIPTION
The Sonar Quality Gate fails (on some branches the Quality Gates succeed, but only because `there are not enough lines to compute coverage`), because Sonar can't read the coverage properly (see [SonarCloud resutls on master](https://sonarcloud.io/summary/new_code?id=com.github.spotbugs.spotbugs&branch=master)). Sonar emits the following warning several times in build log (see [ci run](https://github.com/spotbugs/spotbugs/actions/runs/18822488139/job/53700153427)) :
```
> Task :sonar

No coverage report can be found with sonar.coverage.jacoco.xmlReportPaths='map(property(org.gradle.api.file.Directory,fixed(class org.gradle.api.internal.file.DefaultFilePropertyFactory$FixedDirectory,/home/runner/work/spotbugs/spotbugs/build)))'. Using default locations: target/site/jacoco/jacoco.xml,target/site/jacoco-it/jacoco.xml,build/reports/jacoco/test/jacocoTestReport.xml
```

This PR tries to fix this issue. The problematic lines after `Task :sonar` do not appear in the logs (see [ci](https://github.com/spotbugs/spotbugs/actions/runs/18883883091/job/53894058633)), so hopefully this resolves the problem, but I could not verify it, since `There are not enough lines to compute coverage` in [SonarCloud](https://sonarcloud.io/summary/new_code?id=com.github.spotbugs.spotbugs&branch=sonar-coverage).

Since it's only a CI fix, I haven't added any changelog entry.

This branch is not on my fork, but in the spotbugs/spotbugs, so the Sonar task could be checked in CI. I'll delete it, after  merge.
