### PR TITLE
Add null check to MultipleInstantiationsOfSingletons to called Method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 ### Fixed
 - Fix incorrect bug counts and sizes when unioning reports ([#3721](https://github.com/spotbugs/spotbugs/issues/3721))
 - Enhanced SARIF output with full description sections - adding markdown is still an open issue ([#2339](https://github.com/spotbugs/spotbugs/issues/2339))
+- Added missing null check to `MultipleInstantiationsOfSingletons` detector ([#3823](https://github.com/spotbugs/spotbugs/issues/3823))
 
 ### Removed
 - Removed old deprecated methods: 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MultipleInstantiationsOfSingletons.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MultipleInstantiationsOfSingletons.java
@@ -202,7 +202,10 @@ public class MultipleInstantiationsOfSingletons extends OpcodeStackDetector {
             if (!calledMethodsByMethods.containsKey(getXMethod())) {
                 calledMethodsByMethods.put(getXMethod(), new ArrayList<>());
             }
-            calledMethodsByMethods.get(getXMethod()).add(getXMethodOperand());
+            XMethod calledMethod = getXMethodOperand();
+            if (calledMethod != null) {
+                calledMethodsByMethods.get(getXMethod()).add(calledMethod);
+            }
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/spotbugs/spotbugs/issues/3823.
From the description I couldn't add a testcase recreating the issue, but added the missing null check.

----

- [X] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
