### PR TITLE
fix: avoid building a relative chain of ./././ in jar names saved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Enhanced SARIF output with full description sections - adding markdown is still an open issue ([#2339](https://github.com/spotbugs/spotbugs/issues/2339))
 - Added missing null check to `MultipleInstantiationsOfSingletons` detector ([#3823](https://github.com/spotbugs/spotbugs/issues/3823))
 - Fix tool name in usage info, ([#3847](https://github.com/spotbugs/spotbugs/pull/3847))
+- Fix the building of relative chains of ./././ in filenames in fbp files
 
 ### Removed
 - Removed old deprecated methods: 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/Project.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/Project.java
@@ -788,8 +788,11 @@ public class Project implements XMLWriteable, AutoCloseable {
         if (base.length() <= srcFile.length()) {
             String root = srcFile.substring(0, base.length());
             if (root.equals(base)) {
-                // Strip off the base directory, make relative
-                return "." + SystemProperties.getProperty("file.separator") + srcFile.substring(base.length());
+                // Strip off the base directory, make relative 
+            	// the src part might already start with a relative marker, so only add if it's not there
+            	String relativePrefix = "." + File.separator;
+            	String srcPostfix = srcFile.substring(base.length());
+            	return srcPostfix.startsWith(relativePrefix) ? srcPostfix : relativePrefix + srcPostfix;
             }
         }
 


### PR DESCRIPTION
fix: avoid building a relative chain of ./././ in jar names saved) in fbp files

Before opening a 'pull request'

* Search existing issues and pull requests to see if the issue was already discussed.
* Check our discussions to see if the issue was already discussed.
* Check for specific project we support to raise the issue on, under [spotbugs](https://github.com/spotbugs)
* Do not open intellij plugin issues here, open them at [intellij-plugin](https://github.com/JetBrains/spotbugs-intellij-plugin)

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [ x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
