### PR TITLE
Migrate maven badge to maven-badges.sml.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Build Status](https://github.com/spotbugs/spotbugs/workflows/build/badge.svg)](https://github.com/spotbugs/spotbugs/actions)
 [![Documentation Status](https://readthedocs.org/projects/spotbugs/badge/?version=latest)](https://spotbugs.readthedocs.io/en/latest/?badge=latest)
 [![Coverage Status](https://sonarcloud.io/api/project_badges/measure?branch=master&project=com.github.spotbugs.spotbugs&metric=coverage)](https://sonarcloud.io/component_measures?id=com.github.spotbugs.spotbugs&metric=coverage)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.spotbugs/spotbugs/badge.svg)](https://central.sonatype.com/artifact/com.github.spotbugs/spotbugs)
+[![Maven Central](https://maven-badges.sml.io/maven-central/com.github.spotbugs/spotbugs/badge.svg)](https://central.sonatype.com/artifact/com.github.spotbugs/spotbugs)
 [![Javadocs](https://javadoc.io/badge/com.github.spotbugs/spotbugs.svg)](https://javadoc.io/doc/com.github.spotbugs/spotbugs)
 
 [SpotBugs](https://spotbugs.github.io/) is the spiritual successor of [FindBugs](https://github.com/findbugsproject/findbugs), carrying on from the point where it left off with support of its community.


### PR DESCRIPTION
maven-badges.herokuapp.com was deprecated and must be migrated.

See: https://github.com/softwaremill/maven-badges#a-new-dns-address