### PR TITLE
fix(deps): stop exposing JUnit BOM as transitive dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
       (See [SEI CERT rule LCK00-J](https://wiki.sei.cmu.edu/confluence/display/java/LCK00-J.+Use+private+final+lock+objects+to+synchronize+classes+that+may+interact+with+untrusted+code) and [SEI CERT rule LCK04-J](https://wiki.sei.cmu.edu/confluence/display/java/LCK04-J.+Do+not+synchronize+on+a+collection+view+if+the+backing+collection+is+accessible))
 
 ### Fixed
+- Stop exposing JUnit BOM as a transitive dependency to consumers ([#3908](https://github.com/spotbugs/spotbugs/issues/3908))
 - Fix incorrect bug counts and sizes when unioning reports ([#3721](https://github.com/spotbugs/spotbugs/issues/3721))
 - Classes containing only methods throwing `UnsupportedOperationException` with setter-like names are no longer considered as mutable ([#1601](https://github.com/spotbugs/spotbugs/issues/1601))
 - Enhanced SARIF output with full description sections - adding markdown is still an open issue ([#2339](https://github.com/spotbugs/spotbugs/issues/2339))

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ allprojects {
   }
   dependencies {
     String junitVersion = '5.14.2'
-    implementation platform("org.junit:junit-bom:${junitVersion}")
+    compileOnly platform("org.junit:junit-bom:${junitVersion}")
     testImplementation platform("org.junit:junit-bom:${junitVersion}")
   }
 }


### PR DESCRIPTION
Fixes #3908

## Summary

- Changed JUnit BOM declaration from `implementation` to `compileOnly` in `allprojects` block
- Prevents the JUnit BOM from being exposed as a transitive dependency to consumers of SpotBugs libraries
- `testImplementation` declaration remains unchanged for test compilation

## Checklist

- [x] Added an entry into `CHANGELOG.md`