### PR TITLE
docs: remove invalid self-referencing schemaLocation from findbugsfil…

### DIFF
--- a/spotbugs/etc/findbugsfilter.xsd
+++ b/spotbugs/etc/findbugsfilter.xsd
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<schema targetNamespace="https://github.com/spotbugs/filter/4.8.4" elementFormDefault="unqualified"
-    xsi:schemaLocation="https://github.com/spotbugs/filter/4.8.4 https://raw.githubusercontent.com/spotbugs/spotbugs/4.8.4/spotbugs/etc/findbugsfilter.xsd"
-    xmlns="http://www.w3.org/2001/XMLSchema" xmlns:fb="https://github.com/spotbugs/filter/4.8.4">
+<schema targetNamespace="https://github.com/spotbugs/filter/4.8.4" 
+    elementFormDefault="unqualified"
+    xmlns="http://www.w3.org/2001/XMLSchema" 
+    xmlns:fb="https://github.com/spotbugs/filter/4.8.4">
 
     <element name="FindBugsFilter" type="fb:FindBugsFilterType"></element>
 


### PR DESCRIPTION
Closes #3832. This PR removes the invalid xsi:schemaLocation which was causing circular validation errors in IDEs.