### PR TITLE
chore(build): Add *.salive kotlin files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ deps/
 eclipse/
 bin/
 .vscode/
+*.salive
 
 # to sign eclipse plugin
 spotbugs.jks


### PR DESCRIPTION
no change log as simply adding a gitignore for kotlin build files we don't want checked in.