### PR TITLE
silence FileNotFoundException from PluginLoader.resourceFromFindbugsJar

### DIFF
--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/PluginLoader.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/PluginLoader.java
@@ -633,7 +633,8 @@ public class PluginLoader implements AutoCloseable {
                 resourceUrl.openConnection().getInputStream().close();
                 return resourceUrl;
             } catch (FileNotFoundException e) {
-                // This is not an issue, if logged at IOException it's distracting
+                // Missing JAR entry is expected here when the resource is not packaged in findbugs.jar;
+                // ignore it and fall through so this method returns null.
             } catch (IOException e) {
                 LOG.warn("Failed to load resourceFromFindbugsJar: IOException was thrown at zip file {} loading.",
                         findbugsJar, e);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/PluginLoader.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/PluginLoader.java
@@ -21,6 +21,7 @@ package edu.umd.cs.findbugs;
 
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
@@ -631,6 +632,8 @@ public class PluginLoader implements AutoCloseable {
             try {
                 resourceUrl.openConnection().getInputStream().close();
                 return resourceUrl;
+            } catch (FileNotFoundException e) {
+                // This is not an issue, if logged at IOException it's distracting
             } catch (IOException e) {
                 LOG.warn("Failed to load resourceFromFindbugsJar: IOException was thrown at zip file {} loading.",
                         findbugsJar, e);


### PR DESCRIPTION
https://github.com/spotbugs/spotbugs/pull/3875 introduced some noise like this during build:

<details>

<summary>FileNotFoundException in build log</summary>

```
[main] WARN edu.umd.cs.findbugs.PluginLoader - Failed to load resourceFromFindbugsJar: IOException was thrown at zip file file:/Users/runner/work/spotbugs/spotbugs/spotbugs/build/libs/spotbugs.jar loading.

java.io.FileNotFoundException: JAR entry messages_en_US.xml not found in /Users/runner/work/spotbugs/spotbugs/spotbugs/build/libs/spotbugs.jar
> Task :spotbugs:spotbugsGui
	at java.base/sun.net.www.protocol.jar.JarURLConnection.connect(JarURLConnection.java:131)
	at java.base/sun.net.www.protocol.jar.JarURLConnection.getInputStream(JarURLConnection.java:160)
	at edu.umd.cs.findbugs.PluginLoader.resourceFromFindbugsJar(PluginLoader.java:616)
	at edu.umd.cs.findbugs.PluginLoader.getCoreResource(PluginLoader.java:588)
	at edu.umd.cs.findbugs.PluginLoader.getResource(PluginLoader.java:535)
	at edu.umd.cs.findbugs.PluginLoader.addCollection(PluginLoader.java:1285)
	at edu.umd.cs.findbugs.PluginLoader.getMessageDocuments(PluginLoader.java:1194)
	at edu.umd.cs.findbugs.PluginLoader.init(PluginLoader.java:697)
	at edu.umd.cs.findbugs.PluginLoader.<init>(PluginLoader.java:405)
	at edu.umd.cs.findbugs.PluginLoader.loadCorePlugin(PluginLoader.java:1448)
	at edu.umd.cs.findbugs.PluginLoader.loadInitialPlugins(PluginLoader.java:1402)
	at edu.umd.cs.findbugs.PluginLoader.<clinit>(PluginLoader.java:151)
	at edu.umd.cs.findbugs.DetectorFactoryCollection.getCoreResource(DetectorFactoryCollection.java:349)
	at edu.umd.cs.findbugs.SystemProperties.loadPropertiesFromConfigFile(SystemProperties.java:81)
	at edu.umd.cs.findbugs.SystemProperties.<clinit>(SystemProperties.java:68)
	at edu.umd.cs.findbugs.FindBugs2.<clinit>(FindBugs2.java:100)
```

</details>


The only usage of the relevant function, `PluginLoader.resourceFromFindbugsJar(String)` is when it's called from `PluginLoader.getCoreResource(String)`, which looks for the resource in several places. The other functions which look for it do not throw exceptions. When these exceptions are thrown, the resource is found at a later stage. So these are only misleading noise during build, which doesn't show real issues.
Earlier these FileNotFoundExceptions were not thrown because the `resourceFromPlugin` was only called when the zip entry wasn't null.
[Here](https://github.com/JetBrains/jdk8u_jdk/blob/master/src/share/classes/sun/net/www/protocol/jar/JarURLConnection.java#L119) is JetBrains implementation of `JarURLConnection.connect()`. It shows that FileNotFoundException is thrown when the entry is null.