### PR TITLE
Fixes #4003 : flag EI_EXPOSE_REP in package-private classes overriding public super-type methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Fix `IM_BAD_CHECK_FOR_ODD` false negative when using Yoda-style comparison (`1 == i % 2`) ([#3886](https://github.com/spotbugs/spotbugs/issues/3886))
 - Fix `PluginLoader.close()` to continue closing all `URLClassLoader`s when one close operation fails, suppressing subsequent `IOException`s. ([#3958](https://github.com/spotbugs/spotbugs/pull/3958))
 - Fix broken `bugDescriptions.html#TYPE` links by restoring legacy bug type anchors in generated docs ([#2113](https://github.com/spotbugs/spotbugs/issues/2113))
+- Fix `EI_EXPOSE_REP` false negative in package-private classes that expose mutable state through methods overriding a public super-type ([#4027](https://github.com/spotbugs/spotbugs/pull/4027))
 
 ### Removed
 - Removed old deprecated methods: 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindReturnRefTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindReturnRefTest.java
@@ -287,6 +287,15 @@ class FindReturnRefTest extends AbstractIntegrationTest {
     }
 
     @Test
+    void testPackagePrivateImplOfPublicInterface() {
+        performAnalysis("exposemutable/PackagePrivateImplProvider.class",
+                "exposemutable/PackagePrivateHiddenProvider.class");
+
+        assertBugTypeCount("EI_EXPOSE_REP", 1);
+        assertBugInMethodAtField("EI_EXPOSE_REP", "PackagePrivateHiddenProvider", "getData", "data");
+    }
+
+    @Test
     @DisabledOnJre({ JRE.JAVA_8, JRE.JAVA_11 })
     @Disabled
     void testUnmodifiableRecord() {

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindReturnRefTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindReturnRefTest.java
@@ -291,8 +291,32 @@ class FindReturnRefTest extends AbstractIntegrationTest {
         performAnalysis("exposemutable/PackagePrivateImplProvider.class",
                 "exposemutable/PackagePrivateHiddenProvider.class");
 
+        assertBugTypeCount("EI_EXPOSE_BUF", 0);
+        assertBugTypeCount("EI_EXPOSE_BUF2", 0);
         assertBugTypeCount("EI_EXPOSE_REP", 1);
+        assertBugTypeCount("EI_EXPOSE_REP2", 0);
+        assertBugTypeCount("EI_EXPOSE_STATIC_BUF2", 0);
+        assertBugTypeCount("EI_EXPOSE_STATIC_REP2", 0);
+        assertBugTypeCount("MS_EXPOSE_BUF", 0);
+        assertBugTypeCount("MS_EXPOSE_REP", 0);
+
         assertBugInMethodAtField("EI_EXPOSE_REP", "PackagePrivateHiddenProvider", "getData", "data");
+    }
+
+    @Test
+    void testPackagePrivateImplWithDefensiveCopy() {
+        performAnalysis("exposemutable/PackagePrivateImplProvider.class",
+                "exposemutable/PackagePrivateImplNoBug.class");
+
+        assertNoExposeBug();
+    }
+
+    @Test
+    void testPackagePrivateImplOfPackagePrivateInterface() {
+        performAnalysis("exposemutable/PackagePrivateInterface.class",
+                "exposemutable/PackagePrivateImplOfPackagePrivateInterface.class");
+
+        assertNoExposeBug();
     }
 
     @Test

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindReturnRef.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindReturnRef.java
@@ -28,10 +28,12 @@ import edu.umd.cs.findbugs.ba.AnalysisContext;
 import edu.umd.cs.findbugs.ba.BasicBlock;
 import edu.umd.cs.findbugs.ba.CFG;
 import edu.umd.cs.findbugs.ba.CFGBuilderException;
+import edu.umd.cs.findbugs.ba.Hierarchy2;
 import edu.umd.cs.findbugs.ba.Location;
 import edu.umd.cs.findbugs.ba.OpcodeStackScanner;
 import edu.umd.cs.findbugs.ba.XFactory;
 import edu.umd.cs.findbugs.ba.XField;
+import edu.umd.cs.findbugs.ba.XMethod;
 import edu.umd.cs.findbugs.ba.type.TypeFrameModelingVisitor;
 import edu.umd.cs.findbugs.bcel.OpcodeStackDetector;
 import edu.umd.cs.findbugs.classfile.CheckedAnalysisException;
@@ -152,7 +154,11 @@ public class FindReturnRef extends OpcodeStackDetector {
 
     @Override
     public void visit(Method obj) {
-        check = getThisClass().isPublic() && obj.isPublic();
+        if (!obj.isPublic()) {
+            check = false;
+            return;
+        }
+        check = getThisClass().isPublic() || overridesMethodFromPublicSupertype(obj);
         if (!check) {
             return;
         }
@@ -312,6 +318,23 @@ public class FindReturnRef extends OpcodeStackDetector {
                 paramCloneUnderCast = param;
             }
         }
+    }
+
+    private boolean overridesMethodFromPublicSupertype(Method method) {
+        if (method.isStatic()) {
+            return false;
+        }
+        XMethod xMethod = XFactory.createXMethod(getThisClass(), method);
+        for (XMethod superMethod : Hierarchy2.findSuperMethods(xMethod)) {
+            try {
+                if (superMethod.getClassDescriptor().getXClass().isPublic()) {
+                    return true;
+                }
+            } catch (CheckedAnalysisException e) {
+                AnalysisContext.logError("Error checking visibility of " + superMethod.getClassDescriptor(), e);
+            }
+        }
+        return false;
     }
 
     private boolean isNestedField(XField field) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindReturnRef.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindReturnRef.java
@@ -154,11 +154,7 @@ public class FindReturnRef extends OpcodeStackDetector {
 
     @Override
     public void visit(Method obj) {
-        if (!obj.isPublic()) {
-            check = false;
-            return;
-        }
-        check = getThisClass().isPublic() || overridesMethodFromPublicSupertype(obj);
+        check = obj.isPublic() && (getThisClass().isPublic() || overridesMethodFromPublicSupertype(obj));
         if (!check) {
             return;
         }

--- a/spotbugsTestCases/src/java/exposemutable/PackagePrivateHiddenProvider.java
+++ b/spotbugsTestCases/src/java/exposemutable/PackagePrivateHiddenProvider.java
@@ -1,0 +1,10 @@
+package exposemutable;
+
+class PackagePrivateHiddenProvider implements PackagePrivateImplProvider {
+    private byte[] data = { 1, 2, 3 };
+
+    @Override
+    public byte[] getData() {
+        return data;
+    }
+}

--- a/spotbugsTestCases/src/java/exposemutable/PackagePrivateImplNoBug.java
+++ b/spotbugsTestCases/src/java/exposemutable/PackagePrivateImplNoBug.java
@@ -1,0 +1,23 @@
+package exposemutable;
+
+import java.util.Date;
+
+/**
+ * Package-private class implementing a public interface but with correct defensive copies.
+ * Should NOT be flagged.
+ */
+class PackagePrivateImplNoBug implements PackagePrivateImplProvider {
+    private byte[] data = { 1, 2, 3 };
+    private Date date = new Date();
+
+    @Override
+    public byte[] getData() {
+        return data.clone(); // Defensive copy - no bug
+    }
+
+    // This method is NOT declared in the interface, so even though the class is package-private,
+    // it is not reachable from outside via the super-type. Should NOT be flagged.
+    public Date getDateNotInInterface() {
+        return date;
+    }
+}

--- a/spotbugsTestCases/src/java/exposemutable/PackagePrivateImplOfPackagePrivateInterface.java
+++ b/spotbugsTestCases/src/java/exposemutable/PackagePrivateImplOfPackagePrivateInterface.java
@@ -1,0 +1,14 @@
+package exposemutable;
+
+/**
+ * Package-private class implementing a package-private interface.
+ * Should NOT be flagged because the interface is not externally visible.
+ */
+class PackagePrivateImplOfPackagePrivateInterface implements PackagePrivateInterface {
+    private byte[] secret = { 4, 5, 6 };
+
+    @Override
+    public byte[] getSecret() {
+        return secret; // No bug - interface is package-private
+    }
+}

--- a/spotbugsTestCases/src/java/exposemutable/PackagePrivateImplProvider.java
+++ b/spotbugsTestCases/src/java/exposemutable/PackagePrivateImplProvider.java
@@ -1,0 +1,5 @@
+package exposemutable;
+
+public interface PackagePrivateImplProvider {
+    byte[] getData();
+}

--- a/spotbugsTestCases/src/java/exposemutable/PackagePrivateInterface.java
+++ b/spotbugsTestCases/src/java/exposemutable/PackagePrivateInterface.java
@@ -1,0 +1,8 @@
+package exposemutable;
+
+/**
+ * A package-private interface - not visible from outside the package.
+ */
+interface PackagePrivateInterface {
+    byte[] getSecret();
+}


### PR DESCRIPTION
`FindReturnRef` used to skip any non-public class (`getThisClass().isPublic() && obj.isPublic()`), so that a package-private class that implements a public interface and exposes a private mutable field through an overridden public method was never flagged, even if the exposure is reachable from outside the package via the public super-type.

With these changes, the detector still skips non-public methods, but a package-private declaring class is analysed when the public method overrides one declared in an externally-visible super-type. Static methods are excluded from the new path since they aren't subject to virtual dispatch through a super-type.

Added a unit test reproducing the issue #4003 . Without the changes, the unit test would fail and the violation would not be detected.

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
