### PR TITLE
Micro-optimizations: Replaces common inefficient patterns with their optimized alternative

### DIFF
--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/AbstractBugReporter.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/AbstractBugReporter.java
@@ -267,7 +267,7 @@ public abstract class AbstractBugReporter implements BugReporter {
             return false;
         }
 
-        if ("".equals(message)) {
+        if (message.isEmpty()) {
             // Subtypes2 throws ClassNotFoundExceptions with no message in
             // some cases. Ignore them (the missing classes will already
             // have been reported).

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/EmacsBugReporter.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/EmacsBugReporter.java
@@ -81,7 +81,7 @@ public class EmacsBugReporter extends TextUIBugReporter {
         try {
             fullPath = sourceFinder.findSourceFile(pkgName, line.getSourceFile()).getFullFileName();
         } catch (IOException e) {
-            if ("".equals(pkgName)) {
+            if (pkgName.isEmpty()) {
                 fullPath = line.getSourceFile();
             } else {
                 fullPath = ClassName.toSlashedClassName(pkgName) + "/" + line.getSourceFile();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/FindBugsMessageFormat.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/FindBugsMessageFormat.java
@@ -109,9 +109,9 @@ public class FindBugsMessageFormat {
 
             // System.out.println("fn: " + fieldNum);
             if (fieldNum < 0) {
-                result.append("?<?" + fieldNum + "/" + args.length + "???");
+                result.append("?<?").append(fieldNum).append("/").append(args.length).append("???");
             } else if (fieldNum >= args.length) {
-                result.append("?>?" + fieldNum + "/" + args.length + "???");
+                result.append("?>?").append(fieldNum).append("/").append(args.length).append("???");
             } else {
                 BugAnnotation field = args[fieldNum];
                 String formatted = "";

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/OpcodeStack.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/OpcodeStack.java
@@ -473,8 +473,8 @@ public class OpcodeStack {
             case NOT_SPECIAL:
                 break;
             default:
-                buf.append(", #" + specialKind);
-                buf.append("(" + specialKindToName.get(specialKind) + ")");
+                buf.append(", #").append(specialKind);
+                buf.append("(").append(specialKindToName.get(specialKind)).append(")");
                 break;
 
             }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/PluginLoader.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/PluginLoader.java
@@ -1102,11 +1102,11 @@ public class PluginLoader implements AutoCloseable {
         Plugin constructedPlugin = new Plugin(pluginId, version, parsedDate, this, !optionalPlugin, cannotDisable);
         // Set provider and website, if specified
         String provider = pluginDescriptor.valueOf(XPATH_PLUGIN_PROVIDER).trim();
-        if (!"".equals(provider)) {
+        if (!provider.isEmpty()) {
             constructedPlugin.setProvider(provider);
         }
         String website = pluginDescriptor.valueOf(XPATH_PLUGIN_WEBSITE).trim();
-        if (!"".equals(website)) {
+        if (!website.isEmpty()) {
             try {
                 constructedPlugin.setWebsite(website);
             } catch (URISyntaxException e1) {
@@ -1115,7 +1115,7 @@ public class PluginLoader implements AutoCloseable {
         }
 
         String updateUrl = pluginDescriptor.valueOf("/FindbugsPlugin/@update-url").trim();
-        if (!"".equals(updateUrl)) {
+        if (!updateUrl.isEmpty()) {
             try {
                 constructedPlugin.setUpdateUrl(updateUrl);
             } catch (URISyntaxException e1) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/SAXBugCollectionHandler.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/SAXBugCollectionHandler.java
@@ -330,7 +330,7 @@ public class SAXBugCollectionHandler extends DefaultHandler {
                     assert bugcollection != null;
                     if ("ClassStats".equals(qName)) {
                         String className = getRequiredAttribute(attributes, "class", qName);
-                        Boolean isInterface = Boolean.valueOf(getRequiredAttribute(attributes, "interface", qName));
+                        boolean isInterface = Boolean.parseBoolean(getRequiredAttribute(attributes, "interface", qName));
                         int size = Integer.parseInt(getRequiredAttribute(attributes, "size", qName));
                         String sourceFile = getOptionalAttribute(attributes, "sourceFile");
                         bugcollection.getProjectStats().addClass(className, sourceFile, isInterface, size, false);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/BasicBlock.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/BasicBlock.java
@@ -302,9 +302,9 @@ public class BasicBlock extends AbstractVertex<Edge, BasicBlock> implements Debu
             buf.append("[basicBlock=");
             buf.append(getBasicBlock().getLabel());
             if (next != null) {
-                buf.append(", next=" + next);
+                buf.append(", next=").append(next);
             } else if (getBasicBlock().isExceptionThrower()) {
-                buf.append(", check for" + getBasicBlock().getExceptionThrower());
+                buf.append(", check for").append(getBasicBlock().getExceptionThrower());
             } else {
                 buf.append(", end");
             }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/Path.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/Path.java
@@ -266,7 +266,7 @@ public class Path {
             if (block < SYMBOLS.length()) {
                 buf.append(SYMBOLS.charAt(block));
             } else {
-                buf.append("'" + block + "'");
+                buf.append("'").append(block).append("'");
             }
         }
         return buf.toString();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/deref/UnconditionalValueDerefSet.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/deref/UnconditionalValueDerefSet.java
@@ -380,7 +380,7 @@ public class UnconditionalValueDerefSet {
                 } else {
                     buf.append(',');
                 }
-                buf.append("(" + location.getBasicBlock().getLabel() + ":" + location.getHandle().getPosition() + ")");
+                buf.append("(").append(location.getBasicBlock().getLabel()).append(":").append(location.getHandle().getPosition()).append(")");
             }
             buf.append('}');
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/interproc/PropertyDatabase.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/interproc/PropertyDatabase.java
@@ -141,7 +141,7 @@ public abstract class PropertyDatabase<KeyType extends FieldOrMethodDescriptor, 
             String line;
             while ((line = reader.readLine()) != null) {
                 line = line.trim();
-                if ("".equals(line)) {
+                if (line.isEmpty()) {
                     continue;
                 }
                 int bar = line.indexOf('|');

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/NullDerefAndRedundantComparisonFinder.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/NullDerefAndRedundantComparisonFinder.java
@@ -678,6 +678,7 @@ public class NullDerefAndRedundantComparisonFinder {
                     if (e.getCatchType() == 0 && e.getStartPC() != e.getHandlerPC() && e.getEndPC() <= pc
                             && pc <= e.getEndPC() + 5) {
                         reportIt = false;
+                        break;
                     }
                 }
             }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/vna/ValueNumberFrame.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/vna/ValueNumberFrame.java
@@ -466,7 +466,7 @@ public class ValueNumberFrame extends Frame<ValueNumber> implements ValueNumberA
                 } else {
                     buf.append(',');
                 }
-                buf.append(key + "=" + valueToString(value));
+                buf.append(key).append("=").append(valueToString(value));
             }
 
             buf.append(" #");

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/config/CommandLine.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/config/CommandLine.java
@@ -227,7 +227,7 @@ public abstract class CommandLine {
                 continue;
             }
 
-            if (ignoreBlankLines && "".equals(line)) {
+            if (ignoreBlankLines && line.isEmpty()) {
                 continue;
             }
             if (line.length() >= 2 && line.charAt(0) == '"' && line.charAt(line.length() - 1) == '"') {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BadSyntaxForRegularExpression.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BadSyntaxForRegularExpression.java
@@ -162,7 +162,7 @@ public class BadSyntaxForRegularExpression extends OpcodeStackDetector {
         if (b.length() > 0) {
             b.append(" | ");
         }
-        b.append("Pattern." + name);
+        b.append("Pattern.").append(name);
 
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BuildUnconditionalParamDerefDatabase.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BuildUnconditionalParamDerefDatabase.java
@@ -97,6 +97,7 @@ public abstract class BuildUnconditionalParamDerefDatabase implements Detector {
         for (Type argument : method.getArgumentTypes()) {
             if (argument instanceof ReferenceType) {
                 hasReferenceParameters = true;
+                break;
             }
         }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNullDeref.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNullDeref.java
@@ -1689,6 +1689,7 @@ public class FindNullDeref implements Detector, UseAnnotationDatabase, NullDeref
                 int lineNumber = table.getSourceLine(loc.getHandle().getPosition());
                 if (lineNumber > 0 && !linesMentionedMultipleTimes.get(lineNumber)) {
                     uniqueDereferenceLocations = true;
+                    break;
                 }
             }
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindPuzzlers.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindPuzzlers.java
@@ -534,13 +534,14 @@ public class FindPuzzlers extends OpcodeStackDetector {
                     for (CodeException e : getCode().getExceptionTable()) {
                         if (e.getHandlerPC() <= getPC() && e.getHandlerPC() + 30 >= getPC()) {
                             debuggingContext = true;
+                            break;
                         }
                     }
 
                     for (int i = 1; !debuggingContext && i < stack.getStackDepth(); i++) {
                         OpcodeStack.Item e = stack.getStackItem(i);
 
-                        if (e.getSignature().indexOf("Logger") >= 0 || e.getSignature().indexOf("Exception") >= 0) {
+                        if (e.getSignature().contains("Logger") || e.getSignature().contains("Exception")) {
                             debuggingContext = true;
                         }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/Naming.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/Naming.java
@@ -519,6 +519,7 @@ public class Naming extends PreorderVisitor implements Detector {
                 for (Field f : this.getThisClass().getFields()) {
                     if (!f.isStatic()) {
                         instanceMembers = true;
+                        break;
                     }
                 }
                 if (!codeDoesSomething(code) && !instanceMembers && "java/lang/Object".equals(getSuperclassName())) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/NoiseNullDeref.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/NoiseNullDeref.java
@@ -402,6 +402,7 @@ public class NoiseNullDeref implements Detector, UseAnnotationDatabase, NullDere
                 int lineNumber = table.getSourceLine(loc.getHandle().getPosition());
                 if (!linesMentionedMultipleTimes.get(lineNumber)) {
                     uniqueDereferenceLocations = true;
+                    break;
                 }
             }
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SerializableIdiom.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SerializableIdiom.java
@@ -317,6 +317,7 @@ public class SerializableIdiom extends OpcodeStackDetector {
             for (Field f : obj.getFields()) {
                 if (f.isTransient()) {
                     seenTransientField = true;
+                    break;
                 }
             }
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/filter/TypeMatcher.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/filter/TypeMatcher.java
@@ -51,7 +51,7 @@ public class TypeMatcher implements Matcher {
     @Override
     public boolean match(BugInstance bugInstance) {
         TypeAnnotation typeAnnotation = bugInstance.getPrimaryType();
-        if (role != null && !"".equals(role)) {
+        if (role != null && !role.isEmpty()) {
             for (BugAnnotation a : bugInstance.getAnnotations()) {
                 if (a instanceof TypeAnnotation && role.equals(a.getDescription())) {
                     typeAnnotation = (TypeAnnotation) a;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/graph/AbstractVertex.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/graph/AbstractVertex.java
@@ -64,13 +64,7 @@ public class AbstractVertex<EdgeType extends AbstractEdge<EdgeType, ActualVertex
 
     @Override
     public int compareTo(ActualVertexType other) {
-        if (this.getLabel() < other.getLabel()) {
-            return -1;
-        } else if (this.getLabel() > other.getLabel()) {
-            return 1;
-        } else {
-            return 0;
-        }
+        return Integer.compare(this.getLabel(), other.getLabel());
     }
 
     void addOutgoingEdge(EdgeType edge) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/log/Profiler.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/log/Profiler.java
@@ -308,9 +308,7 @@ public class Profiler implements IProfiler, XMLWriteable {
                 return c1.getSimpleName().compareTo(c2.getSimpleName());
             } catch (RuntimeException e) {
                 AnalysisContext.logError("Error comparing " + c1 + " and " + c2, e);
-                int i1 = System.identityHashCode(c1);
-                int i2 = System.identityHashCode(c2);
-                return Integer.compare(i1, i2);
+                return Integer.compare(System.identityHashCode(c1), System.identityHashCode(c2));
             }
         }
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/log/Profiler.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/log/Profiler.java
@@ -310,13 +310,7 @@ public class Profiler implements IProfiler, XMLWriteable {
                 AnalysisContext.logError("Error comparing " + c1 + " and " + c2, e);
                 int i1 = System.identityHashCode(c1);
                 int i2 = System.identityHashCode(c2);
-                if (i1 < i2) {
-                    return -1;
-                }
-                if (i1 > i2) {
-                    return 1;
-                }
-                return 0;
+                return Integer.compare(i1, i2);
             }
         }
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/FB.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/FB.java
@@ -38,9 +38,7 @@ public class FB {
         } else {
             cmd = args[0];
             a = new String[args.length - 1];
-            for (int i = 1; i < args.length; i++) {
-                a[i - 1] = args[i];
-            }
+            System.arraycopy(args, 1, a, 0, args.length - 1);
         }
 
         DetectorFactoryCollection.instance();


### PR DESCRIPTION
While contributing to this project, IntelliJ highlighted several fragments. So I thought to contribute fixing some that lead to micro-optimizations. Here is the full list:

- Replace `"".equals(...)` with `.isEmpty()` to avoid unnecessary string comparison
- Replace string concatenation inside `StringBuilder.append()` with chained `.append()` calls to avoid intermediate allocations
- Replace Boolean.valueOf() with Boolean.parseBoolean() to avoid unnecessary boxing
- Add early break to loops that only set a boolean flag
- Replace manual compareTo implementations with `Integer.compare()`
- Replace manual array copy with `System.arraycopy()`
- Replace `String.indexOf() >= 0` with `String.contains()` for readability

Existing test suite should pass without modification.