### PR TITLE
Attaches Mockito as a java agent

### DIFF
--- a/eclipsePlugin-junit/build.gradle
+++ b/eclipsePlugin-junit/build.gradle
@@ -12,7 +12,7 @@ tasks.named('compileJava', JavaCompile).configure {
 dependencies {
   implementation project(':eclipsePlugin')
   testImplementation 'org.junit.jupiter:junit-jupiter-engine:6.0.3'
-  testImplementation 'org.mockito:mockito-core:5.23.0'
+  testImplementation libs.mockito
   testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 asm = "9.9.1"
 guice = "7.0.0"
 log4j = "2.26.0"
+mockito = "5.23.0"
 
 [libraries]
 asm = { module = "org.ow2.asm:asm", version.ref = "asm" }
@@ -16,3 +17,6 @@ guice-servlet = { module = "com.google.inject.extensions:guice-servlet", version
 
 log4j-core = { module = "org.apache.logging.log4j:log4j-core", version.ref = "log4j" }
 log4j-slf4j2-impl = { module = "org.apache.logging.log4j:log4j-slf4j2-impl", version.ref = "log4j" }
+
+mockito = { module = "org.mockito:mockito-core", version.ref = "mockito" }
+mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockito" }

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -1,3 +1,11 @@
+configurations {
+  mockitoAgent
+}
+dependencies {
+  mockitoAgent(libs.mockito) {
+    transitive = false
+  }
+}
 tasks.withType(Test) {
   testLogging {
     events 'FAILED'
@@ -5,7 +13,8 @@ tasks.withType(Test) {
   }
   doFirst {
     jvmArgs += [
-      '--add-opens', 'java.base/java.lang=ALL-UNNAMED'
+      '--add-opens', 'java.base/java.lang=ALL-UNNAMED',
+      "-javaagent:${configurations.mockitoAgent.asPath}"
     ]
   }
 }

--- a/spotbugs-tests/build.gradle
+++ b/spotbugs-tests/build.gradle
@@ -21,7 +21,7 @@ dependencies {
   implementation 'org.junit.jupiter:junit-jupiter-engine:6.0.3'
   implementation 'org.junit.jupiter:junit-jupiter-params:6.0.3'
   implementation 'org.hamcrest:hamcrest:3.0'
-  implementation 'org.mockito:mockito-junit-jupiter:5.23.0'
+  implementation libs.mockito.junit.jupiter
   implementation 'org.apache.ant:ant:1.10.17'
   implementation libs.log4j.core
   implementation libs.log4j.slf4j2.impl

--- a/spotbugsTestCases/build.gradle
+++ b/spotbugsTestCases/build.gradle
@@ -40,7 +40,7 @@ dependencies {
   api project(':spotbugs-annotations')
   implementation 'org.apache.groovy:groovy-all:5.0.6'
   implementation 'org.apache.commons:commons-lang3:3.20.0'
-  implementation 'org.mockito:mockito-core:5.23.0'
+  implementation libs.mockito
 }
 
 // spotbugs takes a long time to analyse the module but we don't need that


### PR DESCRIPTION
Attaches Mockito as a java agent to fix the warning during the build and to be future-proof. Also, centralizing the version of mockito.