### PR TITLE
Micro-optimizations: cache hot-path patterns, remove dead code, modernize API

### DIFF
--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/AppVersion.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/AppVersion.java
@@ -152,9 +152,9 @@ public class AppVersion implements XMLWriteable, Cloneable {
     @Override
     public String toString() {
         StringBuilder buf = new StringBuilder();
-        buf.append(String.valueOf(sequence));
+        buf.append(sequence);
         buf.append(',');
-        buf.append(String.valueOf(timestamp));
+        buf.append(timestamp);
         buf.append(',');
         buf.append(releaseName);
         buf.append(',');

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/BugInstance.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/BugInstance.java
@@ -227,9 +227,7 @@ public class BugInstance implements Comparable<BugInstance>, XMLWriteable, Clone
             dup = (BugInstance) super.clone();
 
             // Do deep copying of mutable objects
-            for (int i = 0; i < dup.annotationList.size(); ++i) {
-                dup.annotationList.set(i, (BugAnnotation) dup.annotationList.get(i).clone());
-            }
+            dup.annotationList.replaceAll(bugAnnotation -> (BugAnnotation) bugAnnotation.clone());
             dup.propertyListHead = dup.propertyListTail = null;
             for (Iterator<BugProperty> i = propertyIterator(); i.hasNext();) {
                 dup.addProperty((BugProperty) i.next().clone());
@@ -2411,7 +2409,7 @@ public class BugInstance implements Comparable<BugInstance>, XMLWriteable, Clone
     public void setHistory(BugInstance from) {
         long first = from.getFirstVersion();
         long last = from.getLastVersion();
-        if (first > 0 && last >= 0 && first > last) {
+        if (last >= 0 && first > last) {
 
             throw new IllegalArgumentException("from has version range " + first + "..." + last + " in " + from.getBugPattern()
                     + "\n" + from.getMessage());

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ClassAnnotation.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ClassAnnotation.java
@@ -20,7 +20,6 @@
 package edu.umd.cs.findbugs;
 
 import java.io.IOException;
-import java.util.stream.Collectors;
 
 import edu.umd.cs.findbugs.ba.AnalysisContext;
 import edu.umd.cs.findbugs.ba.SourceInfoMap;
@@ -201,7 +200,7 @@ public class ClassAnnotation extends PackageMemberAnnotation {
 
         if (!getJavaAnnotationNames().isEmpty()) {
             attributeList.addAttribute("classAnnotationNames",
-                    getJavaAnnotationNames().stream().collect(Collectors.joining(",")));
+                    String.join(",", getJavaAnnotationNames()));
         }
 
         String role = getDescription();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/FieldAnnotation.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/FieldAnnotation.java
@@ -20,7 +20,6 @@
 package edu.umd.cs.findbugs;
 
 import java.io.IOException;
-import java.util.stream.Collectors;
 
 import edu.umd.cs.findbugs.util.ClassName;
 import org.apache.bcel.Const;
@@ -399,7 +398,7 @@ public class FieldAnnotation extends PackageMemberAnnotation {
 
         if (!getJavaAnnotationNames().isEmpty()) {
             attributeList.addAttribute("classAnnotationNames",
-                    getJavaAnnotationNames().stream().collect(Collectors.joining(",")));
+                    String.join(",", getJavaAnnotationNames()));
         }
 
         xmlOutput.openTag(ELEMENT_NAME, attributeList);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/FindBugsMessageFormat.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/FindBugsMessageFormat.java
@@ -81,7 +81,7 @@ public class FindBugsMessageFormat {
                 break;
             }
 
-            result.append(pat.substring(0, subst));
+            result.append(pat, 0, subst);
             pat = pat.substring(subst + 1);
 
             int end = pat.indexOf('}');

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/MethodAnnotation.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/MethodAnnotation.java
@@ -21,7 +21,6 @@ package edu.umd.cs.findbugs;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.stream.Collectors;
 
 import org.apache.bcel.Const;
 
@@ -523,7 +522,7 @@ public class MethodAnnotation extends PackageMemberAnnotation {
 
         if (!getJavaAnnotationNames().isEmpty()) {
             attributeList.addAttribute("classAnnotationNames",
-                    getJavaAnnotationNames().stream().collect(Collectors.joining(",")));
+                    String.join(",", getJavaAnnotationNames()));
         }
 
         if (sourceLines == null && !addMessages) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ProjectStats.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ProjectStats.java
@@ -31,6 +31,7 @@ import java.io.Writer;
 import java.text.NumberFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
@@ -282,9 +283,7 @@ public class ProjectStats implements XMLWriteable, Cloneable {
      * Clear bug counts
      */
     public void clearBugCounts() {
-        for (int i = 0; i < totalErrors.length; i++) {
-            totalErrors[i] = 0;
-        }
+        Arrays.fill(totalErrors, 0);
         for (PackageStats stats : packageStatsMap.values()) {
             stats.clearBugCounts();
         }
@@ -352,9 +351,7 @@ public class ProjectStats implements XMLWriteable, Cloneable {
         if (!hasClassStats && !hasPackageStats) {
             return;
         }
-        for (int i = 0; i < totalErrors.length; i++) {
-            totalErrors[i] = 0;
-        }
+        Arrays.fill(totalErrors, 0);
         totalSize = 0;
         totalClasses = 0;
         totalSizeFromPackageStats = 0;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/PropertyBundle.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/PropertyBundle.java
@@ -139,7 +139,7 @@ public class PropertyBundle {
     }
 
     private boolean toBoolean(String name) {
-        return ((name != null) && "true".equalsIgnoreCase(name));
+        return "true".equalsIgnoreCase(name);
     }
 
     /**

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/SAXBugCollectionHandler.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/SAXBugCollectionHandler.java
@@ -26,7 +26,6 @@ import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.*;
-import java.util.regex.Pattern;
 
 import javax.annotation.CheckForNull;
 
@@ -145,11 +144,10 @@ public class SAXBugCollectionHandler extends DefaultHandler {
         pushCompoundMatcher(filter);
     }
 
-    Pattern ignoredElement = Pattern.compile("Message|ShortMessage|LongMessage");
+    private static final Set<String> IGNORED_ELEMENTS = Set.of("Message", "ShortMessage", "LongMessage");
 
     public boolean discardedElement(String qName) {
-        return ignoredElement.matcher(qName).matches();
-
+        return IGNORED_ELEMENTS.contains(qName);
     }
 
     public String getTextContents() {
@@ -546,13 +544,13 @@ public class SAXBugCollectionHandler extends DefaultHandler {
                 }
 
                 bugAnnotation = bugAnnotationWithSourceLines = new MethodAnnotation(classname, fieldOrMethodName, signature,
-                        Boolean.valueOf(isStatic));
+                        Boolean.parseBoolean(isStatic));
 
             } else {
                 String isStatic = getRequiredAttribute(attributes, "isStatic", qName);
                 String sourceSignature = getOptionalAttribute(attributes, "sourceSignature");
                 bugAnnotation = bugAnnotationWithSourceLines = new FieldAnnotation(classname, fieldOrMethodName, signature,
-                        sourceSignature, Boolean.valueOf(isStatic));
+                        sourceSignature, Boolean.parseBoolean(isStatic));
             }
             if (classAnnotationNames != null) {
                 ((PackageMemberAnnotation) bugAnnotation)

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/StackMapAnalyzer.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/StackMapAnalyzer.java
@@ -228,13 +228,12 @@ public class StackMapAnalyzer {
             return Item.typeOnly("J");
         case Const.ITEM_Bogus:
         case Const.ITEM_NewObject:
+        case Const.ITEM_InitObject:
             return Item.typeOnly("Ljava/lang/Object;");
         case Const.ITEM_Null:
             Item it = new Item();
             it.setSpecialKind(Item.TYPE_ONLY);
             return it;
-        case Const.ITEM_InitObject:
-            return Item.typeOnly("Ljava/lang/Object;");
         case Const.ITEM_Object:
             int index = t.getIndex();
             ConstantClass c = (ConstantClass) t.getConstantPool().getConstant(index);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/SystemProperties.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/SystemProperties.java
@@ -150,7 +150,7 @@ public class SystemProperties {
     }
 
     private static boolean toBoolean(String name) {
-        return ((name != null) && "true".equalsIgnoreCase(name));
+        return "true".equalsIgnoreCase(name);
     }
 
     /**

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/WarningSuppressor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/WarningSuppressor.java
@@ -22,6 +22,7 @@ public abstract class WarningSuppressor implements Matcher {
 
     protected final String bugPattern;
     protected final SuppressMatchType matchType;
+    private final Pattern compiledBugPattern;
 
     private Set<WarningSuppressor> alternateSuppressors = Collections.emptySet();
 
@@ -33,6 +34,10 @@ public abstract class WarningSuppressor implements Matcher {
         } else {
             this.matchType = matchType;
         }
+
+        this.compiledBugPattern = (this.matchType == SuppressMatchType.REGEX && bugPattern != null)
+                ? Pattern.compile(bugPattern)
+                : null;
 
         if (DEBUG) {
             System.out.println("Suppressing " + bugPattern);
@@ -69,10 +74,9 @@ public abstract class WarningSuppressor implements Matcher {
                 }
                 break;
             case REGEX:
-                Pattern pattern = Pattern.compile(bugPattern);
-                if (!pattern.matcher(bugInstance.getType()).matches()
-                        && !pattern.matcher(bugInstance.getBugPattern().getCategory()).matches()
-                        && !pattern.matcher(bugInstance.getBugPattern().getAbbrev()).matches()) {
+                if (!compiledBugPattern.matcher(bugInstance.getType()).matches()
+                        && !compiledBugPattern.matcher(bugInstance.getBugPattern().getCategory()).matches()
+                        && !compiledBugPattern.matcher(bugInstance.getBugPattern().getAbbrev()).matches()) {
                     return false;
                 }
                 break;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/PruneUnconditionalExceptionThrowerEdges.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/PruneUnconditionalExceptionThrowerEdges.java
@@ -19,13 +19,11 @@
 
 package edu.umd.cs.findbugs.ba;
 
-import java.util.BitSet;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.regex.Pattern;
 
-import org.apache.bcel.Const;
 import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.classfile.Method;
 import org.apache.bcel.generic.ConstantPoolGen;
@@ -46,8 +44,6 @@ import edu.umd.cs.findbugs.classfile.Global;
 public class PruneUnconditionalExceptionThrowerEdges implements EdgeTypes {
     private static final boolean DEBUG = SystemProperties.getBoolean("cfg.prune.throwers.debug");
 
-    private static final boolean DEBUG_DIFFERENCES = SystemProperties.getBoolean("cfg.prune.throwers.differences.debug");
-
     private static final String UNCONDITIONAL_THROWER_METHOD_NAMES = SystemProperties.getProperty(
             "findbugs.unconditionalThrower", " ").replace(',', '|');
 
@@ -65,14 +61,7 @@ public class PruneUnconditionalExceptionThrowerEdges implements EdgeTypes {
 
     private static final Pattern unconditionalThrowerPattern;
 
-    private static final BitSet RETURN_OPCODE_SET = new BitSet();
     static {
-        RETURN_OPCODE_SET.set(Const.ARETURN);
-        RETURN_OPCODE_SET.set(Const.IRETURN);
-        RETURN_OPCODE_SET.set(Const.LRETURN);
-        RETURN_OPCODE_SET.set(Const.DRETURN);
-        RETURN_OPCODE_SET.set(Const.FRETURN);
-        RETURN_OPCODE_SET.set(Const.RETURN);
         Pattern p;
         try {
             p = Pattern.compile(UNCONDITIONAL_THROWER_METHOD_NAMES);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/SignatureConverter.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/SignatureConverter.java
@@ -251,7 +251,7 @@ public class SignatureConverter {
         result.append(className);
         result.append('.');
         result.append(methodName);
-        result.append(args.toString());
+        result.append(args);
 
         return result.toString();
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/SignatureParser.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/SignatureParser.java
@@ -119,7 +119,7 @@ public class SignatureParser {
                     if (semi < 0) {
                         throw new IllegalStateException("Invalid method signature: " + signature);
                     }
-                    result.append(signature.substring(index, semi + 1));
+                    result.append(signature, index, semi + 1);
                     index = semi + 1;
                     break;
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/StackDepthAnalysis.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/StackDepthAnalysis.java
@@ -117,7 +117,7 @@ public class StackDepthAnalysis extends ForwardDataflowAnalysis<StackDepth> {
             combined = b;
         } else if (b == TOP) {
             combined = a;
-        } else if (a == BOTTOM || b == BOTTOM || a != b) {
+        } else if (b == BOTTOM || a != b) {
             combined = BOTTOM;
         } else {
             combined = a;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/bcp/Binding.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/bcp/Binding.java
@@ -65,7 +65,7 @@ public class Binding {
         StringBuilder buf = new StringBuilder();
         buf.append(varName);
         buf.append('=');
-        buf.append(variable.toString());
+        buf.append(variable);
         return buf.toString();
     }
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/bcp/PatternElementMatch.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/bcp/PatternElementMatch.java
@@ -154,9 +154,9 @@ public class PatternElementMatch {
     public String toString() {
         StringBuilder buf = new StringBuilder();
         PatternElementMatch cur = this;
-        buf.append(cur.patternElement.toString());
+        buf.append(cur.patternElement);
         buf.append(", ");
-        buf.append(cur.matchedInstruction.toString());
+        buf.append(cur.matchedInstruction);
         buf.append(", ");
         buf.append(cur.matchCount);
         return buf.toString();

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/FlowValue.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/jsr305/FlowValue.java
@@ -117,11 +117,10 @@ public enum FlowValue {
         case ALWAYS:
             return FlowValue.ALWAYS;
         case MAYBE:
+        case UNKNOWN:
             return FlowValue.UNKNOWN;
         case NEVER:
             return FlowValue.NEVER;
-        case UNKNOWN:
-            return FlowValue.UNKNOWN;
         default:
             throw new IllegalStateException();
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/TypeQualifierNullnessAnnotationDatabase.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/TypeQualifierNullnessAnnotationDatabase.java
@@ -431,7 +431,6 @@ public class TypeQualifierNullnessAnnotationDatabase implements INullnessAnnotat
         case ALWAYS:
             return NullnessAnnotation.NONNULL;
         case MAYBE:
-            return NullnessAnnotation.CHECK_FOR_NULL;
         case NEVER:
             return NullnessAnnotation.CHECK_FOR_NULL;
         case UNKNOWN:

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/ClassParserUsingASM.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/ClassParserUsingASM.java
@@ -19,7 +19,6 @@
 
 package edu.umd.cs.findbugs.classfile.engine;
 
-import java.util.BitSet;
 import java.util.HashSet;
 import java.util.TreeSet;
 
@@ -59,16 +58,6 @@ public class ClassParserUsingASM implements ClassParserInterface {
 
     // static final boolean NO_SHIFT_INNER_CLASS_CTOR =
     // SystemProperties.getBoolean("classparser.noshift");
-
-    private static final BitSet RETURN_OPCODE_SET = new BitSet();
-    static {
-        RETURN_OPCODE_SET.set(Opcodes.ARETURN);
-        RETURN_OPCODE_SET.set(Opcodes.IRETURN);
-        RETURN_OPCODE_SET.set(Opcodes.LRETURN);
-        RETURN_OPCODE_SET.set(Opcodes.DRETURN);
-        RETURN_OPCODE_SET.set(Opcodes.FRETURN);
-        RETURN_OPCODE_SET.set(Opcodes.RETURN);
-    }
 
     private final ClassReader classReader;
 
@@ -711,14 +700,12 @@ public class ClassParserUsingASM implements ClassParserInterface {
                 break;
             case Const.CONSTANT_String:
             case Const.CONSTANT_MethodType:
+            case Const.CONSTANT_Module:
+            case Const.CONSTANT_Package:
                 size = 3;
                 break;
             case Const.CONSTANT_MethodHandle:
                 size = 4;
-                break;
-            case Const.CONSTANT_Module:
-            case Const.CONSTANT_Package:
-                size = 3;
                 break;
             default:
                 throw new IllegalStateException("Unexpected tag of " + tag + " at offset " + offset + " while parsing "

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BadlyOverriddenAdapter.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BadlyOverriddenAdapter.java
@@ -88,7 +88,7 @@ public class BadlyOverriddenAdapter extends BytecodeScanningDetector {
             String signature = methodMap.get(methodName);
             if (!Const.CONSTRUCTOR_NAME.equals(methodName) && signature != null) {
                 if (!signature.equals(obj.getSignature())) {
-                    if (!badOverrideMap.keySet().contains(methodName)) {
+                    if (!badOverrideMap.containsKey(methodName)) {
                         badOverrideMap.put(methodName, new BugInstance(this, "BOA_BADLY_OVERRIDDEN_ADAPTER", NORMAL_PRIORITY)
                                 .addClassAndMethod(this).addSourceLine(this));
                     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/CloneIdiom.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/CloneIdiom.java
@@ -155,10 +155,7 @@ public class CloneIdiom extends DismantleBytecode implements Detector, Stateless
         }
 
         if (hasCloneMethod && isCloneable && !invokesSuperClone && !isFinal && obj.isPublic()) {
-            int priority = LOW_PRIORITY;
-            if (obj.isPublic() || obj.isProtected()) {
-                priority = NORMAL_PRIORITY;
-            }
+            int priority = NORMAL_PRIORITY;
             try {
                 Subtypes2 subtypes2 = AnalysisContext.currentAnalysisContext().getSubtypes2();
                 Set<ClassDescriptor> directSubtypes = subtypes2.getDirectSubtypes(getClassDescriptor());

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/CrossSiteScripting.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/CrossSiteScripting.java
@@ -54,11 +54,11 @@ public class CrossSiteScripting extends OpcodeStackDetector {
         allFileNameStringMethods = database.getFileNameStringMethods();
     }
 
+    private static final Pattern XML_SAFE = Pattern.compile("\\p{Alnum}+");
+
     Map<String, OpcodeStack.Item> map = new HashMap<>();
 
     OpcodeStack.Item top = null;
-
-    Pattern xmlSafe = Pattern.compile("\\p{Alnum}+");
 
     @Override
     public void visit(Code code) {
@@ -72,7 +72,7 @@ public class CrossSiteScripting extends OpcodeStackDetector {
         assert item.isServletParameterTainted();
         String s = item.getHttpParameterName();
         int pc = item.getInjectionPC();
-        if (s != null && xmlSafe.matcher(s).matches()) {
+        if (s != null && XML_SAFE.matcher(s).matches()) {
             bug.addString(s).describe(StringAnnotation.PARAMETER_NAME_ROLE);
         }
         SourceLineAnnotation thisLine = SourceLineAnnotation.fromVisitedInstruction(this);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindFloatMath.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindFloatMath.java
@@ -53,6 +53,8 @@ public class FindFloatMath extends BytecodeScanningDetector implements Stateless
                         this).addSourceLine(this));
             }
             break;
+        case Const.FCMPG:
+        case Const.FCMPL:
         default:
             break;
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindFloatMath.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindFloatMath.java
@@ -44,9 +44,6 @@ public class FindFloatMath extends BytecodeScanningDetector implements Stateless
                         .addClassAndMethod(this).addSourceLine(this));
             }
             break;
-        case Const.FCMPG:
-        case Const.FCMPL:
-            break;
         case Const.FADD:
         case Const.FSUB:
         case Const.FREM:

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindInstanceLockOnSharedStaticData.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindInstanceLockOnSharedStaticData.java
@@ -55,7 +55,7 @@ public class FindInstanceLockOnSharedStaticData extends OpcodeStackDetector {
             maybeLockObject = Optional.ofNullable(lockObject.getXField());
 
             // Locking on java.lang.Class objects is appropriate, since there is only a single instance of them
-            if (!maybeLockObject.isPresent()) {
+            if (maybeLockObject.isEmpty()) {
                 try {
                     Optional<JavaClass> javaClassOfLockObject = Optional.ofNullable(lockObject.getJavaClass());
                     isLockObjectInstanceOfJavaLangClass = javaClassOfLockObject

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindSelfComparison.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindSelfComparison.java
@@ -217,11 +217,6 @@ public class FindSelfComparison extends OpcodeStackDetector {
         case Const.ISUB:
             checkForSelfOperation(seen, "COMPUTATION");
             break;
-        case Const.FCMPG:
-        case Const.DCMPG:
-        case Const.DCMPL:
-        case Const.FCMPL:
-            break;
         case Const.LCMP:
         case Const.IF_ACMPEQ:
         case Const.IF_ACMPNE:

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindSelfComparison.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindSelfComparison.java
@@ -228,6 +228,10 @@ public class FindSelfComparison extends OpcodeStackDetector {
         case Const.IF_ICMPGE:
             checkForSelfOperation(seen, "COMPARISON");
             break;
+        case Const.FCMPG:
+        case Const.DCMPG:
+        case Const.DCMPL:
+        case Const.FCMPL:
         default:
             break;
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindSelfComparison2.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindSelfComparison2.java
@@ -1,9 +1,5 @@
 package edu.umd.cs.findbugs.detect;
 
-import static org.apache.bcel.Const.DCMPG;
-import static org.apache.bcel.Const.DCMPL;
-import static org.apache.bcel.Const.FCMPG;
-import static org.apache.bcel.Const.FCMPL;
 import static org.apache.bcel.Const.IAND;
 import static org.apache.bcel.Const.IF_ACMPEQ;
 import static org.apache.bcel.Const.IF_ACMPNE;
@@ -143,11 +139,6 @@ public class FindSelfComparison2 implements Detector {
             case IXOR:
             case ISUB:
                 checkForSelfOperation(classContext, location, valueNumberDataflow, "COMPUTATION", method, methodGen, sourceFile);
-                break;
-            case FCMPG:
-            case DCMPG:
-            case DCMPL:
-            case FCMPL:
                 break;
             case LCMP:
             case IF_ACMPEQ:

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindSelfComparison2.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindSelfComparison2.java
@@ -1,5 +1,9 @@
 package edu.umd.cs.findbugs.detect;
 
+import static org.apache.bcel.Const.DCMPG;
+import static org.apache.bcel.Const.DCMPL;
+import static org.apache.bcel.Const.FCMPG;
+import static org.apache.bcel.Const.FCMPL;
 import static org.apache.bcel.Const.IAND;
 import static org.apache.bcel.Const.IF_ACMPEQ;
 import static org.apache.bcel.Const.IF_ACMPNE;
@@ -151,6 +155,10 @@ public class FindSelfComparison2 implements Detector {
             case IF_ICMPGE:
                 checkForSelfOperation(classContext, location, valueNumberDataflow, "COMPARISON", method, methodGen, sourceFile);
                 break;
+            case FCMPG:
+            case DCMPG:
+            case DCMPL:
+            case FCMPL:
             default:
                 break;
             }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MethodReturnCheck.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MethodReturnCheck.java
@@ -316,7 +316,7 @@ public class MethodReturnCheck extends OpcodeStackDetector implements UseAnnotat
                 int priority = annotation.getPriority();
                 if (catchSize <= 1) {
                     priority += 2;
-                } else if (catchSize <= 2) {
+                } else if (catchSize == 2) {
                     priority += 1;
                 }
                 if (!checkReturnAnnotationDatabase.annotationIsDirect(callSeen)

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/model/ClassFeatureSet.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/model/ClassFeatureSet.java
@@ -283,7 +283,7 @@ public class ClassFeatureSet implements XMLWriteable {
 
         int lastBracket = signature.lastIndexOf('[');
         if (lastBracket > 0) {
-            buf.append(signature.substring(0, lastBracket + 1));
+            buf.append(signature, 0, lastBracket + 1);
             signature = signature.substring(lastBracket + 1);
         }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/props/WarningPropertySet.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/props/WarningPropertySet.java
@@ -131,7 +131,7 @@ public class WarningPropertySet<T extends WarningProperty> implements Cloneable 
      * @return true if the set contains the WarningProperty, false if not
      */
     public @CheckReturnValue boolean containsProperty(T prop) {
-        return map.keySet().contains(prop);
+        return map.containsKey(prop);
     }
 
     /**

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/MessageFormat.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/MessageFormat.java
@@ -29,7 +29,7 @@ class MessageFormat {
                 break;
             }
 
-            result.append(pat.substring(0, subst));
+            result.append(pat, 0, subst);
             pat = pat.substring(subst + 1);
 
             int end = pat.indexOf('}');

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Rule.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Rule.java
@@ -103,7 +103,7 @@ final class Rule {
         String name = weaknessCatalog.getName();
         String version = weaknessCatalog.getVersion();
         UUID guidOfCweTaxonomy = GUIDCalculator.fromString(name + version);
-        UUID guidOfCweTaxon = GUIDCalculator.fromNamespaceAndString(guidOfCweTaxonomy, cweId.toString());
+        UUID guidOfCweTaxon = GUIDCalculator.fromNamespaceAndString(guidOfCweTaxonomy, cweId);
 
         JsonObject cweRelationship = new JsonObject();
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/BootstrapMethodsUtil.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/BootstrapMethodsUtil.java
@@ -74,7 +74,7 @@ public class BootstrapMethodsUtil {
                     .filter(m -> m.getNameIndex() == cnat.getNameIndex()
                             && m.getSignatureIndex() == cnat.getSignatureIndex())
                     .findAny();
-            if (!metOpt.isPresent()) {
+            if (metOpt.isEmpty()) {
                 continue;
             }
             return metOpt;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/MineBugHistory.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/workflow/MineBugHistory.java
@@ -217,9 +217,7 @@ public class MineBugHistory {
             }
 
             int paddingNeeded = WIDTH - b.length() % WIDTH;
-            if (paddingNeeded > 0) {
-                b.append("                                                     ".substring(0, paddingNeeded));
-            }
+            b.append(" ".repeat(paddingNeeded));
         }
         int errors = bugCollection.getErrors().size();
         if (errors > 0) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/xml/MetaCharacterMap.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/xml/MetaCharacterMap.java
@@ -52,7 +52,7 @@ public class MetaCharacterMap {
      */
     public void addMeta(char meta, String replacement) {
         metaCharacterSet.set(meta);
-        replacementMap.put(new String(new char[] { meta }), replacement);
+        replacementMap.put(String.valueOf(meta), replacement);
     }
 
     /**

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/xml/QuoteMetaCharacters.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/xml/QuoteMetaCharacters.java
@@ -66,7 +66,7 @@ public abstract class QuoteMetaCharacters {
                 emitLiteral(map.getReplacement(text.substring(meta, meta + 1)));
                 pos = meta + 1;
             } else {
-                emitLiteral(text.substring(pos, text.length()));
+                emitLiteral(text.substring(pos));
                 pos = text.length();
             }
         } while (pos < text.length());


### PR DESCRIPTION
Some more optimizations and cleanups 🙂

Mostly addressing:

- Cache compiled Pattern instances on hot paths in WarningSuppressor and CrossSiteScripting
- Replace Pattern with Set in SAXBugCollectionHandler
- Remove two dead RETURN_OPCODE_SET fields never used in PruneUnconditionalExceptionThrowerEdges and ClassParserUsingASM
- Replace several Collectors.joining with String.join
- Replace keySet().contains() with containsKey()
- Replace Boolean.valueOf with Boolean.parseBoolean
- Replace for loops with Arrays.fill and List.replaceAll
- Replace substring(start, end) with append(str, start, end) to avoid intermediate allocations
- Replace !isPresent() with isEmpty()
- Deduplicate branches from switch
