### PR TITLE
Add regression test for List.copyOf EI_EXPOSE_REP false positive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
     - `USBC_UNSAFE_SYNCHRONIZATION_WITH_INHERITABLE_BACKING_COLLECTION` is reported when the backing collection of a lock can be altered by subclasses.
       (See [SEI CERT rule LCK00-J](https://wiki.sei.cmu.edu/confluence/display/java/LCK00-J.+Use+private+final+lock+objects+to+synchronize+classes+that+may+interact+with+untrusted+code) and [SEI CERT rule LCK04-J](https://wiki.sei.cmu.edu/confluence/display/java/LCK04-J.+Do+not+synchronize+on+a+collection+view+if+the+backing+collection+is+accessible))
 - New detector `FindIncreasedAccessibilityOfMethods` for new bug type `IAOM_DO_NOT_INCREASE_METHOD_ACCESSIBILITY`. This detector reports a bug if a class increases the accessibility of overridden or hidden methods. (See [SEI CERT rule MET04-J](https://wiki.sei.cmu.edu/confluence/display/java/MET04-J.+Do+not+increase+the+accessibility+of+overridden+or+hidden+methods))
+- Add regression test for `List.copyOf` / `Set.copyOf` not triggering `EI_EXPOSE_REP` ([#4033](https://github.com/spotbugs/spotbugs/issues/4033))
 
 ### Fixed
 - Fix `DM_STRING_TOSTRING` false negative when `toString()` is chained before a method call (e.g., `s.toString().toLowerCase()`); multiple occurrences in the same method are now all reported ([#3966](https://github.com/spotbugs/spotbugs/issues/3966))

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue4033Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue4033Test.java
@@ -1,0 +1,18 @@
+package edu.umd.cs.findbugs.detect;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnJre;
+import org.junit.jupiter.api.condition.JRE;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+
+class Issue4033Test extends AbstractIntegrationTest {
+
+    @Test
+    @DisabledOnJre({ JRE.JAVA_8, JRE.JAVA_11 })
+    void testIssue() {
+        performAnalysis("../java17/ghIssues/Issue4033.class");
+        assertNoBugType("EI_EXPOSE_REP");
+        assertNoBugType("MS_EXPOSE_REP");
+    }
+}

--- a/spotbugsTestCases/src/java17/ghIssues/Issue4033.java
+++ b/spotbugsTestCases/src/java17/ghIssues/Issue4033.java
@@ -1,0 +1,37 @@
+package ghIssues;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * <a href="https://github.com/spotbugs/spotbugs/issues/4033">#4033</a>.
+ */
+public class Issue4033 {
+
+    private static final List<String> NAMES_OK = List.of("a", "b", "c");
+    private static final Set<Integer> CODES_OK = Set.of(1, 2, 3);
+
+    private static final List<String> NAMES = List.copyOf(List.of("a", "b", "c"));
+    private static final Set<Integer> CODES = Set.copyOf(Set.of(1, 2, 3));
+    private final List<String> tags = List.copyOf(List.of("x", "y", "z"));
+
+    public List<String> getNamesOk() {
+        return NAMES_OK;
+    }
+
+    public Set<Integer> getCodesOk() {
+        return CODES_OK;
+    }
+
+    public List<String> getNames() {
+        return NAMES;
+    }
+
+    public Set<Integer> getCodes() {
+        return CODES;
+    }
+
+    public List<String> getTags() {
+        return tags;
+    }
+}


### PR DESCRIPTION
## Summary

- Add integration test case `Issue4033` matching the reporter's reproduction from #4033
- Assert no `EI_EXPOSE_REP` / `MS_EXPOSE_REP` warnings for fields initialized via `List.copyOf` / `Set.copyOf` (static and instance)

Fixes #4033

## Notes

The underlying behavior appears to already be handled via `IMMUTABLE_RETURNER_MAP` entries for `copyOf` and the `fieldValues` check in `FindReturnRef`. This PR adds an explicit regression test so the reported scenario stays covered.

## Test plan

- [x] `./gradlew :spotbugsTestCases:classesJava17 :spotbugs-tests:test --tests "edu.umd.cs.findbugs.detect.Issue4033Test"`