### PR TITLE
Fix NP_BOOLEAN_RETURN_NULL for null returned via local variable

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue4037Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue4037Test.java
@@ -1,0 +1,14 @@
+package edu.umd.cs.findbugs.detect;
+
+import org.junit.jupiter.api.Test;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+
+class Issue4037Test extends AbstractIntegrationTest {
+
+    @Test
+    void testIssue() {
+        performAnalysis("ghIssues/Issue4037.class");
+        assertBugTypeCount("NP_BOOLEAN_RETURN_NULL", 3);
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/TypeReturnNull.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/TypeReturnNull.java
@@ -73,7 +73,7 @@ public abstract class TypeReturnNull extends OpcodeStackDetector {
 
     @Override
     public void sawOpcode(int seen) {
-        if (seen == Const.ARETURN && getPrevOpcode(1) == Const.ACONST_NULL) {
+        if (seen == Const.ARETURN && getStack().getStackItem(0).isNull()) {
             accumulateBug();
         }
     }

--- a/spotbugsTestCases/src/java/ghIssues/Issue4037.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue4037.java
@@ -1,0 +1,35 @@
+package ghIssues;
+
+import edu.umd.cs.findbugs.annotations.ExpectWarning;
+
+/**
+ * <a href="https://github.com/spotbugs/spotbugs/issues/4037">#4037</a>.
+ */
+public class Issue4037 {
+
+    @ExpectWarning("NP_BOOLEAN_RETURN_NULL")
+    public Boolean isValidDirect(String input) {
+        if (input == null) {
+            return null;
+        }
+        return Boolean.TRUE;
+    }
+
+    @ExpectWarning("NP_BOOLEAN_RETURN_NULL")
+    public Boolean isValidIndirect(String input) {
+        if (input == null) {
+            Boolean result = null;
+            return result;
+        }
+        return Boolean.TRUE;
+    }
+
+    @ExpectWarning("NP_BOOLEAN_RETURN_NULL")
+    public Boolean checkStatus(int code) {
+        if (code < 0) {
+            Boolean result = null;
+            return result;
+        }
+        return code == 0 ? Boolean.TRUE : Boolean.FALSE;
+    }
+}


### PR DESCRIPTION
## Summary

- Detect null `Boolean` returns using stack nullness on `ARETURN` instead of matching only the `ACONST_NULL` + `ARETURN` opcode pair
- Add regression test `Issue4037` covering direct and indirect null returns

Fixes #4037

## Problem

`TypeReturnNull` missed patterns like:

```java
Boolean result = null;
return result;
```

even though the method still returns null from a `Boolean`-typed method.

## Test plan

- [x] `./gradlew :spotbugsTestCases:classesJava8 :spotbugs-tests:test --tests "edu.umd.cs.findbugs.detect.Issue4037Test"`
- [x] `./gradlew :spotbugs-tests:test --tests "edu.umd.cs.findbugs.detect.RegressionIdeas20111219Test"`
- [x] Verified CLI reports all three methods in the reproduction case