### PR TITLE
Fix EI_EXPOSE_REP false negative for anonymous class getters

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue4032Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue4032Test.java
@@ -1,0 +1,20 @@
+package edu.umd.cs.findbugs.detect;
+
+import org.junit.jupiter.api.Test;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+
+class Issue4032Test extends AbstractIntegrationTest {
+
+    @Test
+    void testAnonymousClassGetterExposesInternalArray() {
+        performAnalysis("ghIssues/Issue4032.class",
+                "ghIssues/Issue4032$NamedProvider.class",
+                "ghIssues/Issue4032$Provider.class",
+                "ghIssues/Issue4032$1.class");
+
+        assertBugInMethodAtField("EI_EXPOSE_REP", "Issue4032$NamedProvider", "getNames", "names");
+        assertBugInMethodAtField("EI_EXPOSE_REP", "Issue4032$1", "getNames", "names");
+        assertBugTypeCount("EI_EXPOSE_REP", 2);
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindReturnRef.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindReturnRef.java
@@ -38,13 +38,17 @@ import edu.umd.cs.findbugs.ba.type.TypeFrameModelingVisitor;
 import edu.umd.cs.findbugs.bcel.OpcodeStackDetector;
 import edu.umd.cs.findbugs.classfile.CheckedAnalysisException;
 import edu.umd.cs.findbugs.classfile.ClassDescriptor;
+import edu.umd.cs.findbugs.classfile.DescriptorFactory;
 import edu.umd.cs.findbugs.classfile.MethodDescriptor;
 import edu.umd.cs.findbugs.util.ClassName;
 import edu.umd.cs.findbugs.util.MutableClasses;
 import edu.umd.cs.findbugs.util.NestedAccessUtil;
 import org.apache.bcel.Const;
+import org.apache.bcel.classfile.Attribute;
+import org.apache.bcel.classfile.ConstantPool;
 import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.classfile.Method;
+import org.apache.bcel.classfile.NestHost;
 import org.apache.bcel.generic.ConstantPoolGen;
 import org.apache.bcel.generic.FieldInstruction;
 import org.apache.bcel.generic.Instruction;
@@ -154,7 +158,8 @@ public class FindReturnRef extends OpcodeStackDetector {
 
     @Override
     public void visit(Method obj) {
-        check = obj.isPublic() && (getThisClass().isPublic() || overridesMethodFromPublicSupertype(obj));
+        check = obj.isPublic() && (getThisClass().isPublic() || overridesMethodFromPublicSupertype(obj)
+                || implementsMethodOfPublicInterface(obj));
         if (!check) {
             return;
         }
@@ -333,6 +338,27 @@ public class FindReturnRef extends OpcodeStackDetector {
         return false;
     }
 
+    private boolean implementsMethodOfPublicInterface(Method method) {
+        if (method.isStatic() || !ClassName.isLocalOrAnonymous(getDottedClassName())) {
+            return false;
+        }
+        try {
+            XMethod xMethod = XFactory.createXMethod(getThisClass(), method);
+            for (String interfaceName : getThisClass().getInterfaceNames()) {
+                ClassDescriptor ifaceDesc = DescriptorFactory.createClassDescriptorFromDottedClassName(interfaceName);
+                if (!ifaceDesc.getXClass().isPublic()) {
+                    continue;
+                }
+                if (ifaceDesc.getXClass().findMatchingMethod(xMethod.getMethodDescriptor()) != null) {
+                    return true;
+                }
+            }
+        } catch (CheckedAnalysisException e) {
+            AnalysisContext.logError("Error checking declared interfaces of " + getDottedClassName(), e);
+        }
+        return false;
+    }
+
     private boolean isNestedField(XField field) {
         if (field != null && getThisClass().isNested() && field.getName().startsWith("this$")) {
             try {
@@ -419,6 +445,10 @@ public class FindReturnRef extends OpcodeStackDetector {
     }
 
     private boolean isFieldOf(XField field, ClassDescriptor clazz) {
+        return isFieldOf(field, clazz, true);
+    }
+
+    private boolean isFieldOf(XField field, ClassDescriptor clazz, boolean tryNestHost) {
         do {
             ClassDescriptor clazz2 = clazz;
             do {
@@ -442,6 +472,27 @@ public class FindReturnRef extends OpcodeStackDetector {
                 return false;
             }
         } while (clazz != null);
+
+        if (tryNestHost && ClassName.isLocalOrAnonymous(getDottedClassName())) {
+            ClassDescriptor nestHost = getNestHostClassDescriptor();
+            if (nestHost != null && isFieldOf(field, nestHost, false)) {
+                return true;
+            }
+        }
         return false;
+    }
+
+    private ClassDescriptor getNestHostClassDescriptor() {
+        for (Attribute attribute : getThisClass().getAttributes()) {
+            if (attribute instanceof NestHost) {
+                NestHost nestHostAttribute = (NestHost) attribute;
+                ConstantPool constantPool = nestHostAttribute.getConstantPool();
+                String hostClassName = constantPool.getConstantString(nestHostAttribute.getHostClassIndex(),
+                        Const.CONSTANT_Class);
+                return DescriptorFactory.createClassDescriptorFromDottedClassName(
+                        ClassName.toDottedClassName(hostClassName));
+            }
+        }
+        return null;
     }
 }

--- a/spotbugsTestCases/src/java/ghIssues/Issue4032.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue4032.java
@@ -1,0 +1,28 @@
+package ghIssues;
+
+/**
+ * <a href="https://github.com/spotbugs/spotbugs/issues/4032">#4032</a>.
+ */
+public class Issue4032 {
+    private static final String[] names = new String[] {"a", "b"};
+
+    public interface Provider {
+        String[] getNames();
+    }
+
+    public static class NamedProvider implements Provider {
+        @Override
+        public String[] getNames() {
+            return names;
+        }
+    }
+
+    public static Provider anonymousProvider() {
+        return new Provider() {
+            @Override
+            public String[] getNames() {
+                return names;
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary

- Fix `FindReturnRef` to report `EI_EXPOSE_REP` when a public getter in an **anonymous class** returns a mutable field from the nest host, matching behavior for named nested classes.
- Anonymous classes do not have `outer_class_info_index` in `InnerClasses`, so `immediateEnclosingClass` is unset; resolve the nest host via the `NestHost` attribute instead.
- Treat public methods declared on anonymous classes that implement a public interface as externally visible API surface.

Fixes #4032

## Test plan

- [x] Added `Issue4032` regression test covering both named nested class and anonymous class getters
- [x] `./gradlew :spotbugs-tests:test --tests "edu.umd.cs.findbugs.detect.Issue4032Test"`
- [x] `./gradlew :spotbugs-tests:test --tests "edu.umd.cs.findbugs.detect.FindReturnRefTest"` (existing tests still pass)