### PR TITLE
Detect ByteBuffer.array() and Arrays.copyOf shallow array exposure

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue4007Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue4007Test.java
@@ -1,0 +1,19 @@
+package edu.umd.cs.findbugs.detect;
+
+import org.junit.jupiter.api.Test;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+
+class Issue4007Test extends AbstractIntegrationTest {
+
+    @Test
+    void testByteBufferArrayAndArraysCopyOfExposure() {
+        performAnalysis("ghIssues/Issue4007.class");
+
+        assertBugInMethodAtField("EI_EXPOSE_BUF", "Issue4007", "getArray", "buf");
+        assertBugInMethodAtField("MS_EXPOSE_BUF", "Issue4007", "getStaticArray", "S_BUF");
+        assertBugInMethodAtField("EI_EXPOSE_BUF", "Issue4007", "getDuplicate", "buf");
+        assertBugInMethodAtField("EI_EXPOSE_REP2", "Issue4007", "setDates", "dates");
+        assertBugInMethodAtField("EI_EXPOSE_REP", "Issue4007", "getDatesClone", "dates");
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindReturnRef.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindReturnRef.java
@@ -70,17 +70,27 @@ public class FindReturnRef extends OpcodeStackDetector {
     private OpcodeStack.Item paramUnderClone = null;
     private XField fieldCloneUnderCast = null;
     private OpcodeStack.Item paramCloneUnderCast = null;
+    private XField fieldCopyUnderCast = null;
+    private OpcodeStack.Item paramCopyUnderCast = null;
     private XField bufferFieldUnderDuplication = null;
     private OpcodeStack.Item bufferParamUnderDuplication = null;
+    private XField bufferFieldUnderArray = null;
+    private OpcodeStack.Item bufferParamUnderArray = null;
     private XField fieldUnderWrapToBuffer = null;
     private OpcodeStack.Item paramUnderWrapToBuffer = null;
+    private XField fieldUnderCopyOf = null;
+    private OpcodeStack.Item paramUnderCopyOf = null;
 
     private final Map<OpcodeStack.Item, XField> bufferFieldDuplicates = new HashMap<>();
     private final Map<OpcodeStack.Item, OpcodeStack.Item> bufferParamDuplicates = new HashMap<>();
+    private final Map<OpcodeStack.Item, XField> bufferFieldArrays = new HashMap<>();
+    private final Map<OpcodeStack.Item, OpcodeStack.Item> bufferParamArrays = new HashMap<>();
     private final Map<OpcodeStack.Item, XField> arrayFieldsWrappedToBuffers = new HashMap<>();
     private final Map<OpcodeStack.Item, OpcodeStack.Item> arrayParamsWrappedToBuffers = new HashMap<>();
     private final Map<OpcodeStack.Item, XField> arrayFieldClones = new HashMap<>();
     private final Map<OpcodeStack.Item, OpcodeStack.Item> arrayParamClones = new HashMap<>();
+    private final Map<OpcodeStack.Item, XField> arrayFieldCopies = new HashMap<>();
+    private final Map<OpcodeStack.Item, OpcodeStack.Item> arrayParamCopies = new HashMap<>();
     private final Map<XField, List<OpcodeStack.Item>> fieldValues = new HashMap<>();
 
     private final BugAccumulator bugAccumulator;
@@ -90,6 +100,8 @@ public class FindReturnRef extends OpcodeStackDetector {
             Pattern.compile("\\(\\)Ljava/nio/[A-Za-z]+Buffer;");
     private static final Pattern WRAP_METHOD_SIGNATURE_PATTERN =
             Pattern.compile("\\(\\[.\\)Ljava/nio/[A-Za-z]+Buffer;");
+    private static final Pattern ARRAY_METHODS_SIGNATURE_PATTERN =
+            Pattern.compile("\\(\\)(\\[.|Ljava/lang/Object;)");
 
     private enum CaptureKind {
         NONE, REP, ARRAY_CLONE, BUF
@@ -178,10 +190,16 @@ public class FindReturnRef extends OpcodeStackDetector {
         paramUnderClone = null;
         fieldCloneUnderCast = null;
         paramCloneUnderCast = null;
+        fieldCopyUnderCast = null;
+        paramCopyUnderCast = null;
         fieldUnderWrapToBuffer = null;
         paramUnderWrapToBuffer = null;
         bufferFieldUnderDuplication = null;
         bufferParamUnderDuplication = null;
+        bufferFieldUnderArray = null;
+        bufferParamUnderArray = null;
+        fieldUnderCopyOf = null;
+        paramUnderCopyOf = null;
 
         if (staticMethod && seen == Const.PUTSTATIC && nonPublicFieldOperand()
                 && MutableClasses.mutableSignature(getSigConstantOperand())) {
@@ -228,6 +246,12 @@ public class FindReturnRef extends OpcodeStackDetector {
             }
             if (field == null) {
                 field = bufferFieldDuplicates.get(item);
+                if (field != null) {
+                    isBuf = true;
+                }
+            }
+            if (field == null) {
+                field = bufferFieldArrays.get(item);
                 if (field != null) {
                     isBuf = true;
                 }
@@ -285,21 +309,44 @@ public class FindReturnRef extends OpcodeStackDetector {
                     bufferParamUnderDuplication = item;
                 }
             }
+
+            if ("array".equals(method.getName())
+                    && ARRAY_METHODS_SIGNATURE_PATTERN.matcher(method.getSignature()).matches()
+                    && BUFFER_CLASS_PATTERN.matcher(method.getClassDescriptor().getSignature()).matches()) {
+                if (field != null && !field.isPublic() && isFieldOf(field, getClassDescriptor())) {
+                    bufferFieldUnderArray = field;
+                } else if (item.isInitialParameter()) {
+                    bufferParamUnderArray = item;
+                }
+            }
         }
 
         if (seen == Const.INVOKESTATIC) {
             MethodDescriptor method = getMethodDescriptorOperand();
-            if (method == null || !"wrap".equals(method.getName())
-                    || !WRAP_METHOD_SIGNATURE_PATTERN.matcher(method.getSignature()).matches()
-                    || !BUFFER_CLASS_PATTERN.matcher(method.getClassDescriptor().getSignature()).matches()) {
+            if (method == null) {
                 return;
             }
-            OpcodeStack.Item arg = stack.getStackItem(0);
-            XField fieldArg = arg.getXField();
-            if (fieldArg != null && !fieldArg.isPublic() && isFieldOf(fieldArg, getClassDescriptor())) {
-                fieldUnderWrapToBuffer = fieldArg;
-            } else if (arg.isInitialParameter()) {
-                paramUnderWrapToBuffer = arg;
+            if ("wrap".equals(method.getName())
+                    && WRAP_METHOD_SIGNATURE_PATTERN.matcher(method.getSignature()).matches()
+                    && BUFFER_CLASS_PATTERN.matcher(method.getClassDescriptor().getSignature()).matches()) {
+                OpcodeStack.Item arg = stack.getStackItem(0);
+                XField fieldArg = arg.getXField();
+                if (fieldArg != null && !fieldArg.isPublic() && isFieldOf(fieldArg, getClassDescriptor())) {
+                    fieldUnderWrapToBuffer = fieldArg;
+                } else if (arg.isInitialParameter()) {
+                    paramUnderWrapToBuffer = arg;
+                }
+            } else if ("copyOf".equals(method.getName())
+                    && "java/util/Arrays".equals(method.getClassDescriptor().getClassName())
+                    && stack.getStackDepth() >= 2
+                    && isMutableObjectArrayCopyOf(method, stack.getStackItem(1))) {
+                OpcodeStack.Item arrayArg = stack.getStackItem(1);
+                XField fieldArg = arrayArg.getXField();
+                if (fieldArg != null && !fieldArg.isPublic() && isFieldOf(fieldArg, getClassDescriptor())) {
+                    fieldUnderCopyOf = fieldArg;
+                } else if (arrayArg.isInitialParameter()) {
+                    paramUnderCopyOf = arrayArg;
+                }
             }
         }
 
@@ -312,6 +359,14 @@ public class FindReturnRef extends OpcodeStackDetector {
             OpcodeStack.Item param = arrayParamClones.get(item);
             if (param != null) {
                 paramCloneUnderCast = param;
+            }
+            XField copyField = arrayFieldCopies.get(item);
+            if (copyField != null) {
+                fieldCopyUnderCast = copyField;
+            }
+            OpcodeStack.Item copyParam = arrayParamCopies.get(item);
+            if (copyParam != null) {
+                paramCopyUnderCast = copyParam;
             }
         }
     }
@@ -364,6 +419,12 @@ public class FindReturnRef extends OpcodeStackDetector {
                     bufferParamDuplicates.put(stack.getStackItem(0), bufferParamUnderDuplication);
                 }
             }
+            if (bufferFieldUnderArray != null) {
+                bufferFieldArrays.put(stack.getStackItem(0), bufferFieldUnderArray);
+            }
+            if (bufferParamUnderArray != null) {
+                bufferParamArrays.put(stack.getStackItem(0), bufferParamUnderArray);
+            }
         }
 
         if (seen == Const.INVOKESTATIC) {
@@ -372,6 +433,12 @@ public class FindReturnRef extends OpcodeStackDetector {
             }
             if (paramUnderWrapToBuffer != null) {
                 arrayParamsWrappedToBuffers.put(stack.getStackItem(0), paramUnderWrapToBuffer);
+            }
+            if (fieldUnderCopyOf != null) {
+                arrayFieldCopies.put(stack.getStackItem(0), fieldUnderCopyOf);
+            }
+            if (paramUnderCopyOf != null) {
+                arrayParamCopies.put(stack.getStackItem(0), paramUnderCopyOf);
             }
         }
 
@@ -382,6 +449,12 @@ public class FindReturnRef extends OpcodeStackDetector {
             }
             if (paramCloneUnderCast != null) {
                 arrayParamClones.put(item, paramCloneUnderCast);
+            }
+            if (fieldCopyUnderCast != null) {
+                arrayFieldCopies.put(item, fieldCopyUnderCast);
+            }
+            if (paramCopyUnderCast != null) {
+                arrayParamCopies.put(item, paramCopyUnderCast);
             }
         }
     }
@@ -394,7 +467,10 @@ public class FindReturnRef extends OpcodeStackDetector {
     private CaptureKind getPotentialCapture(OpcodeStack.Item top) {
         CaptureKind kind = CaptureKind.REP;
         if (!top.isInitialParameter()) {
-            OpcodeStack.Item newTop = arrayParamClones.get(top);
+            OpcodeStack.Item newTop = arrayParamCopies.get(top);
+            if (newTop == null) {
+                newTop = arrayParamClones.get(top);
+            }
             if (newTop == null) {
                 newTop = arrayParamsWrappedToBuffers.get(top);
                 if (newTop == null) {
@@ -416,6 +492,22 @@ public class FindReturnRef extends OpcodeStackDetector {
         // var-arg parameter
         return (top.getRegisterNumber() != parameterCount - 1) ? kind : CaptureKind.NONE;
 
+    }
+
+    private boolean isMutableObjectArrayCopyOf(MethodDescriptor method, OpcodeStack.Item arrayArg) {
+        if (!"copyOf".equals(method.getName())
+                || !"java/util/Arrays".equals(method.getClassDescriptor().getClassName())) {
+            return false;
+        }
+        String signature = method.getSignature();
+        if (!signature.startsWith("([") || !signature.contains(";I)")) {
+            return false;
+        }
+        if (!arrayArg.isArray()) {
+            return false;
+        }
+        String elementSignature = arrayArg.getSignature().substring(1);
+        return elementSignature.startsWith("L") && MutableClasses.mutableSignature(elementSignature);
     }
 
     private boolean isFieldOf(XField field, ClassDescriptor clazz) {

--- a/spotbugsTestCases/src/java/ghIssues/Issue4007.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue4007.java
@@ -1,0 +1,34 @@
+package ghIssues;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Date;
+
+/**
+ * <a href="https://github.com/spotbugs/spotbugs/issues/4007">#4007</a>.
+ */
+public class Issue4007 {
+    private final ByteBuffer buf = ByteBuffer.allocate(16);
+    private static final ByteBuffer S_BUF = ByteBuffer.allocate(16);
+    private Date[] dates = new Date[] {new Date()};
+
+    public byte[] getArray() {
+        return buf.array();
+    }
+
+    public static byte[] getStaticArray() {
+        return S_BUF.array();
+    }
+
+    public ByteBuffer getDuplicate() {
+        return buf.duplicate();
+    }
+
+    public void setDates(Date[] input) {
+        dates = Arrays.copyOf(input, input.length);
+    }
+
+    public Date[] getDatesClone() {
+        return dates.clone();
+    }
+}


### PR DESCRIPTION
## Summary

- Flag `EI/MS_EXPOSE_BUF` when a public getter returns a `ByteBuffer` (or other nio buffer) backing array via `array()`, matching the existing `duplicate()` / `wrap()` coverage.
- Flag `EI_EXPOSE_REP2` when a setter stores the result of `Arrays.copyOf(...)` on an array of mutable elements (e.g. `Date[]`), since the copy is only shallow.
- Propagate `Arrays.copyOf` tracking through `checkcast`, which the compiler inserts for generic `copyOf([Ljava/lang/Object;I)` calls.

Fixes #4007

## Test plan

- [x] Added `Issue4007` regression test covering `ByteBuffer.array()`, `Arrays.copyOf`, and existing duplicate/clone detections
- [x] `./gradlew :spotbugs-tests:test --tests "edu.umd.cs.findbugs.detect.Issue4007Test"`
- [x] `./gradlew :spotbugs-tests:test --tests "edu.umd.cs.findbugs.detect.FindReturnRefTest"` (existing tests still pass)