### PR TITLE
Fix ODR false negative when JDBC resource is cast to supertype

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue4019Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue4019Test.java
@@ -1,0 +1,16 @@
+package edu.umd.cs.findbugs.detect;
+
+import org.junit.jupiter.api.Test;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+
+class Issue4019Test extends AbstractIntegrationTest {
+
+    @Test
+    void testStatementSupertypeResourceLeak() {
+        performAnalysis("ghIssues/Issue4019.class");
+
+        assertBugInMethodCount("ODR_OPEN_DATABASE_RESOURCE", "ghIssues.Issue4019", "fetchUserBefore", 1);
+        assertBugInMethodCount("ODR_OPEN_DATABASE_RESOURCE", "ghIssues.Issue4019", "fetchUserAfter", 1);
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/ResourceValueFrameModelingVisitor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/ResourceValueFrameModelingVisitor.java
@@ -143,18 +143,7 @@ public abstract class ResourceValueFrameModelingVisitor extends AbstractFrameMod
 
     @Override
     public void visitCHECKCAST(CHECKCAST obj) {
-        try {
-            ResourceValueFrame frame = getFrame();
-            ResourceValue topValue;
-
-            topValue = frame.getTopValue();
-
-            if (topValue.equals(ResourceValue.instance())) {
-                frame.setStatus(ResourceValueFrame.State.ESCAPED);
-            }
-        } catch (DataflowAnalysisException e) {
-            AnalysisContext.logError("Analysis error", e);
-        }
+        handleNormalInstruction(obj);
     }
 
     @Override

--- a/spotbugsTestCases/src/java/ghIssues/Issue4019.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue4019.java
@@ -1,0 +1,48 @@
+package ghIssues;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import edu.umd.cs.findbugs.annotations.ExpectWarning;
+
+/**
+ * <a href="https://github.com/spotbugs/spotbugs/issues/4019">#4019</a>.
+ */
+public class Issue4019 {
+    private static final String DB_URL = "jdbc:h2:mem:testdb";
+
+    @ExpectWarning("ODR_OPEN_DATABASE_RESOURCE,OBL_UNSATISFIED_OBLIGATION")
+    public void fetchUserBefore(int id) throws SQLException {
+        Connection conn = null;
+        PreparedStatement ps = null;
+        try {
+            conn = DriverManager.getConnection(DB_URL);
+            ps = conn.prepareStatement("SELECT * FROM users WHERE id = ?");
+            ps.setInt(1, id);
+            ps.executeQuery();
+        } finally {
+            if (conn != null) {
+                conn.close();
+            }
+        }
+    }
+
+    @ExpectWarning("ODR_OPEN_DATABASE_RESOURCE,OBL_UNSATISFIED_OBLIGATION")
+    public void fetchUserAfter(int id) throws SQLException {
+        Connection conn = null;
+        Statement ps = null;
+        try {
+            conn = DriverManager.getConnection(DB_URL);
+            ps = conn.prepareStatement("SELECT * FROM users WHERE id = ?");
+            ((PreparedStatement) ps).setInt(1, id);
+            ((PreparedStatement) ps).executeQuery();
+        } finally {
+            if (conn != null) {
+                conn.close();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Fix `ODR_OPEN_DATABASE_RESOURCE` false negative when a `PreparedStatement` is stored in a `Statement`-typed local and later downcast (e.g. for `setInt` / `executeQuery`).
- `ResourceValueFrameModelingVisitor` previously marked every `CHECKCAST` as an escaped resource, which dropped tracking after the downcast even though the underlying JDBC object is unchanged.
- Preserve resource tags through `CHECKCAST` by using normal stack modeling instead of forcing `ESCAPED`.

Fixes #4019

## Test plan

- [x] Added `Issue4019` regression test with `fetchUserBefore` (PreparedStatement local) and `fetchUserAfter` (Statement local + downcast)
- [x] `./gradlew :spotbugs-tests:test --tests "edu.umd.cs.findbugs.detect.Issue4019Test"`
- [x] Manual CLI repro confirms ODR now reported for both methods