### PR TITLE
Fix IS false negative when synchronized method lacks null check

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3986Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3986Test.java
@@ -1,0 +1,15 @@
+package edu.umd.cs.findbugs.detect;
+
+import org.junit.jupiter.api.Test;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+
+class Issue3986Test extends AbstractIntegrationTest {
+
+    @Test
+    void testInconsistentSyncWithoutNullCheck() {
+        performAnalysis("ghIssues/Issue3986.class");
+
+        assertBugTypeCount("IS2_INCONSISTENT_SYNC", 1);
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindInconsistentSync2.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindInconsistentSync2.java
@@ -469,6 +469,9 @@ public class FindInconsistentSync2 implements Detector {
             int biasedUnlocked = numReadUnlocked + (int) (WRITE_BIAS * (numWriteUnlocked));
             // int writes = numWriteLocked + numWriteUnlocked;
 
+            boolean clearInconsistentSync = hasLockedAndUnlockedAccess(numReadLocked, numWriteLocked, numReadUnlocked,
+                    numWriteUnlocked);
+
             if (unlocked == 0) {
                 continue;
                 // propertySet.addProperty(InconsistentSyncWarningProperty.NEVER_UNLOCKED);
@@ -505,7 +508,8 @@ public class FindInconsistentSync2 implements Detector {
                 System.out.println("  WU: " + numWriteUnlocked);
                 System.out.println("  NU: " + numNullCheckUnlocked);
             }
-            if (!EVAL && numReadUnlocked > 0 && ((int) (UNSYNC_FACTOR * (biasedUnlocked - 1))) > biasedLocked
+            if (!EVAL && !clearInconsistentSync && numReadUnlocked > 0
+                    && ((int) (UNSYNC_FACTOR * (biasedUnlocked - 1))) > biasedLocked
                     && !stats.isServletField()) {
                 // continue;
                 propertySet.addProperty(InconsistentSyncWarningProperty.MANY_BIASED_UNLOCKED);
@@ -548,7 +552,7 @@ public class FindInconsistentSync2 implements Detector {
                 printFreq = freq = 0;
             }
 
-            if (freq < MIN_SYNC_PERCENT) {
+            if (freq < MIN_SYNC_PERCENT && !clearInconsistentSync) {
                 // continue;
                 propertySet.addProperty(InconsistentSyncWarningProperty.BELOW_MIN_SYNC_PERCENT);
             }
@@ -608,6 +612,11 @@ public class FindInconsistentSync2 implements Detector {
      * Implementation
      * ----------------------------------------------------------------------
      */
+
+    private static boolean hasLockedAndUnlockedAccess(int numReadLocked, int numWriteLocked, int numReadUnlocked,
+            int numWriteUnlocked) {
+        return (numReadLocked + numWriteLocked > 0) && (numReadUnlocked + numWriteUnlocked > 0);
+    }
 
     private static boolean isConstructor(String methodName) {
         return Const.CONSTRUCTOR_NAME.equals(methodName) || Const.STATIC_INITIALIZER_NAME.equals(methodName) || "readObject".equals(methodName)

--- a/spotbugsTestCases/src/java/ghIssues/Issue3986.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3986.java
@@ -1,0 +1,31 @@
+package ghIssues;
+
+import edu.umd.cs.findbugs.annotations.ExpectWarning;
+
+/**
+ * <a href="https://github.com/spotbugs/spotbugs/issues/3986">#3986</a>.
+ */
+public class Issue3986 {
+    Object data;
+
+    public Object getData() {
+        return data;
+    }
+
+    public void setData(Object data) {
+        this.data = data;
+    }
+
+    @ExpectWarning("IS2_INCONSISTENT_SYNC")
+    public synchronized int getHashWithoutNullCheck() {
+        return data.hashCode();
+    }
+
+    @ExpectWarning("IS2_INCONSISTENT_SYNC")
+    public synchronized int getHashWithNullCheck() {
+        if (data != null) {
+            return data.hashCode();
+        }
+        return data.hashCode();
+    }
+}

--- a/spotbugsTestCases/src/java/ghIssues/Issue3986.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3986.java
@@ -6,6 +6,7 @@ import edu.umd.cs.findbugs.annotations.ExpectWarning;
  * <a href="https://github.com/spotbugs/spotbugs/issues/3986">#3986</a>.
  */
 public class Issue3986 {
+    @ExpectWarning("IS2_INCONSISTENT_SYNC")
     Object data;
 
     public Object getData() {
@@ -16,12 +17,10 @@ public class Issue3986 {
         this.data = data;
     }
 
-    @ExpectWarning("IS2_INCONSISTENT_SYNC")
     public synchronized int getHashWithoutNullCheck() {
         return data.hashCode();
     }
 
-    @ExpectWarning("IS2_INCONSISTENT_SYNC")
     public synchronized int getHashWithNullCheck() {
         if (data != null) {
             return data.hashCode();


### PR DESCRIPTION
## Summary

- Fix `IS2_INCONSISTENT_SYNC` false negative when a synchronized method reads a field directly (without a preceding null check) while other methods access the same field unsynchronized.
- The detector already recorded both locked and unlocked accesses, but suppressed the warning via `BELOW_MIN_SYNC_PERCENT` and `MANY_BIASED_UNLOCKED` because the sync ratio was only 33% (one locked read vs. one unlocked read + one unlocked write).
- Adding a null check artificially inflated locked-access counts to 50%, which is why only the null-check variant was reported.

Fixes #3986

## Test plan

- [x] Added `Issue3986` regression test covering synchronized getters with and without null checks
- [x] `./gradlew :spotbugs-tests:test --tests "edu.umd.cs.findbugs.detect.Issue3986Test"`
- [x] Manual CLI repro confirms both `ReproFN` and `ReproTP` now report IS