### PR TITLE
Fix NS_NON_SHORT_CIRCUIT false negative for constant boolean operand

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3976Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3976Test.java
@@ -1,0 +1,16 @@
+package edu.umd.cs.findbugs.detect;
+
+import org.junit.jupiter.api.Test;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+
+class Issue3976Test extends AbstractIntegrationTest {
+
+    @Test
+    void testNonShortCircuitWithConstantTrueOperand() {
+        performAnalysis("ghIssues/Issue3976.class");
+
+        assertBugInMethodCount("NS_NON_SHORT_CIRCUIT", "Issue3976", "testTruePositive", 1);
+        assertBugInMethodCount("NS_NON_SHORT_CIRCUIT", "Issue3976", "testFalseNegative", 1);
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNonShortCircuit.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNonShortCircuit.java
@@ -166,7 +166,7 @@ public class FindNonShortCircuit extends OpcodeStackDetector implements Stateles
             // System.out.println("Saw IOR or IAND at distance " + distance);
             OpcodeStack.Item item0 = stack.getStackItem(0);
             OpcodeStack.Item item1 = stack.getStackItem(1);
-            if (item0.getConstant() == null && item1.getConstant() == null && distance < 4) {
+            if (distance < 4 && (item0.getConstant() == null || item1.getConstant() == null)) {
                 //                if (item0.getRegisterNumber() >= 0 && item1.getRegisterNumber() >= 0) {
                 //                    if (false) {
                 //                        clearAll();

--- a/spotbugsTestCases/src/java/ghIssues/Issue3976.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3976.java
@@ -1,0 +1,27 @@
+package ghIssues;
+
+import edu.umd.cs.findbugs.annotations.ExpectWarning;
+
+/**
+ * <a href="https://github.com/spotbugs/spotbugs/issues/3976">#3976</a>.
+ */
+public class Issue3976 {
+    static boolean hasSideEffect() {
+        System.out.println("Side effect executed!");
+        return true;
+    }
+
+    @ExpectWarning("NS_NON_SHORT_CIRCUIT")
+    public void testTruePositive(boolean input) {
+        if (input | hasSideEffect()) {
+            System.out.println("Path A");
+        }
+    }
+
+    @ExpectWarning("NS_NON_SHORT_CIRCUIT")
+    public void testFalseNegative(boolean input) {
+        if (true | hasSideEffect()) {
+            System.out.println("Path B");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Fix `NS_NON_SHORT_CIRCUIT` false negative when one operand of `|`/`&` is a compile-time constant (e.g. `true | hasSideEffect()`).
- `FindNonShortCircuit` previously required **both** operands to be non-constants before flagging non-short-circuit logic, which skipped cases where the left side is `true`/`false` but the right side still executes due to `|`/`&`.

Fixes #3976

## Test plan

- [x] Added `Issue3976` regression test for variable and constant-left-operand cases
- [x] `./gradlew :spotbugs-tests:test --tests "edu.umd.cs.findbugs.detect.Issue3976Test"`
- [x] `./gradlew :spotbugs-tests:test --tests "edu.umd.cs.findbugs.detect.FindNonShortCircuitTest"`
- [x] Manual CLI repro confirms both methods now report NS