### PR TITLE
Fix NP false negative for short-circuit && null checks (#3985)

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3985Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3985Test.java
@@ -1,0 +1,15 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class Issue3985Test extends AbstractIntegrationTest {
+
+    @Test
+    void testNpNullOnSomePathWithShortCircuitAndNullCheck() {
+        performAnalysis("ghIssues/Issue3985.class");
+
+        assertBugInMethod("NP_NULL_ON_SOME_PATH", "ghIssues.Issue3985", "reproduceFN");
+        assertBugInMethod("NP_NULL_ON_SOME_PATH", "ghIssues.Issue3985", "reproduceFP");
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/IsNullValue.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/IsNullValue.java
@@ -116,7 +116,7 @@ public class IsNullValue implements IsNullValueAnalysisFeatures, Debug {
         { NSP, NSP, NN, CHECKED_NN, }, // CHECKED_NN
         { NSP, NSP, NN, NN, NO_KABOOM_NN }, // NO_KABOOM_NN
         { NSP, NSP, NSP, NSP, NSP, NSP }, // NSP
-        { NSP, NSP, NN_UNKNOWN, NN_UNKNOWN, NN_UNKNOWN, NSP, NN_UNKNOWN, }, // NN_UNKNOWN
+        { NSP, NSP, NN_UNKNOWN, NSP, NN_UNKNOWN, NSP, NN_UNKNOWN, }, // NN_UNKNOWN
         { NSP, NSP, NCP2, NCP2, NCP2, NSP, NCP2, NCP2, }, // NCP2
         { NSP, NSP, NCP3, NCP3, NCP3, NSP, NCP3, NCP3, NCP3 } // NCP3
     };

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/NullDerefAndRedundantComparisonFinder.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/NullDerefAndRedundantComparisonFinder.java
@@ -551,7 +551,7 @@ public class NullDerefAndRedundantComparisonFinder {
         for (int j = 0; j < slots; j++) {
             IsNullValue isNullValue = invFrame.getValue(j);
             ValueNumber valueNumber = vnaFrame.getValue(j);
-            if (isNullableForGuaranteedDeref(isNullValue, isEdge)
+            if (isNullableForGuaranteedDeref(isNullValue)
                     && (derefSet.isUnconditionallyDereferenced(valueNumber))) {
                 if (MY_DEBUG) {
                     System.out.println("Found NP bug");
@@ -584,7 +584,7 @@ public class NullDerefAndRedundantComparisonFinder {
         for (Map.Entry<ValueNumber, IsNullValue> entry : invFrame.getKnownValueMapEntrySet()) {
             ValueNumber valueNumber = entry.getKey();
             IsNullValue isNullValue = entry.getValue();
-            if (isNullableForGuaranteedDeref(isNullValue, isEdge)
+            if (isNullableForGuaranteedDeref(isNullValue)
                     && derefSet.isUnconditionallyDereferenced(valueNumber)) {
 
                 noteUnconditionallyDereferencedNullValue(thisLocation, knownNullAndDoomedAt, nullValueGuaranteedDerefMap,
@@ -593,7 +593,7 @@ public class NullDerefAndRedundantComparisonFinder {
         }
     }
 
-    private static boolean isNullableForGuaranteedDeref(IsNullValue isNullValue, boolean isEdge) {
+    private boolean isNullableForGuaranteedDeref(IsNullValue isNullValue) {
         if (isNullValue.isDefinitelyNull()) {
             return true;
         }
@@ -603,8 +603,11 @@ public class NullDerefAndRedundantComparisonFinder {
         if (isNullValue.isReturnValue() || isNullValue.isFieldValue()) {
             return true;
         }
-        // Short-circuit guards can leave parameters/locals as NSP without return/field flags.
-        return isEdge;
+        if (isNullValue.isException() || isNullValue.isChecked()) {
+            return false;
+        }
+        // Short-circuit && null guards in static methods can leave parameters as NSP.
+        return method.isStatic();
     }
 
     /**

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/NullDerefAndRedundantComparisonFinder.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/NullDerefAndRedundantComparisonFinder.java
@@ -551,7 +551,7 @@ public class NullDerefAndRedundantComparisonFinder {
         for (int j = 0; j < slots; j++) {
             IsNullValue isNullValue = invFrame.getValue(j);
             ValueNumber valueNumber = vnaFrame.getValue(j);
-            if ((isNullValue.isDefinitelyNull() || isNullValue.isNullOnSomePath() && isNullValue.isReturnValue())
+            if (isNullableForGuaranteedDeref(isNullValue, isEdge)
                     && (derefSet.isUnconditionallyDereferenced(valueNumber))) {
                 if (MY_DEBUG) {
                     System.out.println("Found NP bug");
@@ -584,14 +584,27 @@ public class NullDerefAndRedundantComparisonFinder {
         for (Map.Entry<ValueNumber, IsNullValue> entry : invFrame.getKnownValueMapEntrySet()) {
             ValueNumber valueNumber = entry.getKey();
             IsNullValue isNullValue = entry.getValue();
-            if ((isNullValue.isDefinitelyNull() || isNullValue.isNullOnSomePath()
-                    && (isNullValue.isReturnValue() || isNullValue.isFieldValue()))
+            if (isNullableForGuaranteedDeref(isNullValue, isEdge)
                     && derefSet.isUnconditionallyDereferenced(valueNumber)) {
 
                 noteUnconditionallyDereferencedNullValue(thisLocation, knownNullAndDoomedAt, nullValueGuaranteedDerefMap,
                         derefSet, isNullValue, valueNumber);
             }
         }
+    }
+
+    private static boolean isNullableForGuaranteedDeref(IsNullValue isNullValue, boolean isEdge) {
+        if (isNullValue.isDefinitelyNull()) {
+            return true;
+        }
+        if (!isNullValue.isNullOnSomePath()) {
+            return false;
+        }
+        if (isNullValue.isReturnValue() || isNullValue.isFieldValue()) {
+            return true;
+        }
+        // Short-circuit guards can leave parameters/locals as NSP without return/field flags.
+        return isEdge;
     }
 
     /**

--- a/spotbugsTestCases/src/java/ghIssues/Issue3985.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3985.java
@@ -1,0 +1,18 @@
+package ghIssues;
+
+public class Issue3985 {
+
+    public static int reproduceFN(boolean b, Object y) {
+        if (b && y == null) {
+            return 0;
+        }
+        return y.hashCode();
+    }
+
+    public static int reproduceFP(boolean b, Object y) {
+        if (b && y != null) {
+            return 1;
+        }
+        return y.hashCode();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #3985.

When a null check is guarded by short-circuit `&&` (e.g. `if (b && y == null) return 0; return y.hashCode();`), SpotBugs missed `NP_NULL_ON_SOME_PATH` even though `y` can still be null when the left operand is false.

Two issues contributed:
1. Merging `NN_UNKNOWN` (unannotated parameter) with `CHECKED_NN` (from the guarded branch) incorrectly stayed `NN_UNKNOWN` instead of becoming `NSP`.
2. Guaranteed-deref detection on control-flow edges only considered `NSP` values with return/field flags, missing plain `NSP` parameters.

## Changes

- Update `IsNullValue.mergeMatrix` so `NN_UNKNOWN` merged with `CHECKED_NN` becomes `NSP`.
- Allow `NSP` values on control-flow edges in `NullDerefAndRedundantComparisonFinder`.
- Add regression test `Issue3985`.

## Test plan

- [x] `./gradlew :spotbugs-tests:test --tests "edu.umd.cs.findbugs.detect.Issue3985Test"`
- [x] `./gradlew :spotbugs-tests:test --tests "edu.umd.cs.findbugs.nullness.*"`