### PR TITLE
Fix SA_FIELD_DOUBLE_ASSIGNMENT for long/double fields (#3975)

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3975Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3975Test.java
@@ -1,0 +1,19 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class Issue3975Test extends AbstractIntegrationTest {
+
+    @Test
+    void testSaFieldDoubleAssignmentForWidePrimitives() {
+        performAnalysis("ghIssues/Issue3975.class",
+                "ghIssues/Issue3975$IntDoubleAssignment.class",
+                "ghIssues/Issue3975$LongDoubleAssignment.class",
+                "ghIssues/Issue3975$DoubleDoubleAssignment.class");
+
+        assertBugInMethod("SA_FIELD_DOUBLE_ASSIGNMENT", "ghIssues.Issue3975$IntDoubleAssignment", "<init>");
+        assertBugInMethod("SA_FIELD_DOUBLE_ASSIGNMENT", "ghIssues.Issue3975$LongDoubleAssignment", "<init>");
+        assertBugInMethod("SA_FIELD_DOUBLE_ASSIGNMENT", "ghIssues.Issue3975$DoubleDoubleAssignment", "<init>");
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindSelfComparison.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindSelfComparison.java
@@ -60,6 +60,13 @@ public class FindSelfComparison extends OpcodeStackDetector {
 
     static final boolean DEBUG = SystemProperties.getBoolean("fsc.debug");
 
+    /**
+     * Maximum bytecode index span between consecutive stores to the same field
+     * while checking for double assignment. Wide constants ({@code long}/{@code double})
+     * use {@code ldc2_w} and {@code dup2_x1}, which occupy more bytes than {@code int}.
+     */
+    private static final int MAX_DOUBLE_ASSIGN_PUTFIELD_DISTANCE = 12;
+
     @Override
     public void visit(Code obj) {
         if (DEBUG) {
@@ -106,7 +113,7 @@ public class FindSelfComparison extends OpcodeStackDetector {
             XField f = getXFieldOperand();
             XClass x = getXClassOperand();
 
-            checkPUTFIELD: if (putFieldPC + 10 > getPC() && f != null && obj != null && f.equals(putFieldXField)
+            checkPUTFIELD: if (putFieldPC + MAX_DOUBLE_ASSIGN_PUTFIELD_DISTANCE > getPC() && f != null && obj != null && f.equals(putFieldXField)
                     && !f.isSynthetic() && obj.sameValue(putFieldObj) && x != null) {
 
 

--- a/spotbugsTestCases/src/java/ghIssues/Issue3975.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3975.java
@@ -1,0 +1,19 @@
+package ghIssues;
+
+public class Issue3975 {
+
+    static class IntDoubleAssignment {
+        int value = 3;
+        boolean b = 1 > (value = 2);
+    }
+
+    static class LongDoubleAssignment {
+        long value = 3L;
+        boolean b = 1 > (value = 2L);
+    }
+
+    static class DoubleDoubleAssignment {
+        double value = 3.0;
+        boolean b = 1 > (value = 2.0);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #3975.

`SA_FIELD_DOUBLE_ASSIGNMENT` was missed for `long` and `double` field double-assignment in instance initializers because wide constants use `ldc2_w`/`dup2_x1`, placing the second `putfield` exactly 10 bytecode indices after the first—outside the previous `putFieldPC + 10 > getPC()` window.

## Changes

- Widen the consecutive-`putfield` distance check to 12 bytes in `FindSelfComparison`.
- Add regression test covering `int`, `long`, and `double` cases.

## Test plan

- [x] `./gradlew :spotbugs-tests:test --tests "edu.umd.cs.findbugs.detect.Issue3975Test"`
- [x] `./gradlew :spotbugs-tests:test --tests "edu.umd.cs.findbugs.detect.RegressionIdeas20090616Test"`