### PR TITLE
Fix UrF false negative for unread fields in enums (#3955)

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3955Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3955Test.java
@@ -1,0 +1,16 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class Issue3955Test extends AbstractIntegrationTest {
+
+    @Test
+    void testUnreadFieldInEnum() {
+        performAnalysis("ghIssues/Issue3955.class",
+                "ghIssues/Issue3955$Inner.class");
+
+        assertBugAtField("URF_UNREAD_FIELD", "ghIssues.Issue3955$Inner", "innerField");
+        assertBugAtField("URF_UNREAD_FIELD", "ghIssues.Issue3955", "enumField");
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UnreadFields.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UnreadFields.java
@@ -226,7 +226,7 @@ public class UnreadFields extends OpcodeStackDetector {
             data.fieldsOfSerializableOrNativeClassed.addAll(data.myFields);
             data.fieldsOfNativeClasses.addAll(data.myFields);
         }
-        if (isSerializable) {
+        if (isSerializable && !obj.isEnum()) {
             data.fieldsOfSerializableOrNativeClassed.addAll(data.myFields);
         }
         if (sawSelfCallInConstructor) {

--- a/spotbugsTestCases/src/java/ghIssues/Issue3955.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3955.java
@@ -1,0 +1,11 @@
+package ghIssues;
+
+enum Issue3955 {
+    ENUM_VALUE;
+
+    class Inner {
+        int innerField = 0;
+    }
+
+    boolean enumField = false;
+}


### PR DESCRIPTION
## Summary

Fixes #3955.

Unread instance fields declared directly in an enum were not reported with `URF_UNREAD_FIELD`, while the same pattern in an enum inner class was detected correctly.

## Root cause

Enums are `Serializable` through `java.lang.Enum`. `UnreadFields` skipped unread-field reporting for all fields of serializable classes, which unintentionally suppressed warnings for enum instance fields.

## Changes

- Do not treat enum fields as serializable-only suppressions in `UnreadFields.visitAfter`.
- Add regression test `Issue3955`.

## Test plan

- [x] `./gradlew :spotbugs-tests:test --tests "edu.umd.cs.findbugs.detect.Issue3955Test"`
- [x] `./gradlew :spotbugs-tests:test --tests "edu.umd.cs.findbugs.detect.UnreadFieldsTest"`
- [x] `./gradlew :spotbugs-tests:test --tests "edu.umd.cs.findbugs.detect.Issue574Test"`