### PR TITLE
Fix false negatives in DMI database password detection (#3990)

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3990Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3990Test.java
@@ -1,0 +1,47 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class Issue3990Test extends AbstractIntegrationTest {
+
+    private static final String CLASS = "ghIssues.Issue3990";
+
+    @Test
+    void testDirectHardcodedPassword() {
+        performAnalysis("ghIssues/Issue3990.class");
+        assertBugInMethodAtLine("DMI_CONSTANT_DB_PASSWORD", CLASS, "directHardcodedPassword", 12);
+    }
+
+    @Test
+    void testPropertiesPassword() {
+        performAnalysis("ghIssues/Issue3990.class");
+        assertBugInMethodAtLine("DMI_CONSTANT_DB_PASSWORD", CLASS, "propertiesPassword", 18);
+    }
+
+    @Test
+    void testUrlEmbeddedPassword() {
+        performAnalysis("ghIssues/Issue3990.class");
+        assertBugInMethodAtLine("DMI_CONSTANT_DB_PASSWORD", CLASS, "urlEmbeddedPassword", 22);
+    }
+
+    @Test
+    void testLocalVariablePassword() {
+        performAnalysis("ghIssues/Issue3990.class");
+        assertBugInMethodAtLine("DMI_CONSTANT_DB_PASSWORD", CLASS, "localVariablePassword", 27);
+    }
+
+    @Test
+    void testEmptyPassword() {
+        performAnalysis("ghIssues/Issue3990.class");
+        assertBugInMethodAtLine("DMI_EMPTY_DB_PASSWORD", CLASS, "emptyPassword", 32);
+    }
+
+    @Test
+    void testExtractJdbcPassword() {
+        org.junit.jupiter.api.Assertions.assertEquals("secret", DumbMethodInvocations.extractJdbcPassword(
+                "jdbc:mysql://localhost/db?user=admin&password=secret"));
+        org.junit.jupiter.api.Assertions.assertNull(DumbMethodInvocations.extractJdbcPassword(
+                "jdbc:mysql://localhost/db?user=admin"));
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/constant/ConstantFrameModelingVisitor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/constant/ConstantFrameModelingVisitor.java
@@ -20,11 +20,17 @@ package edu.umd.cs.findbugs.ba.constant;
 
 import org.apache.bcel.generic.BIPUSH;
 import org.apache.bcel.generic.ConstantPoolGen;
+import org.apache.bcel.generic.GETSTATIC;
 import org.apache.bcel.generic.ICONST;
 import org.apache.bcel.generic.IINC;
 import org.apache.bcel.generic.LDC;
 import org.apache.bcel.generic.LDC2_W;
 import org.apache.bcel.generic.SIPUSH;
+
+import org.apache.bcel.Repository;
+import org.apache.bcel.classfile.ConstantValue;
+import org.apache.bcel.classfile.Field;
+import org.apache.bcel.classfile.JavaClass;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -102,6 +108,36 @@ public class ConstantFrameModelingVisitor extends AbstractFrameModelingVisitor<C
         Constant c = new Constant(value);
         getFrame().pushValue(c);
         getFrame().pushValue(c);
+    }
+
+    @Override
+    public void visitGETSTATIC(GETSTATIC obj) {
+        getFrame().pushValue(getStaticStringConstant(obj));
+    }
+
+    private Constant getStaticStringConstant(GETSTATIC obj) {
+        ConstantPoolGen cpg = getCPG();
+        try {
+            JavaClass javaClass = Repository.lookupClass(obj.getClassName(cpg));
+            String fieldName = obj.getName(cpg);
+            for (Field field : javaClass.getFields()) {
+                if (!field.getName().equals(fieldName)) {
+                    continue;
+                }
+                ConstantValue constantValue = field.getConstantValue();
+                if (constantValue == null) {
+                    break;
+                }
+                org.apache.bcel.classfile.Constant poolConstant = cpg.getConstant(constantValue.getConstantValueIndex());
+                if (poolConstant instanceof org.apache.bcel.classfile.ConstantString) {
+                    return new Constant(((org.apache.bcel.classfile.ConstantString) poolConstant).getBytes(cpg.getConstantPool()));
+                }
+                break;
+            }
+        } catch (ClassNotFoundException e) {
+            // ignore
+        }
+        return Constant.NOT_CONSTANT;
     }
 
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DumbMethodInvocations.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DumbMethodInvocations.java
@@ -2,6 +2,7 @@ package edu.umd.cs.findbugs.detect;
 
 import java.io.File;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
@@ -26,6 +27,9 @@ import edu.umd.cs.findbugs.ba.SignatureParser;
 import edu.umd.cs.findbugs.ba.constant.Constant;
 import edu.umd.cs.findbugs.ba.constant.ConstantDataflow;
 import edu.umd.cs.findbugs.ba.constant.ConstantFrame;
+import edu.umd.cs.findbugs.ba.vna.ValueNumber;
+import edu.umd.cs.findbugs.ba.vna.ValueNumberDataflow;
+import edu.umd.cs.findbugs.ba.vna.ValueNumberFrame;
 import edu.umd.cs.findbugs.classfile.Global;
 import edu.umd.cs.findbugs.classfile.MethodDescriptor;
 import edu.umd.cs.findbugs.detect.BuildStringPassthruGraph.MethodParameter;
@@ -38,6 +42,16 @@ public class DumbMethodInvocations implements Detector {
             new MethodDescriptor("java/lang/StringBuilder", "substring", "(I)Ljava/lang/String;");
     private static final MethodDescriptor STRINGBUFFER_SUBSTRING =
             new MethodDescriptor("java/lang/StringBuffer", "substring", "(I)Ljava/lang/String;");
+
+    private static final MethodDescriptor DRIVER_MANAGER_GET_CONNECTION_2 =
+            new MethodDescriptor("java/sql/DriverManager", "getConnection",
+                    "(Ljava/lang/String;Ljava/util/Properties;)Ljava/sql/Connection;", true);
+
+    private static final MethodDescriptor DRIVER_MANAGER_GET_CONNECTION_1 =
+            new MethodDescriptor("java/sql/DriverManager", "getConnection", "(Ljava/lang/String;)Ljava/sql/Connection;", true);
+
+    private static final MethodDescriptor PROPERTIES_SET_PROPERTY =
+            new MethodDescriptor("java/util/Properties", "setProperty", "(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/Object;");
 
 
     private final BugReporter bugReporter;
@@ -88,6 +102,14 @@ public class DumbMethodInvocations implements Detector {
         ConstantPoolGen cpg = classContext.getConstantPoolGen();
         MethodGen methodGen = classContext.getMethodGen(method);
         String sourceFile = classContext.getJavaClass().getSourceFileName();
+        Map<ValueNumber, String> propertiesPasswords = Collections.emptyMap();
+        ValueNumberDataflow valueNumberDataflow = null;
+        try {
+            valueNumberDataflow = classContext.getValueNumberDataflow(method);
+            propertiesPasswords = collectPropertiesPasswords(cfg, constantDataflow, valueNumberDataflow, cpg);
+        } catch (MethodUnprofitableException e) {
+            // Skip Properties password tracking for unprofitable methods.
+        }
 
         for (Iterator<Location> i = cfg.locationIterator(); i.hasNext();) {
             Location location = i.next();
@@ -109,17 +131,23 @@ public class DumbMethodInvocations implements Detector {
             MethodDescriptor md = new MethodDescriptor(iins, cpg);
             if (allDatabasePasswordMethods.containsKey(md)) {
                 for (int paramNumber : allDatabasePasswordMethods.get(md)) {
-                    Constant operandValue = frame.getArgument(iins, cpg, paramNumber, parser);
-                    if (operandValue.isConstantString()) {
-                        String password = operandValue.getConstantString();
-                        if (password.isEmpty()) {
-                            bugAccumulator.accumulateBug(new BugInstance(this, "DMI_EMPTY_DB_PASSWORD", NORMAL_PRIORITY)
-                                    .addClassAndMethod(methodGen, sourceFile), classContext, methodGen, sourceFile, location);
-                        } else {
-                            bugAccumulator.accumulateBug(new BugInstance(this, "DMI_CONSTANT_DB_PASSWORD", NORMAL_PRIORITY)
-                                    .addClassAndMethod(methodGen, sourceFile), classContext, methodGen, sourceFile, location);
-                        }
-
+                    reportPasswordIfConstant(frame, iins, cpg, parser, paramNumber, classContext, methodGen, sourceFile, location);
+                }
+            } else if (DRIVER_MANAGER_GET_CONNECTION_2.equals(md) && valueNumberDataflow != null) {
+                ValueNumberFrame valueNumberFrame = valueNumberDataflow.getFactAtLocation(location);
+                if (valueNumberFrame.isValid()) {
+                    ValueNumber propertiesValue = valueNumberFrame.getArgument(iins, cpg, 1, parser);
+                    String password = propertiesPasswords.get(propertiesValue);
+                    if (password != null) {
+                        reportPasswordBug(password, classContext, methodGen, sourceFile, location);
+                    }
+                }
+            } else if (DRIVER_MANAGER_GET_CONNECTION_1.equals(md)) {
+                Constant urlValue = frame.getArgument(iins, cpg, 0, parser);
+                if (urlValue.isConstantString()) {
+                    String password = extractJdbcPassword(urlValue.getConstantString());
+                    if (password != null) {
+                        reportPasswordBug(password, classContext, methodGen, sourceFile, location);
                     }
                 }
             }
@@ -168,6 +196,74 @@ public class DumbMethodInvocations implements Detector {
             }
 
         }
+    }
+
+    private Map<ValueNumber, String> collectPropertiesPasswords(CFG cfg, ConstantDataflow constantDataflow,
+            ValueNumberDataflow valueNumberDataflow, ConstantPoolGen cpg) throws DataflowAnalysisException {
+        Map<ValueNumber, String> propertiesPasswords = new HashMap<>();
+        for (Iterator<Location> i = cfg.locationIterator(); i.hasNext();) {
+            Location location = i.next();
+            Instruction ins = location.getHandle().getInstruction();
+            if (!(ins instanceof InvokeInstruction)) {
+                continue;
+            }
+            InvokeInstruction invoke = (InvokeInstruction) ins;
+            MethodDescriptor md = new MethodDescriptor(invoke, cpg);
+            if (!PROPERTIES_SET_PROPERTY.equals(md)) {
+                continue;
+            }
+            ConstantFrame frame = constantDataflow.getFactAtLocation(location);
+            ValueNumberFrame valueNumberFrame = valueNumberDataflow.getFactAtLocation(location);
+            if (!frame.isValid() || !valueNumberFrame.isValid()) {
+                continue;
+            }
+            SignatureParser parser = new SignatureParser(invoke.getSignature(cpg));
+            Constant key = frame.getArgument(invoke, cpg, 0, parser);
+            Constant value = frame.getArgument(invoke, cpg, 1, parser);
+            if (!key.isConstantString() || !value.isConstantString()) {
+                continue;
+            }
+            if (!"password".equalsIgnoreCase(key.getConstantString())) {
+                continue;
+            }
+            ValueNumber propertiesValue = valueNumberFrame.getInstance(invoke, cpg);
+            propertiesPasswords.put(propertiesValue, value.getConstantString());
+        }
+        return propertiesPasswords;
+    }
+
+    private void reportPasswordIfConstant(ConstantFrame frame, InvokeInstruction invoke, ConstantPoolGen cpg,
+            SignatureParser parser, int paramNumber, ClassContext classContext, MethodGen methodGen, String sourceFile,
+            Location location) throws DataflowAnalysisException {
+        Constant operandValue = frame.getArgument(invoke, cpg, paramNumber, parser);
+        if (operandValue.isConstantString()) {
+            reportPasswordBug(operandValue.getConstantString(), classContext, methodGen, sourceFile, location);
+        }
+    }
+
+    private void reportPasswordBug(String password, ClassContext classContext, MethodGen methodGen, String sourceFile,
+            Location location) {
+        String bugType = password.isEmpty() ? "DMI_EMPTY_DB_PASSWORD" : "DMI_CONSTANT_DB_PASSWORD";
+        bugAccumulator.accumulateBug(new BugInstance(this, bugType, NORMAL_PRIORITY).addClassAndMethod(methodGen, sourceFile),
+                classContext, methodGen, sourceFile, location);
+    }
+
+    static String extractJdbcPassword(String url) {
+        int queryStart = url.indexOf('?');
+        if (queryStart < 0) {
+            return null;
+        }
+        String query = url.substring(queryStart + 1);
+        for (String part : query.split("&")) {
+            int equals = part.indexOf('=');
+            if (equals <= 0) {
+                continue;
+            }
+            if ("password".equalsIgnoreCase(part.substring(0, equals))) {
+                return part.substring(equals + 1);
+            }
+        }
+        return null;
     }
 
     private boolean isAbsoluteFileName(String v) {

--- a/spotbugsTestCases/src/java/ghIssues/Issue3990.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3990.java
@@ -1,0 +1,34 @@
+package ghIssues;
+
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Properties;
+
+public class Issue3990 {
+
+    private static final String STATIC_PASS = "static_cred";
+
+    public void directHardcodedPassword() throws SQLException {
+        DriverManager.getConnection("jdbc:mysql://localhost", "user", "direct_hardcoded");
+    }
+
+    public void propertiesPassword() throws SQLException {
+        Properties props = new Properties();
+        props.setProperty("password", "prop_cred");
+        DriverManager.getConnection("jdbc:mysql://localhost", props);
+    }
+
+    public void urlEmbeddedPassword() throws SQLException {
+        DriverManager.getConnection("jdbc:mysql://localhost/db?user=admin&password=url_sec");
+    }
+
+    public void localVariablePassword() throws SQLException {
+        String dynamicPass = STATIC_PASS;
+        DriverManager.getConnection("jdbc:mysql://localhost", "admin", dynamicPass);
+    }
+
+    public void emptyPassword() throws SQLException {
+        String emptyPass = "";
+        DriverManager.getConnection("jdbc:mysql://localhost", "root", emptyPass);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #3990 by extending `DumbMethodInvocations` to detect hardcoded database passwords in additional `DriverManager.getConnection` usage patterns:

- **`getConnection(String, Properties)`** — tracks `Properties.setProperty("password", ...)` via value-number analysis and reports when the same `Properties` instance is passed to `getConnection`.
- **`getConnection(String)`** — parses `password=` from JDBC URL query parameters.
- **Static final string propagation** — `ConstantFrameModelingVisitor` now models `GETSTATIC` for `static final String` fields so inlined constants assigned to locals are still detected.

## Test plan

- [x] Added `Issue3990` test case with separate methods per scenario (avoids `BugAccumulator` merging multiple occurrences into one primary source line).
- [x] `Issue3990Test` passes (direct hardcoded, Properties, URL, local variable, empty password).
- [x] Unit test for `extractJdbcPassword` helper.
- [x] `Issue1928Test` regression (existing `DumbMethodInvocations` substring warnings) still passes.