### PR TITLE
Fix DMI_HARDCODED_ABSOLUTE_FILENAME for string concat (#1929)

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1929Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1929Test.java
@@ -1,0 +1,21 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class Issue1929Test extends AbstractIntegrationTest {
+
+    @Test
+    void testHardcodedAbsoluteFilenameWithConcat() {
+        performAnalysis("ghIssues/Issue1929.class");
+        assertBugInMethodAtLine("DMI_HARDCODED_ABSOLUTE_FILENAME", "ghIssues.Issue1929", "hardcodedAbsoluteFilenameWithConcat",
+                8);
+    }
+
+    @Test
+    void testExtractMakeConcatRecipe() {
+        org.junit.jupiter.api.Assertions.assertArrayEquals(
+                new String[] { "/tmp/fswebcam-pipe-", ".mjpeg" },
+                DumbMethodInvocations.literalPartsFromConcatRecipe("/tmp/fswebcam-pipe-\u0001.mjpeg"));
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DumbMethodInvocations.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DumbMethodInvocations.java
@@ -5,9 +5,18 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
 
+import org.apache.bcel.classfile.Attribute;
+import org.apache.bcel.classfile.BootstrapMethod;
+import org.apache.bcel.classfile.BootstrapMethods;
+import org.apache.bcel.classfile.ConstantInvokeDynamic;
+import org.apache.bcel.classfile.ConstantPool;
+import org.apache.bcel.classfile.ConstantString;
+import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.classfile.Method;
 import org.apache.bcel.generic.ConstantPoolGen;
+import org.apache.bcel.generic.INVOKEDYNAMIC;
 import org.apache.bcel.generic.Instruction;
+import org.apache.bcel.generic.InstructionHandle;
 import org.apache.bcel.generic.InvokeInstruction;
 import org.apache.bcel.generic.MethodGen;
 
@@ -147,27 +156,86 @@ public class DumbMethodInvocations implements Detector {
 
                 for (int paramNumber : allFileNameStringMethods.get(md)) {
                     Constant operandValue = frame.getArgument(iins, cpg, paramNumber, parser);
-                    if (!operandValue.isConstantString()) {
-                        continue;
-                    }
-                    String v = operandValue.getConstantString();
-                    if (isAbsoluteFileName(v) && !v.startsWith("/etc/") && !v.startsWith("/dev/")
-                            && !v.startsWith("/proc")) {
-                        int priority = NORMAL_PRIORITY;
-                        if (v.startsWith("/tmp")) {
-                            priority = LOW_PRIORITY;
-                        } else if (v.indexOf("/home") >= 0) {
-                            priority = HIGH_PRIORITY;
+                    if (operandValue.isConstantString()) {
+                        reportHardcodedAbsoluteFilename(operandValue.getConstantString(), classContext, methodGen, sourceFile,
+                                location);
+                    } else {
+                        String recipe = extractPrecedingMakeConcatRecipe(location, classContext);
+                        if (recipe != null) {
+                            for (String literal : literalPartsFromConcatRecipe(recipe)) {
+                                reportHardcodedAbsoluteFilename(literal, classContext, methodGen, sourceFile, location);
+                            }
                         }
-                        bugAccumulator.accumulateBug(new BugInstance(this, "DMI_HARDCODED_ABSOLUTE_FILENAME", priority)
-                                .addClassAndMethod(methodGen, sourceFile).addString(v).describe("FILE_NAME"), classContext,
-                                methodGen, sourceFile, location);
                     }
                 }
 
             }
 
         }
+    }
+
+    private void reportHardcodedAbsoluteFilename(String v, ClassContext classContext, MethodGen methodGen, String sourceFile,
+            Location location) {
+        if (isAbsoluteFileName(v) && !v.startsWith("/etc/") && !v.startsWith("/dev/") && !v.startsWith("/proc")) {
+            int priority = NORMAL_PRIORITY;
+            if (v.startsWith("/tmp")) {
+                priority = LOW_PRIORITY;
+            } else if (v.indexOf("/home") >= 0) {
+                priority = HIGH_PRIORITY;
+            }
+            bugAccumulator.accumulateBug(new BugInstance(this, "DMI_HARDCODED_ABSOLUTE_FILENAME", priority)
+                    .addClassAndMethod(methodGen, sourceFile).addString(v).describe("FILE_NAME"), classContext, methodGen,
+                    sourceFile, location);
+        }
+    }
+
+    private String extractPrecedingMakeConcatRecipe(Location location, ClassContext classContext) {
+        InstructionHandle handle = location.getHandle().getPrev();
+        if (handle == null) {
+            return null;
+        }
+        return extractMakeConcatRecipe(handle.getInstruction(), classContext.getJavaClass(), classContext.getConstantPoolGen());
+    }
+
+    static String extractMakeConcatRecipe(Instruction instruction, JavaClass javaClass, ConstantPoolGen cpg) {
+        if (!(instruction instanceof INVOKEDYNAMIC)) {
+            return null;
+        }
+        INVOKEDYNAMIC invokeDynamic = (INVOKEDYNAMIC) instruction;
+        if (!"makeConcatWithConstants".equals(invokeDynamic.getMethodName(cpg))) {
+            return null;
+        }
+        ConstantPool constantPool = javaClass.getConstantPool();
+        org.apache.bcel.classfile.Constant poolConstant = constantPool.getConstant(invokeDynamic.getIndex());
+        if (!(poolConstant instanceof ConstantInvokeDynamic)) {
+            return null;
+        }
+        BootstrapMethod bootstrapMethod = findBootstrapMethod(javaClass,
+                ((ConstantInvokeDynamic) poolConstant).getBootstrapMethodAttrIndex());
+        if (bootstrapMethod == null || bootstrapMethod.getBootstrapArguments().length == 0) {
+            return null;
+        }
+        org.apache.bcel.classfile.Constant recipeConstant = constantPool.getConstant(bootstrapMethod.getBootstrapArguments()[0]);
+        if (!(recipeConstant instanceof ConstantString)) {
+            return null;
+        }
+        return ((ConstantString) recipeConstant).getBytes(constantPool);
+    }
+
+    static String[] literalPartsFromConcatRecipe(String recipe) {
+        return recipe.split("\u0001", -1);
+    }
+
+    private static BootstrapMethod findBootstrapMethod(JavaClass javaClass, int bootstrapMethodIndex) {
+        for (Attribute attribute : javaClass.getAttributes()) {
+            if (attribute instanceof BootstrapMethods) {
+                BootstrapMethods bootstrapMethods = (BootstrapMethods) attribute;
+                if (bootstrapMethodIndex >= 0 && bootstrapMethodIndex < bootstrapMethods.getBootstrapMethods().length) {
+                    return bootstrapMethods.getBootstrapMethods()[bootstrapMethodIndex];
+                }
+            }
+        }
+        return null;
     }
 
     private boolean isAbsoluteFileName(String v) {

--- a/spotbugsTestCases/src/java/ghIssues/Issue1929.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue1929.java
@@ -1,0 +1,10 @@
+package ghIssues;
+
+import java.io.File;
+
+public class Issue1929 {
+
+    void hardcodedAbsoluteFilenameWithConcat(File vfile) {
+        File pipe = new File("/tmp/fswebcam-pipe-" + vfile.getName() + ".mjpeg");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1929 by detecting hardcoded absolute path literals embedded in `makeConcatWithConstants` recipes when the result is passed to file-related APIs (e.g. `new File("/tmp/prefix-" + dynamic + ".suffix")`).

Previously, `DumbMethodInvocations` only flagged fully constant string arguments. Dynamic concatenation produced via `invokedynamic` was missed even when the bootstrap recipe contained absolute path literals such as `/tmp/fswebcam-pipe-`.

## Changes

- Extract the `makeConcatWithConstants` recipe from the instruction immediately preceding a file API call.
- Split the recipe on `\u0001` placeholders and report `DMI_HARDCODED_ABSOLUTE_FILENAME` for any literal segment that matches existing absolute-path heuristics.

## Test plan

- [x] Added `Issue1929` regression test case and unit test for recipe literal splitting.
- [x] `Issue1929Test` passes.
- [x] `Issue1928Test` (existing `DumbMethodInvocations` coverage) still passes.