### PR TITLE
Fix NPE false negative for uninitialized reference array elements (#3961)

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3961Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3961Test.java
@@ -1,0 +1,13 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class Issue3961Test extends AbstractIntegrationTest {
+
+    @Test
+    void testUninitializedReferenceArrayElementDereference() {
+        performAnalysis("ghIssues/Issue3961.class");
+        assertBugInMethodAtLine("NP_ALWAYS_NULL", "ghIssues.Issue3961", "reproduceRisk", 9);
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/IsNullValueAnalysis.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/IsNullValueAnalysis.java
@@ -600,6 +600,7 @@ public class IsNullValueAnalysis extends FrameDataflowAnalysis<IsNullValue, IsNu
         }
         super.mergeInto(other, result);
         // FIXME: update decision?
+        result.mergeUninitializedReferenceArrayLocalsWith(other);
         if (trackValueNumbers) {
             result.mergeKnownValuesWith(other);
         }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/IsNullValueFrame.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/IsNullValueFrame.java
@@ -19,6 +19,7 @@
 
 package edu.umd.cs.findbugs.ba.npe;
 
+import java.util.BitSet;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -85,9 +86,15 @@ public class IsNullValueFrame extends Frame<IsNullValue> {
 
     private Map<ValueNumber, IsNullValue> knownValueMap;
 
+    /**
+     * Local variable slots holding reference arrays with no {@code AASTORE} yet.
+     */
+    private final BitSet uninitializedReferenceArrayLocals;
+
     public IsNullValueFrame(int numLocals, boolean trackValueNumbers) {
         super(numLocals);
         this.trackValueNumbers = trackValueNumbers;
+        this.uninitializedReferenceArrayLocals = new BitSet(numLocals);
         if (trackValueNumbers) {
             this.knownValueMap = new HashMap<>(3);
         }
@@ -112,7 +119,6 @@ public class IsNullValueFrame extends Frame<IsNullValue> {
                 i.remove();
             }
         }
-
     }
 
     @Override
@@ -121,6 +127,7 @@ public class IsNullValueFrame extends Frame<IsNullValue> {
         if (trackValueNumbers) {
             knownValueMap.clear();
         }
+        uninitializedReferenceArrayLocals.clear();
         decision = null;
     }
 
@@ -170,6 +177,18 @@ public class IsNullValueFrame extends Frame<IsNullValue> {
             knownValueMap.put(newValueNumber, isNullValue);
             knownValueMap.remove(oldValueNumber);
         }
+    }
+
+    public void setLocalUninitializedReferenceArray(int localSlot) {
+        uninitializedReferenceArrayLocals.set(localSlot);
+    }
+
+    public void clearLocalUninitializedReferenceArray(int localSlot) {
+        uninitializedReferenceArrayLocals.clear(localSlot);
+    }
+
+    public boolean isLocalUninitializedReferenceArray(int localSlot) {
+        return uninitializedReferenceArrayLocals.get(localSlot);
     }
 
     public @CheckForNull IsNullValue getKnownValue(ValueNumber valueNumber) {
@@ -227,6 +246,10 @@ public class IsNullValueFrame extends Frame<IsNullValue> {
         }
     }
 
+    public void mergeUninitializedReferenceArrayLocalsWith(IsNullValueFrame otherFrame) {
+        uninitializedReferenceArrayLocals.and(otherFrame.uninitializedReferenceArrayLocals);
+    }
+
     /*
      * (non-Javadoc)
      *
@@ -239,6 +262,8 @@ public class IsNullValueFrame extends Frame<IsNullValue> {
         if (trackValueNumbers) {
             knownValueMap = Util.makeSmallHashMap(((IsNullValueFrame) other).knownValueMap);
         }
+        uninitializedReferenceArrayLocals.clear();
+        uninitializedReferenceArrayLocals.or(((IsNullValueFrame) other).uninitializedReferenceArrayLocals);
     }
 
     @Override
@@ -254,6 +279,9 @@ public class IsNullValueFrame extends Frame<IsNullValue> {
             return false;
         }
         if (trackValueNumbers && !Objects.equals(knownValueMap, o2.knownValueMap)) {
+            return false;
+        }
+        if (!uninitializedReferenceArrayLocals.equals(o2.uninitializedReferenceArrayLocals)) {
             return false;
         }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/IsNullValueFrameModelingVisitor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/IsNullValueFrameModelingVisitor.java
@@ -23,7 +23,11 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.bcel.generic.ACONST_NULL;
+import org.apache.bcel.generic.AALOAD;
+import org.apache.bcel.generic.AASTORE;
+import org.apache.bcel.generic.ALOAD;
 import org.apache.bcel.generic.ANEWARRAY;
+import org.apache.bcel.generic.ASTORE;
 import org.apache.bcel.generic.CHECKCAST;
 import org.apache.bcel.generic.ConstantPoolGen;
 import org.apache.bcel.generic.GETFIELD;
@@ -34,6 +38,7 @@ import org.apache.bcel.generic.INVOKESPECIAL;
 import org.apache.bcel.generic.INVOKESTATIC;
 import org.apache.bcel.generic.INVOKEVIRTUAL;
 import org.apache.bcel.generic.Instruction;
+import org.apache.bcel.generic.InstructionHandle;
 import org.apache.bcel.generic.InvokeInstruction;
 import org.apache.bcel.generic.LDC;
 import org.apache.bcel.generic.LDC2_W;
@@ -477,6 +482,71 @@ public class IsNullValueFrameModelingVisitor extends AbstractFrameModelingVisito
     public void visitANEWARRAY(ANEWARRAY obj) {
         modelNormalInstruction(obj, getNumWordsConsumed(obj), 0);
         produce(IsNullValue.nonNullValue());
+    }
+
+    @Override
+    public void visitASTORE(ASTORE obj) {
+        InstructionHandle prev = getLocation().getHandle().getPrev();
+        if (prev != null && prev.getInstruction() instanceof ANEWARRAY) {
+            getFrame().setLocalUninitializedReferenceArray(obj.getIndex());
+        }
+        handleStoreInstruction(obj);
+    }
+
+    @Override
+    public void visitAASTORE(AASTORE obj) {
+        InstructionHandle aloadHandle = findAloadOfArrayRefBeforeStore(getLocation().getHandle());
+        if (aloadHandle != null) {
+            getFrame().clearLocalUninitializedReferenceArray(((ALOAD) aloadHandle.getInstruction()).getIndex());
+        }
+        handleNormalInstruction(obj);
+    }
+
+    @Override
+    public void visitAALOAD(AALOAD obj) {
+        if (loadsNullElementFromUninitializedReferenceArray()) {
+            modelNormalInstruction(obj, getNumWordsConsumed(obj), 0);
+            produce(IsNullValue.nullValue());
+            return;
+        }
+        handleNormalInstruction(obj);
+    }
+
+    private InstructionHandle findAloadOfArrayRefBeforeStore(InstructionHandle storeHandle) {
+        InstructionHandle handle = storeHandle.getPrev();
+        if (handle == null) {
+            return null;
+        }
+        handle = handle.getPrev();
+        if (handle == null) {
+            return null;
+        }
+        handle = handle.getPrev();
+        if (handle == null) {
+            return null;
+        }
+        Instruction instruction = handle.getInstruction();
+        if (instruction instanceof ALOAD) {
+            return handle;
+        }
+        return null;
+    }
+
+    private boolean loadsNullElementFromUninitializedReferenceArray() {
+        InstructionHandle handle = getLocation().getHandle();
+        InstructionHandle indexHandle = handle.getPrev();
+        if (indexHandle == null) {
+            return false;
+        }
+        InstructionHandle arrayRefHandle = indexHandle.getPrev();
+        if (arrayRefHandle == null) {
+            return false;
+        }
+        Instruction arrayRefInstruction = arrayRefHandle.getInstruction();
+        if (arrayRefInstruction instanceof ALOAD) {
+            return getFrame().isLocalUninitializedReferenceArray(((ALOAD) arrayRefInstruction).getIndex());
+        }
+        return arrayRefInstruction instanceof ANEWARRAY;
     }
 
     @Override

--- a/spotbugsTestCases/src/java/ghIssues/Issue3961.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3961.java
@@ -1,0 +1,11 @@
+package ghIssues;
+
+import java.lang.ref.Reference;
+
+public class Issue3961 {
+
+    public static void reproduceRisk() {
+        Reference[] refs = new Reference[1];
+        refs[0].get();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #3961 by teaching null pointer analysis that reference array elements are default-null immediately after `ANEWARRAY` until an `AASTORE` writes the local slot holding the array.

## Approach

- Track local variable slots that receive a reference array directly from `ANEWARRAY` (`ASTORE` preceded by `ANEWARRAY`).
- Model `AALOAD` from such locals (or directly from `ANEWARRAY`) as definitely null.
- Clear the tracking when `AASTORE` stores through the same `ALOAD` array reference pattern.

This works without requiring `TRACK_VALUE_NUMBERS_IN_NULL_POINTER_ANALYSIS`, so it applies under default analysis effort used in tests and CLI.

## Test plan

- [x] Added `Issue3961` regression test expecting `NP_ALWAYS_NULL` at the dereference site.
- [x] `Issue3961Test` passes.
- [x] `Issue2965Test` (existing null analysis coverage) still passes.