### PR TITLE
Fix DLS_OVERWRITTEN_INCREMENT for increment in expressions (#1517)

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1517Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1517Test.java
@@ -1,0 +1,21 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class Issue1517Test extends AbstractIntegrationTest {
+
+    private static final String CLASS = "ghIssues.Issue1517";
+
+    @Test
+    void testIncrementInExpression() {
+        performAnalysis("ghIssues/Issue1517.class");
+
+        assertBugInMethodAtLine("DLS_OVERWRITTEN_INCREMENT", CLASS, "incrementInAdditionRight", 7);
+        assertBugInMethodAtLine("DLS_OVERWRITTEN_INCREMENT", CLASS, "incrementInAdditionLeft", 12);
+        assertBugInMethodAtLine("DLS_OVERWRITTEN_INCREMENT", CLASS, "decrementInSubtractionLeft", 17);
+        assertBugInMethodAtLine("DLS_OVERWRITTEN_INCREMENT", CLASS, "decrementInAdditionRight", 22);
+        assertBugInMethodAtLine("DLS_OVERWRITTEN_INCREMENT", CLASS, "directSelfAssignment", 27);
+        assertBugInMethodCount("DLS_OVERWRITTEN_INCREMENT", CLASS, "standaloneIncrementThenAssign", 0);
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindPuzzlers.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindPuzzlers.java
@@ -78,6 +78,7 @@ public class FindPuzzlers extends OpcodeStackDetector {
     @Override
     public void visit(Code obj) {
         prevOpcodeIncrementedRegister = -1;
+        prevOpcodeLoadedRegister = -1;
         best_priority_for_ICAST_INTEGER_MULTIPLY_CAST_TO_LONG = LOW_PRIORITY + 1;
         prevOpCode = Const.NOP;
         previousMethodInvocation = null;
@@ -99,6 +100,8 @@ public class FindPuzzlers extends OpcodeStackDetector {
     boolean imul_operand_is_parameter;
 
     int prevOpcodeIncrementedRegister;
+
+    int prevOpcodeLoadedRegister;
 
     int valueOfConstantArgumentToShift;
 
@@ -447,12 +450,10 @@ public class FindPuzzlers extends OpcodeStackDetector {
                 && getRegisterOperand() == prevOpcodeIncrementedRegister) {
             bugAccumulator.accumulateBug(
                     new BugInstance(this, "DLS_OVERWRITTEN_INCREMENT", HIGH_PRIORITY).addClassAndMethod(this), this);
-
-        }
-        if (seen == Const.IINC) {
-            prevOpcodeIncrementedRegister = getRegisterOperand();
-        } else {
             prevOpcodeIncrementedRegister = -1;
+        }
+        if (seen == Const.IINC && getRegisterOperand() == prevOpcodeLoadedRegister) {
+            prevOpcodeIncrementedRegister = getRegisterOperand();
         }
 
         // Java Puzzlers, Chapter 2, puzzle 1
@@ -733,6 +734,10 @@ public class FindPuzzlers extends OpcodeStackDetector {
                         .addClassAndMethod(this)
                         .addCalledMethod(m).addValueSource(top, this), this);
             }
+        }
+        if (isRegisterLoad() && (seen == Const.ILOAD || seen == Const.ILOAD_0 || seen == Const.ILOAD_1 || seen == Const.ILOAD_2
+                || seen == Const.ILOAD_3)) {
+            prevOpcodeLoadedRegister = getRegisterOperand();
         }
         prevOpCode = seen;
 

--- a/spotbugsTestCases/src/java/ghIssues/Issue1517.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue1517.java
@@ -1,0 +1,35 @@
+package ghIssues;
+
+public class Issue1517 {
+
+    public void incrementInAdditionRight() {
+        int i = 0;
+        i = 2 + (i++);
+    }
+
+    public void incrementInAdditionLeft() {
+        int i = 0;
+        i = (i++) + 2;
+    }
+
+    public void decrementInSubtractionLeft() {
+        int i = 0;
+        i = (i--) - 2;
+    }
+
+    public void decrementInAdditionRight() {
+        int i = 0;
+        i = 2 + (i--);
+    }
+
+    public void directSelfAssignment() {
+        int i = 0;
+        i = i++;
+    }
+
+    public void standaloneIncrementThenAssign() {
+        int i = 0;
+        i++;
+        i = 2 + i;
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1517 by extending `DLS_OVERWRITTEN_INCREMENT` detection to cover assignment expressions such as `i = 2 + (i++)` and `i = (i++) + 2`, not only the direct `i = i++` form.

Previously, the detector only matched `IINC` immediately followed by `ISTORE` to the same local. In expression forms, bytecode inserts `IADD`/`ISUB` (and similar) between the increment and store, which reset tracking too early.

## Approach

- Track the local loaded by the preceding `ILOAD`.
- When `IINC` targets that same local (postfix increment/decrement in an expression), keep the pending register until an `ISTORE` to it.
- Avoid false positives for standalone `i++;` followed by a separate assignment by requiring `ILOAD` immediately before `IINC`.

## Test plan

- [x] Added `Issue1517` regression cases for four expression forms plus direct self-assignment.
- [x] Verified no `DLS_OVERWRITTEN_INCREMENT` for standalone increment followed by separate assignment.
- [x] `Issue1517Test` passes.