### PR TITLE
Fix false negative for uninitialized field dereference via getter (#1405)

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1405Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1405Test.java
@@ -1,0 +1,13 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class Issue1405Test extends AbstractIntegrationTest {
+
+    @Test
+    void testUninitializedFieldDereferenceThroughGetter() {
+        performAnalysis("ghIssues/Issue1405.class");
+        assertBugInMethodAtLine("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", "ghIssues.Issue1405", "main", 19);
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/FieldSummary.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/FieldSummary.java
@@ -51,6 +51,8 @@ import edu.umd.cs.findbugs.util.Util;
 public class FieldSummary {
     private final Set<XField> writtenOutsideOfConstructor = new HashSet<>();
 
+    private final Set<XField> defaultNullReferenceFields = new HashSet<>();
+
     private final Map<XField, OpcodeStack.Item> summary = new HashMap<>();
 
     private final Map<XMethod, Set<XField>> fieldsWritten = new HashMap<>();
@@ -164,6 +166,14 @@ public class FieldSummary {
 
     public boolean addWrittenOutsideOfConstructor(XField field) {
         return writtenOutsideOfConstructor.add(field);
+    }
+
+    public void addDefaultNullReferenceField(XField field) {
+        defaultNullReferenceFields.add(field);
+    }
+
+    public boolean isDefaultNullReferenceField(XField field) {
+        return defaultNullReferenceFields.contains(field);
     }
 
     public void mergeSummary(XField fieldOperand, OpcodeStack.Item mergeValue) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/IsNullValueFrameModelingVisitor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/IsNullValueFrameModelingVisitor.java
@@ -50,6 +50,7 @@ import edu.umd.cs.findbugs.ba.AbstractFrameModelingVisitor;
 import edu.umd.cs.findbugs.ba.AnalysisContext;
 import edu.umd.cs.findbugs.ba.AssertionMethods;
 import edu.umd.cs.findbugs.ba.DataflowAnalysisException;
+import edu.umd.cs.findbugs.ba.FieldSummary;
 import edu.umd.cs.findbugs.ba.Hierarchy2;
 import edu.umd.cs.findbugs.ba.Location;
 import edu.umd.cs.findbugs.ba.NullnessAnnotation;
@@ -270,7 +271,7 @@ public class IsNullValueFrameModelingVisitor extends AbstractFrameModelingVisito
         } else if (annotation == NullnessAnnotation.NULLABLE) {
             pushValue = IsNullValue.nonReportingNotNullValue();
         } else if (annotation == NullnessAnnotation.NONNULL
-                || (alwaysNonNull != null && alwaysNonNull.booleanValue())) {
+                || Boolean.TRUE.equals(alwaysNonNull)) {
             // Method is declared NOT to return null
             if (IsNullValueAnalysis.DEBUG) {
                 System.out.println("NonNull value return from " + calledMethod);
@@ -279,6 +280,10 @@ public class IsNullValueFrameModelingVisitor extends AbstractFrameModelingVisito
                     calledMethod,
                     annotation);
 
+        } else if (Boolean.FALSE.equals(alwaysNonNull)) {
+            pushValue = IsNullValue.nullOnSimplePathValue().markInformationAsComingFromReturnValueOfMethod(
+                    calledMethod,
+                    annotation);
         } else {
             pushValue = IsNullValue.nonReportingNotNullValue();
         }
@@ -360,6 +365,12 @@ public class IsNullValueFrameModelingVisitor extends AbstractFrameModelingVisito
 
         NullnessAnnotation annotation = AnalysisContext.currentAnalysisContext().getNullnessAnnotationDatabase()
                 .getResolvedAnnotation(field, false);
+        FieldSummary fieldSummary = AnalysisContext.currentAnalysisContext().getFieldSummary();
+        if (fieldSummary.getSummary(field).isNull() || fieldSummary.isDefaultNullReferenceField(field)) {
+            modelNormalInstruction(obj, getNumWordsConsumed(obj), 0);
+            produce(IsNullValue.nullOnSimplePathValue().markInformationAsComingFromFieldValue(field));
+            return;
+        }
         if (annotation == NullnessAnnotation.NONNULL) {
             modelNormalInstruction(obj, getNumWordsConsumed(obj), 0);
             produce(IsNullValue.nonNullValue());

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BuildNonnullReturnDatabase.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BuildNonnullReturnDatabase.java
@@ -88,6 +88,8 @@ public class BuildNonnullReturnDatabase {
 
             IsNullValueDataflow inv = classContext.getIsNullValueDataflow(method);
             boolean guaranteedNonNull = true;
+            boolean sawAreReturn = false;
+            boolean mightReturnNull = false;
             for (Iterator<Location> i = cfg.locationIterator(); i.hasNext();) {
                 Location location = i.next();
                 InstructionHandle handle = location.getHandle();
@@ -96,27 +98,36 @@ public class BuildNonnullReturnDatabase {
                 if (!(ins instanceof ARETURN)) {
                     continue;
                 }
+                sawAreReturn = true;
                 IsNullValueFrame frame = inv.getFactAtLocation(location);
                 if (!frame.isValid()) {
                     continue;
                 }
                 IsNullValue value = frame.getTopValue();
+                if (value.mightBeNull()) {
+                    mightReturnNull = true;
+                }
                 if (!value.isDefinitelyNotNull()) {
                     guaranteedNonNull = false;
-                    break;
                 }
 
             }
 
             XMethod xmethod = XFactory.createXMethod(classContext.getJavaClass(), method);
-            if (guaranteedNonNull) {
+            if (guaranteedNonNull && sawAreReturn) {
                 returnsNonNull++;
                 AnalysisContext.currentAnalysisContext().getReturnValueNullnessPropertyDatabase()
-                        .setProperty(xmethod.getMethodDescriptor(), guaranteedNonNull);
+                        .setProperty(xmethod.getMethodDescriptor(), Boolean.TRUE);
                 if (DEBUG) {
                     System.out.println("Unconditional deref: " + xmethod + "=" + guaranteedNonNull);
                 }
 
+            } else if (mightReturnNull && sawAreReturn) {
+                AnalysisContext.currentAnalysisContext().getReturnValueNullnessPropertyDatabase()
+                        .setProperty(xmethod.getMethodDescriptor(), Boolean.FALSE);
+                if (DEBUG) {
+                    System.out.println("Nullable return: " + xmethod);
+                }
             }
 
         } catch (CFGBuilderException | DataflowAnalysisException e) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FieldItemSummary.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FieldItemSummary.java
@@ -138,6 +138,7 @@ public class FieldItemSummary extends OpcodeStackDetector implements NonReportin
                     char firstChar = f.getSignature().charAt(0);
                     if (firstChar == 'L' || firstChar == '[') {
                         item = OpcodeStack.Item.nullItem(f.getSignature());
+                        fieldSummary.addDefaultNullReferenceField(f);
                     } else if (firstChar == 'I') {
                         item = new OpcodeStack.Item("I", (Integer) 0);
                     } else if (firstChar == 'J') {

--- a/spotbugsTestCases/src/java/ghIssues/Issue1405.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue1405.java
@@ -1,0 +1,21 @@
+package ghIssues;
+
+public class Issue1405 {
+
+    public String greeting = "hey";
+
+    private Issue1405 another;
+
+    public Issue1405 getAnother() {
+        return another;
+    }
+
+    public void setAnother(Issue1405 another) {
+        this.another = another;
+    }
+
+    public static void main(String[] args) {
+        Issue1405 some = new Issue1405();
+        System.out.println(some.getAnother().greeting);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1405.

When an instance reference field is left at its default null value in a constructor and accessed through a trivial getter, SpotBugs previously failed to report a null dereference at the call site.

This change:
- Tracks reference fields that remain at default null after constructor execution in a dedicated set on `FieldSummary`, so later setter writes do not erase that information via `OpcodeStack.Item.merge`.
- Models `GETFIELD` for such fields as `nullOnSimplePathValue` in null pointer analysis.
- Records methods that may return null in `ReturnValueNullnessPropertyDatabase`, enabling `NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE` at call sites.

## Test plan

- [x] Added `Issue1405.java` reproducer and `Issue1405Test`
- [x] `./gradlew :spotbugs-tests:test --tests "edu.umd.cs.findbugs.detect.Issue1405Test"`
- [x] Regression: `./gradlew :spotbugs-tests:test --tests "edu.umd.cs.findbugs.detect.Issue2965Test"`