### PR TITLE
Add regression test for null dereference in catch blocks (#2693)

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2693Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2693Test.java
@@ -1,0 +1,13 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class Issue2693Test extends AbstractIntegrationTest {
+
+    @Test
+    void testNullDerefInCatchBlock() {
+        performAnalysis("ghIssues/Issue2693.class");
+        assertBugInMethodAtLine("NP_ALWAYS_NULL_EXCEPTION", "ghIssues.Issue2693", "nullDerefInCatch", 10);
+    }
+}

--- a/spotbugsTestCases/src/java/ghIssues/Issue2693.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue2693.java
@@ -1,0 +1,13 @@
+package ghIssues;
+
+public class Issue2693 {
+
+    public static void nullDerefInCatch() {
+        String str = null;
+        try {
+            throw new NullPointerException();
+        } catch (Exception e) {
+            str.length();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a regression test for #2693.

SpotBugs already reports `NP_ALWAYS_NULL_EXCEPTION` when a definitely-null local is dereferenced inside a catch handler. This test locks in that behavior using the minimal reproducer from the issue.

## Test plan

- [x] `./gradlew :spotbugs-tests:test --tests "edu.umd.cs.findbugs.detect.Issue2693Test"`