### PR TITLE
Fix UWF_UNWRITTEN_FIELD false negative with class literals (#1043)

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1043Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1043Test.java
@@ -1,0 +1,13 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class Issue1043Test extends AbstractIntegrationTest {
+
+    @Test
+    void testUnwrittenFieldWithClassLiteralAccess() {
+        performAnalysis("ghIssues/Issue1043.class");
+        assertBugAtLine("UWF_UNWRITTEN_FIELD", 13);
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ReflectiveClasses.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ReflectiveClasses.java
@@ -41,6 +41,15 @@ public class ReflectiveClasses extends BytecodeScanningDetector implements NonRe
 
     String constantString;
 
+    /** Class name from the most recent {@code LDC}/{@code LDC_W} of a {@code java.lang.Class} constant. */
+    private String pendingClassFromLdc;
+
+    @Override
+    public void visit(org.apache.bcel.classfile.Code obj) {
+        pendingClassFromLdc = null;
+        super.visit(obj);
+    }
+
     @Override
     public void sawString(String s) {
         constantString = s;
@@ -50,18 +59,49 @@ public class ReflectiveClasses extends BytecodeScanningDetector implements NonRe
     public void sawClass() {
         int opcode = getOpcode();
         if ((opcode == Const.LDC) || (opcode == Const.LDC_W)) {
-            process(getClassConstantOperand());
+            pendingClassFromLdc = getClassConstantOperand();
         }
     }
 
     @Override
     public void sawOpcode(int seen) {
+        resolvePendingClassLiteral(seen);
+
         if (seen == Const.INVOKESTATIC && constantString != null && "java/lang/Class".equals(getClassConstantOperand())
                 && "forName".equals(getNameConstantOperand())) {
             process(ClassName.toSlashedClassName(constantString));
         }
 
         constantString = null;
+    }
+
+    private void resolvePendingClassLiteral(int seen) {
+        if (pendingClassFromLdc == null) {
+            return;
+        }
+        if (isBenignClassLiteralUse(seen)) {
+            pendingClassFromLdc = null;
+            return;
+        }
+        if (seen == Const.DUP || seen == Const.POP || seen == Const.POP2) {
+            return;
+        }
+        process(pendingClassFromLdc);
+        pendingClassFromLdc = null;
+    }
+
+    private boolean isBenignClassLiteralUse(int seen) {
+        if (seen == Const.INVOKEVIRTUAL && "java/lang/Class".equals(getClassConstantOperand())) {
+            String methodName = getNameConstantOperand();
+            return "getSimpleName".equals(methodName) || "getName".equals(methodName)
+                    || "getCanonicalName".equals(methodName) || "getTypeName".equals(methodName);
+        }
+        if (seen == Const.INVOKESTATIC && "getLogger".equals(getNameConstantOperand())) {
+            String owner = getClassConstantOperand();
+            return owner.startsWith("org/slf4j/") || owner.startsWith("org/apache/logging/log4j/")
+                    || "java/util/logging/Logger".equals(owner);
+        }
+        return false;
     }
 
     private void process(@SlashedClassName String className) {

--- a/spotbugsTestCases/src/java/ghIssues/Issue1043.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue1043.java
@@ -1,0 +1,20 @@
+package ghIssues;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Issue1043 {
+
+    private static String className = Issue1043.class.getSimpleName();
+
+    private List<String> strings;
+
+    public void add1() {
+        strings.add(className);
+    }
+
+    public void add2() {
+        final List<String> localStrings = new ArrayList<>();
+        localStrings.add(className);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1043.

`ReflectiveClasses` previously marked a class as reflective on every `LDC` of a `Class` constant. That included common patterns like `Foo.class.getSimpleName()` and `LoggerFactory.getLogger(Foo.class)`, which caused `UnreadFields` to lower the priority of `UWF_UNWRITTEN_FIELD` below the default reporting threshold.

This change defers reflective marking until the class literal is used, and skips marking for benign uses such as `Class.getSimpleName()`/`getName()`/`getCanonicalName()`/`getTypeName()` and common logger factory `getLogger(Class)` calls.

## Test plan

- [x] Added `Issue1043.java` reproducer and `Issue1043Test`
- [x] `./gradlew :spotbugs-tests:test --tests "edu.umd.cs.findbugs.detect.Issue1043Test"`
- [x] Regression: `./gradlew :spotbugs-tests:test --tests "edu.umd.cs.findbugs.detect.UnreadFieldsTest"`