### PR TITLE
Fix OBL false negative for obligation subtype references (#3170)

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3170Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3170Test.java
@@ -1,0 +1,14 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class Issue3170Test extends AbstractIntegrationTest {
+
+    @Test
+    void testObligationLeakInHelperClass() {
+        performAnalysis("ghIssues/Issue3170MyConnection.class", "ghIssues/Issue3170Tool.class");
+        assertBugInMethod("OBL_UNSATISFIED_OBLIGATION", "ghIssues.Issue3170MyConnection", "leak");
+        assertBugInMethod("OBL_UNSATISFIED_OBLIGATION", "ghIssues.Issue3170Tool", "leak");
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindUnsatisfiedObligation.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindUnsatisfiedObligation.java
@@ -136,13 +136,13 @@ public class FindUnsatisfiedObligation extends CFGDetector {
             if (c instanceof ConstantNameAndType) {
                 ConstantNameAndType cnt = (ConstantNameAndType) c;
                 String signature = cnt.getSignature(jclass.getConstantPool());
-                if (factory.signatureInvolvesObligations(signature)) {
+                if (signatureReferencesObligationType(factory, signature)) {
                     super.visitClass(classDescriptor);
                     return;
                 }
             } else if (c instanceof ConstantClass) {
                 String className = ((ConstantClass) c).getBytes(jclass.getConstantPool());
-                if (factory.signatureInvolvesObligations(className)) {
+                if (classReferenceIsObligationType(factory, className)) {
                     super.visitClass(classDescriptor);
                     return;
                 }
@@ -151,6 +151,39 @@ public class FindUnsatisfiedObligation extends CFGDetector {
         if (DEBUG) {
             System.out.println(classDescriptor + " isn't interesting for obligation analysis");
         }
+    }
+
+    private static boolean signatureReferencesObligationType(ObligationFactory factory, String signature) {
+        if (factory.signatureInvolvesObligations(signature)) {
+            return true;
+        }
+        try {
+            if (typeReferencesObligationType(factory, Type.getReturnType(signature))) {
+                return true;
+            }
+            for (Type paramType : Type.getArgumentTypes(signature)) {
+                if (typeReferencesObligationType(factory, paramType)) {
+                    return true;
+                }
+            }
+        } catch (RuntimeException e) {
+            // ignore invalid signatures in the constant pool
+        }
+        return false;
+    }
+
+    private static boolean classReferenceIsObligationType(ObligationFactory factory, String className) {
+        if (factory.signatureInvolvesObligations(className)) {
+            return true;
+        }
+        return factory.isObligationType(DescriptorFactory.createClassDescriptor(className));
+    }
+
+    private static boolean typeReferencesObligationType(ObligationFactory factory, Type type) {
+        if (type instanceof ObjectType) {
+            return factory.isObligationType(DescriptorFactory.createClassDescriptor(((ObjectType) type).getClassName()));
+        }
+        return false;
     }
 
     @Override

--- a/spotbugsTestCases/src/java/ghIssues/Issue3170MyConnection.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3170MyConnection.java
@@ -1,0 +1,18 @@
+package ghIssues;
+
+import java.sql.DriverManager;
+
+import edu.umd.cs.findbugs.annotations.CreatesObligation;
+
+public abstract class Issue3170MyConnection implements java.sql.Connection {
+
+    @CreatesObligation
+    public static Issue3170MyConnection connect() throws Exception {
+        return (Issue3170MyConnection) DriverManager.getConnection("my://foo");
+    }
+
+    public void leak() throws Exception {
+        Issue3170MyConnection connection = Issue3170MyConnection.connect();
+        System.out.println(connection);
+    }
+}

--- a/spotbugsTestCases/src/java/ghIssues/Issue3170Tool.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3170Tool.java
@@ -1,0 +1,9 @@
+package ghIssues;
+
+public class Issue3170Tool {
+
+    public void leak() throws Exception {
+        Issue3170MyConnection connection = Issue3170MyConnection.connect();
+        System.out.println(connection);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #3170.

`FindUnsatisfiedObligation` skipped classes whose constant pool did not contain exact obligation type names (such as `java/sql/Connection`). Helper classes that only reference a custom subtype (for example `MyConnection.connect()`) were treated as uninteresting and never analyzed, even when the callee method was annotated with `@CreatesObligation`.

This change treats constant pool class references and method signatures as interesting when they refer to obligation types or their subtypes.

## Test plan

- [x] Added `Issue3170MyConnection`, `Issue3170Tool`, and `Issue3170Test`
- [x] `./gradlew :spotbugs-tests:test --tests "edu.umd.cs.findbugs.detect.Issue3170Test"`
- [x] Regression: `./gradlew :spotbugs-tests:test --tests "edu.umd.cs.findbugs.ba.Issue3069Test"`