### PR TITLE
Fix UWF_NULL_FIELD false negative for cast null initializers (#4034)

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue4034Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue4034Test.java
@@ -1,0 +1,15 @@
+package edu.umd.cs.findbugs.detect;
+
+import org.junit.jupiter.api.Test;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+
+class Issue4034Test extends AbstractIntegrationTest {
+
+    @Test
+    void testUwfNullFieldWithCastNullInitializer() {
+        performAnalysis("ghIssues/Issue4034.class");
+
+        assertBugAtField("UWF_NULL_FIELD", "ghIssues.Issue4034", "strVal");
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UnreadFields.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UnreadFields.java
@@ -735,7 +735,12 @@ public class UnreadFields extends OpcodeStackDetector {
             }
             data.writtenFields.add(f);
 
-            boolean writtingNonNull = previousOpcode != Const.ACONST_NULL || previousPreviousOpcode == Const.GOTO;
+            boolean writtingNonNull;
+            if (item != null) {
+                writtingNonNull = !item.isNull();
+            } else {
+                writtingNonNull = previousOpcode != Const.ACONST_NULL || previousPreviousOpcode == Const.GOTO;
+            }
             if (writtingNonNull) {
                 data.writtenNonNullFields.add(f);
                 if (DEBUG) {

--- a/spotbugsTestCases/src/java/ghIssues/Issue4034.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue4034.java
@@ -1,0 +1,19 @@
+package ghIssues;
+
+import edu.umd.cs.findbugs.annotations.ExpectWarning;
+
+/**
+ * <a href="https://github.com/spotbugs/spotbugs/issues/4034">#4034</a>.
+ */
+public class Issue4034 {
+    @ExpectWarning("UWF_NULL_FIELD")
+    private String strVal = (String) null;
+
+    public int compute(int input) {
+        int result = 0;
+        if (strVal != null) {
+            result += strVal.length();
+        }
+        return result + input;
+    }
+}


### PR DESCRIPTION
## Summary
- Fix `UnreadFields` to determine null field writes from the stack value at `PUTFIELD`, not the previous opcode alone
- A redundant cast such as `(String) null` no longer incorrectly marks the field as written non-null
- Add regression test `Issue4034` for the reported scenario

## Test plan
- [x] `./gradlew :spotbugs-tests:test --tests "edu.umd.cs.findbugs.detect.Issue4034Test"`
- [x] `./gradlew :spotbugs-tests:test --tests "edu.umd.cs.findbugs.detect.UnreadFieldsTest"`
- [x] `./gradlew :spotbugs-tests:test --tests "edu.umd.cs.findbugs.DetectorsTest.testAllRegressionFilesJavac"`