### PR TITLE
Fix UMAC false positive for local class method references (#4055)

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue4055Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue4055Test.java
@@ -1,0 +1,15 @@
+package edu.umd.cs.findbugs.detect;
+
+import org.junit.jupiter.api.Test;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+
+class Issue4055Test extends AbstractIntegrationTest {
+
+    @Test
+    void testLocalClassMethodsReferencedByMethodHandlesAreCallable() {
+        performAnalysis("ghIssues/Issue4055.class", "ghIssues/Issue4055$1Accumulator.class");
+
+        assertNoBugType("UMAC_UNCALLABLE_METHOD_OF_ANONYMOUS_CLASS");
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/CalledMethods.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/CalledMethods.java
@@ -22,6 +22,10 @@ package edu.umd.cs.findbugs.detect;
 import java.util.HashSet;
 
 import org.apache.bcel.Const;
+import org.apache.bcel.classfile.Attribute;
+import org.apache.bcel.classfile.BootstrapMethods;
+import org.apache.bcel.classfile.ConstantInvokeDynamic;
+import org.apache.bcel.classfile.JavaClass;
 
 import edu.umd.cs.findbugs.BugReporter;
 import edu.umd.cs.findbugs.BytecodeScanningDetector;
@@ -31,6 +35,8 @@ import edu.umd.cs.findbugs.ba.XFactory;
 import edu.umd.cs.findbugs.ba.XField;
 import edu.umd.cs.findbugs.ba.ch.Subtypes2;
 import edu.umd.cs.findbugs.classfile.ClassDescriptor;
+import edu.umd.cs.findbugs.classfile.MethodDescriptor;
+import edu.umd.cs.findbugs.util.BootstrapMethodsUtil;
 
 /**
  * Detector to find private methods that are never called.
@@ -46,6 +52,22 @@ public class CalledMethods extends BytecodeScanningDetector implements NonReport
 
     public CalledMethods(BugReporter bugReporter) {
 
+    }
+
+    @Override
+    public void visitJavaClass(JavaClass obj) {
+        Subtypes2 subtypes2 = AnalysisContext.currentAnalysisContext().getSubtypes2();
+        for (Attribute attr : obj.getAttributes()) {
+            if (attr instanceof BootstrapMethods) {
+                for (MethodDescriptor md : BootstrapMethodsUtil.getCalledMethodsFromBootstrapMethods(
+                        (BootstrapMethods) attr, obj.getConstantPool())) {
+                    if (subtypes2.isApplicationClass(md.getClassDescriptor())) {
+                        xFactory.addCalledMethod(md);
+                    }
+                }
+            }
+        }
+        super.visitJavaClass(obj);
     }
 
     @Override
@@ -71,6 +93,22 @@ public class CalledMethods extends BytecodeScanningDetector implements NonReport
             }
         }
         switch (seen) {
+        case Const.INVOKEDYNAMIC:
+            if (getConstantRefOperand() instanceof ConstantInvokeDynamic) {
+                ConstantInvokeDynamic invokeDynamic = (ConstantInvokeDynamic) getConstantRefOperand();
+                for (Attribute attr : getThisClass().getAttributes()) {
+                    if (attr instanceof BootstrapMethods) {
+                        Subtypes2 subtypes2 = AnalysisContext.currentAnalysisContext().getSubtypes2();
+                        for (MethodDescriptor md : BootstrapMethodsUtil.getCalledMethodsFromBootstrap(
+                                (BootstrapMethods) attr, invokeDynamic.getBootstrapMethodAttrIndex(), getConstantPool())) {
+                            if (subtypes2.isApplicationClass(md.getClassDescriptor())) {
+                                xFactory.addCalledMethod(md);
+                            }
+                        }
+                    }
+                }
+            }
+            break;
         case Const.INVOKEVIRTUAL:
         case Const.INVOKESPECIAL:
         case Const.INVOKESTATIC:

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UncallableMethodOfAnonymousClass.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UncallableMethodOfAnonymousClass.java
@@ -25,6 +25,7 @@ import java.util.Set;
 
 import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Attribute;
+import org.apache.bcel.classfile.BootstrapMethods;
 import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.classfile.Method;
@@ -43,7 +44,9 @@ import edu.umd.cs.findbugs.classfile.CheckedAnalysisException;
 import edu.umd.cs.findbugs.classfile.ClassDescriptor;
 import edu.umd.cs.findbugs.classfile.DescriptorFactory;
 import edu.umd.cs.findbugs.classfile.Global;
+import edu.umd.cs.findbugs.classfile.MethodDescriptor;
 import edu.umd.cs.findbugs.internalAnnotations.DottedClassName;
+import edu.umd.cs.findbugs.util.BootstrapMethodsUtil;
 import edu.umd.cs.findbugs.util.ClassName;
 import edu.umd.cs.findbugs.util.EditDistance;
 import edu.umd.cs.findbugs.util.Values;
@@ -271,9 +274,8 @@ public class UncallableMethodOfAnonymousClass extends BytecodeScanningDetector {
 
             JavaClass clazz = getThisClass();
             XMethod xmethod = XFactory.createXMethod(clazz, obj);
-            XFactory factory = AnalysisContext.currentXFactory();
             String key = obj.getName() + ":" + obj.getSignature();
-            if (!factory.isCalled(xmethod) && (obj.isStatic() || !definedInSuperClassOrInterface(clazz, key))) {
+            if (!isMethodCalled(xmethod) && (obj.isStatic() || !definedInSuperClassOrInterface(clazz, key))) {
                 int priority = NORMAL_PRIORITY;
                 JavaClass superClass = clazz.getSuperClass();
                 String superClassName = superClass.getClassName();
@@ -304,6 +306,46 @@ public class UncallableMethodOfAnonymousClass extends BytecodeScanningDetector {
             bugReporter.reportMissingClass(e);
         }
 
+    }
+
+    private boolean isMethodCalled(XMethod xmethod) {
+        XFactory factory = AnalysisContext.currentXFactory();
+        if (factory.isCalled(xmethod)) {
+            return true;
+        }
+        return isReferencedFromEnclosingBootstrap(xmethod);
+    }
+
+    private boolean isReferencedFromEnclosingBootstrap(XMethod xmethod) {
+        MethodDescriptor target = xmethod.getMethodDescriptor();
+        for (String outerName = getImmediateEnclosingClassName(xmethod.getClassName()); outerName != null; outerName = getImmediateEnclosingClassName(
+                outerName)) {
+            try {
+                JavaClass outer = Global.getAnalysisCache().getClassAnalysis(JavaClass.class,
+                        DescriptorFactory.createClassDescriptorFromDottedClassName(outerName));
+                for (Attribute attr : outer.getAttributes()) {
+                    if (attr instanceof BootstrapMethods) {
+                        for (MethodDescriptor called : BootstrapMethodsUtil.getCalledMethodsFromBootstrapMethods(
+                                (BootstrapMethods) attr, outer.getConstantPool())) {
+                            if (called.equals(target)) {
+                                return true;
+                            }
+                        }
+                    }
+                }
+            } catch (CheckedAnalysisException e) {
+                return false;
+            }
+        }
+        return false;
+    }
+
+    private static String getImmediateEnclosingClassName(String className) {
+        int i = className.lastIndexOf('$');
+        if (i >= 0 && i + 1 < className.length() && Character.isDigit(className.charAt(i + 1))) {
+            return className.substring(0, i);
+        }
+        return null;
     }
 
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/util/BootstrapMethodsUtil.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/util/BootstrapMethodsUtil.java
@@ -18,13 +18,16 @@
 
 package edu.umd.cs.findbugs.util;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 import org.apache.bcel.classfile.BootstrapMethod;
 import org.apache.bcel.classfile.BootstrapMethods;
 import org.apache.bcel.classfile.Constant;
 import org.apache.bcel.classfile.ConstantCP;
+import org.apache.bcel.classfile.ConstantClass;
 import org.apache.bcel.classfile.ConstantInterfaceMethodref;
 import org.apache.bcel.classfile.ConstantMethodHandle;
 import org.apache.bcel.classfile.ConstantMethodref;
@@ -32,6 +35,9 @@ import org.apache.bcel.classfile.ConstantNameAndType;
 import org.apache.bcel.classfile.ConstantPool;
 import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.classfile.Method;
+
+import edu.umd.cs.findbugs.classfile.DescriptorFactory;
+import edu.umd.cs.findbugs.classfile.MethodDescriptor;
 
 /**
  * Utility methods for working with bootstrap methods
@@ -80,5 +86,50 @@ public class BootstrapMethodsUtil {
             return metOpt;
         }
         return Optional.empty();
+    }
+
+    /**
+     * Returns application methods referenced by method handles in a bootstrap method.
+     */
+    public static List<MethodDescriptor> getCalledMethodsFromBootstrap(BootstrapMethods bms, int index, ConstantPool cp) {
+        List<MethodDescriptor> result = new ArrayList<>();
+        BootstrapMethod bm = bms.getBootstrapMethods()[index];
+        for (int arg : bm.getBootstrapArguments()) {
+            MethodDescriptor called = getMethodDescriptorFromBootstrapArgument(bms, cp, arg);
+            if (called != null) {
+                result.add(called);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Returns all application methods referenced by method handles in a class bootstrap table.
+     */
+    public static List<MethodDescriptor> getCalledMethodsFromBootstrapMethods(BootstrapMethods bms, ConstantPool cp) {
+        List<MethodDescriptor> result = new ArrayList<>();
+        for (int i = 0; i < bms.getBootstrapMethods().length; i++) {
+            result.addAll(getCalledMethodsFromBootstrap(bms, i, cp));
+        }
+        return result;
+    }
+
+    private static MethodDescriptor getMethodDescriptorFromBootstrapArgument(BootstrapMethods bms, ConstantPool cp,
+            int arg) {
+        Constant c = bms.getConstantPool().getConstant(arg);
+        if (!(c instanceof ConstantMethodHandle)) {
+            return null;
+        }
+        ConstantMethodHandle cmh = (ConstantMethodHandle) c;
+        c = cp.getConstant(cmh.getReferenceIndex());
+        if (!(c instanceof ConstantMethodref) && !(c instanceof ConstantInterfaceMethodref)) {
+            return null;
+        }
+        ConstantCP ccp = (ConstantCP) c;
+        ConstantClass cc = (ConstantClass) cp.getConstant(ccp.getClassIndex());
+        String className = cc.getBytes(cp);
+        ConstantNameAndType cnat = (ConstantNameAndType) cp.getConstant(ccp.getNameAndTypeIndex());
+        boolean isStatic = cmh.getReferenceKind() == org.apache.bcel.Const.REF_invokeStatic;
+        return DescriptorFactory.instance().getMethodDescriptor(className, cnat.getName(cp), cnat.getSignature(cp), isStatic);
     }
 }

--- a/spotbugsTestCases/src/java/ghIssues/Issue4055.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue4055.java
@@ -1,0 +1,33 @@
+package ghIssues;
+
+import java.util.stream.Collector;
+import java.util.stream.Stream;
+
+/**
+ * <a href="https://github.com/spotbugs/spotbugs/issues/4055">#4055</a>.
+ */
+public class Issue4055 {
+    public static <IN extends String> Collector<IN, ?, String> concatenating() {
+        class Accumulator {
+            final StringBuilder sb = new StringBuilder();
+
+            void accumulate(IN s) {
+                sb.append(s);
+            }
+
+            Accumulator combine(Accumulator other) {
+                sb.append(other.sb);
+                return this;
+            }
+
+            String finish() {
+                return sb.toString();
+            }
+        }
+        return Collector.of(Accumulator::new, Accumulator::accumulate, Accumulator::combine, Accumulator::finish);
+    }
+
+    public static void useConcatenating() {
+        Stream.of("a", "b", "c").collect(concatenating());
+    }
+}


### PR DESCRIPTION
## Summary
- Parse bootstrap `MethodHandle` targets in `CalledMethods` so method references used by `Collector.of` mark inner class methods as called
- Fall back to enclosing-class bootstrap tables in `UncallableMethodOfAnonymousClass` when visit order analyzes the inner class first
- Add regression test for generic local class methods referenced via invokedynamic method handles

## Test plan
- [x] `./gradlew :spotbugs-tests:test --tests "edu.umd.cs.findbugs.detect.Issue4055Test"`
- [x] `./gradlew :spotbugs-tests:test --tests "edu.umd.cs.findbugs.detect.Issue2120Test"`
- [x] `./gradlew :spotbugs-tests:test --tests "edu.umd.cs.findbugs.detect.RegressionIdeas20111118Test"`
- [x] `./gradlew :spotbugs-tests:test --tests "edu.umd.cs.findbugs.DetectorsTest.testAllRegressionFilesJavac"`