### PR TITLE
fix: treat vacuous instanceof as null check in NP analysis (#3916)

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/nullness/Issue3916Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/nullness/Issue3916Test.java
@@ -1,0 +1,18 @@
+package edu.umd.cs.findbugs.nullness;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test to reproduce <a href="https://github.com/spotbugs/spotbugs/issues/3916">#3916</a>.
+ */
+class Issue3916Test extends AbstractIntegrationTest {
+
+    @Test
+    void testRedundantInstanceofIsNullCheck() {
+        performAnalysis("ghIssues/Issue3916.class");
+
+        assertBugInMethod("NP_ALWAYS_NULL", "ghIssues.Issue3916", "foo1");
+        assertBugInMethod("NP_ALWAYS_NULL", "ghIssues.Issue3916", "foo2");
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/IsNullValueAnalysis.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/npe/IsNullValueAnalysis.java
@@ -30,10 +30,12 @@ import org.apache.bcel.generic.ALOAD;
 import org.apache.bcel.generic.ATHROW;
 import org.apache.bcel.generic.CodeExceptionGen;
 import org.apache.bcel.generic.IF_ACMPNE;
+import org.apache.bcel.generic.INSTANCEOF;
 import org.apache.bcel.generic.Instruction;
 import org.apache.bcel.generic.InstructionHandle;
 import org.apache.bcel.generic.MethodGen;
 import org.apache.bcel.generic.ObjectType;
+import org.apache.bcel.generic.ReferenceType;
 import org.apache.bcel.generic.Type;
 
 import edu.umd.cs.findbugs.SystemProperties;
@@ -47,6 +49,7 @@ import edu.umd.cs.findbugs.ba.DepthFirstSearch;
 import edu.umd.cs.findbugs.ba.Edge;
 import edu.umd.cs.findbugs.ba.EdgeTypes;
 import edu.umd.cs.findbugs.ba.FrameDataflowAnalysis;
+import edu.umd.cs.findbugs.ba.Hierarchy;
 import edu.umd.cs.findbugs.ba.INullnessAnnotationDatabase;
 import edu.umd.cs.findbugs.ba.JavaClassAndMethod;
 import edu.umd.cs.findbugs.ba.Location;
@@ -56,6 +59,7 @@ import edu.umd.cs.findbugs.ba.XFactory;
 import edu.umd.cs.findbugs.ba.XMethod;
 import edu.umd.cs.findbugs.ba.XMethodParameter;
 import edu.umd.cs.findbugs.ba.type.TypeDataflow;
+import edu.umd.cs.findbugs.ba.type.TypeFrame;
 import edu.umd.cs.findbugs.ba.vna.AvailableLoad;
 import edu.umd.cs.findbugs.ba.vna.ValueNumber;
 import edu.umd.cs.findbugs.ba.vna.ValueNumberDataflow;
@@ -86,6 +90,8 @@ public class IsNullValueAnalysis extends FrameDataflowAnalysis<IsNullValue, IsNu
 
     private final ValueNumberDataflow vnaDataflow;
 
+    private final TypeDataflow typeDataflow;
+
     private final CFG cfg;
 
     private final Set<LocationWhereValueBecomesNull> locationWhereValueBecomesNullSet;
@@ -113,6 +119,7 @@ public class IsNullValueAnalysis extends FrameDataflowAnalysis<IsNullValue, IsNu
         this.visitor = new IsNullValueFrameModelingVisitor(methodGen.getConstantPool(), assertionMethods, vnaDataflow,
                 typeDataflow, trackValueNumbers);
         this.vnaDataflow = vnaDataflow;
+        this.typeDataflow = typeDataflow;
         this.cfg = cfg;
         this.locationWhereValueBecomesNullSet = new HashSet<>();
         this.pointerEqualityCheck = getForPointerEqualityCheck(cfg, vnaDataflow);
@@ -632,6 +639,39 @@ public class IsNullValueAnalysis extends FrameDataflowAnalysis<IsNullValue, IsNu
     }
 
     /**
+     * Return true if the instanceof check is vacuous for non-null values of the static type
+     * (e.g. {@code String s; s instanceof String}), so the branch outcome is equivalent to a null check.
+     */
+    private boolean isInstanceOfEquivalentToNullCheck(InstructionHandle instanceOfHandle, BasicBlock basicBlock) {
+        Instruction ins = instanceOfHandle.getInstruction();
+        if (!(ins instanceof INSTANCEOF)) {
+            return false;
+        }
+        INSTANCEOF instanceOf = (INSTANCEOF) ins;
+        Type checkType = instanceOf.getType(methodGen.getConstantPool());
+        if (!(checkType instanceof ReferenceType)) {
+            return false;
+        }
+        Location atInstanceOf = new Location(instanceOfHandle, basicBlock);
+        try {
+            TypeFrame typeFrame = typeDataflow.getFactAtLocation(atInstanceOf);
+            if (!typeFrame.isValid() || typeFrame.getStackDepth() < 1) {
+                return false;
+            }
+            Type stackType = typeFrame.getStackValue(typeFrame.getStackDepth() - 1);
+            if (!(stackType instanceof ReferenceType)) {
+                return false;
+            }
+            return Hierarchy.isSubtype((ReferenceType) stackType, (ReferenceType) checkType);
+        } catch (ClassNotFoundException e) {
+            AnalysisContext.currentAnalysisContext().getLookupFailureCallback().reportMissingClass(e);
+            return false;
+        } catch (DataflowAnalysisException e) {
+            return false;
+        }
+    }
+
+    /**
      * Determine if the given basic block ends in a redundant null comparison.
      *
      * @param basicBlock
@@ -688,6 +728,14 @@ public class IsNullValueAnalysis extends FrameDataflowAnalysis<IsNullValue, IsNu
                 }
             } else if (tos.isDefinitelyNotNull()) {
                 return null;
+            } else if (isInstanceOfEquivalentToNullCheck(prev, basicBlock)) {
+                if (isNotInstanceOf) {
+                    ifcmpDecision = IsNullValue.pathSensitiveNullValue();
+                    fallThroughDecision = IsNullValue.pathSensitiveNonNullValue();
+                } else {
+                    ifcmpDecision = IsNullValue.pathSensitiveNonNullValue();
+                    fallThroughDecision = IsNullValue.pathSensitiveNullValue();
+                }
             } else {
                 // As far as we know, both branches feasible
                 ifcmpDecision = isNotInstanceOf ? tos : IsNullValue.pathSensitiveNonNullValue();

--- a/spotbugsTestCases/src/java/ghIssues/Issue3916.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3916.java
@@ -1,0 +1,24 @@
+package ghIssues;
+
+import edu.umd.cs.findbugs.annotations.ExpectWarning;
+
+/**
+ * <a href="https://github.com/spotbugs/spotbugs/issues/3916">#3916</a>.
+ */
+public class Issue3916 {
+    @ExpectWarning("NP")
+    private void foo1(String s1) {
+        if (s1 != null) {
+            return;
+        }
+        String str = s1.toString();
+    }
+
+    @ExpectWarning("NP")
+    private void foo2(String s2) {
+        if (s2 instanceof String) {
+            return;
+        }
+        String str = s2.toString();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #3916.

When a value's static type is a subtype of the `instanceof` target (e.g. `String s; s instanceof String`), the check is vacuous for non-null values and equivalent to `s != null`. `IsNullValueAnalysis` previously treated the compared value as unknown in this case, so NP was not reported on the fall-through (null) path.

This change detects vacuous `instanceof` via type dataflow + `Hierarchy.isSubtype`, and models branch nullness the same way as an explicit null comparison.

## Test plan

- [x] Added `Issue3916.java` with explicit null check (`foo1`) and redundant instanceof (`foo2`)
- [x] Added `Issue3916Test` — both methods report `NP_ALWAYS_NULL`
- [x] `DetectorsTest` passes (`@ExpectWarning("NP")`)
- [x] All `edu.umd.cs.findbugs.nullness.*` tests pass