### PR TITLE
fix: report RV when Arrays.copyOf return value is ignored (#3900)

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3900Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3900Test.java
@@ -1,0 +1,17 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test to reproduce <a href="https://github.com/spotbugs/spotbugs/issues/3900">#3900</a>.
+ */
+class Issue3900Test extends AbstractIntegrationTest {
+
+    @Test
+    void testIgnoredArraysCopyOfReturnValue() {
+        performAnalysis("ghIssues/Issue3900.class");
+
+        assertBugInMethod("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT", "ghIssues.Issue3900", "ignoredCopyOf");
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNoSideEffectMethods.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNoSideEffectMethods.java
@@ -140,6 +140,18 @@ public class FindNoSideEffectMethods extends OpcodeStackDetector implements NonR
             new MethodDescriptor("java/util/logging/LogManager", "getLogger", "(Ljava/lang/String;)Ljava/util/logging/Logger;", true),
             new MethodDescriptor("org/apache/log4j/LogManager", "getLogger", "(Ljava/lang/String;)Lorg/apache/log4j/Logger;", true));
 
+    private static final Set<MethodDescriptor> ARRAYS_COPYOF_METHODS = Set.of(
+            new MethodDescriptor("java/util/Arrays", "copyOf", "([Ljava/lang/Object;I)[Ljava/lang/Object;", true),
+            new MethodDescriptor("java/util/Arrays", "copyOf", "([Ljava/lang/Object;ILjava/lang/Class;)[Ljava/lang/Object;", true),
+            new MethodDescriptor("java/util/Arrays", "copyOf", "([ZI)[Z", true),
+            new MethodDescriptor("java/util/Arrays", "copyOf", "([BI)[B", true),
+            new MethodDescriptor("java/util/Arrays", "copyOf", "([CI)[C", true),
+            new MethodDescriptor("java/util/Arrays", "copyOf", "([DI)[D", true),
+            new MethodDescriptor("java/util/Arrays", "copyOf", "([FI)[F", true),
+            new MethodDescriptor("java/util/Arrays", "copyOf", "([II)[I", true),
+            new MethodDescriptor("java/util/Arrays", "copyOf", "([JI)[J", true),
+            new MethodDescriptor("java/util/Arrays", "copyOf", "([SI)[S", true));
+
     private static final Set<MethodDescriptor> NEW_OBJECT_RETURNING_METHODS = Set.of(
             new MethodDescriptor("java/util/Vector", "elements", "()Ljava/util/Enumeration;"),
             new MethodDescriptor("java/util/Hashtable", "elements", "()Ljava/util/Enumeration;"),
@@ -303,6 +315,9 @@ public class FindNoSideEffectMethods extends OpcodeStackDetector implements NonR
 
     public FindNoSideEffectMethods(BugReporter bugReporter) {
         Global.getAnalysisCache().eagerlyPutDatabase(NoSideEffectMethodsDatabase.class, noSideEffectMethods);
+        for (MethodDescriptor m : ARRAYS_COPYOF_METHODS) {
+            noSideEffectMethods.add(m, MethodSideEffectStatus.NSE);
+        }
     }
 
     @Override
@@ -728,6 +743,14 @@ public class FindNoSideEffectMethods extends OpcodeStackDetector implements NonR
 
     /**
      * @param m method to check
+     * @return true if the method is a known JDK/library method with no side effects
+     */
+    public static boolean isKnownNoSideEffectMethod(MethodDescriptor m) {
+        return hasNoSideEffect(m);
+    }
+
+    /**
+     * @param m method to check
      * @return true if given method is known to have no side effects
      */
     private static boolean hasNoSideEffect(MethodDescriptor m) {
@@ -776,6 +799,7 @@ public class FindNoSideEffectMethods extends OpcodeStackDetector implements NonR
             }
         }
         if ((methodName.equals("binarySearch") && (className.equals("java/util/Arrays") || className.equals("java/util/Collections")))
+                || ("java/util/Arrays".equals(className) && methodName.equals("copyOf"))
                 || methodName.startsWith("$SWITCH_TABLE$")
                 || (methodName.equals(Const.CONSTRUCTOR_NAME) && isObjectOnlyClass(className))
                 || (methodName.equals("toString") && methodSig.equals("()Ljava/lang/String;") && className.startsWith("java/"))) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MethodReturnCheck.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MethodReturnCheck.java
@@ -275,7 +275,8 @@ public class MethodReturnCheck extends OpcodeStackDetector implements UseAnnotat
                 if (noSideEffectMethods.excluded(callSeen.getMethodDescriptor())) {
                     sawExcludedNSECall = true;
                 }
-                if (noSideEffectMethods.hasNoSideEffect(callSeen.getMethodDescriptor())) {
+                if (noSideEffectMethods.hasNoSideEffect(callSeen.getMethodDescriptor())
+                        || FindNoSideEffectMethods.isKnownNoSideEffectMethod(callSeen.getMethodDescriptor())) {
                     int priority = NORMAL_PRIORITY;
                     Type callReturnType = Type.getReturnType(callSeen.getMethodDescriptor().getSignature());
                     Type methodReturnType = Type.getReturnType(getMethodSig());

--- a/spotbugsTestCases/src/java/ghIssues/Issue3900.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3900.java
@@ -1,0 +1,16 @@
+package ghIssues;
+
+import java.util.Arrays;
+
+import edu.umd.cs.findbugs.annotations.ExpectWarning;
+
+/**
+ * <a href="https://github.com/spotbugs/spotbugs/issues/3900">#3900</a>.
+ */
+public class Issue3900 {
+    @ExpectWarning("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
+    public void ignoredCopyOf() {
+        int[] arr = {1, 2, 3};
+        Arrays.copyOf(arr, 10);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #3900.

`Arrays.copyOf` has no side effects and returns a new array; ignoring its return value should trigger `RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT`.

Changes:
- Register all `Arrays.copyOf` overloads in the no-side-effect methods database at startup
- Treat `Arrays.copyOf` as a known no-side-effect method in `FindNoSideEffectMethods.hasNoSideEffect`
- Fall back to `isKnownNoSideEffectMethod()` in `MethodReturnCheck` when the database has no entry for JDK methods (e.g. when the `MethodDescriptor` key differs from analyzed project methods)

## Test plan

- [x] Added `Issue3900.java` + `Issue3900Test`
- [x] `DetectorsTest` passes (`@ExpectWarning("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")`)
- [x] `Feature318` regression test passes