### PR TITLE
fix: skip THROWS warning when rethrowing caught RuntimeException (#3918)

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2040Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2040Test.java
@@ -14,7 +14,7 @@ class Issue2040Test extends AbstractIntegrationTest {
                 "ghIssues/issue2040/Generic.class",
                 "ghIssues/issue2040/Caller.class");
 
-        assertBugTypeCount("THROWS_METHOD_THROWS_RUNTIMEEXCEPTION", 3);
+        assertBugTypeCount("THROWS_METHOD_THROWS_RUNTIMEEXCEPTION", 2);
         String runtimeExceptionLambdaName;
         if (Runtime.version().feature() >= 24) {
             // The enumeration of lambdas changed slightly in Java 24, it appears to now count per-method rather than per-class.
@@ -31,7 +31,6 @@ class Issue2040Test extends AbstractIntegrationTest {
             runtimeExceptionLambdaName = "lambda$lambda2$1";
         }
         assertBugInMethodAtLine("THROWS_METHOD_THROWS_RUNTIMEEXCEPTION", "Derived", runtimeExceptionLambdaName, 36);
-        assertBugInMethodAtLine("THROWS_METHOD_THROWS_RUNTIMEEXCEPTION", "Derived", "runtimeExThrownFromCatch", 97);
         assertBugInMethodAtLine("THROWS_METHOD_THROWS_RUNTIMEEXCEPTION", "Derived", "runtimeExceptionThrowingMethod", 45);
 
         assertBugTypeCount("THROWS_METHOD_THROWS_CLAUSE_THROWABLE", 4);

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3918Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3918Test.java
@@ -1,0 +1,19 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test to reproduce <a href="https://github.com/spotbugs/spotbugs/issues/3918">#3918</a>.
+ */
+class Issue3918Test extends AbstractIntegrationTest {
+
+    @Test
+    void testRethrowOfCaughtRuntimeExceptionIsNotReported() {
+        performAnalysis("ghIssues/Issue3918.class");
+
+        assertNoBugInMethod("THROWS_METHOD_THROWS_RUNTIMEEXCEPTION", "ghIssues.Issue3918", "rethrowFromCatch");
+        assertNoBugInMethod("THROWS_METHOD_THROWS_RUNTIMEEXCEPTION", "ghIssues.Issue3918", "<init>");
+        assertBugInMethod("THROWS_METHOD_THROWS_RUNTIMEEXCEPTION", "ghIssues.Issue3918", "throwNewRuntimeException");
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ThrowingExceptions.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ThrowingExceptions.java
@@ -7,6 +7,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.ba.AnalysisContext;
 import edu.umd.cs.findbugs.ba.generic.GenericSignatureParser;
 import edu.umd.cs.findbugs.ba.XMethod;
+import edu.umd.cs.findbugs.ba.ch.Subtypes2;
 import edu.umd.cs.findbugs.bcel.OpcodeStackDetector;
 import edu.umd.cs.findbugs.internalAnnotations.DottedClassName;
 
@@ -18,6 +19,7 @@ import edu.umd.cs.findbugs.util.ClassName;
 import edu.umd.cs.findbugs.util.Values;
 import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
+import org.apache.bcel.classfile.CodeException;
 import org.apache.bcel.classfile.ExceptionTable;
 import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.classfile.Method;
@@ -92,7 +94,8 @@ public class ThrowingExceptions extends OpcodeStackDetector {
     public void sawOpcode(int seen) {
         if (seen == Const.ATHROW) {
             OpcodeStack.Item item = stack.getStackItem(0);
-            if (item != null && "Ljava/lang/RuntimeException;".equals(item.getSignature())) {
+            if (item != null && "Ljava/lang/RuntimeException;".equals(item.getSignature())
+                    && !isRethrowOfCaughtRuntimeException(item)) {
                 bugReporter.reportBug(new BugInstance(this, "THROWS_METHOD_THROWS_RUNTIMEEXCEPTION", LOW_PRIORITY)
                         .addClass(this)
                         .addMethod(getXMethod())
@@ -117,6 +120,45 @@ public class ThrowingExceptions extends OpcodeStackDetector {
             }
 
         }
+    }
+
+    private boolean isRethrowOfCaughtRuntimeException(OpcodeStack.Item thrownItem) {
+        int register = thrownItem.getRegisterNumber();
+        if (register < 0) {
+            return false;
+        }
+        Code code = getCode();
+        if (code == null) {
+            return false;
+        }
+        byte[] codeBytes = code.getCode();
+        for (CodeException handler : code.getExceptionTable()) {
+            if (getLocalVariableIndex(codeBytes, handler.getHandlerPC()) != register) {
+                continue;
+            }
+            if (handler.getCatchType() == 0) {
+                return true;
+            }
+            String catchType = getConstantPool().constantToString(getConstantPool().getConstant(handler.getCatchType()));
+            if (Subtypes2.instanceOf(ClassName.toDottedClassName(catchType), Values.DOTTED_JAVA_LANG_RUNTIMEEXCEPTION)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static int getLocalVariableIndex(byte[] codeBytes, int pc) {
+        if (pc < 0 || pc >= codeBytes.length) {
+            return -1;
+        }
+        int opcode = codeBytes[pc] & 0xff;
+        if (opcode >= Const.ASTORE_0 && opcode <= Const.ASTORE_3) {
+            return opcode - Const.ASTORE_0;
+        }
+        if (opcode == Const.ASTORE && pc + 1 < codeBytes.length) {
+            return codeBytes[pc + 1] & 0xff;
+        }
+        return -1;
     }
 
     private void reportBug(String bugName, XMethod method) {

--- a/spotbugsTestCases/src/java/ghIssues/Issue3918.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3918.java
@@ -1,0 +1,39 @@
+package ghIssues;
+
+import edu.umd.cs.findbugs.annotations.ExpectWarning;
+import edu.umd.cs.findbugs.annotations.NoWarning;
+
+/**
+ * <a href="https://github.com/spotbugs/spotbugs/issues/3918">#3918</a>.
+ */
+public class Issue3918 {
+    @NoWarning("THROWS_METHOD_THROWS_RUNTIMEEXCEPTION")
+    public void rethrowFromCatch() {
+        try {
+            doSomething();
+        } catch (RuntimeException ex) {
+            ++errorCount;
+            throw ex;
+        }
+    }
+
+    @NoWarning("THROWS_METHOD_THROWS_RUNTIMEEXCEPTION")
+    public Issue3918() {
+        try {
+            doSomething();
+        } catch (RuntimeException ex) {
+            throw ex;
+        }
+    }
+
+    @ExpectWarning("THROWS_METHOD_THROWS_RUNTIMEEXCEPTION")
+    public void throwNewRuntimeException() {
+        throw new RuntimeException();
+    }
+
+    private int errorCount;
+
+    private void doSomething() {
+        throw new RuntimeException();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #3918.

`THROWS_METHOD_THROWS_RUNTIMEEXCEPTION` was reported for `throw ex` inside a `catch (RuntimeException ex)` block, even though the method does not newly introduce a runtime exception— it only rethrows what was already caught.

The fix matches exception-handler `ASTORE` registers against the local variable being thrown, and suppresses the warning when the caught type is `RuntimeException` (or a subtype).

## Test plan

- [x] Added `Issue3918.java` with rethrow-in-catch and constructor cases (`@NoWarning`) plus a control case that still reports (`throwNewRuntimeException`)
- [x] Added `Issue3918Test`
- [x] Updated `Issue2040Test` — `runtimeExThrownFromCatch` no longer expected to report
- [x] `ThrowingExceptionsTest`, `DetectorsTest` pass