### PR TITLE
fix: skip THROWS when throwing RuntimeException from helper (#3919)

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3919Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3919Test.java
@@ -1,0 +1,19 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test to reproduce <a href="https://github.com/spotbugs/spotbugs/issues/3919">#3919</a>.
+ */
+class Issue3919Test extends AbstractIntegrationTest {
+
+    @Test
+    void testRuntimeExceptionFromMethodReturnValueIsNotReported() {
+        performAnalysis("ghIssues/Issue3919.class");
+
+        assertNoBugInMethod("THROWS_METHOD_THROWS_RUNTIMEEXCEPTION", "ghIssues.Issue3919", "throwViaHelper");
+        assertNoBugInMethod("THROWS_METHOD_THROWS_RUNTIMEEXCEPTION", "ghIssues.Issue3919", "throwInlineSubtypes");
+        assertBugInMethod("THROWS_METHOD_THROWS_RUNTIMEEXCEPTION", "ghIssues.Issue3919", "throwDirectRuntimeException");
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ThrowingExceptions.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ThrowingExceptions.java
@@ -92,7 +92,8 @@ public class ThrowingExceptions extends OpcodeStackDetector {
     public void sawOpcode(int seen) {
         if (seen == Const.ATHROW) {
             OpcodeStack.Item item = stack.getStackItem(0);
-            if (item != null && "Ljava/lang/RuntimeException;".equals(item.getSignature())) {
+            if (item != null && "Ljava/lang/RuntimeException;".equals(item.getSignature())
+                    && !isReturnValueOfNonConstructorMethod(item)) {
                 bugReporter.reportBug(new BugInstance(this, "THROWS_METHOD_THROWS_RUNTIMEEXCEPTION", LOW_PRIORITY)
                         .addClass(this)
                         .addMethod(getXMethod())
@@ -117,6 +118,11 @@ public class ThrowingExceptions extends OpcodeStackDetector {
             }
 
         }
+    }
+
+    private boolean isReturnValueOfNonConstructorMethod(OpcodeStack.Item thrownItem) {
+        XMethod returnMethod = thrownItem.getReturnValueOf();
+        return returnMethod != null && !Const.CONSTRUCTOR_NAME.equals(returnMethod.getName());
     }
 
     private void reportBug(String bugName, XMethod method) {

--- a/spotbugsTestCases/src/java/ghIssues/Issue3919.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3919.java
@@ -1,0 +1,67 @@
+package ghIssues;
+
+import edu.umd.cs.findbugs.annotations.ExpectWarning;
+import edu.umd.cs.findbugs.annotations.NoWarning;
+
+/**
+ * <a href="https://github.com/spotbugs/spotbugs/issues/3919">#3919</a>.
+ */
+public class Issue3919 {
+    static class RuntimeExceptionTypeA extends RuntimeException {
+        RuntimeExceptionTypeA(Throwable cause) {
+            super(cause);
+        }
+    }
+
+    static class RuntimeExceptionTypeB extends RuntimeException {
+        RuntimeExceptionTypeB(Throwable cause) {
+            super(cause);
+        }
+    }
+
+    static class SpecificCheckedException extends Exception {
+        SpecificCheckedException() {
+            super();
+        }
+    }
+
+    private boolean someSpecificState;
+
+    @NoWarning("THROWS_METHOD_THROWS_RUNTIMEEXCEPTION")
+    public void throwViaHelper() {
+        try {
+            doSomething();
+        } catch (SpecificCheckedException ex) {
+            throw mapException(ex);
+        }
+    }
+
+    @NoWarning("THROWS_METHOD_THROWS_RUNTIMEEXCEPTION")
+    public void throwInlineSubtypes() {
+        try {
+            doSomething();
+        } catch (SpecificCheckedException ex) {
+            if (someSpecificState) {
+                throw new RuntimeExceptionTypeA(ex);
+            } else {
+                throw new RuntimeExceptionTypeB(ex);
+            }
+        }
+    }
+
+    @ExpectWarning("THROWS_METHOD_THROWS_RUNTIMEEXCEPTION")
+    public void throwDirectRuntimeException() {
+        throw new RuntimeException();
+    }
+
+    private void doSomething() throws SpecificCheckedException {
+        throw new SpecificCheckedException();
+    }
+
+    private RuntimeException mapException(Exception ex) {
+        if (someSpecificState) {
+            return new RuntimeExceptionTypeA(ex);
+        }
+        return new RuntimeExceptionTypeB(ex);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #3919.

`THROWS_METHOD_THROWS_RUNTIMEEXCEPTION` was reported for `throw mapException(ex)` when `mapException` returns `RuntimeException`, even though the method throws specific runtime subtypes declared in its `throws` clause — the same as inline `throw new RuntimeExceptionTypeA(ex)`.

The detector now skips ATHROW when the thrown value is the return value of a **non-constructor** method call. Direct `throw new RuntimeException(...)` still reports, because constructor completion is tracked via `<init>` on the stack item.

## Test plan

- [x] Added `Issue3919.java` with helper throw (`@NoWarning`), inline subtypes (`@NoWarning`), and direct `new RuntimeException()` (`@ExpectWarning`)
- [x] Added `Issue3919Test`
- [x] `ThrowingExceptionsTest`, `DetectorsTest` pass

**Note:** Complements #4087 (catch rethrow); both touch `ThrowingExceptions.sawOpcode` and may need a trivial merge.