### PR TITLE
fix: report NP_BOOLEAN_RETURN_NULL when null is returned via local (#4037)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - New detector `FindIncreasedAccessibilityOfMethods` for new bug type `IAOM_DO_NOT_INCREASE_METHOD_ACCESSIBILITY`. This detector reports a bug if a class increases the accessibility of overridden or hidden methods. (See [SEI CERT rule MET04-J](https://wiki.sei.cmu.edu/confluence/display/java/MET04-J.+Do+not+increase+the+accessibility+of+overridden+or+hidden+methods))
 
 ### Fixed
+- Fix `NP_BOOLEAN_RETURN_NULL` false negative when null is returned via a local variable ([#4037](https://github.com/spotbugs/spotbugs/issues/4037))
 - Fix `DM_STRING_TOSTRING` false negative when `toString()` is chained before a method call (e.g., `s.toString().toLowerCase()`); multiple occurrences in the same method are now all reported ([#3966](https://github.com/spotbugs/spotbugs/issues/3966))
 - Stop exposing JUnit BOM as a transitive dependency to consumers ([#3908](https://github.com/spotbugs/spotbugs/issues/3908))
 - Fix incorrect bug counts and sizes when unioning reports ([#3721](https://github.com/spotbugs/spotbugs/issues/3721))

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue4037Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue4037Test.java
@@ -1,0 +1,17 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class Issue4037Test extends AbstractIntegrationTest {
+
+    @Test
+    void testBooleanReturnNullViaLocalVariable() {
+        performAnalysis("ghIssues/Issue4037.class");
+
+        assertBugInMethod("NP_BOOLEAN_RETURN_NULL", "ghIssues.Issue4037", "isValidDirect");
+        assertBugInMethod("NP_BOOLEAN_RETURN_NULL", "ghIssues.Issue4037", "isValidIndirect");
+        assertBugInMethod("NP_BOOLEAN_RETURN_NULL", "ghIssues.Issue4037", "checkStatus");
+        assertNoBugInMethod("NP_BOOLEAN_RETURN_NULL", "ghIssues.Issue4037", "neverNull");
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/TypeReturnNull.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/TypeReturnNull.java
@@ -24,6 +24,7 @@ import org.apache.bcel.classfile.Code;
 
 import edu.umd.cs.findbugs.BugAccumulator;
 import edu.umd.cs.findbugs.BugReporter;
+import edu.umd.cs.findbugs.OpcodeStack;
 import edu.umd.cs.findbugs.ba.AnalysisContext;
 import edu.umd.cs.findbugs.ba.INullnessAnnotationDatabase;
 import edu.umd.cs.findbugs.ba.NullnessAnnotation;
@@ -73,8 +74,11 @@ public abstract class TypeReturnNull extends OpcodeStackDetector {
 
     @Override
     public void sawOpcode(int seen) {
-        if (seen == Const.ARETURN && getPrevOpcode(1) == Const.ACONST_NULL) {
-            accumulateBug();
+        if (seen == Const.ARETURN) {
+            OpcodeStack.Item returnValue = stack.getStackItem(0);
+            if (getPrevOpcode(1) == Const.ACONST_NULL || returnValue.isNull()) {
+                accumulateBug();
+            }
         }
     }
 

--- a/spotbugsTestCases/src/java/ghIssues/Issue4037.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue4037.java
@@ -1,0 +1,41 @@
+package ghIssues;
+
+import edu.umd.cs.findbugs.annotations.ExpectWarning;
+import edu.umd.cs.findbugs.annotations.NoWarning;
+
+/**
+ * <a href="https://github.com/spotbugs/spotbugs/issues/4037">#4037</a>.
+ */
+public class Issue4037 {
+
+    @ExpectWarning("NP_BOOLEAN_RETURN_NULL")
+    public Boolean isValidDirect(String input) {
+        if (input == null) {
+            return null;
+        }
+        return Boolean.TRUE;
+    }
+
+    @ExpectWarning("NP_BOOLEAN_RETURN_NULL")
+    public Boolean isValidIndirect(String input) {
+        if (input == null) {
+            Boolean result = null;
+            return result;
+        }
+        return Boolean.TRUE;
+    }
+
+    @ExpectWarning("NP_BOOLEAN_RETURN_NULL")
+    public Boolean checkStatus(int code) {
+        if (code < 0) {
+            Boolean result = null;
+            return result;
+        }
+        return code == 0 ? Boolean.TRUE : Boolean.FALSE;
+    }
+
+    @NoWarning("NP_BOOLEAN_RETURN_NULL")
+    public Boolean neverNull(int code) {
+        return code == 0 ? Boolean.TRUE : Boolean.FALSE;
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #4037.

`TypeReturnNull` only flagged `return null;` (direct `ACONST_NULL` before `ARETURN`). When null is stored in a local variable first (`Boolean result = null; return result;`), the detector missed it.

The fix also checks whether the value on the stack at `ARETURN` is known null via opcode stack analysis (`returnValue.isNull()`). This applies to `NP_BOOLEAN_RETURN_NULL` and `NP_OPTIONAL_RETURN_NULL` (both extend `TypeReturnNull`).

## Test plan

- [x] Added `Issue4037.java` with direct return, indirect return via local, and ternary-style method
- [x] Added `Issue4037Test`
- [x] `RegressionIdeas20111219Test`, `Bug3277814Test`, `Bug3107916Test` pass