### PR TITLE
fix: report NS_NON_SHORT_CIRCUIT when one operand is a boolean constant (#3976)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - New detector `FindIncreasedAccessibilityOfMethods` for new bug type `IAOM_DO_NOT_INCREASE_METHOD_ACCESSIBILITY`. This detector reports a bug if a class increases the accessibility of overridden or hidden methods. (See [SEI CERT rule MET04-J](https://wiki.sei.cmu.edu/confluence/display/java/MET04-J.+Do+not+increase+the+accessibility+of+overridden+or+hidden+methods))
 
 ### Fixed
+- Fix `NS_NON_SHORT_CIRCUIT` false negative when one operand of `|`/`&` is a compile-time boolean constant ([#3976](https://github.com/spotbugs/spotbugs/issues/3976))
 - Fix `DM_STRING_TOSTRING` false negative when `toString()` is chained before a method call (e.g., `s.toString().toLowerCase()`); multiple occurrences in the same method are now all reported ([#3966](https://github.com/spotbugs/spotbugs/issues/3966))
 - Stop exposing JUnit BOM as a transitive dependency to consumers ([#3908](https://github.com/spotbugs/spotbugs/issues/3908))
 - Fix incorrect bug counts and sizes when unioning reports ([#3721](https://github.com/spotbugs/spotbugs/issues/3721))

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3976Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3976Test.java
@@ -1,0 +1,18 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class Issue3976Test extends AbstractIntegrationTest {
+
+    @Test
+    void testNonShortCircuitWithConstantLeftOperand() {
+        performAnalysis("ghIssues/Issue3976.class");
+
+        assertBugInMethod("NS_NON_SHORT_CIRCUIT", "ghIssues.Issue3976", "testTruePositive");
+        assertBugInMethod("NS_NON_SHORT_CIRCUIT", "ghIssues.Issue3976", "testFalseNegative");
+        assertBugInMethod("NS_NON_SHORT_CIRCUIT", "ghIssues.Issue3976", "testConstantFalseAnd");
+        assertNoBugInMethod("NS_NON_SHORT_CIRCUIT", "ghIssues.Issue3976", "bothConstants");
+        assertNoBugInMethod("NS_NON_SHORT_CIRCUIT", "ghIssues.Issue3976", "bothConstants");
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNonShortCircuit.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNonShortCircuit.java
@@ -166,7 +166,8 @@ public class FindNonShortCircuit extends OpcodeStackDetector implements Stateles
             // System.out.println("Saw IOR or IAND at distance " + distance);
             OpcodeStack.Item item0 = stack.getStackItem(0);
             OpcodeStack.Item item1 = stack.getStackItem(1);
-            if (item0.getConstant() == null && item1.getConstant() == null && distance < 4) {
+            boolean bothOperandsAreConstants = item0.getConstant() != null && item1.getConstant() != null;
+            if (!bothOperandsAreConstants && distance < 4) {
                 //                if (item0.getRegisterNumber() >= 0 && item1.getRegisterNumber() >= 0) {
                 //                    if (false) {
                 //                        clearAll();

--- a/spotbugsTestCases/src/java/ghIssues/Issue3976.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3976.java
@@ -1,0 +1,41 @@
+package ghIssues;
+
+import edu.umd.cs.findbugs.annotations.ExpectWarning;
+import edu.umd.cs.findbugs.annotations.NoWarning;
+
+/**
+ * <a href="https://github.com/spotbugs/spotbugs/issues/3976">#3976</a>.
+ */
+public class Issue3976 {
+
+    static boolean hasSideEffect() {
+        System.out.println("Side effect executed!");
+        return true;
+    }
+
+    @ExpectWarning("NS_NON_SHORT_CIRCUIT")
+    public void testTruePositive(boolean input) {
+        if (input | hasSideEffect()) {
+            System.out.println("Path A");
+        }
+    }
+
+    @ExpectWarning("NS_NON_SHORT_CIRCUIT")
+    public void testFalseNegative() {
+        if (true | hasSideEffect()) {
+            System.out.println("Path B");
+        }
+    }
+
+    @ExpectWarning("NS_NON_SHORT_CIRCUIT")
+    public void testConstantFalseAnd() {
+        if (false & hasSideEffect()) {
+            System.out.println("Path C");
+        }
+    }
+
+    @NoWarning("NS_NON_SHORT_CIRCUIT,NS_DANGEROUS_NON_SHORT_CIRCUIT")
+    public boolean bothConstants() {
+        return true | false;
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #3976.

`FindNonShortCircuit` only flagged `IOR`/`IAND` in boolean context when **neither** operand was a compile-time constant. This missed cases like `true | hasSideEffect()` and `false & hasSideEffect()` where the left operand is a literal but the right still executes unconditionally.

The fix reports unless **both** operands are compile-time constants (e.g. `true | false` remains silent).

## Test plan

- [x] Added `Issue3976.java` with variable/constant left operands and `bothConstants` negative case
- [x] Added `Issue3976Test`
- [x] `FindNonShortCircuitTest` passes