### PR TITLE
fix: treat Objects.nonNull/isNull as null checks in OBL analysis (#4020)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - New detector `FindIncreasedAccessibilityOfMethods` for new bug type `IAOM_DO_NOT_INCREASE_METHOD_ACCESSIBILITY`. This detector reports a bug if a class increases the accessibility of overridden or hidden methods. (See [SEI CERT rule MET04-J](https://wiki.sei.cmu.edu/confluence/display/java/MET04-J.+Do+not+increase+the+accessibility+of+overridden+or+hidden+methods))
 
 ### Fixed
+- Fix `OBL_UNSATISFIED_OBLIGATION` false positive when null-check uses `Objects.nonNull()` ([#4020](https://github.com/spotbugs/spotbugs/issues/4020))
 - Fix `DM_STRING_TOSTRING` false negative when `toString()` is chained before a method call (e.g., `s.toString().toLowerCase()`); multiple occurrences in the same method are now all reported ([#3966](https://github.com/spotbugs/spotbugs/issues/3966))
 - Stop exposing JUnit BOM as a transitive dependency to consumers ([#3908](https://github.com/spotbugs/spotbugs/issues/3908))
 - Fix incorrect bug counts and sizes when unioning reports ([#3721](https://github.com/spotbugs/spotbugs/issues/3721))

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue4020Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue4020Test.java
@@ -1,0 +1,15 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class Issue4020Test extends AbstractIntegrationTest {
+
+    @Test
+    void testObjectsNonNullNullCheckDischargesObligation() {
+        performAnalysis("ghIssues/Issue4020.class");
+
+        assertNoBugInMethod("OBL_UNSATISFIED_OBLIGATION", "ghIssues.Issue4020", "closeWithNullCheck");
+        assertNoBugInMethod("OBL_UNSATISFIED_OBLIGATION", "ghIssues.Issue4020", "closeWithObjectsNonNull");
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/obl/ObligationAnalysis.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/obl/ObligationAnalysis.java
@@ -32,7 +32,9 @@ import javax.annotation.WillClose;
 
 import org.apache.bcel.Const;
 import org.apache.bcel.generic.ConstantPoolGen;
+import org.apache.bcel.generic.Instruction;
 import org.apache.bcel.generic.InstructionHandle;
+import org.apache.bcel.generic.InvokeInstruction;
 import org.apache.bcel.generic.ObjectType;
 import org.apache.bcel.generic.Type;
 
@@ -83,6 +85,8 @@ public class ObligationAnalysis extends ForwardDataflowAnalysis<StateSet> {
 
     private final IsNullValueDataflow invDataflow;
 
+    private final ConstantPoolGen cpg;
+
     private final IErrorLogger errorLogger;
 
     private final InstructionActionCache actionCache;
@@ -119,6 +123,7 @@ public class ObligationAnalysis extends ForwardDataflowAnalysis<StateSet> {
         this.database = database;
         this.typeDataflow = typeDataflow;
         this.invDataflow = invDataflow;
+        this.cpg = cpg;
         this.errorLogger = errorLogger;
         this.actionCache = new InstructionActionCache(database, xmethod, cpg, typeDataflow);
     }
@@ -259,6 +264,11 @@ public class ObligationAnalysis extends ForwardDataflowAnalysis<StateSet> {
         case Const.IF_ACMPNE:
             type = acmpNullCheck(opcode, edge, last, sourceBlock);
             break;
+
+        case Const.IFEQ:
+        case Const.IFNE:
+            type = objectsNullCheckMethod(opcode, edge, last, sourceBlock);
+            break;
         default:
             break;
         }
@@ -293,6 +303,58 @@ public class ObligationAnalysis extends ForwardDataflowAnalysis<StateSet> {
                     System.out.println("ifnull comparison of " + type + " to null at " + last);
                 }
             }
+        }
+        return type;
+    }
+
+    private Type objectsNullCheckMethod(short opcode, Edge edge, InstructionHandle last, BasicBlock sourceBlock)
+            throws DataflowAnalysisException {
+        InstructionHandle prev = last.getPrev();
+        if (prev == null) {
+            return null;
+        }
+        Instruction prevIns = prev.getInstruction();
+        if (prevIns.getOpcode() != Const.INVOKESTATIC || !(prevIns instanceof InvokeInstruction)) {
+            return null;
+        }
+        InvokeInstruction invoke = (InvokeInstruction) prevIns;
+        String className = invoke.getReferenceType(cpg).getClassName();
+        String methodName = invoke.getMethodName(cpg);
+        boolean isNonNull = "java.util.Objects".equals(className) && "nonNull".equals(methodName);
+        boolean isIsNull = "java.util.Objects".equals(className) && "isNull".equals(methodName);
+        if (!isNonNull && !isIsNull) {
+            return null;
+        }
+
+        boolean referenceIsNullOnEdge;
+        if (isNonNull) {
+            if (opcode == Const.IFEQ) {
+                referenceIsNullOnEdge = edge.getType() == EdgeTypes.IFCMP_EDGE;
+            } else if (opcode == Const.IFNE) {
+                referenceIsNullOnEdge = edge.getType() == EdgeTypes.FALL_THROUGH_EDGE;
+            } else {
+                return null;
+            }
+        } else if (opcode == Const.IFEQ) {
+            referenceIsNullOnEdge = edge.getType() == EdgeTypes.FALL_THROUGH_EDGE;
+        } else if (opcode == Const.IFNE) {
+            referenceIsNullOnEdge = edge.getType() == EdgeTypes.IFCMP_EDGE;
+        } else {
+            return null;
+        }
+
+        if (!referenceIsNullOnEdge) {
+            return null;
+        }
+
+        Location location = new Location(prev, sourceBlock);
+        TypeFrame typeFrame = typeDataflow.getFactAtLocation(location);
+        if (!typeFrame.isValid()) {
+            return null;
+        }
+        Type type = typeFrame.getTopValue();
+        if (DEBUG_NULL_CHECK) {
+            System.out.println("Objects null-check comparison of " + type + " to null at " + last);
         }
         return type;
     }

--- a/spotbugsTestCases/src/java/ghIssues/Issue4020.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue4020.java
@@ -1,0 +1,52 @@
+package ghIssues;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Objects;
+
+import edu.umd.cs.findbugs.annotations.NoWarning;
+
+/**
+ * <a href="https://github.com/spotbugs/spotbugs/issues/4020">#4020</a>.
+ */
+public class Issue4020 {
+
+    @NoWarning("OBL_UNSATISFIED_OBLIGATION")
+    public void closeWithNullCheck(Connection conn, String sql) throws SQLException {
+        PreparedStatement stmt = null;
+        try {
+            stmt = conn.prepareStatement(sql);
+            stmt.execute();
+        } catch (SQLException ex) {
+            // log
+        } finally {
+            if (stmt != null) {
+                try {
+                    stmt.close();
+                } catch (SQLException ex) {
+                    // log
+                }
+            }
+        }
+    }
+
+    @NoWarning("OBL_UNSATISFIED_OBLIGATION")
+    public void closeWithObjectsNonNull(Connection conn, String sql) throws SQLException {
+        PreparedStatement stmt = null;
+        try {
+            stmt = conn.prepareStatement(sql);
+            stmt.execute();
+        } catch (SQLException ex) {
+            // log
+        } finally {
+            if (Objects.nonNull(stmt)) {
+                try {
+                    stmt.close();
+                } catch (SQLException ex) {
+                    // log
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #4020.

`ObligationAnalysis` removed obligations on edges where a resource reference was proven null (nothing to close), but only recognized `IFNULL`/`IFNONNULL` and reference equality checks. `Objects.nonNull(x)` compiles to `invokestatic Objects.nonNull` + `IFEQ`/`IFNE` on the boolean result, so the null branch was not recognized and `OBL_UNSATISFIED_OBLIGATION` was reported even when the resource was closed under `Objects.nonNull(stmt)`.

This change treats `Objects.nonNull`/`Objects.isNull` followed by `IFEQ`/`IFNE` equivalently to direct null checks.

## Test plan

- [x] Added `Issue4020.java` with `stmt != null` (baseline) and `Objects.nonNull(stmt)` close patterns
- [x] Added `Issue4020Test` — neither method reports `OBL_UNSATISFIED_OBLIGATION`
- [x] `FindUnsatisfiedObligationTest` passes