### PR TITLE
fix: report ODR when JDBC resource is stored as supertype (#4019)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - New detector `FindIncreasedAccessibilityOfMethods` for new bug type `IAOM_DO_NOT_INCREASE_METHOD_ACCESSIBILITY`. This detector reports a bug if a class increases the accessibility of overridden or hidden methods. (See [SEI CERT rule MET04-J](https://wiki.sei.cmu.edu/confluence/display/java/MET04-J.+Do+not+increase+the+accessibility+of+overridden+or+hidden+methods))
 
 ### Fixed
+- Fix `ODR_OPEN_DATABASE_RESOURCE` false negative when a JDBC resource is stored in a supertype variable and narrowed with `checkcast` ([#4019](https://github.com/spotbugs/spotbugs/issues/4019))
 - Fix `DM_STRING_TOSTRING` false negative when `toString()` is chained before a method call (e.g., `s.toString().toLowerCase()`); multiple occurrences in the same method are now all reported ([#3966](https://github.com/spotbugs/spotbugs/issues/3966))
 - Stop exposing JUnit BOM as a transitive dependency to consumers ([#3908](https://github.com/spotbugs/spotbugs/issues/3908))
 - Fix incorrect bug counts and sizes when unioning reports ([#3721](https://github.com/spotbugs/spotbugs/issues/3721))

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue4019Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue4019Test.java
@@ -1,0 +1,17 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class Issue4019Test extends AbstractIntegrationTest {
+
+    @Test
+    void testStatementSupertypeReportsResourceLeak() {
+        performAnalysis("ghIssues/Issue4019.class");
+
+        assertBugInMethod("OBL_UNSATISFIED_OBLIGATION", "ghIssues.Issue4019", "fetchUserBefore");
+        assertBugInMethod("ODR_OPEN_DATABASE_RESOURCE", "ghIssues.Issue4019", "fetchUserBefore");
+        assertBugInMethod("OBL_UNSATISFIED_OBLIGATION", "ghIssues.Issue4019", "fetchUserAfter");
+        assertBugInMethod("ODR_OPEN_DATABASE_RESOURCE", "ghIssues.Issue4019", "fetchUserAfter");
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/ResourceValueFrameModelingVisitor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/ResourceValueFrameModelingVisitor.java
@@ -143,18 +143,8 @@ public abstract class ResourceValueFrameModelingVisitor extends AbstractFrameMod
 
     @Override
     public void visitCHECKCAST(CHECKCAST obj) {
-        try {
-            ResourceValueFrame frame = getFrame();
-            ResourceValue topValue;
-
-            topValue = frame.getTopValue();
-
-            if (topValue.equals(ResourceValue.instance())) {
-                frame.setStatus(ResourceValueFrame.State.ESCAPED);
-            }
-        } catch (DataflowAnalysisException e) {
-            AnalysisContext.logError("Analysis error", e);
-        }
+        // CHECKCAST preserves the reference; it does not escape the resource.
+        handleNormalInstruction(obj);
     }
 
     @Override

--- a/spotbugsTestCases/src/java/ghIssues/Issue4019.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue4019.java
@@ -1,0 +1,48 @@
+package ghIssues;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import edu.umd.cs.findbugs.annotations.ExpectWarning;
+
+/**
+ * <a href="https://github.com/spotbugs/spotbugs/issues/4019">#4019</a>.
+ */
+public class Issue4019 {
+    private static final String DB_URL = "jdbc:h2:mem:testdb";
+
+    @ExpectWarning("OBL_UNSATISFIED_OBLIGATION,ODR_OPEN_DATABASE_RESOURCE")
+    public void fetchUserBefore(int id) throws SQLException {
+        Connection conn = null;
+        PreparedStatement ps = null;
+        try {
+            conn = DriverManager.getConnection(DB_URL);
+            ps = conn.prepareStatement("SELECT * FROM users WHERE id = ?");
+            ps.setInt(1, id);
+            ps.executeQuery();
+        } finally {
+            if (conn != null) {
+                conn.close();
+            }
+        }
+    }
+
+    @ExpectWarning("OBL_UNSATISFIED_OBLIGATION,ODR_OPEN_DATABASE_RESOURCE")
+    public void fetchUserAfter(int id) throws SQLException {
+        Connection conn = null;
+        Statement ps = null;
+        try {
+            conn = DriverManager.getConnection(DB_URL);
+            ps = conn.prepareStatement("SELECT * FROM users WHERE id = ?");
+            ((PreparedStatement) ps).setInt(1, id);
+            ((PreparedStatement) ps).executeQuery();
+        } finally {
+            if (conn != null) {
+                conn.close();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #4019.

When a JDBC resource from `prepareStatement()` is stored in a `Statement`-typed local and narrowed with `checkcast` to call `PreparedStatement` methods, `ODR_OPEN_DATABASE_RESOURCE` was not reported.

`ResourceValueFrameModelingVisitor` incorrectly treated `CHECKCAST` as a resource escape. Casting a tracked instance to a subtype preserves the same reference and should not clear the open-resource state.

(`OBL_UNSATISFIED_OBLIGATION` already reported correctly on current master; this fix targets the `FindOpenStream` / ODR path.)

## Test plan

- [x] Added `Issue4019.java` with `PreparedStatement` vs `Statement` variable declarations
- [x] Added `Issue4019Test` — both methods report `OBL_UNSATISFIED_OBLIGATION` and `ODR_OPEN_DATABASE_RESOURCE`
- [x] `FindUnsatisfiedObligationTest` passes