### PR TITLE
Fix FindReturnRef FN for ByteBuffer.array() and Arrays.copyOf (#4007)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - New detector `FindIncreasedAccessibilityOfMethods` for new bug type `IAOM_DO_NOT_INCREASE_METHOD_ACCESSIBILITY`. This detector reports a bug if a class increases the accessibility of overridden or hidden methods. (See [SEI CERT rule MET04-J](https://wiki.sei.cmu.edu/confluence/display/java/MET04-J.+Do+not+increase+the+accessibility+of+overridden+or+hidden+methods))
 
 ### Fixed
+- Fix `FindReturnRef` false negatives for `ByteBuffer.array()` buffer exposure and `Arrays.copyOf` on mutable arrays assigned via setter ([#4007](https://github.com/spotbugs/spotbugs/issues/4007))
 - Fix `DM_STRING_TOSTRING` false negative when `toString()` is chained before a method call (e.g., `s.toString().toLowerCase()`); multiple occurrences in the same method are now all reported ([#3966](https://github.com/spotbugs/spotbugs/issues/3966))
 - Stop exposing JUnit BOM as a transitive dependency to consumers ([#3908](https://github.com/spotbugs/spotbugs/issues/3908))
 - Fix incorrect bug counts and sizes when unioning reports ([#3721](https://github.com/spotbugs/spotbugs/issues/3721))

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue4007Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue4007Test.java
@@ -1,0 +1,19 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class Issue4007Test extends AbstractIntegrationTest {
+
+    @Test
+    void testByteBufferArrayExposure() {
+        performAnalysis("ghIssues/Issue4007.class");
+
+        assertBugInMethod("EI_EXPOSE_BUF", "ghIssues.Issue4007", "getArray");
+        assertBugInMethod("MS_EXPOSE_BUF", "ghIssues.Issue4007", "getStaticArray");
+        assertBugInMethod("EI_EXPOSE_BUF", "ghIssues.Issue4007", "getDuplicate");
+        assertBugInMethod("EI_EXPOSE_REP2", "ghIssues.Issue4007", "setDates");
+        assertBugInMethod("EI_EXPOSE_REP", "ghIssues.Issue4007", "getDatesClone");
+        assertNoBugInMethod("EI_EXPOSE_BUF", "ghIssues.Issue4007", "getArrayCopy");
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindReturnRef.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindReturnRef.java
@@ -74,6 +74,10 @@ public class FindReturnRef extends OpcodeStackDetector {
     private OpcodeStack.Item bufferParamUnderDuplication = null;
     private XField fieldUnderWrapToBuffer = null;
     private OpcodeStack.Item paramUnderWrapToBuffer = null;
+    private XField fieldUnderArrayCopyOf = null;
+    private OpcodeStack.Item paramUnderArrayCopyOf = null;
+    private XField fieldCopyOfUnderCast = null;
+    private OpcodeStack.Item paramCopyOfUnderCast = null;
 
     private final Map<OpcodeStack.Item, XField> bufferFieldDuplicates = new HashMap<>();
     private final Map<OpcodeStack.Item, OpcodeStack.Item> bufferParamDuplicates = new HashMap<>();
@@ -81,6 +85,8 @@ public class FindReturnRef extends OpcodeStackDetector {
     private final Map<OpcodeStack.Item, OpcodeStack.Item> arrayParamsWrappedToBuffers = new HashMap<>();
     private final Map<OpcodeStack.Item, XField> arrayFieldClones = new HashMap<>();
     private final Map<OpcodeStack.Item, OpcodeStack.Item> arrayParamClones = new HashMap<>();
+    private final Map<OpcodeStack.Item, XField> arrayFieldCopyOfs = new HashMap<>();
+    private final Map<OpcodeStack.Item, OpcodeStack.Item> arrayParamCopyOfs = new HashMap<>();
     private final Map<XField, List<OpcodeStack.Item>> fieldValues = new HashMap<>();
 
     private final BugAccumulator bugAccumulator;
@@ -88,6 +94,7 @@ public class FindReturnRef extends OpcodeStackDetector {
     private static final Pattern BUFFER_CLASS_PATTERN = Pattern.compile("Ljava/nio/[A-Za-z]+Buffer;");
     private static final Pattern DUPLICATE_METHODS_SIGNATURE_PATTERN =
             Pattern.compile("\\(\\)Ljava/nio/[A-Za-z]+Buffer;");
+    private static final Pattern ARRAY_METHOD_SIGNATURE_PATTERN = Pattern.compile("\\(\\)\\[.");
     private static final Pattern WRAP_METHOD_SIGNATURE_PATTERN =
             Pattern.compile("\\(\\[.\\)Ljava/nio/[A-Za-z]+Buffer;");
 
@@ -182,6 +189,10 @@ public class FindReturnRef extends OpcodeStackDetector {
         paramUnderWrapToBuffer = null;
         bufferFieldUnderDuplication = null;
         bufferParamUnderDuplication = null;
+        fieldUnderArrayCopyOf = null;
+        paramUnderArrayCopyOf = null;
+        fieldCopyOfUnderCast = null;
+        paramCopyOfUnderCast = null;
 
         if (staticMethod && seen == Const.PUTSTATIC && nonPublicFieldOperand()
                 && MutableClasses.mutableSignature(getSigConstantOperand())) {
@@ -276,8 +287,18 @@ public class FindReturnRef extends OpcodeStackDetector {
                 }
             }
 
-            if (seen == Const.INVOKEVIRTUAL && "duplicate".equals(method.getName())
+            if ("duplicate".equals(method.getName())
                     && DUPLICATE_METHODS_SIGNATURE_PATTERN.matcher(method.getSignature()).matches()
+                    && BUFFER_CLASS_PATTERN.matcher(method.getClassDescriptor().getSignature()).matches()) {
+                if (field != null && !field.isPublic() && isFieldOf(field, getClassDescriptor())) {
+                    bufferFieldUnderDuplication = field;
+                } else if (item.isInitialParameter()) {
+                    bufferParamUnderDuplication = item;
+                }
+            }
+
+            if ("array".equals(method.getName())
+                    && ARRAY_METHOD_SIGNATURE_PATTERN.matcher(method.getSignature()).matches()
                     && BUFFER_CLASS_PATTERN.matcher(method.getClassDescriptor().getSignature()).matches()) {
                 if (field != null && !field.isPublic() && isFieldOf(field, getClassDescriptor())) {
                     bufferFieldUnderDuplication = field;
@@ -289,17 +310,32 @@ public class FindReturnRef extends OpcodeStackDetector {
 
         if (seen == Const.INVOKESTATIC) {
             MethodDescriptor method = getMethodDescriptorOperand();
-            if (method == null || !"wrap".equals(method.getName())
-                    || !WRAP_METHOD_SIGNATURE_PATTERN.matcher(method.getSignature()).matches()
-                    || !BUFFER_CLASS_PATTERN.matcher(method.getClassDescriptor().getSignature()).matches()) {
+            if (method == null) {
                 return;
             }
-            OpcodeStack.Item arg = stack.getStackItem(0);
-            XField fieldArg = arg.getXField();
-            if (fieldArg != null && !fieldArg.isPublic() && isFieldOf(fieldArg, getClassDescriptor())) {
-                fieldUnderWrapToBuffer = fieldArg;
-            } else if (arg.isInitialParameter()) {
-                paramUnderWrapToBuffer = arg;
+            if ("wrap".equals(method.getName())
+                    && WRAP_METHOD_SIGNATURE_PATTERN.matcher(method.getSignature()).matches()
+                    && BUFFER_CLASS_PATTERN.matcher(method.getClassDescriptor().getSignature()).matches()) {
+                OpcodeStack.Item arg = stack.getStackItem(0);
+                XField fieldArg = arg.getXField();
+                if (fieldArg != null && !fieldArg.isPublic() && isFieldOf(fieldArg, getClassDescriptor())) {
+                    fieldUnderWrapToBuffer = fieldArg;
+                } else if (arg.isInitialParameter()) {
+                    paramUnderWrapToBuffer = arg;
+                }
+                return;
+            }
+            if ("copyOf".equals(method.getName()) && "java/util/Arrays".equals(getClassConstantOperand())) {
+                // copyOf(T[], int) — array is stack slot 1 (slot 0 is newLength)
+                OpcodeStack.Item arg = stack.getStackItem(1);
+                if (arg.isArray() && MutableClasses.mutableSignature(arg.getSignature().substring(1))) {
+                    XField fieldArg = arg.getXField();
+                    if (fieldArg != null && !fieldArg.isPublic() && isFieldOf(fieldArg, getClassDescriptor())) {
+                        fieldUnderArrayCopyOf = fieldArg;
+                    } else if (arg.isInitialParameter()) {
+                        paramUnderArrayCopyOf = arg;
+                    }
+                }
             }
         }
 
@@ -312,6 +348,14 @@ public class FindReturnRef extends OpcodeStackDetector {
             OpcodeStack.Item param = arrayParamClones.get(item);
             if (param != null) {
                 paramCloneUnderCast = param;
+            }
+            XField fieldCopyOf = arrayFieldCopyOfs.get(item);
+            if (fieldCopyOf != null) {
+                fieldCopyOfUnderCast = fieldCopyOf;
+            }
+            OpcodeStack.Item paramCopyOf = arrayParamCopyOfs.get(item);
+            if (paramCopyOf != null) {
+                paramCopyOfUnderCast = paramCopyOf;
             }
         }
     }
@@ -356,13 +400,11 @@ public class FindReturnRef extends OpcodeStackDetector {
             if (paramUnderClone != null) {
                 arrayParamClones.put(stack.getStackItem(0), paramUnderClone);
             }
-            if (seen == Const.INVOKEVIRTUAL) {
-                if (bufferFieldUnderDuplication != null) {
-                    bufferFieldDuplicates.put(stack.getStackItem(0), bufferFieldUnderDuplication);
-                }
-                if (bufferParamUnderDuplication != null) {
-                    bufferParamDuplicates.put(stack.getStackItem(0), bufferParamUnderDuplication);
-                }
+            if (bufferFieldUnderDuplication != null) {
+                bufferFieldDuplicates.put(stack.getStackItem(0), bufferFieldUnderDuplication);
+            }
+            if (bufferParamUnderDuplication != null) {
+                bufferParamDuplicates.put(stack.getStackItem(0), bufferParamUnderDuplication);
             }
         }
 
@@ -373,6 +415,12 @@ public class FindReturnRef extends OpcodeStackDetector {
             if (paramUnderWrapToBuffer != null) {
                 arrayParamsWrappedToBuffers.put(stack.getStackItem(0), paramUnderWrapToBuffer);
             }
+            if (fieldUnderArrayCopyOf != null) {
+                arrayFieldCopyOfs.put(stack.getStackItem(0), fieldUnderArrayCopyOf);
+            }
+            if (paramUnderArrayCopyOf != null) {
+                arrayParamCopyOfs.put(stack.getStackItem(0), paramUnderArrayCopyOf);
+            }
         }
 
         if (seen == Const.CHECKCAST && !stack.isTop()) {
@@ -382,6 +430,12 @@ public class FindReturnRef extends OpcodeStackDetector {
             }
             if (paramCloneUnderCast != null) {
                 arrayParamClones.put(item, paramCloneUnderCast);
+            }
+            if (fieldCopyOfUnderCast != null) {
+                arrayFieldCopyOfs.put(item, fieldCopyOfUnderCast);
+            }
+            if (paramCopyOfUnderCast != null) {
+                arrayParamCopyOfs.put(item, paramCopyOfUnderCast);
             }
         }
     }
@@ -394,16 +448,26 @@ public class FindReturnRef extends OpcodeStackDetector {
     private CaptureKind getPotentialCapture(OpcodeStack.Item top) {
         CaptureKind kind = CaptureKind.REP;
         if (!top.isInitialParameter()) {
+            if (arrayFieldCopyOfs.containsKey(top)) {
+                return CaptureKind.ARRAY_CLONE;
+            }
             OpcodeStack.Item newTop = arrayParamClones.get(top);
             if (newTop == null) {
-                newTop = arrayParamsWrappedToBuffers.get(top);
+                newTop = arrayParamCopyOfs.get(top);
                 if (newTop == null) {
-                    newTop = bufferParamDuplicates.get(top);
+                    newTop = arrayParamsWrappedToBuffers.get(top);
                     if (newTop == null) {
-                        return CaptureKind.NONE;
+                        newTop = bufferParamDuplicates.get(top);
+                        if (newTop == null) {
+                            return CaptureKind.NONE;
+                        }
+                        kind = CaptureKind.BUF;
+                    } else {
+                        kind = CaptureKind.BUF;
                     }
+                } else {
+                    kind = CaptureKind.ARRAY_CLONE;
                 }
-                kind = CaptureKind.BUF;
             } else {
                 kind = CaptureKind.ARRAY_CLONE;
             }

--- a/spotbugsTestCases/src/java/ghIssues/Issue4007.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue4007.java
@@ -1,0 +1,48 @@
+package ghIssues;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Date;
+
+import edu.umd.cs.findbugs.annotations.ExpectWarning;
+import edu.umd.cs.findbugs.annotations.NoWarning;
+
+/**
+ * <a href="https://github.com/spotbugs/spotbugs/issues/4007">#4007</a>.
+ */
+public class Issue4007 {
+
+    private final ByteBuffer buf = ByteBuffer.allocate(16);
+    private static final ByteBuffer S_BUF = ByteBuffer.allocate(16);
+    private Date[] dates = new Date[] { new Date() };
+
+    @ExpectWarning("EI_EXPOSE_BUF")
+    public byte[] getArray() {
+        return buf.array();
+    }
+
+    @ExpectWarning("MS_EXPOSE_BUF")
+    public static byte[] getStaticArray() {
+        return S_BUF.array();
+    }
+
+    @ExpectWarning("EI_EXPOSE_BUF")
+    public ByteBuffer getDuplicate() {
+        return buf.duplicate();
+    }
+
+    @ExpectWarning("EI_EXPOSE_REP2")
+    public void setDates(Date[] input) {
+        dates = Arrays.copyOf(input, input.length);
+    }
+
+    @ExpectWarning("EI_EXPOSE_REP")
+    public Date[] getDatesClone() {
+        return dates.clone();
+    }
+
+    @NoWarning("EI_EXPOSE_BUF,MS_EXPOSE_BUF,EI_EXPOSE_REP,MS_EXPOSE_REP,EI_EXPOSE_REP2")
+    public byte[] getArrayCopy() {
+        return Arrays.copyOf(buf.array(), buf.array().length);
+    }
+}


### PR DESCRIPTION
## Summary

- Detect `ByteBuffer.array()` (and other buffer `array()` calls) as buffer exposure, same as `duplicate()` / `wrap()`, reporting `EI_EXPOSE_BUF` / `MS_EXPOSE_BUF`.
- Detect `Arrays.copyOf` on mutable arrays assigned via setter as `EI_EXPOSE_REP2`, including when the compiler inserts a `checkcast` after `copyOf`.
- Add regression tests in `Issue4007.java` / `Issue4007Test.java`.

Fixes #4007.

## Test plan

- [x] `./gradlew :spotbugs-tests:test --tests Issue4007Test`
- [x] `./gradlew :spotbugs-tests:test --tests FindReturnRefTest`