### PR TITLE
Fix EI_EXPOSE_REP FN for anonymous class getters (#4032)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - New detector `FindIncreasedAccessibilityOfMethods` for new bug type `IAOM_DO_NOT_INCREASE_METHOD_ACCESSIBILITY`. This detector reports a bug if a class increases the accessibility of overridden or hidden methods. (See [SEI CERT rule MET04-J](https://wiki.sei.cmu.edu/confluence/display/java/MET04-J.+Do+not+increase+the+accessibility+of+overridden+or+hidden+methods))
 
 ### Fixed
+- Fix `FindReturnRef` false negative for `EI_EXPOSE_REP` when a getter in an anonymous class returns an enclosing nest host field ([#4032](https://github.com/spotbugs/spotbugs/issues/4032))
 - Fix `DM_STRING_TOSTRING` false negative when `toString()` is chained before a method call (e.g., `s.toString().toLowerCase()`); multiple occurrences in the same method are now all reported ([#3966](https://github.com/spotbugs/spotbugs/issues/3966))
 - Stop exposing JUnit BOM as a transitive dependency to consumers ([#3908](https://github.com/spotbugs/spotbugs/issues/3908))
 - Fix incorrect bug counts and sizes when unioning reports ([#3721](https://github.com/spotbugs/spotbugs/issues/3721))

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue4032Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue4032Test.java
@@ -1,0 +1,17 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class Issue4032Test extends AbstractIntegrationTest {
+
+    @Test
+    void testExposeRepInAnonymousClass() {
+        performAnalysis("ghIssues/Issue4032.class", "ghIssues/Issue4032$Provider.class",
+                "ghIssues/Issue4032$NamedProvider.class", "ghIssues/Issue4032$1.class");
+
+        assertBugInMethod("EI_EXPOSE_REP", "ghIssues.Issue4032$NamedProvider", "getNames");
+        assertBugInMethod("EI_EXPOSE_REP", "ghIssues.Issue4032$1", "getNames");
+        assertNoBugInMethod("EI_EXPOSE_REP", "ghIssues.Issue4032", "getNamesCopy");
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindReturnRef.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindReturnRef.java
@@ -38,11 +38,13 @@ import edu.umd.cs.findbugs.ba.type.TypeFrameModelingVisitor;
 import edu.umd.cs.findbugs.bcel.OpcodeStackDetector;
 import edu.umd.cs.findbugs.classfile.CheckedAnalysisException;
 import edu.umd.cs.findbugs.classfile.ClassDescriptor;
+import edu.umd.cs.findbugs.classfile.DescriptorFactory;
 import edu.umd.cs.findbugs.classfile.MethodDescriptor;
 import edu.umd.cs.findbugs.util.ClassName;
 import edu.umd.cs.findbugs.util.MutableClasses;
 import edu.umd.cs.findbugs.util.NestedAccessUtil;
 import org.apache.bcel.Const;
+import org.apache.bcel.Repository;
 import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.classfile.Method;
 import org.apache.bcel.generic.ConstantPoolGen;
@@ -433,7 +435,11 @@ public class FindReturnRef extends OpcodeStackDetector {
                 }
             } while (clazz2 != null);
             try {
-                clazz = clazz.getXClass().getImmediateEnclosingClass();
+                ClassDescriptor next = clazz.getXClass().getImmediateEnclosingClass();
+                if (next == null) {
+                    next = getNestHostClassDescriptor(clazz);
+                }
+                clazz = next;
                 if (clazz != null && !clazz.getXClass().isPublic()) {
                     return false;
                 }
@@ -443,5 +449,18 @@ public class FindReturnRef extends OpcodeStackDetector {
             }
         } while (clazz != null);
         return false;
+    }
+
+    private ClassDescriptor getNestHostClassDescriptor(ClassDescriptor clazz) {
+        try {
+            JavaClass javaClass = Repository.lookupClass(clazz.getDottedClassName());
+            List<JavaClass> hostClasses = NestedAccessUtil.getHostClasses(javaClass);
+            if (!hostClasses.isEmpty()) {
+                return DescriptorFactory.createClassDescriptor(hostClasses.get(0));
+            }
+        } catch (ClassNotFoundException e) {
+            AnalysisContext.logError("Error resolving nest host of " + clazz, e);
+        }
+        return null;
     }
 }

--- a/spotbugsTestCases/src/java/ghIssues/Issue4032.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue4032.java
@@ -1,0 +1,39 @@
+package ghIssues;
+
+import edu.umd.cs.findbugs.annotations.ExpectWarning;
+import edu.umd.cs.findbugs.annotations.NoWarning;
+
+/**
+ * <a href="https://github.com/spotbugs/spotbugs/issues/4032">#4032</a>.
+ */
+public class Issue4032 {
+
+    private static final String[] names = new String[] { "a", "b" };
+
+    public interface Provider {
+        String[] getNames();
+    }
+
+    public static class NamedProvider implements Provider {
+        @Override
+        @ExpectWarning("EI_EXPOSE_REP")
+        public String[] getNames() {
+            return names;
+        }
+    }
+
+    public static Provider anonymousProvider() {
+        return new Provider() {
+            @Override
+            @ExpectWarning("EI_EXPOSE_REP")
+            public String[] getNames() {
+                return names;
+            }
+        };
+    }
+
+    @NoWarning("EI_EXPOSE_REP")
+    public static String[] getNamesCopy() {
+        return names.clone();
+    }
+}


### PR DESCRIPTION
## Summary

- When `isFieldOf` walks enclosing classes, fall back to the `NestHost` attribute if `immediateEnclosingClass` is unset (anonymous classes lack `outer_name` in `InnerClasses`).
- Add regression tests comparing named nested vs anonymous `Provider` implementations.

Fixes #4032.

## Test plan

- [x] `./gradlew :spotbugs-tests:test --tests Issue4032Test`
- [x] `./gradlew :spotbugs-tests:test --tests FindReturnRefTest`