### PR TITLE
Fix BC_IMPOSSIBLE_DOWNCAST FN after Object.clone() (#3769)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - New detector `FindIncreasedAccessibilityOfMethods` for new bug type `IAOM_DO_NOT_INCREASE_METHOD_ACCESSIBILITY`. This detector reports a bug if a class increases the accessibility of overridden or hidden methods. (See [SEI CERT rule MET04-J](https://wiki.sei.cmu.edu/confluence/display/java/MET04-J.+Do+not+increase+the+accessibility+of+overridden+or+hidden+methods))
 
 ### Fixed
+- Fix `BC_IMPOSSIBLE_DOWNCAST` false negative when casting the result of `Object.clone()` on a concrete type ([#3769](https://github.com/spotbugs/spotbugs/issues/3769))
 - Fix `DM_STRING_TOSTRING` false negative when `toString()` is chained before a method call (e.g., `s.toString().toLowerCase()`); multiple occurrences in the same method are now all reported ([#3966](https://github.com/spotbugs/spotbugs/issues/3966))
 - Stop exposing JUnit BOM as a transitive dependency to consumers ([#3908](https://github.com/spotbugs/spotbugs/issues/3908))
 - Fix incorrect bug counts and sizes when unioning reports ([#3721](https://github.com/spotbugs/spotbugs/issues/3721))

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3769Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3769Test.java
@@ -1,0 +1,13 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class Issue3769Test extends AbstractIntegrationTest {
+
+    @Test
+    void testImpossibleDowncastAfterClone() {
+        performAnalysis("ghIssues/Issue3769.class");
+        assertBugInMethod("BC_IMPOSSIBLE_DOWNCAST", "ghIssues.Issue3769", "main");
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/type/TypeFrameModelingVisitor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/type/TypeFrameModelingVisitor.java
@@ -650,6 +650,21 @@ public class TypeFrameModelingVisitor extends AbstractFrameModelingVisitor<Type,
                 AnalysisContext.logError("Ooops", e);
             }
         }
+        if ("clone".equals(methodName) && "()Ljava/lang/Object;".equals(signature)) {
+            try {
+                int receiverSlot = frame.getStackLocation(0);
+                boolean receiverExact = frame.isExact(receiverSlot);
+                Type receiver = frame.getStackValue(0);
+                consumeStack(obj);
+                frame.pushValue(receiver);
+                if (receiverExact) {
+                    setTopOfStackIsExact();
+                }
+                return;
+            } catch (DataflowAnalysisException e) {
+                AnalysisContext.logError("Problem analyzing clone() call", e);
+            }
+        }
         if (handleToArray(obj)) {
             return;
         }

--- a/spotbugsTestCases/src/java/ghIssues/Issue3769.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3769.java
@@ -1,0 +1,17 @@
+package ghIssues;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+
+import edu.umd.cs.findbugs.annotations.ExpectWarning;
+
+/**
+ * <a href="https://github.com/spotbugs/spotbugs/issues/3769">#3769</a>.
+ */
+public class Issue3769 {
+    public static void main(String[] args) {
+        HashMap<?, ?> map = new HashMap<>();
+        @ExpectWarning("BC_IMPOSSIBLE_DOWNCAST")
+        LinkedHashMap<?, ?> linkedHashMap = (LinkedHashMap<?, ?>) map.clone();
+    }
+}


### PR DESCRIPTION
## Summary

- Model `clone()` as returning the receiver type (preserving exactness) instead of widening to `Object` in type dataflow.
- Enables `FindBadCast2` to report `BC_IMPOSSIBLE_DOWNCAST` for casts like `(LinkedHashMap) hashMap.clone()`.

Fixes #3769.

## Test plan

- [x] `./gradlew :spotbugs-tests:test --tests Issue3769Test`
- [x] `./gradlew :spotbugs-tests:test --tests RegressionIdeas20090430Test`