### PR TITLE
Fix NN_NAKED_NOTIFY FN when branch precedes notify (#3668)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - New detector `FindIncreasedAccessibilityOfMethods` for new bug type `IAOM_DO_NOT_INCREASE_METHOD_ACCESSIBILITY`. This detector reports a bug if a class increases the accessibility of overridden or hidden methods. (See [SEI CERT rule MET04-J](https://wiki.sei.cmu.edu/confluence/display/java/MET04-J.+Do+not+increase+the+accessibility+of+overridden+or+hidden+methods))
 
 ### Fixed
+- Fix `NN_NAKED_NOTIFY` false negative when control-flow branches appear between `monitorenter` and `notify` ([#3668](https://github.com/spotbugs/spotbugs/issues/3668))
 - Fix `DM_STRING_TOSTRING` false negative when `toString()` is chained before a method call (e.g., `s.toString().toLowerCase()`); multiple occurrences in the same method are now all reported ([#3966](https://github.com/spotbugs/spotbugs/issues/3966))
 - Stop exposing JUnit BOM as a transitive dependency to consumers ([#3908](https://github.com/spotbugs/spotbugs/issues/3908))
 - Fix incorrect bug counts and sizes when unioning reports ([#3721](https://github.com/spotbugs/spotbugs/issues/3721))

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3668Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3668Test.java
@@ -1,0 +1,14 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class Issue3668Test extends AbstractIntegrationTest {
+
+    @Test
+    void testNakedNotifyAfterConditional() {
+        performAnalysis("ghIssues/Issue3668.class");
+        assertBugInMethod("NN_NAKED_NOTIFY", "ghIssues.Issue3668", "foo");
+        assertNoBugInMethod("NN_NAKED_NOTIFY", "ghIssues.Issue3668", "fooWithMutation");
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNakedNotify.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNakedNotify.java
@@ -27,6 +27,7 @@ import edu.umd.cs.findbugs.BugInstance;
 import edu.umd.cs.findbugs.BugReporter;
 import edu.umd.cs.findbugs.BytecodeScanningDetector;
 import edu.umd.cs.findbugs.StatelessDetector;
+import edu.umd.cs.findbugs.visitclass.DismantleBytecode;
 
 //   2:   astore_1
 //   3:   monitorenter
@@ -79,6 +80,8 @@ public class FindNakedNotify extends BytecodeScanningDetector implements Statele
             break;
         case LOADED:
             if (isRegisterLoad() || seen == Const.GETSTATIC || seen == Const.GETFIELD) {
+                break;
+            } else if (DismantleBytecode.isBranch(seen) || DismantleBytecode.isSwitch(seen)) {
                 break;
             } else if (seen == Const.INVOKEVIRTUAL
                     && ("notify".equals(getNameConstantOperand()) || "notifyAll".equals(getNameConstantOperand()))

--- a/spotbugsTestCases/src/java/ghIssues/Issue3668.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3668.java
@@ -1,0 +1,27 @@
+package ghIssues;
+
+import edu.umd.cs.findbugs.annotations.ExpectWarning;
+
+/**
+ * <a href="https://github.com/spotbugs/spotbugs/issues/3668">#3668</a>.
+ */
+public class Issue3668 {
+    volatile String field = Issue3668.class.getCanonicalName();
+
+    @ExpectWarning("NN_NAKED_NOTIFY")
+    public void foo() {
+        String str = "str";
+        synchronized (field) {
+            if (str != null) {
+                field.notifyAll();
+            }
+        }
+    }
+
+    public void fooWithMutation() {
+        synchronized (field) {
+            field = "mutated";
+            field.notifyAll();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- `FindNakedNotify` no longer resets its state machine on branch/switch instructions between loading the lock and calling `notify`/`notifyAll`.
- Fixes the false negative when `notifyAll` is guarded by `if (str != null)` inside a `synchronized` block.

Fixes #3668.

## Test plan

- [x] `./gradlew :spotbugs-tests:test --tests Issue3668Test`
- [x] `./gradlew :spotbugs-tests:test --tests Issue3634Test`