### PR TITLE
Fix CWO_CLOSED_WITHOUT_OPENED false positive when statement precedes lock()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - New detector `FindIncreasedAccessibilityOfMethods` for new bug type `IAOM_DO_NOT_INCREASE_METHOD_ACCESSIBILITY`. This detector reports a bug if a class increases the accessibility of overridden or hidden methods. (See [SEI CERT rule MET04-J](https://wiki.sei.cmu.edu/confluence/display/java/MET04-J.+Do+not+increase+the+accessibility+of+overridden+or+hidden+methods))
 
 ### Fixed
+- Fix `CWO_CLOSED_WITHOUT_OPENED` false positive when a statement before `lock()` can throw an uncaught exception that never reaches `unlock()` ([#3962](https://github.com/spotbugs/spotbugs/issues/3962))
 - Fix `DM_STRING_TOSTRING` false negative when `toString()` is chained before a method call (e.g., `s.toString().toLowerCase()`); multiple occurrences in the same method are now all reported ([#3966](https://github.com/spotbugs/spotbugs/issues/3966))
 - Stop exposing JUnit BOM as a transitive dependency to consumers ([#3908](https://github.com/spotbugs/spotbugs/issues/3908))
 - Fix incorrect bug counts and sizes when unioning reports ([#3721](https://github.com/spotbugs/spotbugs/issues/3721))

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3962Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3962Test.java
@@ -1,0 +1,14 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class Issue3962Test extends AbstractIntegrationTest {
+
+    @Test
+    void testIssue() {
+        performAnalysis("ghIssues/Issue3962.class");
+
+        assertBugTypeCount("CWO_CLOSED_WITHOUT_OPENED", 0);
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindUnreleasedLock.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindUnreleasedLock.java
@@ -294,6 +294,11 @@ public class FindUnreleasedLock extends ResourceTrackingDetector<Lock, FindUnrel
 
             try {
                 Location location = cfg.getExceptionThrowerLocation(edge);
+                Location creationLocation = resource.getLocation();
+                if (location.getHandle().getPosition() < creationLocation.getHandle().getPosition()
+                        && !edge.getTarget().isExceptionHandler()) {
+                    return true;
+                }
                 if (DEBUG) {
                     System.out.println("Exception thrower location: " + location);
                 }

--- a/spotbugsTestCases/src/java/ghIssues/Issue3962.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3962.java
@@ -1,0 +1,27 @@
+package ghIssues;
+
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+public class Issue3962 {
+    private final ReentrantReadWriteLock rwlock = new ReentrantReadWriteLock();
+
+    public Object bugTriggerFP() {
+        Boolean a = false;
+
+        rwlock.readLock().lock();
+        try {
+            return null;
+        } finally {
+            rwlock.readLock().unlock();
+        }
+    }
+
+    public Object bugTriggerTN() {
+        rwlock.readLock().lock();
+        try {
+            return null;
+        } finally {
+            rwlock.readLock().unlock();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Fix `CWO_CLOSED_WITHOUT_OPENED` false positive when bytecode before `lock()` can throw an uncaught exception (e.g. `Boolean.valueOf`) that never reaches `unlock()`.
- In `FindUnreleasedLock.ignoreExceptionEdge`, ignore exception edges from instructions before lock acquisition when the edge does not target a catch handler.
- Add regression test for issue #3962.

## Root cause
`Boolean.valueOf` before `readLock().lock()` creates an exception edge with `NOT_OPEN_ON_EXCEPTION_PATH` status. That path never executes `unlock()`, but merges with the normal try/finally path (`CLOSED`) at method exit, producing a spurious `CLOSED_WITHOUT_OPENED` result.

Caught exceptions that flow into `finally` (e.g. `FileNotFoundException` before `lock()`) still target exception handlers and remain analyzed correctly.

## Test plan
- [x] `./gradlew :spotbugs-tests:test --tests "edu.umd.cs.findbugs.detect.Issue3962Test"`
- [x] `./gradlew :spotbugs-tests:test --tests "edu.umd.cs.findbugs.detect.FindUnreleasedLockTest"`
- [x] `./gradlew :spotbugs-tests:test --tests "edu.umd.cs.findbugs.detect.Issue3616Test"`

Fixes #3962