### PR TITLE
Fix NN_NAKED_NOTIFY false positive when state changes before sync block (#3786)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - New detector `FindIncreasedAccessibilityOfMethods` for new bug type `IAOM_DO_NOT_INCREASE_METHOD_ACCESSIBILITY`. This detector reports a bug if a class increases the accessibility of overridden or hidden methods. (See [SEI CERT rule MET04-J](https://wiki.sei.cmu.edu/confluence/display/java/MET04-J.+Do+not+increase+the+accessibility+of+overridden+or+hidden+methods))
 
 ### Fixed
+- Fix `NN_NAKED_NOTIFY` false positive when guarded state is updated before entering the synchronized block ([#3786](https://github.com/spotbugs/spotbugs/issues/3786))
 - Fix `DM_STRING_TOSTRING` false negative when `toString()` is chained before a method call (e.g., `s.toString().toLowerCase()`); multiple occurrences in the same method are now all reported ([#3966](https://github.com/spotbugs/spotbugs/issues/3966))
 - Stop exposing JUnit BOM as a transitive dependency to consumers ([#3908](https://github.com/spotbugs/spotbugs/issues/3908))
 - Fix incorrect bug counts and sizes when unioning reports ([#3721](https://github.com/spotbugs/spotbugs/issues/3721))

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3786Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3786Test.java
@@ -1,0 +1,18 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class Issue3786Test extends AbstractIntegrationTest {
+
+    @Test
+    void testIssue() {
+        performAnalysis("ghIssues/Issue3786.class");
+
+        assertBugInMethodCount("NN_NAKED_NOTIFY", "ghIssues.Issue3786", "executeFalsePositive", 0);
+        assertBugInMethodCount("NN_NAKED_NOTIFY", "ghIssues.Issue3786", "execute1FalsePositive", 0);
+        assertBugInMethodCount("NN_NAKED_NOTIFY", "ghIssues.Issue3786", "executeOk", 0);
+        assertBugInMethodCount("NN_NAKED_NOTIFY", "ghIssues.Issue3786", "execute1Ok", 0);
+        assertBugInMethodCount("NN_NAKED_NOTIFY", "ghIssues.Issue3786", "executeTruePositive", 1);
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNakedNotify.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNakedNotify.java
@@ -44,6 +44,8 @@ public class FindNakedNotify extends BytecodeScanningDetector implements Statele
 
     private int notifyPC;
 
+    private boolean stateChangedBeforeSync;
+
     public FindNakedNotify(BugReporter bugReporter) {
         this.bugReporter = bugReporter;
     }
@@ -57,15 +59,50 @@ public class FindNakedNotify extends BytecodeScanningDetector implements Statele
     @Override
     public void visit(Code obj) {
         stage = synchronizedMethod ? Stage.MONITOR_ENTERED : Stage.START;
+        stateChangedBeforeSync = false;
         super.visit(obj);
         if (synchronizedMethod && stage == Stage.LOCK_LOADED) {
+            reportNakedNotifyIfNeeded();
+        }
+    }
+
+    private void reportNakedNotifyIfNeeded() {
+        if (!stateChangedBeforeSync) {
             bugReporter.reportBug(new BugInstance(this, "NN_NAKED_NOTIFY", NORMAL_PRIORITY).addClassAndMethod(this)
                     .addSourceLine(this, notifyPC));
         }
     }
 
+    private void noteStateChangeBeforeSync(int seen) {
+        if (stage != Stage.START) {
+            return;
+        }
+        switch (seen) {
+        case Const.PUTFIELD:
+        case Const.PUTSTATIC:
+        case Const.INVOKESTATIC:
+        case Const.INVOKESPECIAL:
+            stateChangedBeforeSync = true;
+            break;
+        case Const.INVOKEVIRTUAL:
+        case Const.INVOKEINTERFACE:
+            if (!isWaitOrNotifyMethod()) {
+                stateChangedBeforeSync = true;
+            }
+            break;
+        default:
+            break;
+        }
+    }
+
+    private boolean isWaitOrNotifyMethod() {
+        String name = getNameConstantOperand();
+        return "notify".equals(name) || "notifyAll".equals(name) || "wait".equals(name);
+    }
+
     @Override
     public void sawOpcode(int seen) {
+        noteStateChangeBeforeSync(seen);
         switch (stage) {
         case START:
             if (seen == Const.MONITORENTER) {
@@ -94,8 +131,7 @@ public class FindNakedNotify extends BytecodeScanningDetector implements Statele
             break;
         case LOCK_LOADED:
             if (seen == Const.MONITOREXIT) {
-                bugReporter.reportBug(new BugInstance(this, "NN_NAKED_NOTIFY", NORMAL_PRIORITY).addClassAndMethod(this)
-                        .addSourceLine(this, notifyPC));
+                reportNakedNotifyIfNeeded();
                 stage = Stage.MONITOR_EXITED;
             } else {
                 stage = Stage.START;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNakedNotify.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNakedNotify.java
@@ -27,6 +27,7 @@ import edu.umd.cs.findbugs.BugInstance;
 import edu.umd.cs.findbugs.BugReporter;
 import edu.umd.cs.findbugs.BytecodeScanningDetector;
 import edu.umd.cs.findbugs.StatelessDetector;
+import edu.umd.cs.findbugs.ba.XField;
 
 //   2:   astore_1
 //   3:   monitorenter
@@ -80,6 +81,11 @@ public class FindNakedNotify extends BytecodeScanningDetector implements Statele
         switch (seen) {
         case Const.PUTFIELD:
         case Const.PUTSTATIC:
+            XField field = getXFieldOperand();
+            if (field != null && field.isVolatile()) {
+                stateChangedBeforeSync = true;
+            }
+            break;
         case Const.INVOKESTATIC:
         case Const.INVOKESPECIAL:
             stateChangedBeforeSync = true;

--- a/spotbugsTestCases/src/java/ghIssues/Issue3786.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3786.java
@@ -1,0 +1,44 @@
+package ghIssues;
+
+public class Issue3786 {
+    final Object saveLock = new Object();
+    volatile double data;
+
+    public void executeFalsePositive() {
+        changeData();
+        synchronized (saveLock) {
+            saveLock.notifyAll();
+        }
+    }
+
+    public void execute1FalsePositive() {
+        data = Math.random();
+        synchronized (saveLock) {
+            saveLock.notifyAll();
+        }
+    }
+
+    public void executeOk() {
+        synchronized (saveLock) {
+            changeData();
+            saveLock.notifyAll();
+        }
+    }
+
+    public void execute1Ok() {
+        synchronized (saveLock) {
+            data = Math.random();
+            saveLock.notifyAll();
+        }
+    }
+
+    public void executeTruePositive() {
+        synchronized (saveLock) {
+            saveLock.notifyAll();
+        }
+    }
+
+    private void changeData() {
+        data = Math.random();
+    }
+}


### PR DESCRIPTION
## Summary
- Fix `NN_NAKED_NOTIFY` false positive when the guarded condition is updated before entering a `synchronized` block (e.g. helper call or field write, then `notifyAll()` inside the block).
- Track state-changing instructions (`putfield`, `putstatic`, and non-wait/notify invocations) that occur before `monitorenter`.
- Add regression test for issue #3786.

## Root cause
`FindNakedNotify` only looked for state changes inside the synchronized region. When the condition variable was updated just before `monitorenter`, the detector still reported a naked notify even though waiting threads would observe the updated state.

## Test plan
- [x] `./gradlew :spotbugs-tests:test --tests "edu.umd.cs.findbugs.detect.Issue3786Test"`
- [x] `./gradlew :spotbugs-tests:test --tests "edu.umd.cs.findbugs.detect.Issue3634Test"`

Fixes #3786