### PR TITLE
Fix NN_NAKED_NOTIFY false negative for non-mutating sync instructions (#3884)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - New detector `FindIncreasedAccessibilityOfMethods` for new bug type `IAOM_DO_NOT_INCREASE_METHOD_ACCESSIBILITY`. This detector reports a bug if a class increases the accessibility of overridden or hidden methods. (See [SEI CERT rule MET04-J](https://wiki.sei.cmu.edu/confluence/display/java/MET04-J.+Do+not+increase+the+accessibility+of+overridden+or+hidden+methods))
 
 ### Fixed
+- Fix `NN_NAKED_NOTIFY` false negative when synchronized block contains only non-mutating instructions before `notify()` ([#3884](https://github.com/spotbugs/spotbugs/issues/3884))
 - Fix `DM_STRING_TOSTRING` false negative when `toString()` is chained before a method call (e.g., `s.toString().toLowerCase()`); multiple occurrences in the same method are now all reported ([#3966](https://github.com/spotbugs/spotbugs/issues/3966))
 - Stop exposing JUnit BOM as a transitive dependency to consumers ([#3908](https://github.com/spotbugs/spotbugs/issues/3908))
 - Fix incorrect bug counts and sizes when unioning reports ([#3721](https://github.com/spotbugs/spotbugs/issues/3721))

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3884Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3884Test.java
@@ -1,0 +1,17 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class Issue3884Test extends AbstractIntegrationTest {
+
+    @Test
+    void testIssue() {
+        performAnalysis("ghIssues/Issue3884.class");
+
+        assertBugInMethodCount("NN_NAKED_NOTIFY", "ghIssues.Issue3884", "testWithFieldRead", 1);
+        assertBugInMethodCount("NN_NAKED_NOTIFY", "ghIssues.Issue3884", "testWithPrintln", 1);
+        assertBugInMethodCount("NN_NAKED_NOTIFY", "ghIssues.Issue3884", "testWithMutation", 0);
+        assertBugInMethodCount("NN_NAKED_NOTIFY", "ghIssues.Issue3884", "testNakedNotify", 1);
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNakedNotify.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNakedNotify.java
@@ -44,6 +44,8 @@ public class FindNakedNotify extends BytecodeScanningDetector implements Statele
 
     private int notifyPC;
 
+    private boolean stateMutatedInSync;
+
     public FindNakedNotify(BugReporter bugReporter) {
         this.bugReporter = bugReporter;
     }
@@ -57,15 +59,59 @@ public class FindNakedNotify extends BytecodeScanningDetector implements Statele
     @Override
     public void visit(Code obj) {
         stage = synchronizedMethod ? Stage.MONITOR_ENTERED : Stage.START;
+        stateMutatedInSync = false;
         super.visit(obj);
         if (synchronizedMethod && stage == Stage.LOCK_LOADED) {
+            reportNakedNotifyIfNeeded();
+        }
+    }
+
+    private void reportNakedNotifyIfNeeded() {
+        if (!stateMutatedInSync) {
             bugReporter.reportBug(new BugInstance(this, "NN_NAKED_NOTIFY", NORMAL_PRIORITY).addClassAndMethod(this)
                     .addSourceLine(this, notifyPC));
         }
     }
 
+    private void noteStateChangeInSync(int seen) {
+        if ((stage == Stage.MONITOR_ENTERED || stage == Stage.LOADED) && isStateMutatingInstruction(seen)) {
+            stateMutatedInSync = true;
+            stage = Stage.START;
+        }
+    }
+
+    private boolean isStateMutatingInstruction(int seen) {
+        switch (seen) {
+        case Const.PUTFIELD:
+        case Const.PUTSTATIC:
+        case Const.IINC:
+            return true;
+        case Const.INVOKEVIRTUAL:
+        case Const.INVOKEINTERFACE:
+        case Const.INVOKESPECIAL:
+        case Const.INVOKESTATIC:
+            return !isBenignSyncInvoke(seen);
+        default:
+            return false;
+        }
+    }
+
+    private boolean isBenignSyncInvoke(int seen) {
+        if (isWaitOrNotifyMethod()) {
+            return true;
+        }
+        String className = getClassConstantOperand();
+        return className.startsWith("java/io/") || "java/lang/System".equals(className);
+    }
+
+    private boolean isWaitOrNotifyMethod() {
+        String name = getNameConstantOperand();
+        return "notify".equals(name) || "notifyAll".equals(name) || "wait".equals(name);
+    }
+
     @Override
     public void sawOpcode(int seen) {
+        noteStateChangeInSync(seen);
         switch (stage) {
         case START:
             if (seen == Const.MONITORENTER) {
@@ -85,7 +131,8 @@ public class FindNakedNotify extends BytecodeScanningDetector implements Statele
                     && "()V".equals(getSigConstantOperand())) {
                 stage = Stage.NOTIFY_CALLED;
                 notifyPC = getPC();
-            } else {
+            } else if (isStateMutatingInstruction(seen)) {
+                stateMutatedInSync = true;
                 stage = Stage.START;
             }
             break;
@@ -94,8 +141,7 @@ public class FindNakedNotify extends BytecodeScanningDetector implements Statele
             break;
         case LOCK_LOADED:
             if (seen == Const.MONITOREXIT) {
-                bugReporter.reportBug(new BugInstance(this, "NN_NAKED_NOTIFY", NORMAL_PRIORITY).addClassAndMethod(this)
-                        .addSourceLine(this, notifyPC));
+                reportNakedNotifyIfNeeded();
                 stage = Stage.MONITOR_EXITED;
             } else {
                 stage = Stage.START;

--- a/spotbugsTestCases/src/java/ghIssues/Issue3884.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3884.java
@@ -1,0 +1,24 @@
+package ghIssues;
+
+public class Issue3884 {
+    private int count = 0;
+
+    public synchronized void testWithFieldRead() {
+        int temp = this.count;
+        this.notifyAll();
+    }
+
+    public synchronized void testWithPrintln() {
+        System.out.println("Log");
+        this.notifyAll();
+    }
+
+    public synchronized void testWithMutation() {
+        this.count++;
+        this.notifyAll();
+    }
+
+    public synchronized void testNakedNotify() {
+        this.notifyAll();
+    }
+}


### PR DESCRIPTION
## Summary
- Fix `NN_NAKED_NOTIFY` false negative when a synchronized block contains only non-mutating instructions (field read, local store, logging) before `notify()`.
- Keep tracking `LOADED` across benign bytecode instead of resetting to `START` on every non-notify instruction.
- Treat field writes and mutating invocations (excluding wait/notify and common I/O helpers) as state changes that suppress the warning.
- Add regression test for issue #3884.

## Root cause
After loading the lock/receiver, benign instructions such as `istore` or `PrintStream.println` reset the state machine to `START`, so the subsequent `notifyAll()` was never recognized as a naked notify.

## Test plan
- [x] `./gradlew :spotbugs-tests:test --tests "edu.umd.cs.findbugs.detect.Issue3884Test"`
- [x] `./gradlew :spotbugs-tests:test --tests "edu.umd.cs.findbugs.detect.Issue3634Test"`

Fixes #3884