### PR TITLE
Fix EI_EXPOSE_REP2 false negative for constructor delegation (#3824)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - New detector `FindIncreasedAccessibilityOfMethods` for new bug type `IAOM_DO_NOT_INCREASE_METHOD_ACCESSIBILITY`. This detector reports a bug if a class increases the accessibility of overridden or hidden methods. (See [SEI CERT rule MET04-J](https://wiki.sei.cmu.edu/confluence/display/java/MET04-J.+Do+not+increase+the+accessibility+of+overridden+or+hidden+methods))
 
 ### Fixed
+- Fix `EI_EXPOSE_REP2` false negative when a public constructor delegates to a private constructor ([#3824](https://github.com/spotbugs/spotbugs/issues/3824))
 - Fix `DM_STRING_TOSTRING` false negative when `toString()` is chained before a method call (e.g., `s.toString().toLowerCase()`); multiple occurrences in the same method are now all reported ([#3966](https://github.com/spotbugs/spotbugs/issues/3966))
 - Stop exposing JUnit BOM as a transitive dependency to consumers ([#3908](https://github.com/spotbugs/spotbugs/issues/3908))
 - Fix incorrect bug counts and sizes when unioning reports ([#3721](https://github.com/spotbugs/spotbugs/issues/3721))

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3824Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3824Test.java
@@ -1,0 +1,15 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class Issue3824Test extends AbstractIntegrationTest {
+
+    @Test
+    void testIssue() {
+        performAnalysis("ghIssues/Issue3824.class", "ghIssues/Issue3824$DirectAssignment.class");
+
+        assertBugInMethodCount("EI_EXPOSE_REP2", "ghIssues.Issue3824", "<init>", 1);
+        assertBugInMethodCount("EI_EXPOSE_REP2", "ghIssues.Issue3824$DirectAssignment", "<init>", 1);
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindReturnRef.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindReturnRef.java
@@ -154,7 +154,9 @@ public class FindReturnRef extends OpcodeStackDetector {
 
     @Override
     public void visit(Method obj) {
-        check = obj.isPublic() && (getThisClass().isPublic() || overridesMethodFromPublicSupertype(obj));
+        boolean isInstanceConstructor = Const.CONSTRUCTOR_NAME.equals(obj.getName()) && !obj.isStatic();
+        check = (getThisClass().isPublic() || overridesMethodFromPublicSupertype(obj))
+                && (obj.isPublic() || isInstanceConstructor);
         if (!check) {
             return;
         }

--- a/spotbugsTestCases/src/java/ghIssues/Issue3824.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3824.java
@@ -1,0 +1,31 @@
+package ghIssues;
+
+import java.util.Date;
+
+public class Issue3824 {
+    private final Date date;
+    private final Object launcher;
+
+    public Issue3824(Date date) {
+        this(date, createLauncher());
+    }
+
+    private Issue3824(Date date, Object launcher) {
+        this.date = date;
+        this.launcher = launcher;
+    }
+
+    public static class DirectAssignment {
+        private final Date date;
+        private final Object launcher;
+
+        public DirectAssignment(Date date) {
+            this.date = date;
+            this.launcher = createLauncher();
+        }
+    }
+
+    private static Object createLauncher() {
+        return new Object();
+    }
+}


### PR DESCRIPTION
## Summary
- Fix `EI_EXPOSE_REP2` false negative when a public constructor delegates to a private constructor via `this(...)`.
- Analyze instance constructors in public classes even when the constructor itself is not public.
- Add regression test for issue #3824.

## Root cause
`FindReturnRef` only analyzed public methods. When mutable references were stored in a private constructor reached through constructor chaining, the assignment was skipped.

## Test plan
- [x] `./gradlew :spotbugs-tests:test --tests "edu.umd.cs.findbugs.detect.Issue3824Test"`
- [x] `./gradlew :spotbugs-tests:test --tests "edu.umd.cs.findbugs.detect.FindReturnRefTest"`

Fixes #3824