### PR TITLE
Fix exclude filter with lowercase <or> suppressing all bugs (#3837)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - New detector `FindIncreasedAccessibilityOfMethods` for new bug type `IAOM_DO_NOT_INCREASE_METHOD_ACCESSIBILITY`. This detector reports a bug if a class increases the accessibility of overridden or hidden methods. (See [SEI CERT rule MET04-J](https://wiki.sei.cmu.edu/confluence/display/java/MET04-J.+Do+not+increase+the+accessibility+of+overridden+or+hidden+methods))
 
 ### Fixed
+- Fix exclude filter with lowercase `<or>` incorrectly suppressing unrelated bugs ([#3837](https://github.com/spotbugs/spotbugs/issues/3837))
 - Fix `DM_STRING_TOSTRING` false negative when `toString()` is chained before a method call (e.g., `s.toString().toLowerCase()`); multiple occurrences in the same method are now all reported ([#3966](https://github.com/spotbugs/spotbugs/issues/3966))
 - Stop exposing JUnit BOM as a transitive dependency to consumers ([#3908](https://github.com/spotbugs/spotbugs/issues/3908))
 - Fix incorrect bug counts and sizes when unioning reports ([#3721](https://github.com/spotbugs/spotbugs/issues/3721))

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/filter/FilterCompoundElementTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/filter/FilterCompoundElementTest.java
@@ -1,0 +1,68 @@
+/*
+ * FindBugs - Find Bugs in Java programs
+ * Copyright (C) 2026, University of Maryland
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+package edu.umd.cs.findbugs.filter;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+
+import org.apache.tools.ant.filters.StringInputStream;
+import org.junit.jupiter.api.Test;
+
+import edu.umd.cs.findbugs.BugInstance;
+
+class FilterCompoundElementTest {
+
+    private static Filter parseFilter(String orElementName) throws IOException {
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                + "\n<FindBugsFilter>"
+                + "\n<Match>"
+                + "\n<" + orElementName + ">"
+                + "\n<Bug pattern=\"THROWS_METHOD_THROWS_RUNTIMEEXCEPTION\" />"
+                + "\n<Bug pattern=\"THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION\" />"
+                + "\n</" + orElementName + ">"
+                + "\n</Match>"
+                + "\n</FindBugsFilter>\n";
+        return new Filter(new StringInputStream(xml));
+    }
+
+    @Test
+    void lowercaseOrMatchesOnlyListedPatterns() throws Exception {
+        Filter filter = parseFilter("or");
+
+        BugInstance sqlBug = new BugInstance("SQL_PREPARED_STATEMENT_GENERATED_FROM_NONCONSTANT_STRING", 3);
+        BugInstance throwsBug = new BugInstance("THROWS_METHOD_THROWS_RUNTIMEEXCEPTION", 2);
+
+        assertFalse(filter.match(sqlBug));
+        assertTrue(filter.match(throwsBug));
+    }
+
+    @Test
+    void uppercaseOrMatchesOnlyListedPatterns() throws Exception {
+        Filter filter = parseFilter("Or");
+
+        BugInstance sqlBug = new BugInstance("SQL_PREPARED_STATEMENT_GENERATED_FROM_NONCONSTANT_STRING", 3);
+        BugInstance throwsBug = new BugInstance("THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION", 2);
+
+        assertFalse(filter.match(sqlBug));
+        assertTrue(filter.match(throwsBug));
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/SAXBugCollectionHandler.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/SAXBugCollectionHandler.java
@@ -396,7 +396,12 @@ public class SAXBugCollectionHandler extends DefaultHandler {
     }
 
     private boolean isCompoundElementTag(String qName) {
-        return outerElementTags.contains(qName);
+        for (String tag : outerElementTags) {
+            if (tag.equalsIgnoreCase(qName)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private boolean isTopLevelFilter(String qName) {
@@ -437,6 +442,10 @@ public class SAXBugCollectionHandler extends DefaultHandler {
 
     boolean nextMatchedIsDisabled;
     private final Set<String> outerElementTags = unmodifiableSet(new HashSet<>(asList("And", "Match", "Or", "Not")));
+
+    private static boolean isFilterCompoundElement(String qName, String canonicalName) {
+        return canonicalName.equalsIgnoreCase(qName);
+    }
 
     private void parseMatcher(String qName, Attributes attributes) throws SAXException {
         if (DEBUG) {
@@ -487,13 +496,13 @@ public class SAXBugCollectionHandler extends DefaultHandler {
             String type = getOptionalAttribute(attributes, "type");
             String role = getOptionalAttribute(attributes, "role");
             addMatcher(new FieldMatcher(name, type, role));
-        } else if ("Or".equals(qName)) {
+        } else if (isFilterCompoundElement(qName, "Or")) {
             CompoundMatcher matcher = new OrMatcher();
             pushCompoundMatcherAsChild(matcher);
-        } else if ("And".equals(qName) || "Match".equals(qName)) {
+        } else if (isFilterCompoundElement(qName, "And") || isFilterCompoundElement(qName, "Match")) {
             AndMatcher matcher = new AndMatcher();
             pushCompoundMatcherAsChild(matcher);
-            if ("Match".equals(qName)) {
+            if (isFilterCompoundElement(qName, "Match")) {
                 String classregex = getOptionalAttribute(attributes, "classregex");
                 String classMatch = getOptionalAttribute(attributes, "class");
 
@@ -503,7 +512,7 @@ public class SAXBugCollectionHandler extends DefaultHandler {
                     addMatcher(new ClassMatcher(classMatch));
                 }
             }
-        } else if ("Not".equals(qName)) {
+        } else if (isFilterCompoundElement(qName, "Not")) {
             NotMatcher matcher = new NotMatcher();
             pushCompoundMatcherAsChild(matcher);
         } else if ("Source".equals(qName)) {


### PR DESCRIPTION
## Summary
- Fix SAX parsing of exclude filter compound elements (`Or`, `And`, `Match`, `Not`) to be case-insensitive
- Lowercase `<or>` was ignored, leaving an empty `Match` block; empty `AndMatcher` matches every bug and incorrectly suppressed unrelated warnings such as `SQL_PREPARED_STATEMENT_GENERATED_FROM_NONCONSTANT_STRING`
- Add regression tests for lowercase and uppercase `<or>` filters

Fixes #3837

## Test plan
- [x] `./gradlew :spotbugs-tests:test --tests edu.umd.cs.findbugs.filter.FilterCompoundElementTest`
- [x] Reproduced with [jpschewe/spotbugs-bugs](https://github.com/jpschewe/spotbugs-bugs) `prepared-statement-non-constant` branch: lowercase `<or>` now keeps SQL bug visible; capital `<Or>` unchanged