### PR TITLE
Fix AT false positives when Lock is acquired via AutoCloseable wrapper (#3516)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - New detector `FindIncreasedAccessibilityOfMethods` for new bug type `IAOM_DO_NOT_INCREASE_METHOD_ACCESSIBILITY`. This detector reports a bug if a class increases the accessibility of overridden or hidden methods. (See [SEI CERT rule MET04-J](https://wiki.sei.cmu.edu/confluence/display/java/MET04-J.+Do+not+increase+the+accessibility+of+overridden+or+hidden+methods))
 
 ### Fixed
+- Fix `AT_NONATOMIC_OPERATIONS_ON_SHARED_VARIABLE` and `AT_STALE_THREAD_WRITE_OF_PRIMITIVE` false positives when a `Lock` is acquired via an AutoCloseable wrapper method such as `open()` ([#3516](https://github.com/spotbugs/spotbugs/issues/3516))
 - Fix `DM_STRING_TOSTRING` false negative when `toString()` is chained before a method call (e.g., `s.toString().toLowerCase()`); multiple occurrences in the same method are now all reported ([#3966](https://github.com/spotbugs/spotbugs/issues/3966))
 - Stop exposing JUnit BOM as a transitive dependency to consumers ([#3908](https://github.com/spotbugs/spotbugs/issues/3908))
 - Fix incorrect bug counts and sizes when unioning reports ([#3721](https://github.com/spotbugs/spotbugs/issues/3721))

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3516Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3516Test.java
@@ -1,0 +1,14 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class Issue3516Test extends AbstractIntegrationTest {
+
+    @Test
+    void noAtomicityWarningWhenLockIsAcquiredViaAutoCloseableWrapper() {
+        performAnalysis("ghIssues/Issue3516.class");
+        assertBugInClassCount("AT_NONATOMIC_OPERATIONS_ON_SHARED_VARIABLE", "ghIssues.Issue3516", 0);
+        assertBugInClassCount("AT_STALE_THREAD_WRITE_OF_PRIMITIVE", "ghIssues.Issue3516", 0);
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SharedVariableAtomicityDetector.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SharedVariableAtomicityDetector.java
@@ -35,17 +35,27 @@ import edu.umd.cs.findbugs.util.MultiThreadedCodeIdentifierUtils;
 import org.apache.bcel.Const;
 import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.classfile.Method;
+import org.apache.bcel.generic.ConstantPoolGen;
+import org.apache.bcel.generic.Instruction;
+import org.apache.bcel.generic.InstructionHandle;
+import org.apache.bcel.generic.InvokeInstruction;
+import org.apache.bcel.generic.MethodGen;
 
+import java.util.BitSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
 public class SharedVariableAtomicityDetector extends OpcodeStackDetector {
+    private static final Set<String> DIRECT_LOCK_METHODS = Set.of(
+            "lock", "unlock", "tryLock", "lockInterruptibly", "newCondition");
+
     private final BugAccumulator bugAccumulator;
     private Method currentMethod;
     private CFG currentCFG;
     private LockDataflow currentLockDataFlow;
+    private BitSet autoCloseableLockPcs = new BitSet(0);
     private boolean isFirstVisit = true;
     private boolean hadOperation = false;
     private final Map<XMethod, Set<XField>> readFieldsByMethods = new HashMap<>();
@@ -114,6 +124,7 @@ public class SharedVariableAtomicityDetector extends OpcodeStackDetector {
             currentMethod = method;
             currentLockDataFlow = getClassContext().getLockDataflow(currentMethod);
             currentCFG = getClassContext().getCFG(currentMethod);
+            autoCloseableLockPcs = computeAutoCloseableLockPcs(method);
         } catch (CFGBuilderException | DataflowAnalysisException e) {
             AnalysisContext.logError("There was an error while SharedVariableAtomicityDetector analyzed " + getClassName(), e);
         }
@@ -131,7 +142,8 @@ public class SharedVariableAtomicityDetector extends OpcodeStackDetector {
     @Override
     public void sawOpcode(int seen) {
         if (Const.CONSTRUCTOR_NAME.equals(getMethodName()) || Const.STATIC_INITIALIZER_NAME.equals(getMethodName())
-                || MultiThreadedCodeIdentifierUtils.isLocked(currentMethod, currentCFG, currentLockDataFlow, getPC())) {
+                || MultiThreadedCodeIdentifierUtils.isLocked(currentMethod, currentCFG, currentLockDataFlow, getPC())
+                || autoCloseableLockPcs.get(getPC())) {
             return;
         }
         XMethod method = getXMethod();
@@ -252,5 +264,57 @@ public class SharedVariableAtomicityDetector extends OpcodeStackDetector {
 
     private boolean is64bitPrimitive(String className) {
         return "D".equals(className) || "J".equals(className);
+    }
+
+    private BitSet computeAutoCloseableLockPcs(Method method) {
+        BitSet lockedPcs = new BitSet();
+        MethodGen methodGen = getClassContext().getMethodGen(method);
+        if (methodGen == null) {
+            return lockedPcs;
+        }
+        ConstantPoolGen constantPool = methodGen.getConstantPool();
+        InstructionHandle handle = methodGen.getInstructionList().getStart();
+        while (handle != null) {
+            Instruction instruction = handle.getInstruction();
+            if (instruction instanceof InvokeInstruction) {
+                InvokeInstruction invoke = (InvokeInstruction) instruction;
+                String methodName = invoke.getMethodName(constantPool);
+                String signature = invoke.getSignature(constantPool);
+                String receiverClass = invoke.getClassName(constantPool);
+                if (!"()V".equals(signature) && isLockType(receiverClass) && !DIRECT_LOCK_METHODS.contains(methodName)) {
+                    markUntilLockGuardClose(handle.getNext(), lockedPcs, constantPool);
+                }
+            }
+            handle = handle.getNext();
+        }
+        return lockedPcs;
+    }
+
+    private static void markUntilLockGuardClose(InstructionHandle start, BitSet lockedPcs, ConstantPoolGen constantPool) {
+        InstructionHandle handle = start;
+        while (handle != null) {
+            lockedPcs.set(handle.getPosition());
+            Instruction instruction = handle.getInstruction();
+            if (instruction instanceof InvokeInstruction) {
+                InvokeInstruction invoke = (InvokeInstruction) instruction;
+                if ("()V".equals(invoke.getSignature(constantPool)) && "close".equals(invoke.getMethodName(constantPool))
+                        && isLockGuardType(invoke.getClassName(constantPool))) {
+                    return;
+                }
+            }
+            handle = handle.getNext();
+        }
+    }
+
+    private static boolean isLockType(String className) {
+        return className.contains("Lock");
+    }
+
+    private static boolean isLockGuardType(String className) {
+        int dollar = className.lastIndexOf('$');
+        if (dollar <= 0) {
+            return false;
+        }
+        return isLockType(className.substring(0, dollar));
     }
 }

--- a/spotbugsTestCases/src/java/ghIssues/Issue3516.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3516.java
@@ -1,0 +1,63 @@
+package ghIssues;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
+
+public class Issue3516 implements Runnable {
+
+    private final CloseableReentrantLock lock = new CloseableReentrantLock();
+
+    private final ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
+
+    private int consecutiveUnsuccessfulCalls;
+
+    @Override
+    public void run() {
+        if (consecutiveUnsuccessfulCalls < 5) {
+            doTask();
+        }
+    }
+
+    public void start() {
+        executor.schedule(this::doTask, 5, TimeUnit.MILLISECONDS);
+    }
+
+    void doTask() {
+        try (var ignored = lock.open()) {
+            try {
+                Thread.sleep(1);
+                consecutiveUnsuccessfulCalls = 0;
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } catch (Exception e) {
+                consecutiveUnsuccessfulCalls++;
+            } finally {
+                scheduleNextCall();
+            }
+        }
+    }
+
+    private void scheduleNextCall() {
+        if (consecutiveUnsuccessfulCalls < 5) {
+            executor.schedule(this::doTask, 5, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    static class CloseableReentrantLock extends ReentrantLock {
+
+        Guard open() {
+            this.lock();
+            return new Guard();
+        }
+
+        class Guard implements AutoCloseable {
+
+            @Override
+            public void close() {
+                CloseableReentrantLock.this.unlock();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Treat try-with-resources regions that acquire a `Lock` through a wrapper method (for example `open()`) as synchronized when analyzing shared primitive field access
- Fixes false positives for `AT_NONATOMIC_OPERATIONS_ON_SHARED_VARIABLE` and `AT_STALE_THREAD_WRITE_OF_PRIMITIVE` when the lock is not invoked directly via `lock()`/`unlock()`

Fixes #3516

## Test plan
- [x] `./gradlew :spotbugsTestCases:classesJava17 :spotbugs-tests:test --tests edu.umd.cs.findbugs.detect.Issue3516Test`
- [x] `./gradlew :spotbugs-tests:test --tests edu.umd.cs.findbugs.detect.SharedVariableAtomicityDetectorTest`