### PR TITLE
Fix @SuppressFBWarnings not applying to lambda bodies (#3808)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - New detector `FindIncreasedAccessibilityOfMethods` for new bug type `IAOM_DO_NOT_INCREASE_METHOD_ACCESSIBILITY`. This detector reports a bug if a class increases the accessibility of overridden or hidden methods. (See [SEI CERT rule MET04-J](https://wiki.sei.cmu.edu/confluence/display/java/MET04-J.+Do+not+increase+the+accessibility+of+overridden+or+hidden+methods))
 
 ### Fixed
+- Apply `@SuppressFBWarnings` on a method to bugs reported in javac-generated lambda bodies for that method ([#3808](https://github.com/spotbugs/spotbugs/issues/3808))
 - Fix `DM_STRING_TOSTRING` false negative when `toString()` is chained before a method call (e.g., `s.toString().toLowerCase()`); multiple occurrences in the same method are now all reported ([#3966](https://github.com/spotbugs/spotbugs/issues/3966))
 - Stop exposing JUnit BOM as a transitive dependency to consumers ([#3908](https://github.com/spotbugs/spotbugs/issues/3908))
 - Fix incorrect bug counts and sizes when unioning reports ([#3721](https://github.com/spotbugs/spotbugs/issues/3721))

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/SuppressionMatcherTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/SuppressionMatcherTest.java
@@ -74,6 +74,16 @@ class SuppressionMatcherTest {
     }
 
     @Test
+    void shouldMatchMethodLevelSuppressorForLambdaBody() {
+        MethodAnnotation outer = new MethodAnnotation(CLASS_NAME, "outer", "()V", false);
+        MethodAnnotation lambda = new MethodAnnotation(CLASS_NAME, "lambda$outer$0", "()V", false);
+        BugInstance bug = new BugInstance("UUF_UNUSED_FIELD", 1).addClass(CLASS_NAME).addMethod(lambda);
+        matcher.addSuppressor(new MethodWarningSuppressor("UUF_UNUSED_FIELD", SuppressMatchType.DEFAULT, CLASS_ANNOTATION, outer, true, true));
+
+        assertThat("Should match the bug in a lambda body", matcher.match(bug), is(true));
+    }
+
+    @Test
     void shouldMatchParameterLevelSuppressor() {
         // given
         MethodAnnotation method = new MethodAnnotation(CLASS_NAME, "test", "bool test()", false);

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3808Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3808Test.java
@@ -1,0 +1,15 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class Issue3808Test extends AbstractIntegrationTest {
+
+    @Test
+    void methodSuppressionsApplyToLambdaBodies() {
+        performAnalysis("ghIssues/Issue3808.class");
+
+        assertBugInClassCount("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT", "ghIssues.Issue3808", 1);
+        assertBugInClassCount("US_USELESS_SUPPRESSION_ON_METHOD", "ghIssues.Issue3808", 0);
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/MethodWarningSuppressor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/MethodWarningSuppressor.java
@@ -36,7 +36,10 @@ public class MethodWarningSuppressor extends ClassWarningSuppressor {
 
         MethodAnnotation bugMethod = bugInstance.getPrimaryMethod();
         if (bugMethod != null && !method.equals(bugMethod)) {
-            return false;
+            String enclosingMethod = MemberUtils.getEnclosingMethodNameFromLambda(bugMethod.getMethodName());
+            if (enclosingMethod == null || !enclosingMethod.equals(method.getMethodName())) {
+                return false;
+            }
         }
         if (DEBUG) {
             System.out.println("Suppressing " + bugInstance);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/bytecode/MemberUtils.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/bytecode/MemberUtils.java
@@ -17,6 +17,8 @@
  */
 package edu.umd.cs.findbugs.bytecode;
 
+import javax.annotation.CheckForNull;
+
 import edu.umd.cs.findbugs.classfile.analysis.AnnotatedObject;
 import edu.umd.cs.findbugs.classfile.analysis.AnnotationValue;
 import org.apache.bcel.classfile.AnnotationEntry;
@@ -146,6 +148,22 @@ public final class MemberUtils {
      */
     public static boolean couldBeLambda(final MethodGen m) {
         return m.isPrivate() && internalIsSynthetic(m);
+    }
+
+    /**
+     * Returns the enclosing source method name for a javac-generated lambda method
+     * (e.g. {@code lambda$outer$0} → {@code outer}), or null if not a lambda name.
+     */
+    @CheckForNull
+    public static String getEnclosingMethodNameFromLambda(@CheckForNull String methodName) {
+        if (methodName == null || !methodName.startsWith("lambda$")) {
+            return null;
+        }
+        int lastDollar = methodName.lastIndexOf('$');
+        if (lastDollar <= "lambda$".length()) {
+            return null;
+        }
+        return methodName.substring("lambda$".length(), lastDollar);
     }
 
     /**

--- a/spotbugsTestCases/src/java/ghIssues/Issue3808.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3808.java
@@ -1,0 +1,21 @@
+package ghIssues;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+public class Issue3808 {
+
+    @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED")
+    public void suppressedMethod() {
+        Runnable r = () -> {
+            Integer.valueOf(1);
+        };
+        r.run();
+    }
+
+    public void notSuppressedMethod() {
+        Runnable r = () -> {
+            Integer.valueOf(1);
+        };
+        r.run();
+    }
+}


### PR DESCRIPTION
## Summary
- Method-level `@SuppressFBWarnings` now suppresses bugs in javac-generated lambda methods (`lambda$<method>$<index>`) for the annotated enclosing method.
- Fixes false `US_USELESS_SUPPRESSION_ON_METHOD` when the suppression was intended for lambda body code.

## Test plan
- [x] `Issue3808Test` — RV in lambda suppressed; only unsuppressed method reports
- [x] `SuppressionMatcherTest.shouldMatchMethodLevelSuppressorForLambdaBody`
- [x] `DetectorsTest` regression suite

Fixes #3808