### PR TITLE
Collapse analyzed file list in default HTML report (#4048)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Reuse DismantleBytecode.isIf introduced in ([#3869](https://github.com/spotbugs/spotbugs/pull/3869))
 
 ### Added
+- Collapse the analyzed file list in the default HTML report behind a `<details>` element ([#4048](https://github.com/spotbugs/spotbugs/issues/4048))
 - Recognize `jakarta.annotation.Nonnull` and `jakarta.annotation.Nullable` ([#3780](https://github.com/spotbugs/spotbugs/pull/3780))
 - Detect use of `sun.misc.Unsafe` and `jdk.internal.misc.Unsafe` ([#3804](https://github.com/spotbugs/spotbugs/pull/3804))
 - New bug type is introduced: `NCR_NOT_PROPERLY_CHECKED_READ`. Improper validation of the return value from the read() method in InputStream and Reader classes may result in an array not being fully filled. ([#3766](https://github.com/spotbugs/spotbugs/pull/3766))

--- a/spotbugs/src/xsl/default.xsl
+++ b/spotbugs/src/xsl/default.xsl
@@ -228,12 +228,14 @@
 	</p>
 	<p>SpotBugs version: <xsl:value-of select="/BugCollection/@version"/></p>
 	
-	<p>Code analyzed:</p>
-	<ul>
-		<xsl:for-each select="./Jar">
-			<li><xsl:value-of select="text()"/></li>
-		</xsl:for-each>
-	</ul>
+	<details>
+		<summary>Code analyzed (<xsl:value-of select="count(./Jar)"/> files)</summary>
+		<ul>
+			<xsl:for-each select="./Jar">
+				<li><xsl:value-of select="text()"/></li>
+			</xsl:for-each>
+		</ul>
+	</details>
 	<p><br/><br/></p>
 </xsl:template>
 


### PR DESCRIPTION
## Summary
- Wrap the analyzed file (`Jar`) list in `default.xsl` with HTML `<details>` / `<summary>`.
- Summary shows file count, e.g. "Code analyzed (4123 files)", collapsed by default.

## Motivation
Large projects can list thousands of analyzed paths before the summary/warnings sections, making the HTML report hard to navigate ([#4048](https://github.com/spotbugs/spotbugs/issues/4048)).

## Test plan
- [ ] Generate HTML with `-html` on a project with many classes and confirm the file list is collapsed
- [ ] Confirm warnings/summary sections remain unchanged

Fixes #4048