### PR TITLE
Fix ST false negative for static field writes in named inner classes (#3893)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - New detector `FindIncreasedAccessibilityOfMethods` for new bug type `IAOM_DO_NOT_INCREASE_METHOD_ACCESSIBILITY`. This detector reports a bug if a class increases the accessibility of overridden or hidden methods. (See [SEI CERT rule MET04-J](https://wiki.sei.cmu.edu/confluence/display/java/MET04-J.+Do+not+increase+the+accessibility+of+overridden+or+hidden+methods))
 
 ### Fixed
+- Fix `ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD` false negatives in named inner classes ([#3893](https://github.com/spotbugs/spotbugs/issues/3893))
 - Fix `DM_STRING_TOSTRING` false negative when `toString()` is chained before a method call (e.g., `s.toString().toLowerCase()`); multiple occurrences in the same method are now all reported ([#3966](https://github.com/spotbugs/spotbugs/issues/3966))
 - Stop exposing JUnit BOM as a transitive dependency to consumers ([#3908](https://github.com/spotbugs/spotbugs/issues/3908))
 - Fix incorrect bug counts and sizes when unioning reports ([#3721](https://github.com/spotbugs/spotbugs/issues/3721))

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3893Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3893Test.java
@@ -1,0 +1,15 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class Issue3893Test extends AbstractIntegrationTest {
+
+    @Test
+    void reportsStInInnerClassDespiteLocalShadowing() {
+        performAnalysis("ghIssues/Issue3893.class", "ghIssues/Issue3893$Inner.class");
+        assertBugInMethod("ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD", "ghIssues.Issue3893", "accessTopLevel");
+        assertBugInMethod("ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD", "ghIssues.Issue3893$Inner", "accessWithShadowing");
+        assertBugInMethod("ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD", "ghIssues.Issue3893$Inner", "accessQualified");
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UnreadFields.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UnreadFields.java
@@ -508,7 +508,7 @@ public class UnreadFields extends OpcodeStackDetector {
                 if (getThisClass().isPrivate() || getMethod().isPrivate()) {
                     priority++;
                 }
-                if (getClassName().indexOf('$') != -1 || BCELUtil.isSynthetic(getMethod()) || f.isSynthetic()
+                if (getClassDescriptor().isAnonymousClass() || BCELUtil.isSynthetic(getMethod()) || f.isSynthetic()
                         || f.getName().indexOf('$') >= 0) {
                     priority++;
                 }

--- a/spotbugsTestCases/src/java/ghIssues/Issue3893.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3893.java
@@ -1,0 +1,19 @@
+package ghIssues;
+
+public class Issue3893 {
+    private static int f;
+
+    void accessTopLevel(Issue3893 o) {
+        f = o.f++;
+    }
+
+    class Inner {
+        void accessWithShadowing(Issue3893 o) {
+            int f = o.f++;
+        }
+
+        void accessQualified(Issue3893 o) {
+            int f = Issue3893.f++;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Stop deprioritizing `ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD` for every class whose name contains `$`.
- Only apply that extra deprioritization for anonymous classes (plus existing synthetic-member rules).
- Named inner classes that write to an outer class static field are reported again.

## Test plan
- [x] `Issue3893Test` — outer class, inner class with local shadowing, inner class with qualified static write
- [x] `DetectorsTest` regression suite

Fixes #3893

Related: leemeii #3946 (same root cause; this branch is rebased on current master)