### PR TITLE
fix: report each UCF occurrence in a method (#3894)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - New detector `FindIncreasedAccessibilityOfMethods` for new bug type `IAOM_DO_NOT_INCREASE_METHOD_ACCESSIBILITY`. This detector reports a bug if a class increases the accessibility of overridden or hidden methods. (See [SEI CERT rule MET04-J](https://wiki.sei.cmu.edu/confluence/display/java/MET04-J.+Do+not+increase+the+accessibility+of+overridden+or+hidden+methods))
 
 ### Fixed
+- Report each `UCF_USELESS_CONTROL_FLOW` occurrence in a method instead of deduplicating via `BugAccumulator` ([#3894](https://github.com/spotbugs/spotbugs/issues/3894))
 - Fix `DM_STRING_TOSTRING` false negative when `toString()` is chained before a method call (e.g., `s.toString().toLowerCase()`); multiple occurrences in the same method are now all reported ([#3966](https://github.com/spotbugs/spotbugs/issues/3966))
 - Stop exposing JUnit BOM as a transitive dependency to consumers ([#3908](https://github.com/spotbugs/spotbugs/issues/3908))
 - Fix incorrect bug counts and sizes when unioning reports ([#3721](https://github.com/spotbugs/spotbugs/issues/3721))

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3894Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3894Test.java
@@ -1,0 +1,25 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class Issue3894Test extends AbstractIntegrationTest {
+
+    @Test
+    void reportsEachUselessControlFlowOccurrenceInMethod() {
+        performAnalysis("ghIssues/Issue3894.class");
+
+        assertBugInMethodCount("UCF_USELESS_CONTROL_FLOW", "ghIssues.Issue3894", "multipleCasesInMethod", 4);
+        assertBugInMethodAtLine("UCF_USELESS_CONTROL_FLOW", "ghIssues.Issue3894", "multipleCasesInMethod", 13);
+        assertBugInMethodAtLine("UCF_USELESS_CONTROL_FLOW", "ghIssues.Issue3894", "multipleCasesInMethod", 19);
+        assertBugInMethodAtLine("UCF_USELESS_CONTROL_FLOW", "ghIssues.Issue3894", "multipleCasesInMethod", 23);
+        assertBugInMethodAtLine("UCF_USELESS_CONTROL_FLOW", "ghIssues.Issue3894", "multipleCasesInMethod", 26);
+
+        assertBugInMethodCount("UCF_USELESS_CONTROL_FLOW", "ghIssues.Issue3894", "multipleEmptyIfs", 3);
+        assertBugInMethodAtLine("UCF_USELESS_CONTROL_FLOW", "ghIssues.Issue3894", "multipleEmptyIfs", 31);
+        assertBugInMethodAtLine("UCF_USELESS_CONTROL_FLOW", "ghIssues.Issue3894", "multipleEmptyIfs", 33);
+        assertBugInMethodAtLine("UCF_USELESS_CONTROL_FLOW", "ghIssues.Issue3894", "multipleEmptyIfs", 35);
+
+        assertNoBugInMethod("UCF_USELESS_CONTROL_FLOW", "ghIssues.Issue3894", "nonEmptyIf");
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindUselessControlFlow.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindUselessControlFlow.java
@@ -19,11 +19,9 @@
 
 package edu.umd.cs.findbugs.detect;
 
-import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.LineNumber;
 import org.apache.bcel.classfile.LineNumberTable;
 
-import edu.umd.cs.findbugs.BugAccumulator;
 import edu.umd.cs.findbugs.BugInstance;
 import edu.umd.cs.findbugs.BugReporter;
 import edu.umd.cs.findbugs.BytecodeScanningDetector;
@@ -50,16 +48,10 @@ import edu.umd.cs.findbugs.StatelessDetector;
  */
 public class FindUselessControlFlow extends BytecodeScanningDetector implements StatelessDetector {
 
-    private final BugAccumulator bugAccumulator;
+    private final BugReporter bugReporter;
 
     public FindUselessControlFlow(BugReporter bugReporter) {
-        this.bugAccumulator = new BugAccumulator(bugReporter);
-    }
-
-    @Override
-    public void visit(Code obj) {
-        super.visit(obj);
-        bugAccumulator.reportAccumulatedBugs();
+        this.bugReporter = bugReporter;
     }
 
     @Override
@@ -82,9 +74,10 @@ public class FindUselessControlFlow extends BytecodeScanningDetector implements 
             } else {
                 priority = LOW_PRIORITY;
             }
-            bugAccumulator.accumulateBug(new BugInstance(this,
+            bugReporter.reportBug(new BugInstance(this,
                     priority == HIGH_PRIORITY ? "UCF_USELESS_CONTROL_FLOW_NEXT_LINE" : "UCF_USELESS_CONTROL_FLOW", priority)
-                    .addClassAndMethod(this), this);
+                    .addClassAndMethod(this)
+                    .addSourceLine(this));
         }
     }
 

--- a/spotbugsTestCases/src/java/ghIssues/Issue3894.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3894.java
@@ -1,0 +1,44 @@
+package ghIssues;
+
+public class Issue3894 {
+
+    static int x = 0;
+    static int y = 0;
+
+    static void trigger() throws Exception {
+        throw new Exception();
+    }
+
+    public static void multipleCasesInMethod() {
+        if (x > 0) {
+        }
+
+        try {
+            trigger();
+        } catch (Exception e) {
+            if (x == 0) {
+            }
+        }
+
+        if (y != 0) {
+        }
+
+        if (x == 0 && true) {
+        }
+    }
+
+    public static void multipleEmptyIfs(int a, int b, int c) {
+        if (a > 0) {
+        }
+        if (b > 0) {
+        }
+        if (c > 0) {
+        }
+    }
+
+    public static void nonEmptyIf() {
+        if (x > 0) {
+            y = 1;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **Root cause**: `FindUselessControlFlow` used `BugAccumulator`, which deduplicates bugs with the same hash when `MERGE_SIMILAR_WARNINGS` is enabled. For `UCF_USELESS_CONTROL_FLOW`, the hash is bug type + class + method only, so only the first empty `if` in a method was kept.
- **Fix**: Report each occurrence with `bugReporter.reportBug(...).addSourceLine(this)` instead of accumulating.
- **Tests**: `Issue3894` covers multiple empty `if` blocks in one method (including inside `catch` and after `try-catch`), multiple empty `if`s in another method, and a non-empty `if` control case.

## Related work

Same approach as #3947 by @leemeii (opened earlier). Happy to close this PR in favor of that one if maintainers prefer the original.

Fixes #3894

## Test plan

- [x] `./gradlew :spotbugs-tests:test --tests edu.umd.cs.findbugs.detect.Issue3894Test`
- [x] `./gradlew :spotbugs-tests:test --tests edu.umd.cs.findbugs.DetectorsTest`