### PR TITLE
fix: omit invented sourcepath when source file is missing (#3818)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - New detector `FindIncreasedAccessibilityOfMethods` for new bug type `IAOM_DO_NOT_INCREASE_METHOD_ACCESSIBILITY`. This detector reports a bug if a class increases the accessibility of overridden or hidden methods. (See [SEI CERT rule MET04-J](https://wiki.sei.cmu.edu/confluence/display/java/MET04-J.+Do+not+increase+the+accessibility+of+overridden+or+hidden+methods))
 
 ### Fixed
+- Omit invented `sourcepath` values when the source file cannot be resolved on the configured source path (e.g., Gradle package relocation) ([#3818](https://github.com/spotbugs/spotbugs/issues/3818))
 - Fix `DM_STRING_TOSTRING` false negative when `toString()` is chained before a method call (e.g., `s.toString().toLowerCase()`); multiple occurrences in the same method are now all reported ([#3966](https://github.com/spotbugs/spotbugs/issues/3966))
 - Stop exposing JUnit BOM as a transitive dependency to consumers ([#3908](https://github.com/spotbugs/spotbugs/issues/3908))
 - Fix incorrect bug counts and sizes when unioning reports ([#3721](https://github.com/spotbugs/spotbugs/issues/3721))

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue3818Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue3818Test.java
@@ -1,0 +1,80 @@
+package edu.umd.cs.findbugs.ba;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import edu.umd.cs.findbugs.Project;
+import edu.umd.cs.findbugs.SourceLineAnnotation;
+import edu.umd.cs.findbugs.xml.OutputStreamXMLOutput;
+
+class Issue3818Test {
+
+    @TempDir
+    Path tempDir;
+
+    @AfterEach
+    void tearDown() {
+        SourceLineAnnotation.clearGenerateRelativeSource();
+    }
+
+    @Test
+    void getSourcePathUsesResolvedSourceTreePath() throws Exception {
+        Path srcRoot = tempDir.resolve("src");
+        Files.createDirectories(srcRoot.resolve("com/example"));
+        Files.writeString(srcRoot.resolve("com/example/Example.java"), "class Example {}\n");
+
+        Project project = new Project();
+        project.getSourceFinder().setSourceBaseList(Collections.singletonList(srcRoot.toString()));
+        SourceLineAnnotation.generateRelativeSource(tempDir.toFile(), project);
+
+        SourceLineAnnotation annotation = new SourceLineAnnotation("com.example.Example", "Example.java", 1, 1, 0, 0);
+
+        assertEquals("com/example/Example.java", annotation.getSourcePath());
+    }
+
+    @Test
+    void getSourcePathOmitsInventedPathForRelocatedClassName() throws Exception {
+        Path srcRoot = tempDir.resolve("src");
+        Files.createDirectories(srcRoot.resolve("com/example"));
+        Files.writeString(srcRoot.resolve("com/example/Example.java"), "class Example {}\n");
+
+        Project project = new Project();
+        project.getSourceFinder().setSourceBaseList(Collections.singletonList(srcRoot.toString()));
+        SourceLineAnnotation.generateRelativeSource(tempDir.toFile(), project);
+
+        SourceLineAnnotation annotation = new SourceLineAnnotation("relocated.shaded.com.example.Example",
+                "Example.java", 1, 1, 0, 0);
+
+        assertNull(annotation.getSourcePath());
+    }
+
+    @Test
+    void writeXmlOmitsSourcepathWhenSourceIsNotResolvable() throws Exception {
+        Path srcRoot = tempDir.resolve("src");
+        Files.createDirectories(srcRoot.resolve("com/example"));
+        Files.writeString(srcRoot.resolve("com/example/Example.java"), "class Example {}\n");
+
+        Project project = new Project();
+        project.getSourceFinder().setSourceBaseList(Collections.singletonList(srcRoot.toString()));
+        SourceLineAnnotation.generateRelativeSource(tempDir.toFile(), project);
+
+        SourceLineAnnotation annotation = new SourceLineAnnotation("relocated.shaded.com.example.Example",
+                "Example.java", 10, 10, 0, 0);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        annotation.writeXML(new OutputStreamXMLOutput(out), false, true);
+        String xml = out.toString(StandardCharsets.UTF_8);
+
+        assertEquals(-1, xml.indexOf("sourcepath="));
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/SourceLineAnnotation.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/SourceLineAnnotation.java
@@ -904,7 +904,9 @@ public class SourceLineAnnotation implements BugAnnotation {
 
         if (isSourceFileKnown()) {
             attributeList.addAttribute("sourcefile", sourceFile);
-            attributeList.addAttribute("sourcepath", sourcePath);
+            if (sourcePath != null) {
+                attributeList.addAttribute("sourcepath", sourcePath);
+            }
             Project project = myProject.get();
             if (project != null) {
                 try {
@@ -938,7 +940,21 @@ public class SourceLineAnnotation implements BugAnnotation {
         }
     }
 
-    public String getSourcePath() {
+    public @CheckForNull String getSourcePath() {
+        if (!isSourceFileKnown()) {
+            return deriveSourcePathFromClassName();
+        }
+        SourceFinder sourceFinder = getSourceFinder();
+        if (sourceFinder != null) {
+            if (sourceFinder.hasSourceFile(this)) {
+                return SourceFinder.getCanonicalName(this);
+            }
+            return null;
+        }
+        return deriveSourcePathFromClassName();
+    }
+
+    private String deriveSourcePathFromClassName() {
         String classname = getClassName();
         String packageName = "";
         if (classname.indexOf('.') > 0) {


### PR DESCRIPTION
## Summary

- **Problem**: `SourceLineAnnotation.getSourcePath()` always built a path from the analyzed class’s package name plus `sourcefile`, even when that path does not exist on the configured source path (common with Gradle package relocation / shading).
- **Fix**: When a `SourceFinder` is available, use `hasSourceFile()` and return the canonical path only if the file is actually present; otherwise return `null` and omit the `sourcepath` attribute in XML output.
- **Tests**: `Issue3818Test` covers a resolvable class, a relocated class name with no matching source tree entry, and XML output without `sourcepath`.

## Notes

This does not deduplicate bugs for both original and relocated class names in the same JAR (that would be a separate change). It stops reporting non-existent `sourcepath` values that break `find`-style navigation.

Fixes #3818

## Test plan

- [x] `./gradlew :spotbugs-tests:test --tests edu.umd.cs.findbugs.ba.Issue3818Test`