### PR TITLE
Fix ODR false negative for JDBC resources from helper methods (#1293)

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1293Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1293Test.java
@@ -1,0 +1,14 @@
+package edu.umd.cs.findbugs.detect;
+
+import org.junit.jupiter.api.Test;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+
+class Issue1293Test extends AbstractIntegrationTest {
+
+    @Test
+    void reportsOdrWhenResourcesObtainedViaHelperMethods() {
+        performAnalysis("ghIssues/Issue1293.class");
+        assertBugInMethod("ODR_OPEN_DATABASE_RESOURCE", "ghIssues.Issue1293", "getList");
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DelegatingResourceMethodStreamFactory.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DelegatingResourceMethodStreamFactory.java
@@ -1,0 +1,60 @@
+/*
+ * FindBugs - Find bugs in Java programs
+ * Copyright (C) 2026 University of Maryland
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ */
+
+package edu.umd.cs.findbugs.detect;
+
+import java.util.Set;
+
+import org.apache.bcel.Const;
+import org.apache.bcel.generic.ConstantPoolGen;
+import org.apache.bcel.generic.Instruction;
+import org.apache.bcel.generic.InvokeInstruction;
+import org.apache.bcel.generic.ObjectType;
+
+import edu.umd.cs.findbugs.ba.Location;
+import edu.umd.cs.findbugs.ba.RepositoryLookupFailureCallback;
+
+/**
+ * Treats calls to same-class helper methods as opening tracked resources when the
+ * callee is known to delegate to a JDBC (or similar) resource factory.
+ */
+public class DelegatingResourceMethodStreamFactory implements StreamFactory {
+
+    private final Set<String> delegatingMethods;
+
+    DelegatingResourceMethodStreamFactory(Set<String> delegatingMethods) {
+        this.delegatingMethods = delegatingMethods;
+    }
+
+    @Override
+    public Stream createStream(Location location, ObjectType type, ConstantPoolGen cpg,
+            RepositoryLookupFailureCallback lookupFailureCallback) {
+        Instruction ins = location.getHandle().getInstruction();
+        short opcode = ins.getOpcode();
+        if (opcode != Const.INVOKEVIRTUAL && opcode != Const.INVOKESPECIAL && opcode != Const.INVOKESTATIC
+                && opcode != Const.INVOKEINTERFACE) {
+            return null;
+        }
+
+        InvokeInstruction inv = (InvokeInstruction) ins;
+        String key = OpenDatabaseResourceDelegators.methodKey(inv.getClassName(cpg), inv.getMethodName(cpg),
+                inv.getSignature(cpg));
+        if (!delegatingMethods.contains(key)) {
+            return null;
+        }
+
+        String streamClass = type.getClassName();
+        if ("java.sql.CallableStatement".equals(streamClass)) {
+            streamClass = "java.sql.PreparedStatement";
+        }
+        return new Stream(location, streamClass, streamClass).setIgnoreImplicitExceptions(true).setIsOpenOnCreation(true)
+                .setInteresting("ODR_OPEN_DATABASE_RESOURCE");
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindOpenStream.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindOpenStream.java
@@ -21,9 +21,11 @@ package edu.umd.cs.findbugs.detect;
 
 import java.util.ArrayList;
 import java.util.BitSet;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 
 import edu.umd.cs.findbugs.bytecode.MemberUtils;
 import org.apache.bcel.Const;
@@ -267,6 +269,8 @@ public final class FindOpenStream extends ResourceTrackingDetector<Stream, Strea
 
     private final List<PotentialOpenStream> potentialOpenStreamList;
 
+    private Set<String> resourceDelegatingMethods = Collections.emptySet();
+
     /*
      * ----------------------------------------------------------------------
      * Implementation
@@ -347,7 +351,9 @@ public final class FindOpenStream extends ResourceTrackingDetector<Stream, Strea
         }
 
         if (sawResourceClass) {
+            resourceDelegatingMethods = OpenDatabaseResourceDelegators.findDelegatingMethods(classContext.getJavaClass());
             super.visitClassContext(classContext);
+            resourceDelegatingMethods = Collections.emptySet();
         }
     }
 
@@ -364,7 +370,14 @@ public final class FindOpenStream extends ResourceTrackingDetector<Stream, Strea
 
     @Override
     public StreamResourceTracker getResourceTracker(ClassContext classContext, Method method) {
-        return new StreamResourceTracker(streamFactoryList, bugReporter);
+        StreamFactory[] factories = streamFactoryList;
+        if (!resourceDelegatingMethods.isEmpty()) {
+            StreamFactory[] extended = new StreamFactory[streamFactoryList.length + 1];
+            System.arraycopy(streamFactoryList, 0, extended, 0, streamFactoryList.length);
+            extended[streamFactoryList.length] = new DelegatingResourceMethodStreamFactory(resourceDelegatingMethods);
+            factories = extended;
+        }
+        return new StreamResourceTracker(factories, bugReporter);
     }
 
     @Override

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/OpenDatabaseResourceDelegators.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/OpenDatabaseResourceDelegators.java
@@ -1,0 +1,148 @@
+/*
+ * FindBugs - Find bugs in Java programs
+ * Copyright (C) 2026 University of Maryland
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ */
+
+package edu.umd.cs.findbugs.detect;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.bcel.classfile.JavaClass;
+import org.apache.bcel.classfile.Method;
+import org.apache.bcel.generic.ConstantPoolGen;
+import org.apache.bcel.generic.Instruction;
+import org.apache.bcel.generic.InstructionHandle;
+import org.apache.bcel.generic.InstructionList;
+import org.apache.bcel.generic.InvokeInstruction;
+import org.apache.bcel.generic.MethodGen;
+import org.apache.bcel.generic.Type;
+
+import edu.umd.cs.findbugs.ba.Hierarchy;
+import edu.umd.cs.findbugs.ba.ObjectTypeFactory;
+
+/**
+ * Identifies methods in a class that return JDBC resources by delegating to
+ * {@code DriverManager}, {@code Connection}, or {@code Statement} factory APIs.
+ */
+final class OpenDatabaseResourceDelegators {
+
+    private OpenDatabaseResourceDelegators() {
+    }
+
+    static String methodKey(String className, String methodName, String signature) {
+        return className + '#' + methodName + signature;
+    }
+
+    static Set<String> findDelegatingMethods(JavaClass javaClass) {
+        ConstantPoolGen cpg = new ConstantPoolGen(javaClass.getConstantPool());
+        String className = javaClass.getClassName();
+        Set<String> result = new HashSet<>();
+        boolean changed;
+        do {
+            changed = false;
+            for (Method method : javaClass.getMethods()) {
+                if (method.getCode() == null || !returnsTrackedResource(method)) {
+                    continue;
+                }
+                String key = methodKey(className, method.getName(), method.getSignature());
+                if (result.contains(key)) {
+                    continue;
+                }
+                if (methodDelegatesToResourceFactory(method, javaClass, cpg, className, result)) {
+                    result.add(key);
+                    changed = true;
+                }
+            }
+        } while (changed);
+        return result;
+    }
+
+    private static boolean returnsTrackedResource(Method method) {
+        Type returnType = Type.getReturnType(method.getSignature());
+        if (!(returnType instanceof org.apache.bcel.generic.ObjectType)) {
+            return false;
+        }
+        org.apache.bcel.generic.ObjectType objectType = (org.apache.bcel.generic.ObjectType) returnType;
+        try {
+            for (org.apache.bcel.generic.ObjectType streamBase : FindOpenStream.streamBaseList) {
+                if (Hierarchy.isSubtype(objectType, streamBase)) {
+                    return true;
+                }
+            }
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+        return false;
+    }
+
+    private static boolean methodDelegatesToResourceFactory(Method method, JavaClass javaClass, ConstantPoolGen cpg,
+            String className, Set<String> knownDelegators) {
+        MethodGen methodGen = new MethodGen(method, javaClass.getClassName(), cpg);
+        InstructionList instructionList = methodGen.getInstructionList();
+        if (instructionList == null) {
+            return false;
+        }
+        for (InstructionHandle handle = instructionList.getStart(); handle != null; handle = handle.getNext()) {
+            Instruction instruction = handle.getInstruction();
+            if (!(instruction instanceof InvokeInstruction)) {
+                continue;
+            }
+            InvokeInstruction invoke = (InvokeInstruction) instruction;
+            if (isDirectResourceFactoryInvoke(invoke, cpg)) {
+                return true;
+            }
+            if (className.equals(invoke.getClassName(cpg))) {
+                String calleeKey = methodKey(className, invoke.getMethodName(cpg), invoke.getSignature(cpg));
+                if (knownDelegators.contains(calleeKey)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static boolean isDirectResourceFactoryInvoke(InvokeInstruction invoke, ConstantPoolGen cpg) {
+        String className = invoke.getClassName(cpg);
+        String methodName = invoke.getMethodName(cpg);
+        String signature = invoke.getSignature(cpg);
+
+        if ("java/sql/DriverManager".equals(className) && "getConnection".equals(methodName)
+                && signature.endsWith(")Ljava/sql/Connection;")) {
+            return true;
+        }
+        if (isSubtypeOf(className, "javax/sql/DataSource") && "getConnection".equals(methodName)
+                && signature.endsWith(")Ljava/sql/Connection;")) {
+            return true;
+        }
+        if (isSubtypeOf(className, "java/sql/Connection")) {
+            if ("createStatement".equals(methodName) && signature.endsWith(")Ljava/sql/Statement;")) {
+                return true;
+            }
+            if ("prepareStatement".equals(methodName) && signature.endsWith(")Ljava/sql/PreparedStatement;")) {
+                return true;
+            }
+            if ("prepareCall".equals(methodName) && signature.endsWith(")Ljava/sql/CallableStatement;")) {
+                return true;
+            }
+        }
+        if (isSubtypeOf(className, "java/sql/Statement") && "executeQuery".equals(methodName)
+                && signature.endsWith(")Ljava/sql/ResultSet;")) {
+            return true;
+        }
+        return false;
+    }
+
+    private static boolean isSubtypeOf(String className, String baseClass) {
+        try {
+            return Hierarchy.isSubtype(ObjectTypeFactory.getInstance(className), ObjectTypeFactory.getInstance(baseClass));
+        } catch (ClassNotFoundException e) {
+            return className.equals(baseClass);
+        }
+    }
+}

--- a/spotbugsTestCases/src/java/ghIssues/Issue1293.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue1293.java
@@ -1,0 +1,40 @@
+package ghIssues;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * <a href="https://github.com/spotbugs/spotbugs/issues/1293">#1293</a>.
+ */
+public class Issue1293 {
+
+    public List<String> getList() throws Exception {
+        Class.forName("org.postgresql.Driver");
+        Connection connection = getConnection();
+        Statement statement = getStatement(connection);
+        ResultSet resultSet = getResultSet(statement);
+
+        List<String> results = new ArrayList<>();
+        while (resultSet.next()) {
+            results.add(resultSet.getString("ename"));
+        }
+        return results;
+    }
+
+    private ResultSet getResultSet(Statement statement) throws SQLException {
+        return statement.executeQuery("select * from emp");
+    }
+
+    private Statement getStatement(Connection connection) throws SQLException {
+        return connection.createStatement();
+    }
+
+    private Connection getConnection() throws SQLException {
+        return DriverManager.getConnection("jdbc:postgresql://127.0.0.1:5432/example", "example", "example");
+    }
+}

--- a/spotbugsTestCases/src/java/sfBugs/Bug3506138.java
+++ b/spotbugsTestCases/src/java/sfBugs/Bug3506138.java
@@ -27,7 +27,7 @@ public class Bug3506138 {
         }
     }
 
-    @DesireWarning("ODR_OPEN_DATABASE_RESOURCE")
+    @ExpectWarning("ODR_OPEN_DATABASE_RESOURCE")
     public static void test1() throws Exception {
         Connection conn;
         PreparedStatement pstm = null;


### PR DESCRIPTION
## Summary

Fixes #1293.

When `Connection`, `Statement`, or `ResultSet` instances are obtained through same-class helper methods (e.g. `getConnection()` → `DriverManager.getConnection(...)`), `FindOpenStream` previously did not treat the call site as opening a resource.

This change:
- Scans each analyzed class for methods that return tracked JDBC types and delegate to known factory APIs (`DriverManager.getConnection`, `Connection.createStatement`, `Statement.executeQuery`, etc.), including transitive same-class calls.
- Registers those methods with a new `DelegatingResourceMethodStreamFactory` so `ODR_OPEN_DATABASE_RESOURCE` is reported at the caller when resources are not closed.

## Test plan

- [x] Added `Issue1293` / `Issue1293Test` (reproducer from the issue)
- [x] Promoted `Bug3506138.test1` from `@DesireWarning` to `@ExpectWarning`
- [x] `./gradlew :spotbugs-tests:test --tests edu.umd.cs.findbugs.detect.Issue1293Test`
- [x] `./gradlew :spotbugs-tests:test --tests edu.umd.cs.findbugs.DetectorsTest`

Made with [Cursor](https://cursor.com)