### PR TITLE
Fix FL_FLOATS_AS_LOOP_COUNTERS false negatives (#2241)

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2241Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2241Test.java
@@ -1,0 +1,15 @@
+package edu.umd.cs.findbugs.detect;
+
+import org.junit.jupiter.api.Test;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+
+class Issue2241Test extends AbstractIntegrationTest {
+
+    @Test
+    void reportsFloatLoopCountersForAdditionalPatterns() {
+        performAnalysis("ghIssues/Issue2241.class");
+        assertBugInMethod("FL_FLOATS_AS_LOOP_COUNTERS", "ghIssues.Issue2241", "descendingFloatLoop");
+        assertBugInMethod("FL_FLOATS_AS_LOOP_COUNTERS", "ghIssues.Issue2241", "incrementBeforeUse");
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DontUseFloatsAsLoopCounters.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DontUseFloatsAsLoopCounters.java
@@ -26,13 +26,15 @@ public class DontUseFloatsAsLoopCounters extends OpcodeStackDetector implements 
             (int) Const.DLOAD_2, 1,
             (int) Const.DLOAD_3, 1);
 
-    private static final Map<Integer, Integer> FLOAT_CONSTANT_PUSHERS = Map.of(
-            (int) Const.FCONST_1, 1,
-            (int) Const.FCONST_2, 1,
-            (int) Const.DCONST_1, 1,
-            (int) Const.LDC, 2,
-            (int) Const.LDC_W, 3,
-            (int) Const.LDC2_W, 3);
+    private static final Map<Integer, Integer> FLOAT_CONSTANT_PUSHERS = Map.ofEntries(
+            Map.entry((int) Const.FCONST_0, 1),
+            Map.entry((int) Const.FCONST_1, 1),
+            Map.entry((int) Const.FCONST_2, 1),
+            Map.entry((int) Const.DCONST_0, 1),
+            Map.entry((int) Const.DCONST_1, 1),
+            Map.entry((int) Const.LDC, 2),
+            Map.entry((int) Const.LDC_W, 3),
+            Map.entry((int) Const.LDC2_W, 3));
 
     private static final Set<Integer> FLOAT_COMPARERS = Set.of(
             (int) Const.FCMPG,
@@ -72,9 +74,16 @@ public class DontUseFloatsAsLoopCounters extends OpcodeStackDetector implements 
         }
     }
 
+    private static final int MAX_LOOP_UPDATE_SCAN = 20;
+
     private boolean checkLoopEnd() {
-        return FLOAT_STORERS.contains(getPrevOpcode(1)) &&
-                FLOAT_ADDITIVE_OPS.contains(getPrevOpcode(2));
+        for (int distance = 1; distance <= MAX_LOOP_UPDATE_SCAN; distance++) {
+            if (FLOAT_STORERS.contains(getPrevOpcode(distance))
+                    && FLOAT_ADDITIVE_OPS.contains(getPrevOpcode(distance + 1))) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private boolean checkLoopStart(int startPC) {

--- a/spotbugsTestCases/src/java/ghIssues/Issue2241.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue2241.java
@@ -1,0 +1,23 @@
+package ghIssues;
+
+/**
+ * <a href="https://github.com/spotbugs/spotbugs/issues/2241">#2241</a>.
+ */
+public class Issue2241 {
+
+    public static void descendingFloatLoop() {
+        float x = 10.1f;
+        while (x > 0) {
+            System.out.println(x);
+            x--;
+        }
+    }
+
+    public static void incrementBeforeUse() {
+        float x = 0.1f;
+        while (x < 10) {
+            x++;
+            System.out.println(x);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #2241.

`DontUseFloatsAsLoopCounters` missed several common float `while` loops:

1. **Descending comparisons** (`while (x > 0)`): javac uses `fconst_0` / `dconst_0` at the loop head, which were not treated as constant pushers.
2. **Counter update before other body work** (`x++; System.out.println(x);`): the `fstore` after `fadd`/`fsub` is not always the instruction immediately before the back-branch `goto`.

## Changes

- Add `FCONST_0` and `DCONST_0` to the loop-head constant pusher map.
- Scan up to 20 instructions before the back-branch for a float/double store following `fadd`/`fsub`/`dadd`/`dsub`.

## Test plan

- [x] Added `Issue2241` / `Issue2241Test` (descending loop + increment-before-use)
- [x] `./gradlew :spotbugs-tests:test --tests edu.umd.cs.findbugs.detect.Issue2241Test`
- [x] `./gradlew :spotbugs-tests:test --tests edu.umd.cs.findbugs.detect.DontUseFloatsAsLoopCountersTest`
- [x] `./gradlew :spotbugs-tests:test --tests edu.umd.cs.findbugs.DetectorsTest`

Made with [Cursor](https://cursor.com)