### PR TITLE
Fix IL_INFINITE_RECURSIVE_LOOP false negative for constant boolean guards (#1641)

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1641Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1641Test.java
@@ -1,0 +1,14 @@
+package edu.umd.cs.findbugs.detect;
+
+import org.junit.jupiter.api.Test;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+
+class Issue1641Test extends AbstractIntegrationTest {
+
+    @Test
+    void reportsInfiniteRecursionWhenBothBranchesRecurse() {
+        performAnalysis("ghIssues/Issue1641.class");
+        assertBugInMethodCount("IL_INFINITE_RECURSIVE_LOOP", "ghIssues.Issue1641", "methodA", 2);
+    }
+}

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3469Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3469Test.java
@@ -1,0 +1,14 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class Issue3469Test extends AbstractIntegrationTest {
+
+    @Test
+    void testRecursiveLoopWithConstantBooleanHelper() {
+        performAnalysis("ghIssues/Issue3469.class");
+
+        assertBugInMethod("IL_INFINITE_RECURSIVE_LOOP", "ghIssues.Issue3469", "infiniteLoopMethod");
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InfiniteRecursiveLoop.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/InfiniteRecursiveLoop.java
@@ -21,6 +21,7 @@ package edu.umd.cs.findbugs.detect;
 
 import edu.umd.cs.findbugs.util.ClassName;
 import org.apache.bcel.Const;
+import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.Method;
 import org.apache.bcel.generic.Type;
 
@@ -227,11 +228,70 @@ public class InfiniteRecursiveLoop extends OpcodeStackDetector implements Statel
                     || "log".equals(getNameConstantOperand()) || "toString".equals(getNameConstantOperand())) {
                 break;
             }
-            seenStateChange = true;
+            if (!isTrivialConstantBooleanProvider() && !isDirectRecursiveSelfCall(seen)) {
+                seenStateChange = true;
+            }
             break;
         default:
             break;
         }
+    }
+
+    private boolean isDirectRecursiveSelfCall(int seen) {
+        if (!getNameConstantOperand().equals(getMethodName()) || !getSigConstantOperand().equals(getMethodSig())) {
+            return false;
+        }
+        if ((seen == Const.INVOKESTATIC) != getMethod().isStatic()) {
+            return false;
+        }
+        if (seen == Const.INVOKESPECIAL && !(getMethod().isPrivate() && !getMethod().isStatic()
+                || Const.CONSTRUCTOR_NAME.equals(getMethodName()))) {
+            return false;
+        }
+        XMethod callee = XFactory.createReferencedXMethod(this);
+        return ClassName.toSlashedClassName(callee.getClassName()).equals(getClassName());
+    }
+
+    /**
+     * Same-class {@code ()Z} helpers that always return a constant do not make a
+     * recursive call's control flow data-dependent (e.g. {@code if (getCondition()) a(); else a();}).
+     */
+    private boolean isTrivialConstantBooleanProvider() {
+        if (!"()Z".equals(getSigConstantOperand())) {
+            return false;
+        }
+        String calleeClass = getClassConstantOperand().replace('.', '/');
+        if (!calleeClass.equals(getClassName())) {
+            return false;
+        }
+        for (Method method : getThisClass().getMethods()) {
+            if (method.getName().equals(getNameConstantOperand()) && method.getSignature().equals(getSigConstantOperand())) {
+                Code code = method.getCode();
+                return code != null && methodAlwaysReturnsConstantBoolean(code.getCode());
+            }
+        }
+        return false;
+    }
+
+    private static boolean methodAlwaysReturnsConstantBoolean(byte[] code) {
+        int index = 0;
+        while (index < code.length) {
+            int opcode = code[index] & 0xff;
+            if (opcode == Const.ALOAD_0) {
+                index++;
+                continue;
+            }
+            if (opcode == Const.ICONST_0 || opcode == Const.ICONST_1) {
+                index++;
+                return index < code.length && (code[index] & 0xff) == Const.IRETURN;
+            }
+            if (opcode == Const.BIPUSH || opcode == Const.SIPUSH) {
+                index += opcode == Const.BIPUSH ? 2 : 3;
+                return index < code.length && (code[index] & 0xff) == Const.IRETURN;
+            }
+            return false;
+        }
+        return false;
     }
 
 }

--- a/spotbugsTestCases/src/java/ghIssues/Issue1641.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue1641.java
@@ -1,0 +1,20 @@
+package ghIssues;
+
+/**
+ * <a href="https://github.com/spotbugs/spotbugs/issues/1641">#1641</a>.
+ */
+public class Issue1641 {
+
+    public boolean getCondition() {
+        return true;
+    }
+
+    public void methodA() {
+        boolean condition = getCondition();
+        if (condition) {
+            methodA();
+        } else {
+            methodA();
+        }
+    }
+}

--- a/spotbugsTestCases/src/java/ghIssues/Issue3469.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3469.java
@@ -1,0 +1,22 @@
+package ghIssues;
+
+import edu.umd.cs.findbugs.annotations.ExpectWarning;
+
+/**
+ * <a href="https://github.com/spotbugs/spotbugs/issues/3469">#3469</a>.
+ */
+class Issue3469 {
+    @ExpectWarning("IL_INFINITE_RECURSIVE_LOOP")
+    public static void infiniteLoopMethod() {
+        boolean shouldLoop = getCondition();
+        if (shouldLoop) {
+            infiniteLoopMethod();
+        } else {
+            System.out.println("This branch should never execute.");
+        }
+    }
+
+    public static boolean getCondition() {
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1641.

`InfiniteRecursiveLoop` missed recursion guarded by a same-class helper that always returns a constant boolean (e.g. `if (getCondition()) methodA(); else methodA();`) because:

1. The boolean helper `invoke` was treated as a state change, disabling the `match1` path.
2. The first recursive self-call in the `then` branch also set `seenStateChange`, so the recursive call in the `else` branch was not reported.

## Changes

- Skip `seenStateChange` for same-class `()Z` methods whose bytecode always returns a constant boolean.
- Skip `seenStateChange` for direct recursive calls to the method currently being analyzed.

## Test plan

- [x] Added `Issue1641` / `Issue1641Test` (both branches report `IL_INFINITE_RECURSIVE_LOOP`)
- [x] `./gradlew :spotbugs-tests:test --tests edu.umd.cs.findbugs.detect.Issue1641Test`
- [x] `./gradlew :spotbugs-tests:test --tests edu.umd.cs.findbugs.DetectorsTest`

Made with [Cursor](https://cursor.com)