### PR TITLE
fix: report BC_IMPOSSIBLE_INSTANCEOF for null array instanceof (#3598482)

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3598482Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3598482Test.java
@@ -1,0 +1,15 @@
+package edu.umd.cs.findbugs.detect;
+
+import org.junit.jupiter.api.Test;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+
+class Issue3598482Test extends AbstractIntegrationTest {
+
+    @Test
+    void reportsImpossibleInstanceofForNullByteArray() {
+        performAnalysis("ghIssues/Issue3598482.class");
+        assertBugInMethod("BC_IMPOSSIBLE_INSTANCEOF", "ghIssues.Issue3598482", "nullByteArrayInstanceof");
+        assertBugInMethod("NP_NULL_INSTANCEOF", "ghIssues.Issue3598482", "nullByteArrayInstanceof");
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindBadCast2.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindBadCast2.java
@@ -318,6 +318,11 @@ public class FindBadCast2 implements Detector {
                 if (!isCast) {
                     accumulator.accumulateBug(new BugInstance(this, "NP_NULL_INSTANCEOF", split ? LOW_PRIORITY : NORMAL_PRIORITY)
                             .addClassAndMethod(methodGen, sourceFile).addType(castSig), sourceLineAnnotation);
+                    if (castSig.charAt(0) == '[') {
+                        accumulator.accumulateBug(new BugInstance(this, "BC_IMPOSSIBLE_INSTANCEOF", NORMAL_PRIORITY)
+                                .addClassAndMethod(methodGen, sourceFile).addFoundAndExpectedType(castSig, castSig),
+                                sourceLineAnnotation);
+                    }
                 }
                 continue;
 

--- a/spotbugsTestCases/src/java/ghIssues/Issue3598482.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3598482.java
@@ -1,0 +1,14 @@
+package ghIssues;
+
+/**
+ * Regression for <a href="https://github.com/spotbugs/spotbugs/issues/3598482">#3598482</a>.
+ */
+public class Issue3598482 {
+
+    public static void nullByteArrayInstanceof() {
+        byte[] msg = null;
+        if (msg instanceof byte[]) {
+            System.out.println("byte array");
+        }
+    }
+}

--- a/spotbugsTestCases/src/java/sfBugs/Bug3598482.java
+++ b/spotbugsTestCases/src/java/sfBugs/Bug3598482.java
@@ -29,8 +29,7 @@ public class Bug3598482 {
     }
 
 
-    @DesireWarning("BC_IMPOSSIBLE_INSTANCEOF")
-    @ExpectWarning("NP_NULL_INSTANCEOF")
+    @ExpectWarning("NP_NULL_INSTANCEOF,BC_IMPOSSIBLE_INSTANCEOF")
     public static void main2(String[] args) {
 
         byte[] msg = null;

--- a/spotbugsTestCases/src/java/sfBugsNew/Bug1148.java
+++ b/spotbugsTestCases/src/java/sfBugsNew/Bug1148.java
@@ -1,10 +1,10 @@
 package sfBugsNew;
 
-import edu.umd.cs.findbugs.annotations.NoWarning;
+import edu.umd.cs.findbugs.annotations.ExpectWarning;
 
 public class Bug1148 {
 
-    @NoWarning("BC_IMPOSSIBLE_INSTANCEOF")
+    @ExpectWarning("NP_NULL_INSTANCEOF,BC_IMPOSSIBLE_INSTANCEOF")
     public static void main(String[] args) {
 
         byte[] msg = null;


### PR DESCRIPTION
## Summary

- When `instanceof` is applied to a definitely-null value and the target type is an array (e.g. `byte[] msg = null; if (msg instanceof byte[])`), report `BC_IMPOSSIBLE_INSTANCEOF` in addition to the existing `NP_NULL_INSTANCEOF` warning.
- The existing `!typesAreEqual` guard for non-null operands (bug 3598482 false positive) is unchanged.

## Test plan

- [x] `Issue3598482Test` — ghIssues regression for null `byte[]` instanceof
- [x] `DetectorsTest` — updated `Bug3598482`, `Bug1148` expectations
- [x] `./gradlew :spotbugsTestCases:classesJava17 :spotbugs-tests:test --tests edu.umd.cs.findbugs.detect.Issue3598482Test --tests edu.umd.cs.findbugs.DetectorsTest`

Fixes #3598482

Made with [Cursor](https://cursor.com)