### PR TITLE
Fix SA_FIELD_DOUBLE_ASSIGNMENT false negative for long/double fields (#3975)

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3975Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3975Test.java
@@ -1,0 +1,19 @@
+package edu.umd.cs.findbugs.detect;
+
+import org.junit.jupiter.api.Test;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+
+class Issue3975Test extends AbstractIntegrationTest {
+
+    @Test
+    void reportsDoubleAssignmentForWidePrimitiveFields() {
+        performAnalysis(
+                "ghIssues/Issue3975$IntFieldDoubleAssignment.class",
+                "ghIssues/Issue3975$LongFieldDoubleAssignment.class",
+                "ghIssues/Issue3975$DoubleFieldDoubleAssignment.class");
+        assertBugInMethod("SA_FIELD_DOUBLE_ASSIGNMENT", "ghIssues.Issue3975$IntFieldDoubleAssignment", "<init>");
+        assertBugInMethod("SA_FIELD_DOUBLE_ASSIGNMENT", "ghIssues.Issue3975$LongFieldDoubleAssignment", "<init>");
+        assertBugInMethod("SA_FIELD_DOUBLE_ASSIGNMENT", "ghIssues.Issue3975$DoubleFieldDoubleAssignment", "<init>");
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindSelfComparison.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindSelfComparison.java
@@ -22,6 +22,8 @@ package edu.umd.cs.findbugs.detect;
 import java.util.BitSet;
 import java.util.Objects;
 
+import javax.annotation.CheckForNull;
+
 import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.LineNumberTable;
@@ -106,7 +108,7 @@ public class FindSelfComparison extends OpcodeStackDetector {
             XField f = getXFieldOperand();
             XClass x = getXClassOperand();
 
-            checkPUTFIELD: if (putFieldPC + 10 > getPC() && f != null && obj != null && f.equals(putFieldXField)
+            checkPUTFIELD: if (putFieldPC + maxDoubleAssignmentPutFieldDistance(f) > getPC() && f != null && obj != null && f.equals(putFieldXField)
                     && !f.isSynthetic() && obj.sameValue(putFieldObj) && x != null) {
 
 
@@ -257,6 +259,17 @@ public class FindSelfComparison extends OpcodeStackDetector {
     int whichRegister;
 
     int registerLoadCount;
+
+    private static int maxDoubleAssignmentPutFieldDistance(@CheckForNull XField field) {
+        if (field == null) {
+            return 10;
+        }
+        String signature = field.getSignature();
+        if ("J".equals(signature) || "D".equals(signature)) {
+            return 14;
+        }
+        return 10;
+    }
 
     private void checkForSelfOperation(int opCode, String op) {
         {

--- a/spotbugsTestCases/src/java/ghIssues/Issue3975.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3975.java
@@ -1,0 +1,22 @@
+package ghIssues;
+
+/**
+ * Regression for <a href="https://github.com/spotbugs/spotbugs/issues/3975">#3975</a>.
+ */
+public class Issue3975 {
+
+    static class IntFieldDoubleAssignment {
+        int value = 3;
+        boolean b = 1 > (value = 2);
+    }
+
+    static class LongFieldDoubleAssignment {
+        long value = 3L;
+        boolean b = 1 > (value = 2L);
+    }
+
+    static class DoubleFieldDoubleAssignment {
+        double value = 3.0;
+        boolean b = 1.0 > (value = 2.0);
+    }
+}


### PR DESCRIPTION
## Summary

- Fix false negative for `SA_FIELD_DOUBLE_ASSIGNMENT` when a `long` or `double` field is assigned twice during field initialization (e.g. `boolean b = 1 > (value = 2L);`).
- Root cause: consecutive `PUTFIELD` instructions for wide primitives can be 10 bytecode offsets apart, but the detector only considered pairs within 10 PCs.
- Extend the PC window to 14 for `J`/`D` field signatures; int and other types keep the existing window of 10.

## Test plan

- [x] `Issue3975Test` — int/long/double field initializer regression
- [x] `RegressionIdeas20090616Test` — existing int constructor case still passes
- [x] `DetectorsTest`

Fixes #3975

Made with [Cursor](https://cursor.com)