### PR TITLE
Fix ODR false negative when JDBC resource is cast from supertype (#4019)

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue4019Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue4019Test.java
@@ -1,0 +1,15 @@
+package edu.umd.cs.findbugs.detect;
+
+import org.junit.jupiter.api.Test;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+
+class Issue4019Test extends AbstractIntegrationTest {
+
+    @Test
+    void reportsOpenDatabaseResourceForStatementSupertype() {
+        performAnalysis("ghIssues/Issue4019.class");
+        assertBugInMethod("ODR_OPEN_DATABASE_RESOURCE", "ghIssues.Issue4019", "preparedStatementVariable");
+        assertBugInMethod("ODR_OPEN_DATABASE_RESOURCE", "ghIssues.Issue4019", "statementSupertypeVariable");
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/ResourceValueFrameModelingVisitor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/ResourceValueFrameModelingVisitor.java
@@ -22,7 +22,6 @@ package edu.umd.cs.findbugs.ba;
 import org.apache.bcel.generic.AASTORE;
 import org.apache.bcel.generic.ARETURN;
 import org.apache.bcel.generic.ArrayInstruction;
-import org.apache.bcel.generic.CHECKCAST;
 import org.apache.bcel.generic.ConstantPoolGen;
 import org.apache.bcel.generic.FieldInstruction;
 import org.apache.bcel.generic.INVOKEINTERFACE;
@@ -139,22 +138,6 @@ public abstract class ResourceValueFrameModelingVisitor extends AbstractFrameMod
         }
 
         handleNormalInstruction(inv);
-    }
-
-    @Override
-    public void visitCHECKCAST(CHECKCAST obj) {
-        try {
-            ResourceValueFrame frame = getFrame();
-            ResourceValue topValue;
-
-            topValue = frame.getTopValue();
-
-            if (topValue.equals(ResourceValue.instance())) {
-                frame.setStatus(ResourceValueFrame.State.ESCAPED);
-            }
-        } catch (DataflowAnalysisException e) {
-            AnalysisContext.logError("Analysis error", e);
-        }
     }
 
     @Override

--- a/spotbugsTestCases/src/java/ghIssues/Issue4019.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue4019.java
@@ -1,0 +1,45 @@
+package ghIssues;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+/**
+ * Regression for <a href="https://github.com/spotbugs/spotbugs/issues/4019">#4019</a>.
+ */
+public class Issue4019 {
+
+    private static final String DB_URL = "jdbc:h2:mem:testdb";
+
+    public void preparedStatementVariable(int id) throws SQLException {
+        Connection conn = null;
+        PreparedStatement ps = null;
+        try {
+            conn = DriverManager.getConnection(DB_URL);
+            ps = conn.prepareStatement("SELECT * FROM users WHERE id = ?");
+            ps.setInt(1, id);
+            ps.executeQuery();
+        } finally {
+            if (conn != null) {
+                conn.close();
+            }
+        }
+    }
+
+    public void statementSupertypeVariable(int id) throws SQLException {
+        Connection conn = null;
+        Statement ps = null;
+        try {
+            conn = DriverManager.getConnection(DB_URL);
+            ps = conn.prepareStatement("SELECT * FROM users WHERE id = ?");
+            ((PreparedStatement) ps).setInt(1, id);
+            ((PreparedStatement) ps).executeQuery();
+        } finally {
+            if (conn != null) {
+                conn.close();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Fix false negative for `ODR_OPEN_DATABASE_RESOURCE` when a `PreparedStatement` is stored in a `Statement` variable and later cast before calling `PreparedStatement` methods.
- Root cause: `ResourceValueFrameModelingVisitor.visitCHECKCAST` incorrectly marked tracked resources as `ESCAPED`. A `CHECKCAST` only refines the local reference type and does not let the resource leave the method.
- Remove the special-case `CHECKCAST` handling so the default frame modeling keeps the resource open until a real escape (return, field store, etc.).

## Test plan

- [x] `Issue4019Test` — compares `PreparedStatement` vs `Statement` variable with casts
- [x] `DetectorsTest`
- [x] Manual repro: both `fetchUserBefore` and `fetchUserAfter` now report ODR

Fixes #4019

Made with [Cursor](https://cursor.com)