### PR TITLE
Fix ODR false negative for JDBC resources from Connection parameters

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/IssueConnectionParamOdrTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/IssueConnectionParamOdrTest.java
@@ -1,0 +1,14 @@
+package edu.umd.cs.findbugs.detect;
+
+import org.junit.jupiter.api.Test;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+
+class IssueConnectionParamOdrTest extends AbstractIntegrationTest {
+
+    @Test
+    void reportsOpenDatabaseResourceForStatementFromConnectionParameter() {
+        performAnalysis("ghIssues/IssueConnectionParamOdr.class");
+        assertBugInMethod("ODR_OPEN_DATABASE_RESOURCE", "ghIssues.IssueConnectionParamOdr", "statementFromConnectionParameter");
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/StreamFrameModelingVisitor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/StreamFrameModelingVisitor.java
@@ -129,7 +129,7 @@ public class StreamFrameModelingVisitor extends ResourceValueFrameModelingVisito
         }
 
         // Record the fact that this might be a stream escape
-        if (stream.getOpenLocation() != null) {
+        if (escapes && stream.getOpenLocation() != null) {
             resourceTracker.addStreamEscape(stream, location);
         }
 

--- a/spotbugsTestCases/src/java/ghIssues/IssueConnectionParamOdr.java
+++ b/spotbugsTestCases/src/java/ghIssues/IssueConnectionParamOdr.java
@@ -1,0 +1,16 @@
+package ghIssues;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+/**
+ * Regression for JDBC resources created from a Connection method parameter.
+ */
+public class IssueConnectionParamOdr {
+
+    public void statementFromConnectionParameter(Connection conn) throws SQLException {
+        Statement statement = conn.prepareStatement("SELECT 1");
+        statement.executeQuery("SELECT 1");
+    }
+}


### PR DESCRIPTION
## Summary

- Fix false negative for `ODR_OPEN_DATABASE_RESOURCE` when a JDBC resource is created from a `Connection` passed as a method parameter (e.g. `Statement s = conn.prepareStatement(...)`).
- Root cause: `StreamFrameModelingVisitor.instanceEscapes` always recorded a stream escape when the tracked resource was open, even when `instanceEscapes` returned `false` for receiver calls. Uninteresting parameter `Connection` instances then poisoned newly created `Statement`/`PreparedStatement` resources during transitive escape propagation.
- Only record stream escapes when `instanceEscapes` returns true.

## Test plan

- [x] `IssueConnectionParamOdrTest` — `Connection` parameter + `prepareStatement`
- [x] `DetectorsTest` — includes existing `DeadStore.testDatabaseStore` case
- [x] Manual check: `DeadStore.testDatabaseStore` now reports ODR

Related to #4019 (supertype/cast path); this covers the Connection-parameter propagation path.

Made with [Cursor](https://cursor.com)