### PR TITLE
Fix BIT_AND and mutable static field false negatives (#3456, #3464, #3465)

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3456Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3456Test.java
@@ -1,0 +1,16 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class Issue3456Test extends AbstractIntegrationTest {
+
+    @Test
+    void testBitAndWithTemporary() {
+        performAnalysis("ghIssues/Issue3456.class");
+
+        assertBugInMethod("BIT_AND", "ghIssues.Issue3456", "showBugWithTemporary");
+        assertBugInMethod("BIT_AND", "ghIssues.Issue3456", "showBugDirect");
+        assertBugInMethod("BIT_AND_ZZ", "ghIssues.Issue3456", "showBugZeroMaskWithTemporary");
+    }
+}

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3464Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3464Test.java
@@ -1,0 +1,14 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class Issue3464Test extends AbstractIntegrationTest {
+
+    @Test
+    void testMutableStaticStringBuilder() {
+        performAnalysis("ghIssues/Issue3464.class");
+
+        assertBugInClass("MS_SHOULD_BE_FINAL", "ghIssues.Issue3464");
+    }
+}

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3465Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3465Test.java
@@ -1,0 +1,14 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class Issue3465Test extends AbstractIntegrationTest {
+
+    @Test
+    void testMutableArrayLiteralInitializer() {
+        performAnalysis("ghIssues/Issue3465.class");
+
+        assertBugInClass("MS_PKGPROTECT", "ghIssues.Issue3465");
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/IncompatMask.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/IncompatMask.java
@@ -47,6 +47,8 @@ public class IncompatMask extends OpcodeStackDetector {
 
     private Item bitresultItem;
 
+    private int bitResultRegister = -1;
+
     public IncompatMask(BugReporter bugReporter) {
         this.bugReporter = bugReporter;
     }
@@ -160,8 +162,7 @@ public class IncompatMask extends OpcodeStackDetector {
                 bugReporter.reportBug(bug);
             }
         }
-        arg1 = arg2 = null;
-        bitresultItem = null;
+        clearBitResultTracking();
     }
 
     private static String toHex(Number n) {
@@ -169,16 +170,32 @@ public class IncompatMask extends OpcodeStackDetector {
     }
 
     private boolean checkItem(int n) {
-        if (bitresultItem != null) {
+        if (bitresultItem != null || bitResultRegister >= 0) {
             for (int i = 0; i < n; i++) {
-                if (stack.getStackItem(i) == bitresultItem) {
+                if (isBitResultOnStack(stack.getStackItem(i))) {
                     return true;
                 }
             }
         }
+        clearBitResultTracking();
+        return false;
+    }
+
+    private boolean isBitResultOnStack(Item item) {
+        if (bitresultItem != null && item == bitresultItem) {
+            return true;
+        }
+        if (bitResultRegister >= 0 && item.getRegisterNumber() == bitResultRegister) {
+            return true;
+        }
+        return bitresultItem != null && bitresultItem.getRegisterNumber() >= 0
+                && item.getRegisterNumber() == bitresultItem.getRegisterNumber();
+    }
+
+    private void clearBitResultTracking() {
         arg1 = arg2 = null;
         bitresultItem = null;
-        return false;
+        bitResultRegister = -1;
     }
 
     @Override
@@ -189,8 +206,22 @@ public class IncompatMask extends OpcodeStackDetector {
         case Const.LAND:
         case Const.IOR:
         case Const.LOR:
+            bitResultRegister = -1;
             if (stack.getStackDepth() > 0) {
                 bitresultItem = stack.getStackItem(0);
+            }
+            break;
+        case Const.ISTORE:
+            if (bitresultItem != null) {
+                bitResultRegister = getRegisterOperand();
+            }
+            break;
+        case Const.ISTORE_0:
+        case Const.ISTORE_1:
+        case Const.ISTORE_2:
+        case Const.ISTORE_3:
+            if (bitresultItem != null) {
+                bitResultRegister = seen - Const.ISTORE_0;
             }
             break;
         default:

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MutableStaticFields.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MutableStaticFields.java
@@ -299,8 +299,8 @@ public class MutableStaticFields extends BytecodeScanningDetector {
             return;
         }
         boolean isFinal = (flags & Const.ACC_FINAL) != 0;
-        boolean isPublic = publicClass && (flags & Const.ACC_PUBLIC) != 0;
-        boolean isProtected = publicClass && (flags & Const.ACC_PROTECTED) != 0;
+        boolean isPublic = (flags & Const.ACC_PUBLIC) != 0;
+        boolean isProtected = (flags & Const.ACC_PROTECTED) != 0;
         if (!isPublic && !isProtected) {
             return;
         }

--- a/spotbugsTestCases/src/java/ghIssues/Issue3456.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3456.java
@@ -1,0 +1,25 @@
+package ghIssues;
+
+import edu.umd.cs.findbugs.annotations.ExpectWarning;
+
+class Issue3456 {
+    private static final int C = 0b1010;
+    private static final int D = 0b1100;
+
+    @ExpectWarning("BIT_AND")
+    public boolean showBugWithTemporary(int e) {
+        int temporary = (e & C);
+        return temporary == D;
+    }
+
+    @ExpectWarning("BIT_AND")
+    public boolean showBugDirect(int e) {
+        return (e & C) == D;
+    }
+
+    @ExpectWarning("BIT_AND_ZZ")
+    public boolean showBugZeroMaskWithTemporary(int number) {
+        int temporary = number & 0;
+        return temporary == 0;
+    }
+}

--- a/spotbugsTestCases/src/java/ghIssues/Issue3464.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3464.java
@@ -1,0 +1,14 @@
+package ghIssues;
+
+import edu.umd.cs.findbugs.annotations.ExpectWarning;
+
+class Issue3464 {
+    @ExpectWarning("MS_SHOULD_BE_FINAL")
+    public static StringBuilder mutableStaticField = new StringBuilder("Initial Value");
+
+    public String showBug(String newValue) {
+        mutableStaticField.setLength(0);
+        mutableStaticField.append(newValue);
+        return mutableStaticField.toString();
+    }
+}

--- a/spotbugsTestCases/src/java/ghIssues/Issue3465.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3465.java
@@ -1,0 +1,14 @@
+package ghIssues;
+
+import edu.umd.cs.findbugs.annotations.ExpectWarning;
+
+class Issue3465 {
+    @ExpectWarning("MS_PKGPROTECT")
+    public static final int[] ARRAY = {1, 2, 3, 4, 5};
+
+    public static void showBug() {
+        System.out.println(ARRAY[0]);
+        ARRAY[0] = 10;
+        System.out.println(ARRAY[0]);
+    }
+}


### PR DESCRIPTION
## Summary

- **#3456 (BIT_AND / BIT_AND_ZZ):** Track bitwise-and results through `istore`/`iload` so incompatible mask checks are reported when the masked value is stored in a local variable before comparison.
- **#3464 / #3465 (MutableStaticFields):** Stop requiring the enclosing class to be `public` before considering `public`/`protected` static fields. Package-private classes with `public static` mutable fields (e.g. `StringBuilder`, `int[]` array literals) are now reported.

## Test plan

- [x] `Issue3456Test` — BIT_AND with temporary local, direct compare, and BIT_AND_ZZ via temporary
- [x] `Issue3464Test` — public static `StringBuilder` on package-private class
- [x] `Issue3465Test` — public static final array literal on package-private class
- [x] `IncompatMaskTest` — existing unit tests still pass

Fixes #3456
Fixes #3464
Fixes #3465

Made with [Cursor](https://cursor.com)