### PR TITLE
Fix SING false negative when helper call precedes lazy init (#3457)

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3457Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3457Test.java
@@ -1,0 +1,17 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class Issue3457Test extends AbstractIntegrationTest {
+
+    @Test
+    void testSingletonGetterWithHelperMethod() {
+        performAnalysis("ghIssues/Issue3457WithHelper.class", "ghIssues/Issue3457WithLiteral.class",
+                "ghIssues/Issue3457SynchronizedHelper.class");
+
+        assertBugInMethod("SING_SINGLETON_GETTER_NOT_SYNCHRONIZED", "ghIssues.Issue3457WithLiteral", "getInstance");
+        assertBugInMethod("SING_SINGLETON_GETTER_NOT_SYNCHRONIZED", "ghIssues.Issue3457WithHelper", "getInstance");
+        assertBugInClassCount("SING_SINGLETON_GETTER_NOT_SYNCHRONIZED", "ghIssues.Issue3457SynchronizedHelper", 0);
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MultipleInstantiationsOfSingletons.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/MultipleInstantiationsOfSingletons.java
@@ -39,6 +39,12 @@ import org.apache.bcel.Const;
 import org.apache.bcel.Repository;
 import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.classfile.Method;
+import org.apache.bcel.generic.GETSTATIC;
+import org.apache.bcel.generic.IFNONNULL;
+import org.apache.bcel.generic.Instruction;
+import org.apache.bcel.generic.InstructionHandle;
+import org.apache.bcel.generic.InstructionList;
+import org.apache.bcel.generic.MethodGen;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
@@ -168,6 +174,9 @@ public class MultipleInstantiationsOfSingletons extends OpcodeStackDetector {
                             bugReporter.logError(String.format("Detector %s caught an exception while analyzing %s.",
                                     this.getClass().getName(), getClassContext().getJavaClass().getClassName()), e);
                         }
+                        if (!isInstanceFieldLazilyInitialized) {
+                            isInstanceFieldLazilyInitialized = isProtectedByInstanceNullCheck(field);
+                        }
                     }
                 }
             }
@@ -212,6 +221,49 @@ public class MultipleInstantiationsOfSingletons extends OpcodeStackDetector {
     private boolean isInstanceField(XField field, String clsName) {
         String className = "L" + clsName + ";";
         return field != null && field.isPrivate() && field.isStatic() && className.equals(field.getSignature());
+    }
+
+    /**
+     * Detect {@code if (instance == null) { instance = new ...; }} when value-number tracking
+     * loses the null fact after unrelated instructions (e.g. a helper method call).
+     */
+    private boolean isProtectedByInstanceNullCheck(XField field) {
+        MethodGen methodGen = getClassContext().getMethodGen(getMethod());
+        if (methodGen == null) {
+            return false;
+        }
+        InstructionList instructionList = methodGen.getInstructionList();
+        int pc = getPC();
+        org.apache.bcel.generic.ConstantPoolGen cpg = getClassContext().getConstantPoolGen();
+        for (InstructionHandle handle = instructionList.getStart(); handle != null; handle = handle.getNext()) {
+            if (handle.getPosition() >= pc) {
+                break;
+            }
+            Instruction instruction = handle.getInstruction();
+            if (!(instruction instanceof GETSTATIC)) {
+                continue;
+            }
+            GETSTATIC getStatic = (GETSTATIC) instruction;
+            if (!field.getName().equals(getStatic.getName(cpg))
+                    || !getDottedClassName().equals(getStatic.getClassName(cpg))) {
+                continue;
+            }
+            InstructionHandle ifHandle = handle.getNext();
+            if (ifHandle == null || !(ifHandle.getInstruction() instanceof IFNONNULL)) {
+                continue;
+            }
+            IFNONNULL ifNonNull = (IFNONNULL) ifHandle.getInstruction();
+            InstructionHandle nullBranchStart = ifHandle.getNext();
+            if (nullBranchStart == null) {
+                continue;
+            }
+            int nullBranchStartPc = nullBranchStart.getPosition();
+            int nonNullTargetPc = ifNonNull.getTarget().getPosition();
+            if (nullBranchStartPc <= pc && nonNullTargetPc > nullBranchStartPc && pc < nonNullTargetPc) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/spotbugsTestCases/src/java/ghIssues/Issue3457.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3457.java
@@ -1,0 +1,70 @@
+package ghIssues;
+
+import edu.umd.cs.findbugs.annotations.ExpectWarning;
+import edu.umd.cs.findbugs.annotations.NoWarning;
+
+class Issue3457WithLiteral {
+    private static Issue3457WithLiteral instance;
+
+    private Issue3457WithLiteral() {
+    }
+
+    @ExpectWarning("SING_SINGLETON_GETTER_NOT_SYNCHRONIZED")
+    public static Issue3457WithLiteral getInstance() {
+        if (instance == null) {
+            int value = 0;
+            switch (value) {
+            case 1:
+                break;
+            }
+            instance = new Issue3457WithLiteral();
+        }
+        return instance;
+    }
+}
+
+class Issue3457WithHelper {
+    private static Issue3457WithHelper instance;
+
+    private Issue3457WithHelper() {
+    }
+
+    @ExpectWarning("SING_SINGLETON_GETTER_NOT_SYNCHRONIZED")
+    public static Issue3457WithHelper getInstance() {
+        if (instance == null) {
+            int value = getUnreachableValue();
+            switch (value) {
+            case 1:
+                break;
+            }
+            instance = new Issue3457WithHelper();
+        }
+        return instance;
+    }
+
+    private static int getUnreachableValue() {
+        return 0;
+    }
+}
+
+class Issue3457SynchronizedHelper {
+    private static Issue3457SynchronizedHelper instance;
+
+    private Issue3457SynchronizedHelper() {
+    }
+
+    @NoWarning("SING_SINGLETON_GETTER_NOT_SYNCHRONIZED")
+    public static Issue3457SynchronizedHelper getInstance() {
+        if (instance == null) {
+            int value = getSynchronizedValue();
+            instance = new Issue3457SynchronizedHelper();
+        }
+        return instance;
+    }
+
+    private static int getSynchronizedValue() {
+        synchronized (Issue3457SynchronizedHelper.class) {
+            return 0;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #3457.

`MultipleInstantiationsOfSingletons` only marked a singleton field as lazily initialized when value-number / null analysis still tracked the field as definitely null at the `putstatic` site. Unrelated code between the `if (instance == null)` check and the assignment (such as `getUnreachableValue()` or a `switch`) could invalidate that tracking and suppress `SING_SINGLETON_GETTER_NOT_SYNCHRONIZED` entirely.

This change adds a bytecode fallback that recognizes the standard pattern:

```java
getstatic instance
ifnonnull skip_init
... // null branch
putstatic instance
skip_init:
```

Synchronization is still detected via the existing recursive `hasSynchronized()` logic, so helpers that use monitors do not produce a false positive.

## Test plan

- [x] Added `Issue3457WithLiteral`, `Issue3457WithHelper`, and `Issue3457SynchronizedHelper` with `Issue3457Test`
- [x] `./gradlew :spotbugs-tests:test --tests edu.umd.cs.findbugs.detect.Issue3457Test`
- [x] `./gradlew :spotbugs-tests:test --tests edu.umd.cs.findbugs.detect.MultipleInstantiationsOfSingletonsTest`
- [x] `./gradlew :spotbugs-tests:test --tests edu.umd.cs.findbugs.DetectorsTest`

Fixes #3457

Made with [Cursor](https://cursor.com)