### PR TITLE
Skip THROWS warnings for abstract method declarations (#3644)

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2040Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2040Test.java
@@ -40,11 +40,10 @@ class Issue2040Test extends AbstractIntegrationTest {
         assertBugInMethod("THROWS_METHOD_THROWS_CLAUSE_THROWABLE", "GenericBase", "method1");
         assertBugInMethod("THROWS_METHOD_THROWS_CLAUSE_THROWABLE", "GenericBase", "method2");
 
-        assertBugTypeCount("THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION", 5);
+        assertBugTypeCount("THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION", 4);
         assertBugInMethod("THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION", "Derived", "exceptionThrowingMethod");
         assertBugInMethod("THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION", "Derived", "exThrownFromCatch");
         assertBugInMethod("THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION", "GenericBase", "method");
         assertBugInMethod("THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION", "GenericBase", "method2");
-        assertBugInMethod("THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION", "Interface", "iMethod");
     }
 }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3644Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3644Test.java
@@ -1,0 +1,17 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class Issue3644Test extends AbstractIntegrationTest {
+
+    @Test
+    void testAbstractMethodsDoNotReportThrowsClause() {
+        performAnalysis("ghIssues/Issue3644AbstractMethod.class", "ghIssues/Issue3644InterfaceMethod.class");
+
+        assertBugInMethod("THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION", "ghIssues.Issue3644AbstractMethod",
+                "concreteMethod");
+        assertBugInClassCount("THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION", "ghIssues.Issue3644AbstractMethod", 1);
+        assertBugInClassCount("THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION", "ghIssues.Issue3644InterfaceMethod", 0);
+    }
+}

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/ThrowingExceptionsTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/ThrowingExceptionsTest.java
@@ -12,7 +12,7 @@ class ThrowingExceptionsTest extends AbstractIntegrationTest {
 
         assertBugTypeCount("THROWS_METHOD_THROWS_RUNTIMEEXCEPTION", 1);
         assertBugTypeCount("THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION", 1);
-        assertBugTypeCount("THROWS_METHOD_THROWS_CLAUSE_THROWABLE", 2);
+        assertBugTypeCount("THROWS_METHOD_THROWS_CLAUSE_THROWABLE", 1);
 
         assertBugInMethod("THROWS_METHOD_THROWS_RUNTIMEEXCEPTION", "MethodsThrowingExceptions", "isCapitalizedThrowingRuntimeException");
         assertNoBugInMethod("THROWS_METHOD_THROWS_RUNTIMEEXCEPTION", "MethodsThrowingExceptions", "isCapitalizedThrowingSpecializedException");
@@ -21,6 +21,5 @@ class ThrowingExceptionsTest extends AbstractIntegrationTest {
         assertNoBugInMethod("THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION", "MethodsThrowingExceptions", "methodThrowingIOException");
 
         assertBugInMethod("THROWS_METHOD_THROWS_CLAUSE_THROWABLE", "MethodsThrowingExceptions", "methodThrowingThrowable");
-        assertBugInMethod("THROWS_METHOD_THROWS_CLAUSE_THROWABLE", "MethodsThrowingExceptions$ThrowThrowable", "run");
     }
 }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ThrowingExceptions.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/ThrowingExceptions.java
@@ -37,7 +37,7 @@ public class ThrowingExceptions extends OpcodeStackDetector {
     public void visit(Method obj) {
         exceptionThrown = null;
 
-        if (obj.isSynthetic()) {
+        if (obj.isSynthetic() || obj.isAbstract()) {
             return;
         }
 

--- a/spotbugsTestCases/src/java/ghIssues/Issue3644.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3644.java
@@ -1,0 +1,19 @@
+package ghIssues;
+
+import edu.umd.cs.findbugs.annotations.ExpectWarning;
+import edu.umd.cs.findbugs.annotations.NoWarning;
+
+abstract class Issue3644AbstractMethod {
+    @NoWarning("THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION")
+    public abstract void abstractMethod() throws Exception;
+
+    @ExpectWarning("THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION")
+    public void concreteMethod() throws Exception {
+        throw new Exception();
+    }
+}
+
+interface Issue3644InterfaceMethod {
+    @NoWarning("THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION")
+    void interfaceMethod() throws Exception;
+}


### PR DESCRIPTION
## Summary

Fixes #3644.

`ThrowingExceptions` reported `THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION` / `THROWS_METHOD_THROWS_CLAUSE_THROWABLE` on abstract method declarations (including interface methods) that only specify API contracts and have no implementation body.

Skip analysis for `Method.isAbstract()` methods, consistent with the detector already ignoring synthetic methods.

## Test plan

- [x] Added `Issue3644` / `Issue3644Test` (abstract + interface methods suppressed; concrete method still reported)
- [x] Updated `Issue2040Test` and `ThrowingExceptionsTest` expectations
- [x] `./gradlew :spotbugs-tests:test --tests edu.umd.cs.findbugs.detect.Issue3644Test`
- [x] `./gradlew :spotbugs-tests:test --tests edu.umd.cs.findbugs.DetectorsTest`

Fixes #3644

Made with [Cursor](https://cursor.com)