### PR TITLE
Fix SF_SWITCH_NO_DEFAULT when default merges with last case (#3905)

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3905Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3905Test.java
@@ -1,0 +1,15 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class Issue3905Test extends AbstractIntegrationTest {
+
+    @Test
+    void testSwitchNoDefaultWithEmptyLastCase() {
+        performAnalysis("ghIssues/Issue3905.class");
+
+        assertBugInMethod("SF_SWITCH_NO_DEFAULT", "ghIssues.Issue3905", "testWithAssignmentInLastCase");
+        assertBugInMethod("SF_SWITCH_NO_DEFAULT", "ghIssues.Issue3905", "testWithBreakOnlyInLastCase");
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/SwitchHandler.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/SwitchHandler.java
@@ -179,6 +179,23 @@ public class SwitchHandler {
     }
 
     /**
+     * Returns true when the switch has no {@code default} label in source but the
+     * compiler merged the implicit default target with the last {@code case} label
+     * (e.g. when the last case contains only a {@code break}).
+     */
+    public boolean isMissingDefaultWithMergedLastCase() {
+        int size = switchOffsetStack.size();
+        if (size == 0) {
+            return false;
+        }
+        SwitchDetails details = switchOffsetStack.get(size - 1);
+        if (details.exhaustive || details.swOffsets.length == 0) {
+            return false;
+        }
+        return details.swOffsets[details.swOffsets.length - 1] == details.defaultOffset;
+    }
+
+    /**
      * For type switches introduced in Java 21 we are using the invocation of a bootstrap 'typeswitch()' method to
      * detect that the switch operates on the class of the object.
      *

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SwitchFallthrough.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SwitchFallthrough.java
@@ -278,6 +278,9 @@ public class SwitchFallthrough extends OpcodeStackDetector implements StatelessD
             reachable = false;
             biggestJumpTarget = -1;
             switchHdlr.enterSwitch(this, enumType);
+            if (switchHdlr.isMissingDefaultWithMergedLastCase()) {
+                foundSwitchNoDefault(switchHdlr.getCurrentSwitchStatement(this));
+            }
             if (DEBUG) {
                 System.out.printf("  entered switch, default is %d%n", switchHdlr.getDefaultCasePC());
             }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SwitchFallthrough.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/SwitchFallthrough.java
@@ -278,7 +278,7 @@ public class SwitchFallthrough extends OpcodeStackDetector implements StatelessD
             reachable = false;
             biggestJumpTarget = -1;
             switchHdlr.enterSwitch(this, enumType);
-            if (switchHdlr.isMissingDefaultWithMergedLastCase()) {
+            if (enumType == null && switchHdlr.isMissingDefaultWithMergedLastCase()) {
                 foundSwitchNoDefault(switchHdlr.getCurrentSwitchStatement(this));
             }
             if (DEBUG) {

--- a/spotbugsTestCases/src/java/ghIssues/Issue3905.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3905.java
@@ -1,0 +1,28 @@
+package ghIssues;
+
+import edu.umd.cs.findbugs.annotations.ExpectWarning;
+
+class Issue3905 {
+    @ExpectWarning("SF_SWITCH_NO_DEFAULT")
+    public void testWithAssignmentInLastCase(int x) {
+        switch (x) {
+        case 0:
+            x = 0;
+            break;
+        case 1:
+            x = 1;
+            break;
+        }
+    }
+
+    @ExpectWarning("SF_SWITCH_NO_DEFAULT")
+    public void testWithBreakOnlyInLastCase(int x) {
+        switch (x) {
+        case 0:
+            x = 0;
+            break;
+        case 1:
+            break;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #3905.

When the last `switch` case contains only a `break`, javac may compile the implicit default target to the same bytecode offset as that case. The existing fallthrough-based `SF_SWITCH_NO_DEFAULT` logic only fires when control falls through into a separate default offset, so these switches were missed.

This change detects the merged-default pattern at switch entry (`defaultOffset == lastCaseOffset` for non-exhaustive switches) and reports `SF_SWITCH_NO_DEFAULT`.

## Test plan

- [x] Added `Issue3905` / `Issue3905Test` (assignment in last case + break-only last case both report)
- [x] `./gradlew :spotbugs-tests:test --tests edu.umd.cs.findbugs.detect.Issue3905Test`
- [x] `./gradlew :spotbugs-tests:test --tests edu.umd.cs.findbugs.DetectorsTest`

Fixes #3905

Made with [Cursor](https://cursor.com)