### PR TITLE
chore(build): Add cleanup action to cleanup old job history

### DIFF
--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -1,0 +1,22 @@
+name: Cleanup Old Workflow Runs
+on:
+  schedule:
+    - cron: '0 0 * * *' # daily at midnight
+  workflow_dispatch:
+
+permissions:
+  actions: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Mattraks/delete-workflow-runs@0cf693bc9909e5e867ee8f27b813224ba862939c # v2
+        with:
+          repository: ${{ github.repository }}
+          retain_days: 30
+          token: ${{ github.token }}


### PR DESCRIPTION
Currently github will delete the content of build results after a period of time.  What github fails to do is actually delete the jobs which then are useless and do take some space.  This new action is a long well tested action that simply runs daily to delete old jobs from showing up.

I have added no change log as not user facing, this is to just cleanup jobs that are not accessible going back a year then keeping it clean on ongoing basis at 30 days.