### PR TITLE
chore(build): Add verification on tag release that version matches the tag

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,6 +30,23 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+      - name: Verify release version
+        if: github.ref_type == 'tag'
+        shell: bash
+        run: |
+          VERSION=$(./gradlew properties -q | awk '/^version:/ {print $2}')
+
+          if [[ "${VERSION}" == *-SNAPSHOT ]]; then
+            echo "Refusing to release SNAPSHOT version: ${VERSION}"
+            exit 1
+          fi
+
+          if [[ "${VERSION}" != "${{ github.ref_name }}" ]]; then
+            echo "Tag (${{
+              github.ref_name
+            }}) does not match build version (${VERSION})"
+            exit 1
+          fi
       - name: Ensure tag is on master
         if: github.ref_type == 'tag'
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased - 2025-??-??
+## Unreleased - 2026-??-??
+### Build
+- Add release protection to ensure version released matches the tag and that snapshot has been removed.
 
 ## 4.10.1 - 2026-06-08
 - 4.10.0 was not released due to a release process error (artifacts were built from a -SNAPSHOT version). 4.10.1 is the corrected release and contains the intended 4.10.0 contents.


### PR DESCRIPTION
When 4.10.0 was released, -SNAPSHOT was not removed.  As a result, the release did not happen while release notes got shipped.  After review, it was clear we did no validation on the tag at all.  It could have been a tag elsewhere, so this will ensure its version is as expected to prevent both situations (ie where snapshot still present and possibility tag is against wrong version)

- [X] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code

Both 4.10.0 and 4.10.1 on releases indicate the issue that occurred.  Further a discussion here https://github.com/spotbugs/spotbugs/discussions/4155.  This was done mainly due to fact that so many hours elapsed since the release was published, the releases are immutable now, and it was felt there would be more confusion and possible issues in trying to recut same version.  This post change is intended then to prevent that situation in the future as it can easily happen, more so when moving up minor|major versions as focus drifts.
