### PR TITLE
update sonatype link in `RELEASE_PROCEDURE.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Building SpotBugs requires JDK 21 to run all the tests (using SpotBugs requires 
 
 To see a list of build options, run `gradle tasks` (or `gradlew tasks`). The `build` task will perform a full build and test.
 
-To build the SpotBugs plugin for Eclipse, you'll need to create the file `eclipsePlugin/local.properties`, containing a property `eclipseRoot.dir` that points to an Eclipse installation's root directory (see `.github/workflows/release.yml` for an example), then run the build.
+To build the SpotBugs plugin for Eclipse, you'll need to create the file `eclipsePlugin/local.properties`, containing a property `eclipseRoot.dir` that points to an Eclipse installation's root directory (see `.github/workflows/release.yaml` for an example), then run the build.
 To prepare Eclipse environment only, run `./gradlew eclipse`. See also [detailed steps](https://github.com/spotbugs/spotbugs/blob/master/eclipsePlugin/doc/building_spotbugs_plugin.txt).
 
 # Using SpotBugs

--- a/RELEASE_PROCEDURE.md
+++ b/RELEASE_PROCEDURE.md
@@ -12,7 +12,7 @@ The PR containing these changes needs to be rebased and merged to master. Since 
 
 ## Release to Maven Central
 
-When we push a tag, the build result on GitHub Actions will be deployed to the [SonaType Nexus](https://oss.sonatype.org/), and published to the Maven Central automatically by [Gradle Nexus Publish Plugin](https://github.com/gradle-nexus/publish-plugin). Then we can find [artifacts in the Maven Central](https://repo1.maven.org/maven2/com/github/spotbugs/) after several hours.
+When we push a tag, the build result on GitHub Actions will be deployed to the [SonaType Nexus](https://central.sonatype.com/), and published to the Maven Central automatically by [Gradle Nexus Publish Plugin](https://github.com/gradle-nexus/publish-plugin). Then we can find [artifacts in the Maven Central](https://repo1.maven.org/maven2/com/github/spotbugs/) after several hours.
 See the `build` phase in `.github/workflows/release.yml` calling the `publishToSonatype` and `closeSonatypeStagingRepository` gradle tasks.
 
 ## Release to Eclipse Update Site

--- a/RELEASE_PROCEDURE.md
+++ b/RELEASE_PROCEDURE.md
@@ -13,7 +13,7 @@ The PR containing these changes needs to be rebased and merged to master. Since 
 ## Release to Maven Central
 
 When we push a tag, the build result on GitHub Actions will be deployed to the [SonaType Nexus](https://central.sonatype.com/), and published to the Maven Central automatically by [Gradle Nexus Publish Plugin](https://github.com/gradle-nexus/publish-plugin). Then we can find [artifacts in the Maven Central](https://repo1.maven.org/maven2/com/github/spotbugs/) after several hours.
-See the `build` phase in `.github/workflows/release.yml` calling the `publishToSonatype` and `closeSonatypeStagingRepository` gradle tasks.
+See the `build` phase in `.github/workflows/release.yaml` calling the `publishToSonatype` and `closeSonatypeStagingRepository` gradle tasks.
 
 ## Release to Eclipse Update Site
 
@@ -22,7 +22,7 @@ It's automated by GitHub CI.
 When we push tag, the build result will be deployed to [eclipse-candidate repository](https://github.com/spotbugs/eclipse-candidate).
 When we push tag and its name doesn't contain `_RC`, the build result will be deployed to [eclipse repository](https://github.com/spotbugs/eclipse).
 
-See `Deploy eclipse`, `Deploy eclipse-candidate` and `Deploy eclipse-latest` phases in `.github/workflows/release.yml` for detail.
+See `Deploy eclipse`, `Deploy eclipse-candidate` and `Deploy eclipse-latest` phases in `.github/workflows/release.yaml` for detail.
 
 ## Release to Eclipse Marketplace
 


### PR DESCRIPTION
The old Sonatype OSS website was shut down and moved to central (see [sunset announcement](https://central.sonatype.org/news/20250326_ossrh_sunset/)). This PR is only a really small docs change updating the sonatype link, so I did not add a changelog entry.