### PR TITLE
Fix message for `UNS_UNSAFE_CALL` BugPattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased - 2026-??-??
+### Fixed
+- Fix message for `UNS_UNSAFE_CALL` bug pattern
 
 ## 4.10.2 - 2026-06-09
 ### Build

--- a/spotbugs/etc/messages.xml
+++ b/spotbugs/etc/messages.xml
@@ -9868,7 +9868,7 @@ Using floating-point variables should not be used as loop counters, as they are 
 
   <BugPattern type="UNS_UNSAFE_CALL">
     <ShortDescription>Call to Unsafe.</ShortDescription>
-    <LongDescription>Do not use {0}. As the class name indicates, its methods are not safe to use.
+    <LongDescription>Do not use {4}. As the class name indicates, its methods are not safe to use.
     </LongDescription>
     <Details>
       <![CDATA[

--- a/spotbugs/etc/messages_fr.xml
+++ b/spotbugs/etc/messages_fr.xml
@@ -3385,7 +3385,7 @@ Ce string utilisé dans un format contient le caractère newline (\n). Il est g�
  </BugPattern>
   <BugPattern type="UNS_UNSAFE_CALL">
     <ShortDescription>Appel à Unsafe.</ShortDescription>
-    <LongDescription>N'utilisez pas {0}. Comme l'indique le nom de cette classe, l'utilisation de ses méthodes peut causer des failles de sécurité.
+    <LongDescription>N'utilisez pas {4}. Comme l'indique le nom de cette classe, l'utilisation de ses méthodes peut causer des failles de sécurité.
     </LongDescription>
     <Details>
       <![CDATA[

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UnsafeDetector.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UnsafeDetector.java
@@ -71,7 +71,7 @@ public class UnsafeDetector extends OpcodeStackDetector {
                             .addClassAndMethod(this)
                             .addSourceLine(this, getPC())
                             .addCalledMethod(this)
-                            .addString(getClassConstantOperand());
+                            .addClass(getClassConstantOperand());
             bugReporter.reportBug(bug);
         }
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UnsafeDetector.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UnsafeDetector.java
@@ -70,7 +70,8 @@ public class UnsafeDetector extends OpcodeStackDetector {
                     new BugInstance(this, "UNS_UNSAFE_CALL", HIGH_PRIORITY)
                             .addClassAndMethod(this)
                             .addSourceLine(this, getPC())
-                            .addCalledMethod(this);
+                            .addCalledMethod(this)
+                            .addString(getClassConstantOperand());
             bugReporter.reportBug(bug);
         }
     }


### PR DESCRIPTION
The `UNS_UNSAFE_CALL` bug is reported here:
https://github.com/spotbugs/spotbugs/blob/680fc980bf2ae3e088e237e6b11fe6381adab8a3/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/UnsafeDetector.java#L63-L74
The 0th parameter is the class where the function of Unsafe class is called, not the Unsafe class.
The 3rd parameter is the called method, for which only the container class cannot be added, as `.givenClass` also adds the function. (See `MethodAnnotation.formatPackageMember(String, ClassAnnotation)` [function](https://github.com/spotbugs/spotbugs/blob/master/spotbugs/src/main/java/edu/umd/cs/findbugs/MethodAnnotation.java#L332).) So I added a new parameter and refered that in the `messages.xml` and `messages-fr.xml`, the `messages-ja.xml` doesn't contain this bugpattern.