### PR TITLE
Fixes #4192 : Stop flagging meaningful signed-byte comparisons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This is the changelog for SpotBugs. This follows [Keep a Changelog v1.0.0](http:
 Currently the versioning policy of this project follows [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased - 2026-??-??
+### Fixed
+- Fix `INT_BAD_COMPARISON_WITH_SIGNED_BYTE` false positive for meaningful comparisons of a signed byte with `127` (`b < 127`, `b >= 127`) ([#4201](https://github.com/spotbugs/spotbugs/pull/4201))
 
 ## 4.10.3 - 2026-07-12
 ### Fixed

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue4192Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue4192Test.java
@@ -1,0 +1,26 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class Issue4192Test extends AbstractIntegrationTest {
+
+    private static final String BUG = "INT_BAD_COMPARISON_WITH_SIGNED_BYTE";
+    private static final String CLASS = "ghIssues.Issue4192";
+
+    @Test
+    void testSignedByteComparison() {
+        performAnalysis("ghIssues/Issue4192.class");
+
+        // Only always-true, never-true, out-of-range comparisons are reported.
+        assertBugTypeCount(BUG, 3);
+        assertBugInMethod(BUG, CLASS, "lessOrEqual127");
+        assertBugInMethod(BUG, CLASS, "greaterThan127");
+        assertBugInMethod(BUG, CLASS, "equal255");
+
+        // Meaningful comparisons against 127 must not be reported (the #4192 fix).
+        assertNoBugInMethod(BUG, CLASS, "lessThan127");
+        assertNoBugInMethod(BUG, CLASS, "greaterOrEqual127");
+        assertNoBugInMethod(BUG, CLASS, "equal127");
+    }
+}

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue4192Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue4192Test.java
@@ -13,10 +13,14 @@ class Issue4192Test extends AbstractIntegrationTest {
         performAnalysis("ghIssues/Issue4192.class");
 
         // Only always-true, never-true, out-of-range comparisons are reported.
-        assertBugTypeCount(BUG, 3);
+        assertBugTypeCount(BUG, 5);
         assertBugInMethod(BUG, CLASS, "lessOrEqual127");
         assertBugInMethod(BUG, CLASS, "greaterThan127");
         assertBugInMethod(BUG, CLASS, "equal255");
+
+        // Out-of-range comparisons must still be reported (no false negatives).
+        assertBugInMethod(BUG, CLASS, "lessThan128");
+        assertBugInMethod(BUG, CLASS, "greaterThanMinus129");
 
         // Meaningful comparisons against 127 must not be reported (the #4192 fix).
         assertNoBugInMethod(BUG, CLASS, "lessThan127");

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DumbMethods.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DumbMethods.java
@@ -1010,21 +1010,19 @@ public class DumbMethods extends OpcodeStackDetector {
                     Object constant1 = item1.getConstant();
                     if (item0.getSpecialKind() == OpcodeStack.Item.SIGNED_BYTE && constant1 instanceof Number) {
                         int v1 = ((Number) constant1).intValue();
-                        if (v1 <= -129 || v1 >= 128 || v1 == 127 && !(seen2 == Const.IF_ICMPEQ || seen2 == Const.IF_ICMPNE)) {
+                        // For a signed byte x (range -128..127), comparing against 127 is only
+                        // suspicious when it is always true (127 >= x, i.e. x <= 127) or never true
+                        // (127 < x, i.e. x > 127). The comparisons x < 127 (127 > x) and x >= 127
+                        // (127 <= x) are meaningful and must not be reported.
+                        if (v1 <= -129 || v1 >= 128 || v1 == 127 && (seen2 == Const.IF_ICMPGE || seen2 == Const.IF_ICMPLT)) {
                             int priority = HIGH_PRIORITY;
                             if (v1 == 127) {
                                 switch (seen2) {
-                                case Const.IF_ICMPGT: // 127 > x
-                                    priority = LOW_PRIORITY;
-                                    break;
                                 case Const.IF_ICMPGE: // 127 >= x : always true
                                     priority = NORMAL_PRIORITY;
                                     break;
                                 case Const.IF_ICMPLT: // 127 < x : never true
                                     priority = NORMAL_PRIORITY;
-                                    break;
-                                case Const.IF_ICMPLE: // 127 <= x
-                                    priority = LOW_PRIORITY;
                                     break;
                                 }
                             } else if (v1 == 128) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DumbMethods.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DumbMethods.java
@@ -1010,10 +1010,8 @@ public class DumbMethods extends OpcodeStackDetector {
                     Object constant1 = item1.getConstant();
                     if (item0.getSpecialKind() == OpcodeStack.Item.SIGNED_BYTE && constant1 instanceof Number) {
                         int v1 = ((Number) constant1).intValue();
-                        // For a signed byte x (range -128..127), comparing against 127 is only
-                        // suspicious when it is always true (127 >= x, i.e. x <= 127) or never true
-                        // (127 < x, i.e. x > 127). The comparisons x < 127 (127 > x) and x >= 127
-                        // (127 <= x) are meaningful and must not be reported.
+                        // For 127, only report x <= 127 (always true) and x > 127 (never true);
+                        // x < 127 and x >= 127 are meaningful comparisons of a signed byte.
                         if (v1 <= -129 || v1 >= 128 || v1 == 127 && (seen2 == Const.IF_ICMPGE || seen2 == Const.IF_ICMPLT)) {
                             int priority = HIGH_PRIORITY;
                             if (v1 == 127) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DumbMethods.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/DumbMethods.java
@@ -1012,7 +1012,7 @@ public class DumbMethods extends OpcodeStackDetector {
                         int v1 = ((Number) constant1).intValue();
                         // For 127, only report x <= 127 (always true) and x > 127 (never true);
                         // x < 127 and x >= 127 are meaningful comparisons of a signed byte.
-                        if (v1 <= -129 || v1 >= 128 || v1 == 127 && (seen2 == Const.IF_ICMPGE || seen2 == Const.IF_ICMPLT)) {
+                        if (v1 <= -129 || v1 >= 128 || (v1 == 127 && (seen2 == Const.IF_ICMPGE || seen2 == Const.IF_ICMPLT))) {
                             int priority = HIGH_PRIORITY;
                             if (v1 == 127) {
                                 switch (seen2) {

--- a/spotbugsTestCases/src/java/ghIssues/Issue4192.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue4192.java
@@ -32,6 +32,16 @@ public class Issue4192 {
         return b == 255;
     }
 
+    /** Reported: out of range above the maximum, always true. */
+    public boolean lessThan128(byte b) {
+        return b < 128;
+    }
+
+    /** Reported: out of range below the minimum, always true. */
+    public boolean greaterThanMinus129(byte b) {
+        return b > -129;
+    }
+
     /** Not reported: equality against the boundary is meaningful. */
     public boolean equal127(byte b) {
         return b == 127;

--- a/spotbugsTestCases/src/java/ghIssues/Issue4192.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue4192.java
@@ -1,0 +1,39 @@
+package ghIssues;
+
+/**
+ * INT_BAD_COMPARISON_WITH_SIGNED_BYTE must only fire on comparisons of a signed
+ * byte (range -128..127) that are always true or never true, not on meaningful
+ * ones. See https://github.com/spotbugs/spotbugs/issues/4192
+ */
+public class Issue4192 {
+
+    /** False positive fixed by #4192: true for -128..126, false at 127. */
+    public boolean lessThan127(byte b) {
+        return b < 127;
+    }
+
+    /** False positive fixed by #4192: true only at 127. */
+    public boolean greaterOrEqual127(byte b) {
+        return b >= 127;
+    }
+
+    /** Reported: always true (b is at most 127). */
+    public boolean lessOrEqual127(byte b) {
+        return b <= 127;
+    }
+
+    /** Reported: never true (b is at most 127). */
+    public boolean greaterThan127(byte b) {
+        return b > 127;
+    }
+
+    /** Reported: out-of-range unsigned confusion, never true. */
+    public boolean equal255(byte b) {
+        return b == 255;
+    }
+
+    /** Not reported: equality against the boundary is meaningful. */
+    public boolean equal127(byte b) {
+        return b == 127;
+    }
+}


### PR DESCRIPTION
`INT_BAD_COMPARISON_WITH_SIGNED_BYTE` reported a false positive for b < 127 (and b >= 127), which are valid comparisons for a signed byte, not always-true/never-true.

For the constant 127, this PR only reports the always-true (b <= 127) and never-true (b > 127) cases. Comparisons against 128 / <= -129 are unchanged.

Fixes #4192 