### PR TITLE
Fixes #4168 : Quote spotbugs.jar path in spotbugs2 launcher to allow spaces

### DIFF
--- a/spotbugs/src/scripts/standard/spotbugs2
+++ b/spotbugs/src/scripts/standard/spotbugs2
@@ -117,5 +117,5 @@ exec "$fb_javacmd" \
 	-Dspotbugs.home="$spotbugs_home" \
 	$jvm_debug $jvm_maxheap $jvm_ea $jvm_conservespace $jvm_user_props \
 	-Dfindbugs.launchUI=$fb_launchui \
-	-jar $spotbugs_home/lib/spotbugs.jar \
+	-jar "$spotbugs_home/lib/spotbugs.jar" \
 	${@:+"$@"}


### PR DESCRIPTION
Quote spotbugs.jar path in spotbugs2 launcher to allow spaces.

Fixes #4168