### PR TITLE
Remove deprecated IO.close(InputStream) usages

### DIFF
--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/ClassPathBuilder.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/impl/ClassPathBuilder.java
@@ -33,6 +33,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.jar.Attributes;
@@ -59,7 +60,6 @@ import edu.umd.cs.findbugs.classfile.ResourceNotFoundException;
 import edu.umd.cs.findbugs.classfile.analysis.ClassNameAndSuperclassInfo;
 import edu.umd.cs.findbugs.classfile.engine.ClassParser;
 import edu.umd.cs.findbugs.classfile.engine.ClassParserInterface;
-import edu.umd.cs.findbugs.io.IO;
 import edu.umd.cs.findbugs.util.Archive;
 import edu.umd.cs.findbugs.util.ClassPathUtil;
 
@@ -709,13 +709,8 @@ public class ClassPathBuilder implements IClassPathBuilder {
      *            the resource
      */
     private void parseClassName(ICodeBaseEntry entry) {
-        DataInputStream in = null;
-        try {
-            InputStream resourceIn = entry.openResource();
-            if (resourceIn == null) {
-                throw new NullPointerException("Got null resource");
-            }
-            in = new DataInputStream(resourceIn);
+        try (InputStream resourceIn = entry.openResource();
+                DataInputStream in = new DataInputStream(Objects.requireNonNull(resourceIn, "Got null resource"))) {
             ClassParserInterface parser = new ClassParser(in, null, entry);
             ClassNameAndSuperclassInfo.Builder builder = new ClassNameAndSuperclassInfo.Builder();
             parser.parse(builder);
@@ -726,8 +721,6 @@ public class ClassPathBuilder implements IClassPathBuilder {
             }
         } catch (IOException | InvalidClassFileFormatException e) {
             errorLogger.logError("Invalid class resource " + entry.getResourceName() + " in " + entry, e);
-        } finally {
-            IO.close(in);
         }
     }
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/io/IO.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/io/IO.java
@@ -76,7 +76,7 @@ public class IO {
             copy(in, byteSink);
             return byteSink.toByteArray();
         } finally {
-            close(in);
+            close((Closeable) in);
         }
     }
 
@@ -113,7 +113,7 @@ public class IO {
                 result[pos++] = (byte) nextByte;
             }
         } finally {
-            close(in);
+            close((Closeable) in);
         }
     }
 


### PR DESCRIPTION
This PR completes the cleanup started in #4194. These were the only spots left where the deprecate method was being used.