### PR TITLE
Fixes #724: @SuppressFBWarnings annotation on a method or a constructor now suppresses warnings reported in their lambdas too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 ### Fixed
 - Fix `INT_BAD_COMPARISON_WITH_SIGNED_BYTE` false positive for meaningful comparisons of a signed byte with `127` (`b < 127`, `b >= 127`) ([#4201](https://github.com/spotbugs/spotbugs/pull/4201))
 
+### Changed
+- `@SuppressFBWarnings` annotation on a method or a constructor now suppresses warnings reported in their lambdas too ([#724](https://github.com/spotbugs/spotbugs/issues/724))
+
 ## 4.10.3 - 2026-07-12
 ### Fixed
 - Fix `LI_LAZY_INIT_STATIC` false negative when the null guard is written in yoda-style (`null == field`) ([#4144](https://github.com/spotbugs/spotbugs/pull/4144))

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/SuppressionMatcherTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/SuppressionMatcherTest.java
@@ -74,6 +74,46 @@ class SuppressionMatcherTest {
     }
 
     @Test
+    void shouldMatchMethodLevelSuppressorForLambdaOfMethod() {
+        // given
+        MethodAnnotation method = new MethodAnnotation(CLASS_NAME, "test", "()V", false);
+        MethodAnnotation lambda = new MethodAnnotation(CLASS_NAME, "lambda$test$0", "()V", true);
+        BugInstance bug = new BugInstance("UUF_UNUSED_FIELD", 1).addClass(CLASS_NAME).addMethod(lambda);
+        matcher.addSuppressor(new MethodWarningSuppressor("UUF_UNUSED_FIELD", SuppressMatchType.DEFAULT, CLASS_ANNOTATION, method, true, true));
+        // when
+        boolean matched = matcher.match(bug);
+        // then
+        assertThat("Should match the bug", matched, is(true));
+    }
+
+    @Test
+    void shouldNotMatchMethodLevelSuppressorForLambdaOfOtherMethod() {
+        // given
+        MethodAnnotation method = new MethodAnnotation(CLASS_NAME, "test", "()V", false);
+        MethodAnnotation lambda = new MethodAnnotation(CLASS_NAME, "lambda$other$0", "()V", true);
+        BugInstance bug = new BugInstance("UUF_UNUSED_FIELD", 1).addClass(CLASS_NAME).addMethod(lambda);
+        matcher.addSuppressor(new MethodWarningSuppressor("UUF_UNUSED_FIELD", SuppressMatchType.DEFAULT, CLASS_ANNOTATION, method, true, true));
+        // when
+        boolean matched = matcher.match(bug);
+        // then
+        assertThat("Should not match the bug", matched, is(false));
+    }
+
+    @Test
+    void shouldNotMatchMethodLevelSuppressorForLambdaOfSameNamedMethodInInnerClass() {
+        // given
+        String innerClassName = CLASS_NAME + "$Inner";
+        MethodAnnotation method = new MethodAnnotation(CLASS_NAME, "test", "()V", false);
+        MethodAnnotation lambda = new MethodAnnotation(innerClassName, "lambda$test$0", "()V", true);
+        BugInstance bug = new BugInstance("UUF_UNUSED_FIELD", 1).addClass(innerClassName).addMethod(lambda);
+        matcher.addSuppressor(new MethodWarningSuppressor("UUF_UNUSED_FIELD", SuppressMatchType.DEFAULT, CLASS_ANNOTATION, method, true, true));
+        // when
+        boolean matched = matcher.match(bug);
+        // then
+        assertThat("Should not match the bug", matched, is(false));
+    }
+
+    @Test
     void shouldMatchParameterLevelSuppressor() {
         // given
         MethodAnnotation method = new MethodAnnotation(CLASS_NAME, "test", "bool test()", false);

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/WarningSuppressorTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/WarningSuppressorTest.java
@@ -35,6 +35,19 @@ class WarningSuppressorTest extends AbstractIntegrationTest {
     }
 
     @Test
+    void methodSuppressionAppliesToInnerLambdas() {
+        performAnalysis("ghIssues/Issue724.class");
+
+        assertNoBugType("US_USELESS_SUPPRESSION_ON_METHOD");
+
+        assertBugTypeCount("NP_ALWAYS_NULL", 1);
+        assertBugTypeCount("NP_LOAD_OF_KNOWN_NULL_VALUE", 1);
+
+        assertBugAtLine("NP_ALWAYS_NULL", 63);
+        assertBugAtLine("NP_LOAD_OF_KNOWN_NULL_VALUE", 63);
+    }
+
+    @Test
     void customSuppressAnnotationMethodTest() {
         performAnalysis("suppress/custom/CustomSuppressedBugs.class", "suppress/custom/SuppressFBWarnings.class");
 

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/MethodWarningSuppressor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/MethodWarningSuppressor.java
@@ -1,5 +1,7 @@
 package edu.umd.cs.findbugs;
 
+import org.apache.bcel.Const;
+
 import edu.umd.cs.findbugs.annotations.SuppressMatchType;
 import edu.umd.cs.findbugs.bytecode.MemberUtils;
 import edu.umd.cs.findbugs.detect.UselessSuppressionDetector;
@@ -35,7 +37,7 @@ public class MethodWarningSuppressor extends ClassWarningSuppressor {
         }
 
         MethodAnnotation bugMethod = bugInstance.getPrimaryMethod();
-        if (bugMethod != null && !method.equals(bugMethod)) {
+        if (bugMethod != null && !method.equals(bugMethod) && !isLambdaOfSuppressedMethod(bugMethod)) {
             return false;
         }
         if (DEBUG) {
@@ -55,5 +57,17 @@ public class MethodWarningSuppressor extends ClassWarningSuppressor {
     @Override
     public boolean isUselessSuppressionReportable() {
         return userGeneratedMethod && super.isUselessSuppressionReportable();
+    }
+
+    private boolean isLambdaOfSuppressedMethod(MethodAnnotation bugMethod) {
+        if (!method.getClassName().equals(bugMethod.getClassName())) {
+            return false;
+        }
+
+        if (Const.CONSTRUCTOR_NAME.equals(method.getMethodName())) {
+            return bugMethod.getMethodName().startsWith("lambda$new$");
+        }
+
+        return bugMethod.getMethodName().startsWith("lambda$" + method.getMethodName() + "$");
     }
 }

--- a/spotbugsTestCases/src/java/ghIssues/Issue724.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue724.java
@@ -1,0 +1,66 @@
+package ghIssues;
+
+import java.util.function.Supplier;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+/**
+ * @see <a href="https://github.com/spotbugs/spotbugs/issues/724">GitHub issue #724</a>
+ */
+public class Issue724 {
+
+    // Compiled into the annotated constructor below, so its lambda is covered by the constructor suppression
+    public final Supplier<Integer> suppressedFieldInitializer = () -> {
+        String x = null;
+        return x.length();
+    };
+
+    public final Supplier<Integer> suppressedInConstructor;
+
+    @SuppressFBWarnings(value = "NP", justification = "Suppression on a constructor covers its lambdas")
+    public Issue724() {
+        suppressedInConstructor = () -> {
+            String x = null;
+            return x.length();
+        };
+    }
+
+    @SuppressFBWarnings(value = "NP", justification = "Suppression on a method covers its lambdas")
+    public Supplier<Integer> suppressedInLambda() {
+        return () -> {
+            String x = null;
+            return x.length();
+        };
+    }
+
+    @SuppressFBWarnings(value = "NP", justification = "Suppression on a method covers its nested lambdas")
+    public Supplier<Integer> suppressedInNestedLambda() {
+        return () -> {
+            Supplier<Integer> inner = () -> {
+                String x = null;
+                return x.length();
+            };
+            return inner.get();
+        };
+    }
+
+    @SuppressFBWarnings(value = "NP", justification = "Suppression on a method covers its lambdas")
+    public Supplier<Integer> suppressedOverload(int overload) {
+        return () -> overload;
+    }
+
+    // Known limitation: lambda method names do not encode signature, so the suppression above also covers the lambda of this overload
+    public Supplier<Integer> suppressedOverload(String overload) {
+        return () -> {
+            String x = null;
+            return x.length();
+        };
+    }
+
+    public Supplier<Integer> notSuppressedInLambda() {
+        return () -> {
+            String x = null;
+            return x.length();
+        };
+    }
+}


### PR DESCRIPTION
Fixes #724

Updated MethodWarningSuppressor to consider lambdas of suppressed methods/constructors too. 

Please note, that overloaded methods + different constructors can be over-suppressed since the lambda names do not specify which signature it belongs to. To keep the change small I avoided implementing a complex workaround for this (but I did add it to the test as a known limitation). Please let me know, if this is not the right decision.

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
- [x] ./gradlew spotlessApply build smoketest passes.