### PR TITLE
chore(build): Remove deprecated usage of junit annotations

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue1254Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue1254Test.java
@@ -1,8 +1,6 @@
 package edu.umd.cs.findbugs.ba;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledForJreRange;
-import org.junit.jupiter.api.condition.JRE;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
 
@@ -28,7 +26,6 @@ class Issue1254Test extends AbstractIntegrationTest {
      * Test that accessing private members of a nested class doesn't result in uncalled method problems.
      */
     @Test
-    @EnabledForJreRange(min = JRE.JAVA_11)
     void testUncalledPrivateMethod() {
         performAnalysis(CLASS_LIST);
         assertBugTypeCount("UPM_UNCALLED_PRIVATE_METHOD", 2);

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue1254Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue1254Test.java
@@ -1,7 +1,7 @@
 package edu.umd.cs.findbugs.ba;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnJre;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
@@ -28,7 +28,7 @@ class Issue1254Test extends AbstractIntegrationTest {
      * Test that accessing private members of a nested class doesn't result in uncalled method problems.
      */
     @Test
-    @DisabledOnJre(JRE.JAVA_8)
+    @EnabledForJreRange(min = JRE.JAVA_11)
     void testUncalledPrivateMethod() {
         performAnalysis(CLASS_LIST);
         assertBugTypeCount("UPM_UNCALLED_PRIVATE_METHOD", 2);

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue1338Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue1338Test.java
@@ -1,8 +1,6 @@
 package edu.umd.cs.findbugs.ba;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledForJreRange;
-import org.junit.jupiter.api.condition.JRE;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
 
@@ -18,7 +16,6 @@ class Issue1338Test extends AbstractIntegrationTest {
      * Test that calling a method call when initializing a try-with-resource variable doesn't result in redundant nullcheck of nonnull value.
      */
     @Test
-    @EnabledForJreRange(min = JRE.JAVA_11)
     void testMethodCallInTryWithResource() {
         performAnalysis(CLASS_LIST);
         assertNoBugType("RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE");

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue1338Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue1338Test.java
@@ -1,7 +1,7 @@
 package edu.umd.cs.findbugs.ba;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnJre;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
@@ -18,7 +18,7 @@ class Issue1338Test extends AbstractIntegrationTest {
      * Test that calling a method call when initializing a try-with-resource variable doesn't result in redundant nullcheck of nonnull value.
      */
     @Test
-    @DisabledOnJre(JRE.JAVA_8)
+    @EnabledForJreRange(min = JRE.JAVA_11)
     void testMethodCallInTryWithResource() {
         performAnalysis(CLASS_LIST);
         assertNoBugType("RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE");

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue1367Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue1367Test.java
@@ -9,8 +9,6 @@ import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 import java.nio.file.Path;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledForJreRange;
-import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
@@ -23,7 +21,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 class Issue1367Test {
 
     @Test
-    @EnabledForJreRange(min = JRE.JAVA_17)
     void testIssue(SpotBugsRunner spotbugs) {
         BugCollection bugCollection = spotbugs.performAnalysis(Path.of("../spotbugsTestCases/build/classes/java/java17/Issue1367.class"));
         BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder().bugType("EQ_UNUSUAL").build();

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue1367Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue1367Test.java
@@ -9,7 +9,7 @@ import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
 import java.nio.file.Path;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnJre;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -23,7 +23,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 class Issue1367Test {
 
     @Test
-    @DisabledOnJre({ JRE.JAVA_8, JRE.JAVA_11 })
+    @EnabledForJreRange(min = JRE.JAVA_17)
     void testIssue(SpotBugsRunner spotbugs) {
         BugCollection bugCollection = spotbugs.performAnalysis(Path.of("../spotbugsTestCases/build/classes/java/java17/Issue1367.class"));
         BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder().bugType("EQ_UNUSUAL").build();

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue408Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue408Test.java
@@ -8,8 +8,6 @@ import java.io.IOException;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledForJreRange;
-import org.junit.jupiter.api.condition.JRE;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
 
@@ -20,7 +18,6 @@ import edu.umd.cs.findbugs.AbstractIntegrationTest;
 class Issue408Test extends AbstractIntegrationTest {
 
     @Test
-    @EnabledForJreRange(min = JRE.JAVA_11)
     void testSingleClass() {
         Throwable throwable = Assertions.assertThrows(AssertionError.class, () -> performAnalysis("../java11/module-info.class"));
         Assertions.assertEquals("Analysis failed with exception", throwable.getMessage());
@@ -28,7 +25,6 @@ class Issue408Test extends AbstractIntegrationTest {
     }
 
     @Test
-    @EnabledForJreRange(min = JRE.JAVA_11)
     void testFewClasses() {
         Assertions.assertDoesNotThrow(() -> performAnalysis("../java11/module-info.class", "../java11/Issue408.class"));
     }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue408Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/Issue408Test.java
@@ -8,7 +8,7 @@ import java.io.IOException;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnJre;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
@@ -20,7 +20,7 @@ import edu.umd.cs.findbugs.AbstractIntegrationTest;
 class Issue408Test extends AbstractIntegrationTest {
 
     @Test
-    @DisabledOnJre(JRE.JAVA_8)
+    @EnabledForJreRange(min = JRE.JAVA_11)
     void testSingleClass() {
         Throwable throwable = Assertions.assertThrows(AssertionError.class, () -> performAnalysis("../java11/module-info.class"));
         Assertions.assertEquals("Analysis failed with exception", throwable.getMessage());
@@ -28,7 +28,7 @@ class Issue408Test extends AbstractIntegrationTest {
     }
 
     @Test
-    @DisabledOnJre(JRE.JAVA_8)
+    @EnabledForJreRange(min = JRE.JAVA_11)
     void testFewClasses() {
         Assertions.assertDoesNotThrow(() -> performAnalysis("../java11/module-info.class", "../java11/Issue408.class"));
     }

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindReturnRefTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindReturnRefTest.java
@@ -3,7 +3,7 @@ package edu.umd.cs.findbugs.detect;
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnJre;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 
 class FindReturnRefTest extends AbstractIntegrationTest {
@@ -258,7 +258,7 @@ class FindReturnRefTest extends AbstractIntegrationTest {
     }
 
     @Test
-    @DisabledOnJre({ JRE.JAVA_8, JRE.JAVA_11 })
+    @EnabledForJreRange(min = JRE.JAVA_17)
     void testUnmodifiableClass() {
         performAnalysis("../java17/exposemutable/UnmodifiableClass.class");
 
@@ -320,7 +320,7 @@ class FindReturnRefTest extends AbstractIntegrationTest {
     }
 
     @Test
-    @DisabledOnJre({ JRE.JAVA_8, JRE.JAVA_11 })
+    @EnabledForJreRange(min = JRE.JAVA_17)
     @Disabled
     void testUnmodifiableRecord() {
         performAnalysis("../java17/exposemutable/UnmodifiableRecord.class");
@@ -328,7 +328,7 @@ class FindReturnRefTest extends AbstractIntegrationTest {
     }
 
     @Test
-    @DisabledOnJre({ JRE.JAVA_8, JRE.JAVA_11 })
+    @EnabledForJreRange(min = JRE.JAVA_17)
     void testUnmodifiableRecordWithAllParamConstructor() {
         performAnalysis("../java17/exposemutable/UnmodifiableRecordWithAllParamConstructor.class");
         assertNoExposeBug();

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindReturnRefTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindReturnRefTest.java
@@ -3,8 +3,6 @@ package edu.umd.cs.findbugs.detect;
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledForJreRange;
-import org.junit.jupiter.api.condition.JRE;
 
 class FindReturnRefTest extends AbstractIntegrationTest {
     @Test
@@ -258,7 +256,6 @@ class FindReturnRefTest extends AbstractIntegrationTest {
     }
 
     @Test
-    @EnabledForJreRange(min = JRE.JAVA_17)
     void testUnmodifiableClass() {
         performAnalysis("../java17/exposemutable/UnmodifiableClass.class");
 
@@ -320,7 +317,6 @@ class FindReturnRefTest extends AbstractIntegrationTest {
     }
 
     @Test
-    @EnabledForJreRange(min = JRE.JAVA_17)
     @Disabled
     void testUnmodifiableRecord() {
         performAnalysis("../java17/exposemutable/UnmodifiableRecord.class");
@@ -328,7 +324,6 @@ class FindReturnRefTest extends AbstractIntegrationTest {
     }
 
     @Test
-    @EnabledForJreRange(min = JRE.JAVA_17)
     void testUnmodifiableRecordWithAllParamConstructor() {
         performAnalysis("../java17/exposemutable/UnmodifiableRecordWithAllParamConstructor.class");
         assertNoExposeBug();

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/IncorrectSelfComparisonInstanceOfPatternMatchingTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/IncorrectSelfComparisonInstanceOfPatternMatchingTest.java
@@ -7,8 +7,6 @@ import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
 import java.nio.file.Path;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledForJreRange;
-import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import edu.umd.cs.findbugs.BugCollection;
@@ -25,7 +23,6 @@ class IncorrectSelfComparisonInstanceOfPatternMatchingTest {
      *      issue</a>
      */
     @Test
-    @EnabledForJreRange(min = JRE.JAVA_17)
     void testIssue1136(SpotBugsRunner spotbugs) {
         final BugInstanceMatcher selfComparisonMatcher = new BugInstanceMatcherBuilder()
                 .bugType("SA_LOCAL_SELF_COMPARISON").build();

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/IncorrectSelfComparisonInstanceOfPatternMatchingTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/IncorrectSelfComparisonInstanceOfPatternMatchingTest.java
@@ -7,7 +7,7 @@ import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
 import java.nio.file.Path;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnJre;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -25,7 +25,7 @@ class IncorrectSelfComparisonInstanceOfPatternMatchingTest {
      *      issue</a>
      */
     @Test
-    @DisabledOnJre({ JRE.JAVA_8, JRE.JAVA_11 })
+    @EnabledForJreRange(min = JRE.JAVA_17)
     void testIssue1136(SpotBugsRunner spotbugs) {
         final BugInstanceMatcher selfComparisonMatcher = new BugInstanceMatcherBuilder()
                 .bugType("SA_LOCAL_SELF_COMPARISON").build();

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1771Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1771Test.java
@@ -1,7 +1,7 @@
 package edu.umd.cs.findbugs.detect;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnJre;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
@@ -9,7 +9,7 @@ import edu.umd.cs.findbugs.AbstractIntegrationTest;
 class Issue1771Test extends AbstractIntegrationTest {
 
     @Test
-    @DisabledOnJre(JRE.JAVA_8)
+    @EnabledForJreRange(min = JRE.JAVA_11)
     void testIssue() {
         performAnalysis("../java11/ghIssues/Issue1771.class");
         assertNoBugType("EI_EXPOSE_REP");

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1771Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1771Test.java
@@ -1,15 +1,12 @@
 package edu.umd.cs.findbugs.detect;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledForJreRange;
-import org.junit.jupiter.api.condition.JRE;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
 
 class Issue1771Test extends AbstractIntegrationTest {
 
     @Test
-    @EnabledForJreRange(min = JRE.JAVA_11)
     void testIssue() {
         performAnalysis("../java11/ghIssues/Issue1771.class");
         assertNoBugType("EI_EXPOSE_REP");

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1877Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1877Test.java
@@ -1,15 +1,12 @@
 package edu.umd.cs.findbugs.detect;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledForJreRange;
-import org.junit.jupiter.api.condition.JRE;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
 
 class Issue1877Test extends AbstractIntegrationTest {
 
     @Test
-    @EnabledForJreRange(min = JRE.JAVA_17)
     void testIssue() {
         performAnalysis("../java17/Issue1877.class");
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1877Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue1877Test.java
@@ -1,7 +1,7 @@
 package edu.umd.cs.findbugs.detect;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnJre;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
@@ -9,7 +9,7 @@ import edu.umd.cs.findbugs.AbstractIntegrationTest;
 class Issue1877Test extends AbstractIntegrationTest {
 
     @Test
-    @DisabledOnJre({ JRE.JAVA_8, JRE.JAVA_11 })
+    @EnabledForJreRange(min = JRE.JAVA_17)
     void testIssue() {
         performAnalysis("../java17/Issue1877.class");
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2114Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2114Test.java
@@ -1,15 +1,12 @@
 package edu.umd.cs.findbugs.detect;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledForJreRange;
-import org.junit.jupiter.api.condition.JRE;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
 
 class Issue2114Test extends AbstractIntegrationTest {
 
     @Test
-    @EnabledForJreRange(min = JRE.JAVA_11)
     void testIssue() {
         performAnalysis("../java11/Issue2114.class");
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2114Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2114Test.java
@@ -1,7 +1,7 @@
 package edu.umd.cs.findbugs.detect;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnJre;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
@@ -9,7 +9,7 @@ import edu.umd.cs.findbugs.AbstractIntegrationTest;
 class Issue2114Test extends AbstractIntegrationTest {
 
     @Test
-    @DisabledOnJre(JRE.JAVA_8)
+    @EnabledForJreRange(min = JRE.JAVA_11)
     void testIssue() {
         performAnalysis("../java11/Issue2114.class");
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2120Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2120Test.java
@@ -1,7 +1,7 @@
 package edu.umd.cs.findbugs.detect;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnJre;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
@@ -9,7 +9,7 @@ import edu.umd.cs.findbugs.AbstractIntegrationTest;
 class Issue2120Test extends AbstractIntegrationTest {
 
     @Test
-    @DisabledOnJre({ JRE.JAVA_8, JRE.JAVA_11 })
+    @EnabledForJreRange(min = JRE.JAVA_17)
     void testIssue() {
         performAnalysis("../java17/Issue2120.class",
                 "../java17/Issue2120$1MyEnum.class",

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2120Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2120Test.java
@@ -1,15 +1,12 @@
 package edu.umd.cs.findbugs.detect;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledForJreRange;
-import org.junit.jupiter.api.condition.JRE;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
 
 class Issue2120Test extends AbstractIntegrationTest {
 
     @Test
-    @EnabledForJreRange(min = JRE.JAVA_17)
     void testIssue() {
         performAnalysis("../java17/Issue2120.class",
                 "../java17/Issue2120$1MyEnum.class",

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2182Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2182Test.java
@@ -1,15 +1,12 @@
 package edu.umd.cs.findbugs.detect;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledForJreRange;
-import org.junit.jupiter.api.condition.JRE;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
 
 class Issue2182Test extends AbstractIntegrationTest {
 
     @Test
-    @EnabledForJreRange(min = JRE.JAVA_11)
     void testIssue() {
         performAnalysis("../java11/ghIssues/Issue2182.class");
         assertBugInMethodAtLine("SBSC_USE_STRINGBUFFER_CONCATENATION", "Issue2182", "test", 22);

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2182Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2182Test.java
@@ -1,7 +1,7 @@
 package edu.umd.cs.findbugs.detect;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnJre;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
@@ -9,7 +9,7 @@ import edu.umd.cs.findbugs.AbstractIntegrationTest;
 class Issue2182Test extends AbstractIntegrationTest {
 
     @Test
-    @DisabledOnJre(JRE.JAVA_8)
+    @EnabledForJreRange(min = JRE.JAVA_11)
     void testIssue() {
         performAnalysis("../java11/ghIssues/Issue2182.class");
         assertBugInMethodAtLine("SBSC_USE_STRINGBUFFER_CONCATENATION", "Issue2182", "test", 22);

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2183Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2183Test.java
@@ -1,7 +1,7 @@
 package edu.umd.cs.findbugs.detect;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnJre;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
@@ -10,7 +10,7 @@ import edu.umd.cs.findbugs.annotations.Confidence;
 class Issue2183Test extends AbstractIntegrationTest {
 
     @Test
-    @DisabledOnJre(JRE.JAVA_8)
+    @EnabledForJreRange(min = JRE.JAVA_11)
     void testIssue() {
         performAnalysis("../java11/ghIssues/Issue2183.class");
         assertBugInMethodAtLineWithConfidence("SQL_NONCONSTANT_STRING_PASSED_TO_EXECUTE", "Issue2183", "test", 11, Confidence.HIGH);

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2183Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2183Test.java
@@ -1,8 +1,6 @@
 package edu.umd.cs.findbugs.detect;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledForJreRange;
-import org.junit.jupiter.api.condition.JRE;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
 import edu.umd.cs.findbugs.annotations.Confidence;
@@ -10,7 +8,6 @@ import edu.umd.cs.findbugs.annotations.Confidence;
 class Issue2183Test extends AbstractIntegrationTest {
 
     @Test
-    @EnabledForJreRange(min = JRE.JAVA_11)
     void testIssue() {
         performAnalysis("../java11/ghIssues/Issue2183.class");
         assertBugInMethodAtLineWithConfidence("SQL_NONCONSTANT_STRING_PASSED_TO_EXECUTE", "Issue2183", "test", 11, Confidence.HIGH);

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2184Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2184Test.java
@@ -1,15 +1,12 @@
 package edu.umd.cs.findbugs.detect;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledForJreRange;
-import org.junit.jupiter.api.condition.JRE;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
 
 class Issue2184Test extends AbstractIntegrationTest {
 
     @Test
-    @EnabledForJreRange(min = JRE.JAVA_17)
     void testIssue() {
         performAnalysis("../java17/ghIssues/Issue2184.class");
         assertBugInMethodAtLine("PT_RELATIVE_PATH_TRAVERSAL", "Issue2184", "test", 17);

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2184Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2184Test.java
@@ -1,7 +1,7 @@
 package edu.umd.cs.findbugs.detect;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnJre;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
@@ -9,7 +9,7 @@ import edu.umd.cs.findbugs.AbstractIntegrationTest;
 class Issue2184Test extends AbstractIntegrationTest {
 
     @Test
-    @DisabledOnJre({ JRE.JAVA_8, JRE.JAVA_11 })
+    @EnabledForJreRange(min = JRE.JAVA_17)
     void testIssue() {
         performAnalysis("../java17/ghIssues/Issue2184.class");
         assertBugInMethodAtLine("PT_RELATIVE_PATH_TRAVERSAL", "Issue2184", "test", 17);

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2552Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2552Test.java
@@ -1,15 +1,12 @@
 package edu.umd.cs.findbugs.detect;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledForJreRange;
-import org.junit.jupiter.api.condition.JRE;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
 
 class Issue2552Test extends AbstractIntegrationTest {
 
     @Test
-    @EnabledForJreRange(min = JRE.JAVA_17)
     void testIssue() {
         performAnalysis("../java17/ghIssues/Issue2552.class");
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2552Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2552Test.java
@@ -1,7 +1,7 @@
 package edu.umd.cs.findbugs.detect;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnJre;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
@@ -9,7 +9,7 @@ import edu.umd.cs.findbugs.AbstractIntegrationTest;
 class Issue2552Test extends AbstractIntegrationTest {
 
     @Test
-    @DisabledOnJre({ JRE.JAVA_8, JRE.JAVA_11 })
+    @EnabledForJreRange(min = JRE.JAVA_17)
     void testIssue() {
         performAnalysis("../java17/ghIssues/Issue2552.class");
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2782Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2782Test.java
@@ -2,13 +2,13 @@ package edu.umd.cs.findbugs.detect;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnJre;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 
 class Issue2782Test extends AbstractIntegrationTest {
 
     @Test
-    @DisabledOnJre({ JRE.JAVA_8, JRE.JAVA_11, JRE.JAVA_17 })
+    @EnabledForJreRange(min = JRE.JAVA_21)
     void testIssue() {
         performAnalysis(
                 "../java21/Issue2782.class",

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2793Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2793Test.java
@@ -1,15 +1,12 @@
 package edu.umd.cs.findbugs.detect;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledForJreRange;
-import org.junit.jupiter.api.condition.JRE;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
 
 class Issue2793Test extends AbstractIntegrationTest {
 
     @Test
-    @EnabledForJreRange(min = JRE.JAVA_17)
     void testRecordSerialVersionUid() {
         performAnalysis("../java17/ghIssues/Issue2793.class",
                 "../java17/ghIssues/Issue2793$RecordWithoutSerialVersionUid.class",

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2793Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue2793Test.java
@@ -1,7 +1,7 @@
 package edu.umd.cs.findbugs.detect;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnJre;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
@@ -9,7 +9,7 @@ import edu.umd.cs.findbugs.AbstractIntegrationTest;
 class Issue2793Test extends AbstractIntegrationTest {
 
     @Test
-    @DisabledOnJre({ JRE.JAVA_8, JRE.JAVA_11 })
+    @EnabledForJreRange(min = JRE.JAVA_17)
     void testRecordSerialVersionUid() {
         performAnalysis("../java17/ghIssues/Issue2793.class",
                 "../java17/ghIssues/Issue2793$RecordWithoutSerialVersionUid.class",

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3471Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3471Test.java
@@ -1,7 +1,7 @@
 package edu.umd.cs.findbugs.detect;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnJre;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
@@ -9,7 +9,7 @@ import edu.umd.cs.findbugs.AbstractIntegrationTest;
 class Issue3471Test extends AbstractIntegrationTest {
 
     @Test
-    @DisabledOnJre({ JRE.JAVA_8, JRE.JAVA_11 })
+    @EnabledForJreRange(min = JRE.JAVA_17)
     void testRecordsSuppressions() {
         performAnalysis("../java17/Issue3471.class",
                 "../java17/Issue3471$Issue3471ExposeRep.class",

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3471Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3471Test.java
@@ -1,15 +1,12 @@
 package edu.umd.cs.findbugs.detect;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledForJreRange;
-import org.junit.jupiter.api.condition.JRE;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
 
 class Issue3471Test extends AbstractIntegrationTest {
 
     @Test
-    @EnabledForJreRange(min = JRE.JAVA_17)
     void testRecordsSuppressions() {
         performAnalysis("../java17/Issue3471.class",
                 "../java17/Issue3471$Issue3471ExposeRep.class",

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3622Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3622Test.java
@@ -1,15 +1,12 @@
 package edu.umd.cs.findbugs.detect;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledForJreRange;
-import org.junit.jupiter.api.condition.JRE;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
 
 class Issue3622Test extends AbstractIntegrationTest {
 
     @Test
-    @EnabledForJreRange(min = JRE.JAVA_17)
     void testRecordsSuppressions() {
         performAnalysis("../java17/Issue3622.class");
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3622Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3622Test.java
@@ -1,7 +1,7 @@
 package edu.umd.cs.findbugs.detect;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnJre;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
@@ -9,7 +9,7 @@ import edu.umd.cs.findbugs.AbstractIntegrationTest;
 class Issue3622Test extends AbstractIntegrationTest {
 
     @Test
-    @DisabledOnJre({ JRE.JAVA_8, JRE.JAVA_11 })
+    @EnabledForJreRange(min = JRE.JAVA_17)
     void testRecordsSuppressions() {
         performAnalysis("../java17/Issue3622.class");
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3645Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3645Test.java
@@ -2,13 +2,13 @@ package edu.umd.cs.findbugs.detect;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnJre;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 
 class Issue3645Test extends AbstractIntegrationTest {
 
     @Test
-    @DisabledOnJre({ JRE.JAVA_8, JRE.JAVA_11, JRE.JAVA_17 })
+    @EnabledForJreRange(min = JRE.JAVA_21)
     void testIssue() {
         performAnalysis(
                 "../java21/Issue3645.class",

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3853Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3853Test.java
@@ -1,7 +1,7 @@
 package edu.umd.cs.findbugs.detect;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnJre;
+import org.junit.jupiter.api.condition.EnabledOnJre;
 import org.junit.jupiter.api.condition.JRE;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
@@ -9,7 +9,7 @@ import edu.umd.cs.findbugs.AbstractIntegrationTest;
 class Issue3853Test extends AbstractIntegrationTest {
 
     @Test
-    @DisabledOnJre({ JRE.JAVA_21, JRE.JAVA_25 })
+    @EnabledOnJre(JRE.JAVA_17)
     void testIssueJre17() {
         performAnalysis("../java17/Issue3853.class");
 
@@ -17,7 +17,7 @@ class Issue3853Test extends AbstractIntegrationTest {
     }
 
     @Test
-    @DisabledOnJre({ JRE.JAVA_17 })
+    @EnabledOnJre(JRE.JAVA_21)
     void testIssueJre21() {
         performAnalysis("../java21/Issue3853.class");
 

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/MultipleInstantiationsOfSingletonsTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/MultipleInstantiationsOfSingletonsTest.java
@@ -3,8 +3,6 @@ package edu.umd.cs.findbugs.detect;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import org.junit.jupiter.api.condition.EnabledForJreRange;
-import org.junit.jupiter.api.condition.JRE;
 
 class MultipleInstantiationsOfSingletonsTest extends AbstractIntegrationTest {
     @Test
@@ -298,7 +296,6 @@ class MultipleInstantiationsOfSingletonsTest extends AbstractIntegrationTest {
     }
 
     @Test
-    @EnabledForJreRange(min = JRE.JAVA_17)
     void recordNotSingletonTest() {
         performAnalysis("../java17/Issue2981.class");
         assertNoBugs();

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/MultipleInstantiationsOfSingletonsTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/MultipleInstantiationsOfSingletonsTest.java
@@ -3,7 +3,7 @@ package edu.umd.cs.findbugs.detect;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
-import org.junit.jupiter.api.condition.DisabledOnJre;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 
 class MultipleInstantiationsOfSingletonsTest extends AbstractIntegrationTest {
@@ -298,7 +298,7 @@ class MultipleInstantiationsOfSingletonsTest extends AbstractIntegrationTest {
     }
 
     @Test
-    @DisabledOnJre({ JRE.JAVA_8, JRE.JAVA_11 })
+    @EnabledForJreRange(min = JRE.JAVA_17)
     void recordNotSingletonTest() {
         performAnalysis("../java17/Issue2981.class");
         assertNoBugs();

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/util/MutableClassesTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/util/MutableClassesTest.java
@@ -17,8 +17,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledForJreRange;
-import org.junit.jupiter.api.condition.JRE;
 
 @Immutable
 class Annotated {
@@ -148,9 +146,7 @@ class MutableClassesTest {
         Assertions.assertFalse(MutableClasses.mutableSignature("Ledu/umd/cs/findbugs/util/MutableClassesTest$Immutable;"));
     }
 
-    // This tests fails on java 8/11, so disable it and only run on java 17+ unless its determined how to fix
     @Test
-    @EnabledForJreRange(min = JRE.JAVA_17)
     void testImmutableValuedBased() {
         // Annotated with @jdk.internal.ValueBased and has "setValue", which should normally trip detection
         System.out.println("starting.....");

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/util/MutableClassesTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/util/MutableClassesTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnJre;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 
 @Immutable
@@ -150,7 +150,7 @@ class MutableClassesTest {
 
     // This tests fails on java 8/11, so disable it and only run on java 17+ unless its determined how to fix
     @Test
-    @DisabledOnJre({ JRE.JAVA_8, JRE.JAVA_11 })
+    @EnabledForJreRange(min = JRE.JAVA_17)
     void testImmutableValuedBased() {
         // Annotated with @jdk.internal.ValueBased and has "setValue", which should normally trip detection
         System.out.println("starting.....");


### PR DESCRIPTION
with junit 6, it hard requires java 17 or better.  Our annotation usage aligned with our older support lines for java 8, 11, etc.  I did not add a change log as this changes nothing.  Initially to reduce the deprecation warnings I tried to add expected positive ranges but junit 6 throws a very nondescript and known error as they are trying to remove notion of anything less than java 17 including any usage of flagging to give ranging for java 17 or better as already true.  The subsequent commits here just show backing that off which will be squashed upon merge.

A later change needs to come in to move the java flagged directories to start at java 17+ but was out of scope for just fixing build concerns.