### PR TITLE
Fix EI_EXPOSE_REP not reported for anonymous-class getters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 ### Fixed
 - Fix `ASE_ASSERTION_WITH_SIDE_EFFECT` and `ASE_ASSERTION_WITH_SIDE_EFFECT_METHOD` false positives in every method analysed after a method that reads `$assertionsDisabled` without throwing an `AssertionError` ([#3483](https://github.com/spotbugs/spotbugs/issues/3483))
 - Fix `INT_BAD_COMPARISON_WITH_SIGNED_BYTE` false positive for meaningful comparisons of a signed byte with `127` (`b < 127`, `b >= 127`) ([#4201](https://github.com/spotbugs/spotbugs/pull/4201))
+- Fix `EI_EXPOSE_REP` false negative for public getters in anonymous classes ([#4237](https://github.com/spotbugs/spotbugs/pull/4237))
 - Fix missing class report for `java.util.Collections$EmptyNavigableSet` and `java.util.Collections$EmptyNavigableMap` when the result of `Collections.emptySortedSet()`, `emptyNavigableSet()`, `emptySortedMap()` or `emptyNavigableMap()` is stored ([#4244](https://github.com/spotbugs/spotbugs/pull/4244))
 
 ## 4.10.3 - 2026-07-12

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue4032Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue4032Test.java
@@ -1,0 +1,22 @@
+package edu.umd.cs.findbugs.detect;
+
+import org.junit.jupiter.api.Test;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+
+class Issue4032Test extends AbstractIntegrationTest {
+
+    @Test
+    void anonymousClassGetterExposesInternalArray() {
+        performAnalysis("ghIssues/Issue4032.class",
+                "ghIssues/Issue4032$Provider.class",
+                "ghIssues/Issue4032$NamedProvider.class",
+                "ghIssues/Issue4032$1.class");
+
+        // Named nested class: already reported before the fix.
+        assertBugInMethodAtField("EI_EXPOSE_REP", "Issue4032$NamedProvider", "getNames", "names");
+        // Anonymous class implementing the same public interface: the false negative fixed by #4032.
+        assertBugInMethodAtField("EI_EXPOSE_REP", "Issue4032$1", "getNames", "names");
+        assertBugTypeCount("EI_EXPOSE_REP", 2);
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/ClassParserUsingASM.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/ClassParserUsingASM.java
@@ -645,7 +645,15 @@ public class ClassParserUsingASM implements ClassParserInterface {
 
             @Override
             public void visitOuterClass(String owner, String name, String desc) {
-
+                // ASM fires this for the EnclosingMethod attribute, which per JVMS 4.7.7 is present
+                // only for local and anonymous classes. For those the InnerClasses attribute does not
+                // carry the enclosing class (outer_class_info_index is unset), so visitInnerClass above
+                // never sets the immediate enclosing class. Populate it here so all callers of
+                // XClass.getImmediateEnclosingClass() resolve local/anonymous classes correctly.
+                if (owner != null && cBuilder instanceof ClassInfo.Builder) {
+                    ClassDescriptor outerClassDescriptor = DescriptorFactory.createClassDescriptor(owner);
+                    ((ClassInfo.Builder) cBuilder).setImmediateEnclosingClass(outerClassDescriptor);
+                }
             }
 
             @Override

--- a/spotbugsTestCases/src/java/ghIssues/Issue4032.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue4032.java
@@ -1,0 +1,32 @@
+package ghIssues;
+
+/**
+ * <a href="https://github.com/spotbugs/spotbugs/issues/4032">#4032</a>.
+ *
+ * <p>EI_EXPOSE_REP must be reported identically for a public getter that returns an internal
+ * mutable array regardless of whether the getter lives in a named nested class or in an
+ * anonymous class implementing the same public interface.
+ */
+public class Issue4032 {
+    private static final String[] names = new String[] {"a", "b"};
+
+    public interface Provider {
+        String[] getNames();
+    }
+
+    public static class NamedProvider implements Provider {
+        @Override
+        public String[] getNames() {
+            return names;
+        }
+    }
+
+    public static Provider anonymousProvider() {
+        return new Provider() {
+            @Override
+            public String[] getNames() {
+                return names;
+            }
+        };
+    }
+}


### PR DESCRIPTION
## What

Report `EI_EXPOSE_REP` for a public getter that returns an internal mutable field when the getter lives in an **anonymous class** implementing a public interface. Previously only the identical getter in a named nested class was flagged; the anonymous-class form was silently skipped (#4032).

## Why

Whether returning an internal array exposes the representation depends on the field and the visibility of the returning method, not on whether the method is declared in a named class or an anonymous one. A `new Provider(){ public String[] getNames(){ return names; } }` is the exact same exposure as the same getter in a named `Provider` implementation, yet only the latter was reported — a coverage gap.

## How

The visibility gate (`FindReturnRef.visit(Method)`) already handles anonymous classes correctly: `overridesMethodFromPublicSupertype` walks the interface list via `Hierarchy2.findSuperMethods` and returns `true` for a method implementing a public interface method, so `check` passes.

The actual false negative is upstream of the detector. `FindReturnRef.isFieldOf()` walks the enclosing-class chain via `XClass.getImmediateEnclosingClass()`, which is populated by `ClassParserUsingASM.visitInnerClass`. That callback only sets `immediateEnclosingClass` when the `InnerClasses` attribute carries `outer_class_info_index`, which is **unset** for local and anonymous classes (JVMS 4.7.7). So `getImmediateEnclosingClass()` returned `null` for every local/anonymous class, the enclosing walk stopped before reaching the class that owns the captured field, and the getter was skipped.

The fix populates `immediateEnclosingClass` in `visitOuterClass` instead — the ASM callback for the `EnclosingMethod` attribute (JVMS 4.7.7), which is required for every local/anonymous class and names the enclosing class directly. This fixes the root cause for **all** callers of `getImmediateEnclosingClass()`, not just `FindReturnRef`, and leaves the already-correct visibility gate untouched.

## Root cause

`ClassParserUsingASM.visitInnerClass` only set `immediateEnclosingClass` when `InnerClasses.outer_class_info_index` was present; anonymous/local classes leave it unset (JVMS 4.7.7), so `getImmediateEnclosingClass()` was `null` for them and the captured outer field looked foreign to `isFieldOf`.

## Impact on `getImmediateEnclosingClass()` semantics

This broadens `getImmediateEnclosingClass()` for local/anonymous classes project-wide: it now returns the enclosing class instead of `null`. Named nested classes are unaffected — their enclosing class is already populated from `InnerClasses` via `visitInnerClass`, and they carry no `EnclosingMethod` attribute, so `visitOuterClass` never fires for them. Other current callers (`FindBugs2` referenced-class scan, `ClassInfo.getContainingScope()`) only gain a previously-missing value, i.e. they behave more correctly. Verified by self-analysis (`:spotbugs:spotbugsMain`, green) and the full EI/MS corpus diff below.

## Testing

- New `Issue4032Test`: asserts `EI_EXPOSE_REP` hits both the named nested `Issue4032$NamedProvider.getNames`/`names` (already detected, baseline) and the anonymous `Issue4032$1.getNames`/`names` (the false negative), count = 2. Fails on master (anonymous class not reported), passes with the fix.
- `FindReturnRefTest`: all green, no regression.
- Full before/after EI/MS report diff over the `spotbugsTestCases` corpus (rebuilt `spotbugs.jar` with and without the change, normalized/sorted): **exactly one new true positive** (the anonymous-class getter), zero new false positives, zero existing reports disappeared.
- Gate: `spotlessApply` + `:spotbugs:checkstyleMain` + `:spotbugs:spotbugsMain` (self-analysis) + full `:spotbugs-tests:test` all green.

## Verification of the original issue

Issue #4032's reproducer — anonymous `new Provider(){ public String[] getNames(){ return names; } }`:

- Before (master): not reported.
- After (this PR): reported as `EI_EXPOSE_REP`, identically to the named nested class.

## Prior work

Two earlier PRs (#4065, #4094) by @wyf027 also targeted this but were closed without merge. They resolved the enclosing class via the `NestHost` attribute and adjusted the visibility gate. `NestHost` names the *top-level* nest host rather than the *immediate* enclosing class, which is the wrong granularity for an enclosing-class walk; this PR instead fixes the root cause in the parser (`EnclosingMethod` attribute via `visitOuterClass`) and leaves the already-correct visibility gate untouched.

Fixes #4032