### PR TITLE
Fix NP_NULL_ON_SOME_PATH false positive for guarded field dereference

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue4147Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue4147Test.java
@@ -1,0 +1,27 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression test for issue #4147: {@code NP_NULL_ON_SOME_PATH} verdict must
+ * not depend on the operand order of a reference null check. Both
+ * {@code x == null} (direct form, single-operand {@code IFNULL}/{@code IFNONNULL})
+ * and {@code null == x} (Yoda form, two-operand {@code IF_ACMPEQ}/{@code IF_ACMPNE})
+ * are identical conditions, so the null-dataflow analysis must reach the same
+ * verdict on the non-null (else) branch that dereferences the field.
+ */
+class Issue4147Test extends AbstractIntegrationTest {
+
+    @Test
+    void testDirectForm() {
+        performAnalysis("ghIssues/Issue4147.class");
+        assertNoBugInMethod("NP_NULL_ON_SOME_PATH", "ghIssues.Issue4147", "directForm");
+    }
+
+    @Test
+    void testYodaForm() {
+        performAnalysis("ghIssues/Issue4147.class");
+        assertNoBugInMethod("NP_NULL_ON_SOME_PATH", "ghIssues.Issue4147", "yodaForm");
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/deref/UnconditionalValueDerefAnalysis.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/ba/deref/UnconditionalValueDerefAnalysis.java
@@ -215,6 +215,19 @@ public class UnconditionalValueDerefAnalysis extends BackwardDataflowAnalysis<Un
             throws DataflowAnalysisException {
         if (reportPotentialDereference(location, invDataflow.getFactAtLocation(location))) {
             ValueNumber vn = vnaFrame.getTopValue();
+            // A field read is represented by a single value number shared across every
+            // getfield of that field (available-load elimination), so modelling an
+            // `if (field == null) throw new NullPointerException()` guard as an
+            // unconditional dereference would also cover every earlier read of the same
+            // field. That turns a protective guard into a false NP_NULL_ON_SOME_PATH
+            // whenever the field has a preceding null path (issue #4147). For local
+            // variables and parameters the value number is specific to the guarded
+            // value, so the modelling stays precise and remains required to recognize
+            // require-nonnull guard methods (NP_NULL_PARAM_DEREF) and explicit local
+            // null guards (NP_NULL_ON_SOME_PATH).
+            if (vnaFrame.getLoad(vn) != null) {
+                return;
+            }
             fact.addDeref(vn, location);
         }
     }

--- a/spotbugsTestCases/src/java/ghIssues/Issue4147.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue4147.java
@@ -1,0 +1,40 @@
+package ghIssues;
+
+/**
+ * Reproducer for issue #4147: {@code NP_NULL_ON_SOME_PATH} verdict depends on
+ * the operand order of a reference null check. {@code x == null} and
+ * {@code null == x} are the same condition, so both forms must reach the same
+ * verdict on the else branch that dereferences {@code x}.
+ *
+ * <p>Both methods guard a dereference of {@code x} with a null check that
+ * throws on the null branch and dereferences {@code x} on the non-null branch.
+ * Neither method should report {@code NP_NULL_ON_SOME_PATH}.</p>
+ */
+public class Issue4147 {
+
+    Object x;
+
+    /** Direct form {@code x == null} — must not report {@code NP_NULL_ON_SOME_PATH}. */
+    int directForm() {
+        if (x == null) {
+            System.out.println("x is null");
+        }
+        if (x == null) {
+            throw new NullPointerException();
+        } else {
+            return x.hashCode();
+        }
+    }
+
+    /** Yoda form {@code null == x} — must not report {@code NP_NULL_ON_SOME_PATH}. */
+    int yodaForm() {
+        if (null == x) {
+            System.out.println("x is null");
+        }
+        if (null == x) {
+            throw new NullPointerException();
+        } else {
+            return x.hashCode();
+        }
+    }
+}


### PR DESCRIPTION
## What

Stop reporting `NP_NULL_ON_SOME_PATH` for a guarded field dereference written in the direct operand order — `if (field == null) throw new NullPointerException(); else field.hashCode()`. The Yoda form (`null == field`) was already not reported; the direct form was, even though both are the same condition (#4147).

## Why

Whether a guard makes the else-branch dereference safe depends on the condition, not on the operand order. `field == null` (compiled to `getfield; ifnonnull`) and `null == field` (compiled to `aconst_null; getfield; if_acmpne`) are identical checks, so the null-dataflow analysis must reach the same verdict on both.

## How

The asymmetry is in `UnconditionalValueDerefAnalysis.handleNullCheck`, which is gated by `isNullCheck` and therefore only runs for the IFNONNULL (direct) form. `handleNullCheck` models the guard as an unconditional dereference of the checked value. For a **field**, available-load elimination represents every `getfield` of that field with a single value number, so the synthetic dereference propagates back to every earlier read of the field. When an earlier read establishes a null path (e.g. a preceding `if (field == null) ...`), the analysis concludes the field is null on some path and unconditionally dereferenced — producing the false positive.

The fix skips field values in `handleNullCheck` (`vnaFrame.getLoad(vn) != null`): the guard is protective, and the field-read value numbering makes the modelling over-broad. Local variables and parameters keep the existing behaviour — their value number is specific to the guarded value, so the modelling stays precise and remains required to recognize require-nonnull guard methods (`NP_NULL_PARAM_DEREF`) and explicit local null guards (`NP_NULL_ON_SOME_PATH`).

## Root cause

`handleNullCheck` ran only for the direct (IFNONNULL) null-check form, and modelled the guard as an unconditional dereference that — through field available-load value numbering — propagated to every earlier read of the same field, turning a protective guard into a false positive whenever the field had a preceding null path.

## Testing

- New `Issue4147Test`: `assertNoBugInMethod("NP_NULL_ON_SOME_PATH", ...)` for both `directForm` and `yodaForm`. `testDirectForm` fails on master (NP reported at the `return x.hashCode()` dereference), passes with the fix; `testYodaForm` passes throughout.
- `Bug3277814Test` (local-variable guard, `NP_NULL_ON_SOME_PATH`): green — local guards still detected.
- `RegressionIdeas20090105Test` (parameter guard, `NP_NULL_PARAM_DEREF`): green — require-nonnull guard detection preserved.
- `FindNullDerefIntegrationTest` + full `:spotbugs-tests:test`: green — no new FP, no new FN.
- Gate: `spotlessApply` + `:spotbugs:checkstyleMain` + `:spotbugs:spotbugsMain` (self-analysis) all green.

## Verification of the original issue

Issue #4147's reproducer — `if (field == null) throw new NPE(); else field.hashCode()`:

- Before (master), direct form `field == null`: reported `NP_NULL_ON_SOME_PATH`.
- Before (master), Yoda form `null == field`: not reported.
- After (this PR): both forms not reported — verdict no longer depends on operand order.

Note: the existing `npe/GuaranteedFieldDereference.java` test case already contained this exact pattern (`test12DoNotReport`) but had no automated assertion; this PR adds one for both operand orders.

Fixes #4147
