### PR TITLE
Reset inAssert at method entry in AbstractAssertDetector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ## Unreleased - 2026-??-??
 ### Fixed
+- Fix `ASE_ASSERTION_WITH_SIDE_EFFECT` and `ASE_ASSERTION_WITH_SIDE_EFFECT_METHOD` false positives in every method analysed after a method that reads `$assertionsDisabled` without throwing an `AssertionError` ([#3483](https://github.com/spotbugs/spotbugs/issues/3483))
 - Fix `INT_BAD_COMPARISON_WITH_SIGNED_BYTE` false positive for meaningful comparisons of a signed byte with `127` (`b < 127`, `b >= 127`) ([#4201](https://github.com/spotbugs/spotbugs/pull/4201))
 
 ## 4.10.3 - 2026-07-12

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3483Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3483Test.java
@@ -1,0 +1,36 @@
+package edu.umd.cs.findbugs.detect;
+
+import org.junit.jupiter.api.Test;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+
+/**
+ * @see <a href="https://github.com/spotbugs/spotbugs/issues/3483">GitHub issue #3483</a>
+ */
+class Issue3483Test extends AbstractIntegrationTest {
+
+    /**
+     * A method that reads {@code $assertionsDisabled} without ever creating an
+     * {@code AssertionError} must not leave the detector "inside an assertion" for the
+     * methods scanned afterwards.
+     */
+    @Test
+    void assertionStateDoesNotLeakBetweenMethods() {
+        performAnalysis("ghIssues/Issue3483.class");
+
+        assertBugTypeCount("ASE_ASSERTION_WITH_SIDE_EFFECT", 0);
+        assertBugTypeCount("ASE_ASSERTION_WITH_SIDE_EFFECT_METHOD", 0);
+    }
+
+    /**
+     * Detector instances are reused for the whole analysis run, so the state must not leak
+     * into the following classes either.
+     */
+    @Test
+    void assertionStateDoesNotLeakBetweenClasses() {
+        performAnalysis("ghIssues/Issue3483Poison.class", "ghIssues/Issue3483Victim.class");
+
+        assertBugTypeCount("ASE_ASSERTION_WITH_SIDE_EFFECT", 0);
+        assertBugTypeCount("ASE_ASSERTION_WITH_SIDE_EFFECT_METHOD", 0);
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/AbstractAssertDetector.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/AbstractAssertDetector.java
@@ -19,7 +19,7 @@
 package edu.umd.cs.findbugs.detect;
 
 import org.apache.bcel.Const;
-import org.apache.bcel.classfile.Code;
+import org.apache.bcel.classfile.Method;
 
 import edu.umd.cs.findbugs.BugInstance;
 import edu.umd.cs.findbugs.BugReporter;
@@ -43,18 +43,8 @@ public abstract class AbstractAssertDetector extends OpcodeStackDetector {
      */
     protected abstract void detect(int seen);
 
-    /**
-     * Resets the state before scanning a method.
-     *
-     * <p>An assertion never spans a method boundary, but {@code inAssert} is only cleared when
-     * a {@code new AssertionError} is seen. A method that reads {@code $assertionsDisabled}
-     * without ever throwing (for example a guard that just returns) therefore leaves the flag
-     * set, and every method scanned afterwards is treated as if it were inside an assertion.
-     * Detector instances are reused for the whole analysis run, so the state also leaks into
-     * the following classes.</p>
-     */
     @Override
-    public void visit(Code obj) {
+    public void visit(Method obj) {
         inAssert = false;
         super.visit(obj);
     }

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/AbstractAssertDetector.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/AbstractAssertDetector.java
@@ -19,6 +19,7 @@
 package edu.umd.cs.findbugs.detect;
 
 import org.apache.bcel.Const;
+import org.apache.bcel.classfile.Code;
 
 import edu.umd.cs.findbugs.BugInstance;
 import edu.umd.cs.findbugs.BugReporter;
@@ -41,6 +42,22 @@ public abstract class AbstractAssertDetector extends OpcodeStackDetector {
      * Implement this method in a concrete detector
      */
     protected abstract void detect(int seen);
+
+    /**
+     * Resets the state before scanning a method.
+     *
+     * <p>An assertion never spans a method boundary, but {@code inAssert} is only cleared when
+     * a {@code new AssertionError} is seen. A method that reads {@code $assertionsDisabled}
+     * without ever throwing (for example a guard that just returns) therefore leaves the flag
+     * set, and every method scanned afterwards is treated as if it were inside an assertion.
+     * Detector instances are reused for the whole analysis run, so the state also leaks into
+     * the following classes.</p>
+     */
+    @Override
+    public void visit(Code obj) {
+        inAssert = false;
+        super.visit(obj);
+    }
 
     /**
      * Searches for assertion opening, and closing points.

--- a/spotbugsTestCases/src/java/ghIssues/Issue3483.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3483.java
@@ -1,0 +1,63 @@
+package ghIssues;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Reproducer for https://github.com/spotbugs/spotbugs/issues/3483
+ *
+ * <p>{@code AbstractAssertDetector} sets {@code inAssert} when it sees a read of
+ * {@code $assertionsDisabled} and only clears it when it sees {@code new AssertionError}.
+ * A method that reads the flag without ever throwing leaves the detector "inside an
+ * assertion" for every method analysed afterwards.</p>
+ *
+ * <p>NOTE: this class declares {@code $assertionsDisabled} by hand, so it must not contain
+ * any {@code assert} statement - javac would then emit a synthetic field with the same
+ * name and the compilation would fail.</p>
+ */
+public class Issue3483 {
+
+    public static boolean $assertionsDisabled;
+
+    private static int field;
+
+    private static final List<String> list = new ArrayList<>();
+
+    private final Object first;
+    private final Object second;
+
+    /** Reads {@code $assertionsDisabled} but never creates an {@code AssertionError}. */
+    public static void poison() {
+        if ($assertionsDisabled) {
+            return;
+        }
+    }
+
+    /** No assertion in sight: the PUTSTATIC must not be reported. */
+    public static void victim() {
+        field = 42;
+    }
+
+    /** Same leak for the ..._METHOD variant named in the issue title. */
+    public static void victimMethod() {
+        list.remove(null);
+    }
+
+    /** Same leak inside a constructor: two PUTFIELDs. */
+    public Issue3483(Object first, Object second) {
+        this.first = first;
+        this.second = second;
+    }
+
+    public static int getField() {
+        return field;
+    }
+
+    public Object getFirst() {
+        return first;
+    }
+
+    public Object getSecond() {
+        return second;
+    }
+}

--- a/spotbugsTestCases/src/java/ghIssues/Issue3483Poison.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3483Poison.java
@@ -1,0 +1,16 @@
+package ghIssues;
+
+/**
+ * Companion of {@link Issue3483}: leaks the {@code inAssert} state across a class boundary.
+ * See https://github.com/spotbugs/spotbugs/issues/3483
+ */
+public class Issue3483Poison {
+
+    public static boolean $assertionsDisabled;
+
+    public static void poison() {
+        if ($assertionsDisabled) {
+            return;
+        }
+    }
+}

--- a/spotbugsTestCases/src/java/ghIssues/Issue3483Victim.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3483Victim.java
@@ -1,0 +1,19 @@
+package ghIssues;
+
+/**
+ * Companion of {@link Issue3483}: an untouched class that must not inherit the
+ * {@code inAssert} state left over by {@link Issue3483Poison}.
+ * See https://github.com/spotbugs/spotbugs/issues/3483
+ */
+public class Issue3483Victim {
+
+    private static int field;
+
+    public static void victim() {
+        field = 1;
+    }
+
+    public static int getField() {
+        return field;
+    }
+}


### PR DESCRIPTION
Fixes the reproducers reported in #3483 by @woess.

## Problem

`AbstractAssertDetector` tracks whether the scanner is inside an `assert` with a single instance field:

```java
// AbstractAssertDetector.java
protected boolean inAssert = false;

public void sawOpcode(int seen) {
    if (inAssert) { detect(seen); }
    if (seen == Const.GETSTATIC && "$assertionsDisabled".equals(getNameConstantOperand())) { inAssert = true; }
    if (seen == Const.NEW && getClassConstantOperand().equals("java/lang/AssertionError")) { inAssert = false; }
}
```

The flag is set by a read of `$assertionsDisabled` and cleared **only** by a `new AssertionError`. A method that reads the flag without ever throwing — a plain `if ($assertionsDisabled) return;` guard, which is what `javac` emits for some shapes and what bytecode generators produce routinely — leaves `inAssert == true` when the method ends.

Nothing resets it. Neither `FindAssertionsWithSideEffects` nor `FindArgumentAssertions` implements `StatelessDetector`, so a single detector instance is reused for the whole analysis run: every method scanned afterwards, **including methods of the following classes**, is analysed as if it were inside an assertion.

## Reproducers

All three reproducers from @woess's comment fail on `master`. The new fixture merges them:

| method | reported before the fix | why it is wrong |
|---|---|---|
| `Issue3483.victim()` | `ASE_ASSERTION_WITH_SIDE_EFFECT` | plain `PUTSTATIC`, no assertion |
| `Issue3483.<init>()` | `ASE_ASSERTION_WITH_SIDE_EFFECT` ×2 | two field assignments in a constructor |
| `Issue3483.<clinit>()` | `ASE_ASSERTION_WITH_SIDE_EFFECT` | static initializer |
| `Issue3483.victimMethod()` | `ASE_ASSERTION_WITH_SIDE_EFFECT_METHOD` | the pattern named in the issue title |
| `Issue3483Victim.victim()` | `ASE_ASSERTION_WITH_SIDE_EFFECT` | different class — leak across a class boundary |

The `..._METHOD` case matters because it is the pattern @dougxc originally reported; the reproducers in the thread only covered `ASE_ASSERTION_WITH_SIDE_EFFECT`.

## Fix

Reset the flag when a method starts, which is what the rest of the codebase does (`visit(Code obj)` is overridden by ~55 detectors in `detect/`, e.g. `FindNakedNotify`):

```java
@Override
public void visit(Code obj) {
    inAssert = false;
    super.visit(obj);
}
```

@gtoison guessed this correctly in the thread and pushed `visitAfter(Code)` on `gtoison/spotbugs:issue-3483`. I verified both variants against the reproducers and **both clear them**, so his diagnosis was right. I went with `visit(Code)` for two reasons:

1. It is the idiomatic hook in this codebase.
2. `visitAfter` is not guaranteed to run. In `PreorderVisitor.visitCode` the call sits *after* the opcode scan and is not in a `finally`:

   ```java
   public void visitCode(Code obj) {
       code = obj;
       super.visitCode(obj);        // opcode scan
       ...
       visitAfter(obj);             // skipped if anything above throws
       code = null;
   }
   ```

   `FindBugs2` swallows analysis failures per detector (`catch (CheckedAnalysisException | RuntimeException e) { logRecoverableException(...); }`) and moves on to the next class, so a single recoverable failure inside the scan would leave `inAssert` set for the remainder of the run. Resetting on entry cannot be skipped.

## Note on the original report

@dougxc said the `visitAfter` patch did not fix the Graal build, and I could not reproduce that setup. This PR fixes the reproducers @woess posted, so I have deliberately **not** written "closes #3483" — @dougxc, could you re-check the Graal case against this branch? If it still reports, the remaining cause is separate from the state leak and worth tracking on its own.

## Verification

- `./gradlew --configure-on-demand :spotbugs-tests:test --tests 'edu.umd.cs.findbugs.detect.Issue3483Test'` fails on `master` (both tests) and passes with the fix.
- `FindAssertionsWithSideEffectsTest` (3 × `ASE_ASSERTION_WITH_SIDE_EFFECT` + 1 × `ASE_ASSERTION_WITH_SIDE_EFFECT_METHOD`) and `FindArgumentAssertionsTest` (23 × `AA_ASSERTION_OF_ARGUMENTS`) are unchanged — real assertions with side effects are still reported.
- `./gradlew spotlessApply build smoketest` per `.github/CONTRIBUTING.md` — green (311 test classes, 1152 tests, 0 failures, 0 errors). `spotlessApply` left every file in this PR unchanged.
- `CHANGELOG.md` updated under `## Unreleased` / `### Fixed`.

No bug type, detector id or metadata was touched, so `findbugs.xml` / `messages*.xml` are untouched as well.

---

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code

*AI-assisted: I used Claude to help explore the detector's state handling and to draft the fixture, the test and this description. I reviewed every line, ran the new test against unpatched `master` first to confirm it fails without the fix, and ran the full `spotlessApply build smoketest` locally; the analysis and the runs are mine.*