### PR TITLE
Fix naked notify detection after local stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ## Unreleased - 2026-??-??
 ### Fixed
+- Fix `NN_NAKED_NOTIFY` false negatives when a field read is stored in a local variable before `notify()` or `notifyAll()` ([#3884](https://github.com/spotbugs/spotbugs/issues/3884))
 - Fix `ASE_ASSERTION_WITH_SIDE_EFFECT` and `ASE_ASSERTION_WITH_SIDE_EFFECT_METHOD` false positives in every method analysed after a method that reads `$assertionsDisabled` without throwing an `AssertionError` ([#3483](https://github.com/spotbugs/spotbugs/issues/3483))
 - Fix `INT_BAD_COMPARISON_WITH_SIGNED_BYTE` false positive for meaningful comparisons of a signed byte with `127` (`b < 127`, `b >= 127`) ([#4201](https://github.com/spotbugs/spotbugs/pull/4201))
 - Fix missing class report for `java.util.Collections$EmptyNavigableSet` and `java.util.Collections$EmptyNavigableMap` when the result of `Collections.emptySortedSet()`, `emptyNavigableSet()`, `emptySortedMap()` or `emptyNavigableMap()` is stored ([#4244](https://github.com/spotbugs/spotbugs/pull/4244))

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3884Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3884Test.java
@@ -1,0 +1,20 @@
+package edu.umd.cs.findbugs.detect;
+
+import org.junit.jupiter.api.Test;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+
+class Issue3884Test extends AbstractIntegrationTest {
+
+    @Test
+    void testNakedNotifyAfterNonMutatingRead() {
+        performAnalysis("ghIssues/Issue3884.class");
+
+        assertBugInMethodCount("NN_NAKED_NOTIFY", "ghIssues.Issue3884", "notifyAfterFieldRead", 1);
+        assertBugInMethodCount("NN_NAKED_NOTIFY", "ghIssues.Issue3884", "blockNotifyAfterFieldRead", 1);
+        assertBugInMethodCount("NN_NAKED_NOTIFY", "ghIssues.Issue3884", "nakedNotify", 1);
+
+        assertBugInMethodCount("NN_NAKED_NOTIFY", "ghIssues.Issue3884", "notifyAfterMutation", 0);
+        assertBugInMethodCount("NN_NAKED_NOTIFY", "ghIssues.Issue3884", "notifyAfterFieldAssignment", 0);
+    }
+}

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3884Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue3884Test.java
@@ -10,6 +10,7 @@ class Issue3884Test extends AbstractIntegrationTest {
     void testNakedNotifyAfterNonMutatingRead() {
         performAnalysis("ghIssues/Issue3884.class");
 
+        assertBugTypeCount("NN_NAKED_NOTIFY", 3);
         assertBugInMethodCount("NN_NAKED_NOTIFY", "ghIssues.Issue3884", "notifyAfterFieldRead", 1);
         assertBugInMethodCount("NN_NAKED_NOTIFY", "ghIssues.Issue3884", "blockNotifyAfterFieldRead", 1);
         assertBugInMethodCount("NN_NAKED_NOTIFY", "ghIssues.Issue3884", "nakedNotify", 1);

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNakedNotify.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNakedNotify.java
@@ -78,10 +78,6 @@ public class FindNakedNotify extends BytecodeScanningDetector implements Statele
             }
             break;
         case LOADED:
-            // Storing a value into a local variable cannot change the state of the monitored
-            // object, so a notify() that follows is still naked. Everything that may mutate
-            // state - PUTFIELD, PUTSTATIC, invocations, arithmetic feeding them - still falls
-            // through to the reset below.
             if (isRegisterLoad() || isRegisterStore() || seen == Const.GETSTATIC || seen == Const.GETFIELD) {
                 break;
             } else if (seen == Const.INVOKEVIRTUAL

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNakedNotify.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindNakedNotify.java
@@ -78,7 +78,11 @@ public class FindNakedNotify extends BytecodeScanningDetector implements Statele
             }
             break;
         case LOADED:
-            if (isRegisterLoad() || seen == Const.GETSTATIC || seen == Const.GETFIELD) {
+            // Storing a value into a local variable cannot change the state of the monitored
+            // object, so a notify() that follows is still naked. Everything that may mutate
+            // state - PUTFIELD, PUTSTATIC, invocations, arithmetic feeding them - still falls
+            // through to the reset below.
+            if (isRegisterLoad() || isRegisterStore() || seen == Const.GETSTATIC || seen == Const.GETFIELD) {
                 break;
             } else if (seen == Const.INVOKEVIRTUAL
                     && ("notify".equals(getNameConstantOperand()) || "notifyAll".equals(getNameConstantOperand()))

--- a/spotbugsTestCases/src/java/ghIssues/Issue3884.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue3884.java
@@ -1,0 +1,37 @@
+package ghIssues;
+
+public class Issue3884 {
+
+    private int count = 0;
+
+    /** Reporter's case 1: a field read stored into a local does not change the state. */
+    public synchronized void notifyAfterFieldRead() {
+        int temp = this.count;
+        this.notifyAll();
+    }
+
+    /** Same, expressed with an explicit synchronized block. */
+    public void blockNotifyAfterFieldRead() {
+        synchronized (this) {
+            int temp = this.count;
+            this.notifyAll();
+        }
+    }
+
+    /** Control: already detected today, must stay detected. */
+    public synchronized void nakedNotify() {
+        this.notifyAll();
+    }
+
+    /** Control: a real mutation, must stay unreported. */
+    public synchronized void notifyAfterMutation() {
+        this.count++;
+        this.notifyAll();
+    }
+
+    /** Control: a mutation expressed as a field assignment, must stay unreported. */
+    public synchronized void notifyAfterFieldAssignment() {
+        this.count = 1;
+        this.notifyAll();
+    }
+}


### PR DESCRIPTION
A local store after reading a monitored field does not mutate the object, but it reset the detector state and suppressed NN_NAKED_NOTIFY. Keep tracking through register stores and cover both synchronized forms plus mutation controls.

Fixes #3884

Before opening a 'pull request'

* Search existing issues and pull requests to see if the issue was already discussed.
* Check our discussions to see if the issue was already discussed.
* Check for specific project we support to raise the issue on, under [spotbugs](https://github.com/spotbugs)
* Do not open intellij plugin issues here, open them at [intellij-plugin](https://github.com/JetBrains/spotbugs-intellij-plugin)

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
