### PR TITLE
Gradle build cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,16 +20,6 @@ buildscript {
     gradlePluginPortal()
     mavenCentral()
   }
-  // commons-compress 1.28.0 refactored GzipCompressorInputStream to use the Builder pattern,
-  // calling AbstractStreamBuilder.getInputStream(). Gradle 9.3.1 to 9.6.1 bundles commons-io-2.15.1 in
-  // its own runtime classloader (parent of all plugin classloaders). With parent-first delegation,
-  // AbstractStreamBuilder from commons-io-2.15.1 (protected getInputStream) is found before the
-  // resolved commons-io-2.20.0, causing IllegalAccessException across classloaders.
-  // commons-compress 1.27.1 and earlier use a direct constructor without any AbstractStreamBuilder
-  // reference, so forcing 1.27.1 avoids the cross-classloader access check entirely.
-  configurations.classpath.resolutionStrategy {
-    force 'org.apache.commons:commons-compress:1.27.1'
-  }
 }
 
 plugins {

--- a/eclipsePlugin/build.gradle
+++ b/eclipsePlugin/build.gradle
@@ -49,7 +49,7 @@ String computeVersion(String baseVersion) {
   }
 }
 
-version = computeVersion(version)
+version = computeVersion(project.version.toString())
 
 sourceSets {
   main {
@@ -430,7 +430,7 @@ TaskProvider<Copy> siteDailyXml = tasks.register('siteDailyXml', Copy) {
 
 // sign all .jar file under specified dir
 ext.signJar = { File dir ->
-  String keystorepass = project.hasProperty('keystorepass') ? keystorepass : ''
+  String keystorepass = providers.gradleProperty('keystorepass').getOrElse('')
   if (keystorepass.isEmpty()) {
     logger.lifecycle('to sign eclipse plugins, set "keystorepass" project property')
     return


### PR DESCRIPTION
- Remove older fix due to gradle not being to modern commons-io, they are now
- Cleanup some considered deprecated usage but not flagged yet usage

no change log as part of the gradle build.