### PR TITLE
remove tgz and zip from maven publication

### DIFF
--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -395,8 +395,6 @@ smokeTest.configure {
 }
 
 publishing.publications.maven {
-  artifact distTar
-  artifact distZip
   pom {
     name = 'SpotBugs'
     description = 'SpotBugs: Because it is easy!'


### PR DESCRIPTION
Sonatype introduces publishing limits to maven central (see [announcement](https://central.sonatype.org/publish/maven-central-publishing-limits/) and the relevant [discussion](https://github.com/spotbugs/spotbugs/discussions/4173)).
When looking at the released artifacts and their size, the zip and the tgz takes up a significant amount.
For [4.10.4](https://repo1.maven.org/maven2/com/github/spotbugs/spotbugs/4.10.4/) both the zip and the tgz takes up ~15.1 MB each, while all the other artifacts together take up ~13 MB.
These are not required by Sonatype (see their [requirements](https://central.sonatype.org/publish/requirements/)).

These artifacts are created by the [distTar](https://github.com/spotbugs/spotbugs/blob/master/spotbugs/build.gradle#L318-L321) and [distZip](https://github.com/spotbugs/spotbugs/blob/master/spotbugs/build.gradle#L322-L327) gradle tasks respectively.
As far as I can see the compression of these could not be improved easily without changing the file extension.
For zip already the DEFLATED compression is used by default (see the [docs](https://docs.gradle.org/current/dsl/org.gradle.api.tasks.bundling.Zip.html#org.gradle.api.tasks.bundling.Zip:entryCompression)).

This PR removes the tgz and the zip artifacts from the maven publications. All the other artifacts will be still uploaded to maven central, and the tgz and zip artifacts will be still uploaded to the github release.

I could not find statistics on maven central about the downloads of each artifacts, so I can't say whether our users download these files from there specifically, but the files will be still available at the github releases.

This change would help to fit into Sonatype's limits.
The other components which are released from this repository ([spotbugs-annotations](https://repo1.maven.org/maven2/com/github/spotbugs/spotbugs-annotations/4.10.4/), [spotbugs-ant](https://repo1.maven.org/maven2/com/github/spotbugs/spotbugs-ant/4.10.4/), [test-harness](http://repo1.maven.org/maven2/com/github/spotbugs/test-harness/4.10.4/), [test-harness-core](https://repo1.maven.org/maven2/com/github/spotbugs/test-harness-core/), [test-harness-jupiter](https://repo1.maven.org/maven2/com/github/spotbugs/test-harness-jupiter/)) take up significantly less space, so they don't contribute that much to the size limit.
This PR is rather about release management, so I did not add a changelog entry. LMK if you think I should.