### PR TITLE
Sonar build cleanup

### DIFF
--- a/gradle/sonar.gradle
+++ b/gradle/sonar.gradle
@@ -21,3 +21,11 @@ sonar {
 tasks.named('sonar').configure {
   dependsOn jacocoRootReport
 }
+
+allprojects {
+    tasks.matching { task -> task.name == 'sonarResolver' }.configureEach {
+        dependsOn tasks.matching { task -> task.name == 'compileJava' }
+        dependsOn tasks.matching { task -> task.name == 'compileGroovy' }
+        dependsOn tasks.matching { task -> task.name == 'processResources' }
+    }
+}

--- a/gradle/sonar.gradle
+++ b/gradle/sonar.gradle
@@ -17,8 +17,6 @@ tasks.named('sonar').configure {
 
 allprojects {
     tasks.matching { task -> task.name == 'sonarResolver' }.configureEach {
-        dependsOn tasks.matching { task -> task.name == 'compileJava' }
-        dependsOn tasks.matching { task -> task.name == 'compileGroovy' }
-        dependsOn tasks.matching { task -> task.name == 'processResources' }
+        dependsOn tasks.matching { task -> task.name == 'classes' }
     }
 }

--- a/gradle/sonar.gradle
+++ b/gradle/sonar.gradle
@@ -1,10 +1,3 @@
-// Workaround for Sonar plugin classloader collision with Gradle 9 runtime:
-// commons-compress 1.28.0+ uses AbstractStreamBuilder.getInputStream() (public in commons-io 2.18+),
-// but Gradle 9's parent classloader exposes commons-io 2.15.1 (where it was protected).
-// Forcing commons-compress 1.27.1 avoids the Builder pattern and cross-classloader check.
-buildscript.configurations.getByName("classpath").resolutionStrategy {
-    force 'org.apache.commons:commons-compress:1.27.1'
-}
 apply plugin: 'org.sonarqube'
 
 sonar {


### PR DESCRIPTION
this removes the last attempted patch for commons-io as did not work and sonar since released a patch.  Few other minor items cleaned up based on output from sonar.  No change log as purely build end.