### PR TITLE
chore(build): Add gradle files to spotless and cleanup gradle build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,13 +14,6 @@ import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.util.PatternFilterable
 import org.gradle.crypto.checksum.Checksum
 
-buildscript {
-  repositories {
-    gradlePluginPortal()
-    mavenCentral()
-  }
-}
-
 plugins {
   id 'org.sonarqube' version '7.5.0.8588'
   id 'org.gradle.crypto.checksum' version '1.4.0'

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ version = '4.10.5-SNAPSHOT'
 
 apply from: "${rootDir}/gradle/java.gradle"
 apply from: "${rootDir}/gradle/jacoco.gradle"
+apply from: "${rootDir}/gradle/spotless.gradle"
 
 subprojects {
   apply from: "${rootDir}/gradle/java.gradle"
@@ -63,9 +64,9 @@ subprojects {
 
     // Explicitly skip the test case modules you don't want to enforce rules on
     if (project.name == 'eclipsePlugin-junit' || project.name == 'eclipsePlugin-test'
-        || project.name == 'spotbugsTestCases' || project.name == 'spotbugs-tests'
-        || project.name == 'test-harness' || project.name == 'test-harness-core'
-        || project.name == 'test-harness-jupiter') {
+    || project.name == 'spotbugsTestCases' || project.name == 'spotbugs-tests'
+    || project.name == 'test-harness' || project.name == 'test-harness-core'
+    || project.name == 'test-harness-jupiter') {
       return
     }
 
@@ -74,7 +75,9 @@ subprojects {
       description = 'Enforces that production dependency binaries are fully compatible with Java 11 (Major version <= 55)'
 
       Provider<NamedDomainObjectSet> runtimeConfigs = provider {
-        configurations.matching { it.name.endsWith('RuntimeClasspath') && it.canBeResolved }
+        configurations.matching {
+          it.name.endsWith('RuntimeClasspath') && it.canBeResolved
+        }
       }
 
       inputs.files(runtimeConfigs)
@@ -121,7 +124,7 @@ subprojects {
                       int minor = (zip.read() << 8) | zip.read()
                       int major = (zip.read() << 8) | zip.read()
 
-                      if (major > maxAllowedMajorVersion) {
+                      if (major> maxAllowedMajorVersion) {
                         String id = "${artifact.moduleVersion.id} (${file.name})"
                         String details = "      - ${entry.name} (Compiled for Java ${major - 44} / Major: ${major})"
 
@@ -129,7 +132,7 @@ subprojects {
                           illegalDependencies[id] = []
                         }
                         illegalDependencies[id] << details
-                        break 
+                        break
                       }
                     }
                   }
@@ -252,7 +255,9 @@ createReleaseBody.configure { Task releaseTask ->
 """
     fileTree(layout.buildDirectory.dir('checksums')).matching { PatternFilterable pattern ->
       pattern.include '*.sha256'
-    }.sort { File a, File b -> a.name <=> b.name }.forEach { File checksumFile ->
+    }.sort { File a, File b ->
+      a.name <=> b.name
+    }.forEach { File checksumFile ->
       String name = checksumFile.name.replace('.sha256', '')
       String hash = checksumFile.text.trim()
       outputFile.get().asFile << "| ${name} | ${hash} |\n"

--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ subprojects {
   plugins.withType(JavaPlugin) {
 
     // Explicitly skip the test case modules you don't want to enforce rules on
-    if (project.name in [
+    Set<String> excludedProjects = [
       'eclipsePlugin-junit',
       'eclipsePlugin-test',
       'spotbugsTestCases',
@@ -68,7 +68,9 @@ subprojects {
       'test-harness',
       'test-harness-core',
       'test-harness-jupiter'
-    ]) {
+    ]
+
+    if (project.name in excludedProjects) {
       return
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,4 @@
 import java.io.BufferedInputStream
-import java.io.BufferedInputStream
 import java.util.zip.ZipEntry
 import java.util.zip.ZipInputStream
 
@@ -34,6 +33,10 @@ version = '4.10.5-SNAPSHOT'
 
 apply from: "${rootDir}/gradle/java.gradle"
 apply from: "${rootDir}/gradle/jacoco.gradle"
+
+// Apply Spotless to the root project so Gradle build scripts, including those
+// under spotbugsTestCases, are formatted. Subprojects apply it separately below
+// to format their Java sources; spotbugsTestCases intentionally skips that.
 apply from: "${rootDir}/gradle/spotless.gradle"
 
 subprojects {
@@ -41,6 +44,7 @@ subprojects {
   apply from: "${rootDir}/gradle/eclipse.gradle"
   apply from: "${rootDir}/gradle/idea.gradle"
   apply from: "${rootDir}/gradle/test.gradle"
+
   if (!project.name.equals('spotbugsTestCases')) {
     apply from: "${rootDir}/gradle/spotless.gradle"
   }
@@ -64,9 +68,9 @@ subprojects {
 
     // Explicitly skip the test case modules you don't want to enforce rules on
     if (project.name == 'eclipsePlugin-junit' || project.name == 'eclipsePlugin-test'
-    || project.name == 'spotbugsTestCases' || project.name == 'spotbugs-tests'
-    || project.name == 'test-harness' || project.name == 'test-harness-core'
-    || project.name == 'test-harness-jupiter') {
+        || project.name == 'spotbugsTestCases' || project.name == 'spotbugs-tests'
+        || project.name == 'test-harness' || project.name == 'test-harness-core'
+        || project.name == 'test-harness-jupiter') {
       return
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,17 +2,17 @@ import java.io.BufferedInputStream
 import java.util.zip.ZipEntry
 import java.util.zip.ZipInputStream
 
-import org.gradle.crypto.checksum.Checksum
 import org.gradle.api.NamedDomainObjectSet
-import org.gradle.api.Task;
+import org.gradle.api.Project
+import org.gradle.api.Task
 import org.gradle.api.artifacts.Configuration
-import org.gradle.api.tasks.TaskProvider;
-import org.gradle.api.file.RegularFile;
-import org.gradle.api.provider.Provider;
-import org.gradle.api.Project;
-import org.gradle.api.publish.PublishingExtension;
-import org.gradle.api.publish.maven.MavenArtifact;
-import org.gradle.api.tasks.util.PatternFilterable;
+import org.gradle.api.file.RegularFile
+import org.gradle.api.provider.Provider
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenArtifact
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.api.tasks.util.PatternFilterable
+import org.gradle.crypto.checksum.Checksum
 
 buildscript {
   repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -60,10 +60,15 @@ subprojects {
   plugins.withType(JavaPlugin) {
 
     // Explicitly skip the test case modules you don't want to enforce rules on
-    if (project.name == 'eclipsePlugin-junit' || project.name == 'eclipsePlugin-test'
-        || project.name == 'spotbugsTestCases' || project.name == 'spotbugs-tests'
-        || project.name == 'test-harness' || project.name == 'test-harness-core'
-        || project.name == 'test-harness-jupiter') {
+    if (project.name in [
+      'eclipsePlugin-junit',
+      'eclipsePlugin-test',
+      'spotbugsTestCases',
+      'spotbugs-tests',
+      'test-harness',
+      'test-harness-core',
+      'test-harness-jupiter'
+    ]) {
       return
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -156,7 +156,9 @@ subprojects {
 
           illegalDependencies.each { dependencyId, classes ->
             errorMsg.append("\n  * Found Banned Dependency: ${dependencyId}\n")
-            classes.each { errorMsg.append("${it}\n") }
+            classes.each {
+              errorMsg.append("${it}\n")
+            }
           }
 
           errorMsg.append("\nUse './gradlew :${project.name}:dependencies' to locate the dependency tree paths.\n")
@@ -213,7 +215,9 @@ createChecksums.configure { Checksum checksumTask ->
         }
       }
       return []
-    }.flatten().findAll { File file -> file != null && file.exists() }
+    }.flatten().findAll { File file ->
+      file != null && file.exists()
+    }
   }
   if (publishTask != null) {
     checksumTask.dependsOn publishTask

--- a/eclipsePlugin/build.gradle
+++ b/eclipsePlugin/build.gradle
@@ -65,12 +65,15 @@ sourceSets {
 }
 
 File findEclipseExecutable() {
-  if (!file("${projectDir}/local.properties").exists()) {
+  Path localProperties = projectDir.toPath().resolve('local.properties')
+  if (!Files.exists(localProperties)) {
     return null
   }
 
   Properties localProps = new Properties()
-  localProps.load(Files.newInputStream(Path.of("${projectDir}/local.properties")))
+  Files.newInputStream(localProperties).withCloseable { InputStream input ->
+    localProps.load(input)
+  }
   File eclipseRootDir = new File(localProps.getProperty('eclipseRoot.dir'))
   // Eclipse 4.5+ uses a different directory layout under macOS. Try to detect this first.
   String os = System.getProperty('os.name').toLowerCase(Locale.ROOT)
@@ -134,7 +137,7 @@ TaskProvider<Copy> copyLibsForEclipse = tasks.register('copyLibsForEclipse', Cop
 File resolvedBuildDir = project.layout.buildDirectory.asFile.get()
 
 TaskProvider<Exec> distSrcZip = tasks.register('distSrcZip', Exec) {
-  String out = "${resolvedBuildDir}/distributions/${eclipsePluginId}_${project.version}-source.zip"
+  File out = resolvedBuildDir.toPath().resolve('distributions').resolve("${eclipsePluginId}_${project.version}-source.zip").toFile()
   outputs.file out
   commandLine 'git', 'archive', '-o', out, 'HEAD'
 }
@@ -155,7 +158,7 @@ TaskProvider<Task> updateManifest = tasks.register('updateManifest') {
       attributes 'Bundle-SymbolicName': "${eclipsePluginId}; singleton:=true",
       'Bundle-Version': version,
       'Bundle-ClassPath': '.,spotbugs-plugin.jar,' + libFiles.collect { File file ->
-        projectDir.toPath().relativize(file.toPath()).toString().replace('\\', '/')
+        relativizePath(file)
       }.join(',')
     }
 
@@ -164,7 +167,7 @@ TaskProvider<Task> updateManifest = tasks.register('updateManifest') {
       attributes 'Bundle-SymbolicName': "${eclipsePluginId}; singleton:=true",
       'Bundle-Version': version,
       'Bundle-ClassPath': 'spotbugs-plugin.jar,' + libFiles.collect { File file ->
-        projectDir.toPath().relativize(file.toPath()).toString().replace('\\', '/')
+        relativizePath(file)
       }.join(',')
     }
     // write manifests
@@ -172,15 +175,23 @@ TaskProvider<Task> updateManifest = tasks.register('updateManifest') {
     distManifestSpec.writeTo("${projectDir}/META-INF/MANIFEST-DIST.MF")
 
     // write build.properties
-    File propsTemplate = file("${projectDir}/build-template.properties")
+    Path propsTemplate = projectDir.toPath().resolve('build-template.properties')
     Properties props = new Properties()
-    props.load(propsTemplate.newDataInputStream())
+    Files.newInputStream(propsTemplate).withCloseable { InputStream input ->
+      props.load(input)
+    }
     props.setProperty('bin.includes', props.getProperty('bin.includes') + ',' +
         libFiles.collect { File file ->
-          projectDir.toPath().relativize(file.toPath()).toString().replace('\\', '/')
+          relativizePath(file)
         }.join(','))
-    props.store(file('build.properties').newWriter(), null)
+    Files.newBufferedWriter(projectDir.toPath().resolve('build.properties')).withCloseable { Writer writer ->
+      props.store(writer, null)
+    }
   }
+}
+
+String relativizePath(File file) {
+  return projectDir.toPath().relativize(file.toPath()).toString().replace('\\', '/')
 }
 
 tasks.named('compileJava').configure {
@@ -189,7 +200,7 @@ tasks.named('compileJava').configure {
 
 // create manifest when importing to eclipse
 tasks.named('eclipse').configure {
-  dependsOn copyLibsForEclipse, updateManifest
+  dependsOn updateManifest
 }
 
 class FileRef implements FileReference {
@@ -276,7 +287,7 @@ TaskProvider<Zip> distZip = tasks.register('distZip', Zip) {
 }
 
 TaskProvider<Task> testPluginJar = tasks.register('testPluginJar') {
-  String jarFile = "${resolvedBuildDir}/site/eclipse/plugins/${eclipsePluginId}_${project.version}.jar"
+  File jarFile = resolvedBuildDir.toPath().resolve("site/eclipse/plugins/${eclipsePluginId}_${project.version}.jar").toFile()
   inputs.file jarFile
   doLast {
     File spotbugsJar = zipTree(jarFile).matching {
@@ -454,7 +465,7 @@ ext.signJar = { File dir ->
   }
 
   dir.traverse(type: FILES, nameFilter: ~/.*\.jar$/) { File jarFile ->
-    String relativePath = rootDir.toPath().relativize(jarFile.toPath())
+    String relativePath = rootDir.toPath().relativize(jarFile.toPath()).toString()
     logger.lifecycle("signing ${relativePath}")
     ant.signjar(
         destDir: jarFile.parentFile,

--- a/eclipsePlugin/build.gradle
+++ b/eclipsePlugin/build.gradle
@@ -97,7 +97,7 @@ String eclipsePluginId = 'com.github.spotbugs.plugin.eclipse'
 File eclipseExecutable = findEclipseExecutable()
 
 dependencies {
-  api (project(':spotbugs')) {
+  api(project(':spotbugs')) {
     transitive = true
   }
   compileOnly 'jakarta.annotation:jakarta.annotation-api:3.0.0'
@@ -124,7 +124,7 @@ tasks.named('javadoc', Javadoc).configure {
 }
 
 TaskProvider<Copy> copyLibsForEclipse = tasks.register('copyLibsForEclipse', Copy) {
-  from (configurations.runtimeClasspath) {
+  from(configurations.runtimeClasspath) {
     include '*.jar'
     exclude 'Saxon*.jar'
   }
@@ -153,17 +153,19 @@ TaskProvider<Task> updateManifest = tasks.register('updateManifest') {
     Manifest manifestSpec = java.manifest {
       from "${projectDir}/META-INF/MANIFEST-TEMPLATE.MF"
       attributes 'Bundle-SymbolicName': "${eclipsePluginId}; singleton:=true",
-                 'Bundle-Version': version,
-                 'Bundle-ClassPath': '.,spotbugs-plugin.jar,' + libFiles.collect { File file ->
-                      projectDir.toPath().relativize(file.toPath()).toString().replace('\\', '/') }.join(',')
+      'Bundle-Version': version,
+      'Bundle-ClassPath': '.,spotbugs-plugin.jar,' + libFiles.collect { File file ->
+        projectDir.toPath().relativize(file.toPath()).toString().replace('\\', '/')
+      }.join(',')
     }
 
     Manifest distManifestSpec = java.manifest {
       from "${projectDir}/META-INF/MANIFEST-TEMPLATE.MF"
       attributes 'Bundle-SymbolicName': "${eclipsePluginId}; singleton:=true",
-                 'Bundle-Version': version,
-                 'Bundle-ClassPath': 'spotbugs-plugin.jar,' + libFiles.collect { File file ->
-                        projectDir.toPath().relativize(file.toPath()).toString().replace('\\', '/') }.join(',')
+      'Bundle-Version': version,
+      'Bundle-ClassPath': 'spotbugs-plugin.jar,' + libFiles.collect { File file ->
+        projectDir.toPath().relativize(file.toPath()).toString().replace('\\', '/')
+      }.join(',')
     }
     // write manifests
     manifestSpec.writeTo("${projectDir}/META-INF/MANIFEST.MF")
@@ -174,7 +176,9 @@ TaskProvider<Task> updateManifest = tasks.register('updateManifest') {
     Properties props = new Properties()
     props.load(propsTemplate.newDataInputStream())
     props.setProperty('bin.includes', props.getProperty('bin.includes') + ',' +
-        libFiles.collect { File file -> projectDir.toPath().relativize(file.toPath()).toString().replace('\\', '/') }.join(','))
+        libFiles.collect { File file ->
+          projectDir.toPath().relativize(file.toPath()).toString().replace('\\', '/')
+        }.join(','))
     props.store(file('build.properties').newWriter(), null)
   }
 }
@@ -182,7 +186,9 @@ TaskProvider<Task> updateManifest = tasks.register('updateManifest') {
 tasks.named('compileJava').configure { dependsOn ':spotbugs:jar' }
 
 // create manifest when importing to eclipse
-tasks.named('eclipse').configure { dependsOn copyLibsForEclipse, updateManifest }
+tasks.named('eclipse').configure {
+  dependsOn copyLibsForEclipse, updateManifest
+}
 
 class FileRef implements FileReference {
   File file
@@ -270,8 +276,8 @@ TaskProvider<Task> testPluginJar = tasks.register('testPluginJar') {
   inputs.file jarFile
   doLast {
     File spotbugsJar = zipTree(jarFile)
-            .matching { include 'lib/spotbugs.jar' }
-            .singleFile
+    .matching { include 'lib/spotbugs.jar' }
+    .singleFile
     if (!spotbugsJar.exists()) {
       throw new TaskInstantiationException('Eclipse plugin does not contain spotbugs.jar')
     } else {
@@ -305,20 +311,20 @@ TaskProvider<Copy> pluginDailyJar = tasks.register('pluginDailyJar', Copy) {
 
 Map<String, String> siteFilterTokens = [
   'PLUGIN_ID': eclipsePluginId,
-  'PLUGIN_VERSION':project.version.toString(),
+  'PLUGIN_VERSION': project.version.toString(),
   'FEATURE_ID': eclipsePluginId,
-  'FEATURE_VERSION':project.version.toString()
+  'FEATURE_VERSION': project.version.toString()
 ]
 
 TaskProvider<Zip> featureJar = tasks.register('featureJar', Zip) {
   archiveFileName = "${eclipsePluginId}_${project.version}.jar"
   entryCompression = ZipEntryCompression.STORED // no compression, this is a jar with no manifest
   from('plugin_feature.xml') {
-    filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
+    filter(tokens: siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
     rename { 'feature.xml' }
   }
   from('feature_p2.inf') {
-    filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
+    filter(tokens: siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
     rename { 'p2.inf' }
   }
   destinationDirectory = layout.buildDirectory.dir('site/eclipse/features/')
@@ -328,11 +334,11 @@ TaskProvider<Zip> featureCandidateJar = tasks.register('featureCandidateJar', Zi
   archiveFileName = "${eclipsePluginId}_${project.version}.jar"
   entryCompression = ZipEntryCompression.STORED // no compression, this is a jar with no manifest
   from('plugin_feature-candidate.xml') {
-    filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
+    filter(tokens: siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
     rename { 'feature.xml' }
   }
   from('feature_p2.inf') {
-    filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
+    filter(tokens: siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
     rename { 'p2.inf' }
   }
   destinationDirectory = layout.buildDirectory.dir('site/eclipse-candidate/features/')
@@ -342,18 +348,18 @@ TaskProvider<Zip> featureDailyJar = tasks.register('featureDailyJar', Zip) {
   archiveFileName = "${eclipsePluginId}_${project.version}.jar"
   entryCompression = ZipEntryCompression.STORED // no compression, this is a jar with no manifest
   from('plugin_feature-daily.xml') {
-    filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
+    filter(tokens: siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
     rename { 'feature.xml' }
   }
   from('feature_p2.inf') {
-    filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
+    filter(tokens: siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
     rename { 'p2.inf' }
   }
   destinationDirectory = layout.buildDirectory.dir('site/eclipse-daily/features/')
 }
 
 TaskProvider<Copy> siteHtml = tasks.register('siteHtml', Copy) {
-  filter(tokens:[
+  filter(tokens: [
     'URL': 'https://spotbugs.github.io/eclipse/'
   ] + siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
   from 'plugin_site.html'
@@ -368,7 +374,7 @@ TaskProvider<Copy> siteHtml = tasks.register('siteHtml', Copy) {
 }
 
 TaskProvider<Copy> siteCandidateHtml = tasks.register('siteCandidateHtml', Copy) {
-  filter(tokens:[
+  filter(tokens: [
     'URL': 'https://spotbugs.github.io/eclipse-candidate/'
   ] + siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
   from 'plugin_site.html'
@@ -381,7 +387,7 @@ TaskProvider<Copy> siteCandidateHtml = tasks.register('siteCandidateHtml', Copy)
 }
 
 TaskProvider<Copy> siteDailyHtml = tasks.register('siteDailyHtml', Copy) {
-  filter(tokens:[
+  filter(tokens: [
     'URL': 'https://spotbugs.github.io/eclipse-latest/'
   ] + siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
   from 'plugin_site.html'
@@ -394,7 +400,7 @@ TaskProvider<Copy> siteDailyHtml = tasks.register('siteDailyHtml', Copy) {
 }
 
 TaskProvider<Copy> siteXml = tasks.register('siteXml', Copy) {
-  filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
+  filter(tokens: siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
   from 'plugin_site.xml'
   into layout.buildDirectory.dir('site/eclipse')
   rename { 'site.xml' }
@@ -407,7 +413,7 @@ TaskProvider<Copy> siteXml = tasks.register('siteXml', Copy) {
 }
 
 TaskProvider<Copy> siteCandidateXml = tasks.register('siteCandidateXml', Copy) {
-  filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
+  filter(tokens: siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
   from 'plugin_site-candidate.xml'
   into layout.buildDirectory.dir('site/eclipse-candidate')
   rename { 'site.xml' }
@@ -418,7 +424,7 @@ TaskProvider<Copy> siteCandidateXml = tasks.register('siteCandidateXml', Copy) {
 }
 
 TaskProvider<Copy> siteDailyXml = tasks.register('siteDailyXml', Copy) {
-  filter(tokens:siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
+  filter(tokens: siteFilterTokens, org.apache.tools.ant.filters.ReplaceTokens)
   from 'plugin_site-daily.xml'
   into layout.buildDirectory.dir('site/eclipse-daily')
   rename { 'site.xml' }
@@ -450,7 +456,7 @@ ext.signJar = { File dir ->
         storepass: keystorepass,
         tsaurl: 'http://timestamp.digicert.com',
         verbose: true
-    )
+        )
   }
 }
 
@@ -466,8 +472,12 @@ TaskProvider<Task> confirmEclipse = tasks.register('confirmEclipse') {
 TaskProvider<Exec> generateP2Metadata = tasks.register('generateP2Metadata', Exec) {
   doFirst {
     Provider<Directory> eclipseSiteDir = layout.buildDirectory.dir('site/eclipse')
-    File artifactsXml = eclipseSiteDir.map { Directory dir -> dir.file('artifacts.xml') }.get().asFile
-    File contentXml = eclipseSiteDir.map { Directory dir -> dir.file('content.xml') }.get().asFile
+    File artifactsXml = eclipseSiteDir.map { Directory dir ->
+      dir.file('artifacts.xml')
+    }.get().asFile
+    File contentXml = eclipseSiteDir.map { Directory dir ->
+      dir.file('content.xml')
+    }.get().asFile
     delete artifactsXml
     delete contentXml
     signJar(eclipseSiteDir.get().asFile)
@@ -475,18 +485,22 @@ TaskProvider<Exec> generateP2Metadata = tasks.register('generateP2Metadata', Exe
   inputs.file 'local.properties'
   dependsOn confirmEclipse, pluginJar, featureJar, siteXml, siteHtml
   commandLine eclipseExecutable, '-nosplash',
-    '-application', 'org.eclipse.equinox.p2.publisher.UpdateSitePublisher',
-    '-metadataRepository', "file:${resolvedBuildDir}/site/eclipse",
-    '-artifactRepository', "file:${resolvedBuildDir}/site/eclipse",
-    '-source', "${resolvedBuildDir}/site/eclipse",
-    '-vm', "${System.getProperty('java.home')}/bin"
+      '-application', 'org.eclipse.equinox.p2.publisher.UpdateSitePublisher',
+      '-metadataRepository', "file:${resolvedBuildDir}/site/eclipse",
+      '-artifactRepository', "file:${resolvedBuildDir}/site/eclipse",
+      '-source', "${resolvedBuildDir}/site/eclipse",
+      '-vm', "${System.getProperty('java.home')}/bin"
 }
 
 TaskProvider<Exec> generateCandidateP2Metadata = tasks.register('generateCandidateP2Metadata', Exec) {
   doFirst {
     Provider<Directory> eclipseSiteCandidateDir = layout.buildDirectory.dir('site/eclipse-candidate')
-    File artifactsXml = eclipseSiteCandidateDir.map { Directory dir -> dir.file('artifacts.xml') }.get().asFile
-    File contentXml = eclipseSiteCandidateDir.map { Directory dir -> dir.file('content.xml') }.get().asFile
+    File artifactsXml = eclipseSiteCandidateDir.map { Directory dir ->
+      dir.file('artifacts.xml')
+    }.get().asFile
+    File contentXml = eclipseSiteCandidateDir.map { Directory dir ->
+      dir.file('content.xml')
+    }.get().asFile
     delete artifactsXml
     delete contentXml
     signJar(eclipseSiteCandidateDir.get().asFile)
@@ -494,18 +508,22 @@ TaskProvider<Exec> generateCandidateP2Metadata = tasks.register('generateCandida
   inputs.file 'local.properties'
   dependsOn confirmEclipse, pluginCandidateJar, featureCandidateJar, siteCandidateXml, siteCandidateHtml
   commandLine eclipseExecutable, '-nosplash',
-    '-application', 'org.eclipse.equinox.p2.publisher.UpdateSitePublisher',
-    '-metadataRepository', "file:${resolvedBuildDir}/site/eclipse-candidate",
-    '-artifactRepository', "file:${resolvedBuildDir}/site/eclipse-candidate",
-    '-source', "${resolvedBuildDir}/site/eclipse-candidate",
-    '-vm', "${System.getProperty('java.home')}/bin"
+      '-application', 'org.eclipse.equinox.p2.publisher.UpdateSitePublisher',
+      '-metadataRepository', "file:${resolvedBuildDir}/site/eclipse-candidate",
+      '-artifactRepository', "file:${resolvedBuildDir}/site/eclipse-candidate",
+      '-source', "${resolvedBuildDir}/site/eclipse-candidate",
+      '-vm', "${System.getProperty('java.home')}/bin"
 }
 
 TaskProvider<Exec> generateP2MetadataDaily = tasks.register('generateP2MetadataDaily', Exec) {
   doFirst {
     Provider<Directory> eclipseSiteDailyDir = layout.buildDirectory.dir('site/eclipse-daily')
-    File artifactsXml = eclipseSiteDailyDir.map { Directory dir -> dir.file('artifacts.xml') }.get().asFile
-    File contentXml = eclipseSiteDailyDir.map { Directory dir -> dir.file('content.xml') }.get().asFile
+    File artifactsXml = eclipseSiteDailyDir.map { Directory dir ->
+      dir.file('artifacts.xml')
+    }.get().asFile
+    File contentXml = eclipseSiteDailyDir.map { Directory dir ->
+      dir.file('content.xml')
+    }.get().asFile
     delete artifactsXml
     delete contentXml
     signJar(eclipseSiteDailyDir.get().asFile)
@@ -513,11 +531,11 @@ TaskProvider<Exec> generateP2MetadataDaily = tasks.register('generateP2MetadataD
   inputs.file 'local.properties'
   dependsOn confirmEclipse, pluginDailyJar, featureDailyJar, siteDailyXml, siteDailyHtml
   commandLine eclipseExecutable, '-nosplash',
-    '-application', 'org.eclipse.equinox.p2.publisher.UpdateSitePublisher',
-    '-metadataRepository', "file:${resolvedBuildDir}/site/eclipse-daily",
-    '-artifactRepository', "file:${resolvedBuildDir}/site/eclipse-daily",
-    '-source', "${resolvedBuildDir}/site/eclipse-daily",
-    '-vm', "${System.getProperty('java.home')}/bin"
+      '-application', 'org.eclipse.equinox.p2.publisher.UpdateSitePublisher',
+      '-metadataRepository', "file:${resolvedBuildDir}/site/eclipse-daily",
+      '-artifactRepository', "file:${resolvedBuildDir}/site/eclipse-daily",
+      '-source', "${resolvedBuildDir}/site/eclipse-daily",
+      '-vm', "${System.getProperty('java.home')}/bin"
 }
 
 TaskProvider<Task> eclipseSite = tasks.register('eclipseSite') {

--- a/eclipsePlugin/build.gradle
+++ b/eclipsePlugin/build.gradle
@@ -216,7 +216,7 @@ eclipse.classpath.file {
     classpath.entries.removeAll { ClasspathEntry entry ->
       entry.kind == 'lib'
     }
-    copyLibsForEclipse
+
     Set<File> libFiles = fileTree(dir: 'lib').files
     libFiles.forEach { File file ->
       File rel = projectDir.toPath().relativize(file.toPath()).toFile()

--- a/eclipsePlugin/build.gradle
+++ b/eclipsePlugin/build.gradle
@@ -183,7 +183,9 @@ TaskProvider<Task> updateManifest = tasks.register('updateManifest') {
   }
 }
 
-tasks.named('compileJava').configure { dependsOn ':spotbugs:jar' }
+tasks.named('compileJava').configure {
+  dependsOn ':spotbugs:jar'
+}
 
 // create manifest when importing to eclipse
 tasks.named('eclipse').configure {
@@ -233,7 +235,9 @@ TaskProvider<Jar> jar = tasks.named('jar', Jar) {
 }
 
 CopySpec distSpec = copySpec {
-  from jar.map { Jar jarTask -> jarTask.outputs.files }
+  from jar.map { Jar jarTask ->
+    jarTask.outputs.files
+  }
   from(project.projectDir) {
     include 'RELEASENOTES'
     include 'plugin.xml'
@@ -297,13 +301,17 @@ TaskProvider<Zip> pluginJar = tasks.register('pluginJar', Zip) {
 
 TaskProvider<Copy> pluginCandidateJar = tasks.register('pluginCandidateJar', Copy) {
   dependsOn pluginJar
-  from pluginJar.map { Zip zipTask -> zipTask.outputs.files }
+  from pluginJar.map { Zip zipTask ->
+    zipTask.outputs.files
+  }
   into layout.buildDirectory.dir('site/eclipse-candidate/plugins/')
 }
 
 TaskProvider<Copy> pluginDailyJar = tasks.register('pluginDailyJar', Copy) {
   dependsOn pluginJar
-  from pluginJar.map { Zip zipTask -> zipTask.outputs.files }
+  from pluginJar.map { Zip zipTask ->
+    zipTask.outputs.files
+  }
   into layout.buildDirectory.dir('site/eclipse-daily/plugins/')
   mustRunAfter(siteHtml)
   mustRunAfter(siteXml)
@@ -552,7 +560,9 @@ TaskProvider<Zip> eclipseSiteZip = tasks.register('eclipseSiteZip', Zip) {
 if (eclipseExecutable == null) {
   logger.lifecycle('Create local.properties to build eclipse site')
 } else {
-  tasks.named('assemble').configure { dependsOn eclipseSiteZip }
+  tasks.named('assemble').configure {
+    dependsOn eclipseSiteZip
+  }
 }
 
 spotbugs {

--- a/eclipsePlugin/build.gradle
+++ b/eclipsePlugin/build.gradle
@@ -279,9 +279,9 @@ TaskProvider<Task> testPluginJar = tasks.register('testPluginJar') {
   String jarFile = "${resolvedBuildDir}/site/eclipse/plugins/${eclipsePluginId}_${project.version}.jar"
   inputs.file jarFile
   doLast {
-    File spotbugsJar = zipTree(jarFile)
-        .matching { include 'lib/spotbugs.jar' }
-        .singleFile
+    File spotbugsJar = zipTree(jarFile).matching {
+      include 'lib/spotbugs.jar'
+    }.singleFile
     if (!spotbugsJar.exists()) {
       throw new TaskInstantiationException('Eclipse plugin does not contain spotbugs.jar')
     } else {

--- a/eclipsePlugin/build.gradle
+++ b/eclipsePlugin/build.gradle
@@ -276,8 +276,8 @@ TaskProvider<Task> testPluginJar = tasks.register('testPluginJar') {
   inputs.file jarFile
   doLast {
     File spotbugsJar = zipTree(jarFile)
-    .matching { include 'lib/spotbugs.jar' }
-    .singleFile
+        .matching { include 'lib/spotbugs.jar' }
+        .singleFile
     if (!spotbugsJar.exists()) {
       throw new TaskInstantiationException('Eclipse plugin does not contain spotbugs.jar')
     } else {

--- a/eclipsePlugin/build.gradle
+++ b/eclipsePlugin/build.gradle
@@ -1,7 +1,7 @@
 import static groovy.io.FileType.FILES
 
-import java.nio.file.Files;
-import java.nio.file.Path;
+import java.nio.file.Files
+import java.nio.file.Path
 import org.ajoberstar.grgit.Grgit
 import org.gradle.plugins.ide.eclipse.model.Classpath
 import org.gradle.plugins.ide.eclipse.model.ClasspathEntry
@@ -442,7 +442,7 @@ ext.signJar = { File dir ->
     return
   } else {
     logger.lifecycle('Signing of Eclipse plugins is disabled now, see https://github.com/spotbugs/spotbugs/issues/3406')
-    return;
+    return
   }
 
   dir.traverse(type: FILES, nameFilter: ~/.*\.jar$/) { File jarFile ->

--- a/gradle/eclipse-formatter.xml
+++ b/gradle/eclipse-formatter.xml
@@ -179,7 +179,7 @@
         <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_try_clause" value="common_lines"/>
         <setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="16"/>
         <setting id="org.eclipse.jdt.core.formatter.never_indent_block_comments_on_first_column" value="false"/>
-        <setting id="org.eclipse.jdt.core.compiler.source" value="10"/>
+        <setting id="org.eclipse.jdt.core.compiler.source" value="11"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_synchronized" value="do not insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_throws" value="insert"/>
         <setting id="org.eclipse.jdt.core.formatter.tabulation.size" value="4"/>
@@ -201,7 +201,7 @@
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_throw" value="insert"/>
         <setting id="org.eclipse.jdt.core.formatter.wrap_before_assignment_operator" value="false"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_labeled_statement" value="do not insert"/>
-        <setting id="org.eclipse.jdt.core.compiler.codegen.targetPlatform" value="10"/>
+        <setting id="org.eclipse.jdt.core.compiler.codegen.targetPlatform" value="11"/>
         <setting id="org.eclipse.jdt.core.formatter.brace_position_for_switch" value="end_of_line"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_superinterfaces" value="do not insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_parameters" value="insert"/>
@@ -271,7 +271,7 @@
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_method_declaration" value="insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_parameters" value="insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_catch" value="do not insert"/>
-        <setting id="org.eclipse.jdt.core.compiler.compliance" value="10"/>
+        <setting id="org.eclipse.jdt.core.compiler.compliance" value="11"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_reference" value="do not insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_annotation" value="insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_constant_arguments" value="do not insert"/>

--- a/gradle/eclipse.gradle
+++ b/gradle/eclipse.gradle
@@ -17,11 +17,11 @@ eclipse {
     buildCommand 'org.eclipse.pde.ManifestBuilder'
     buildCommand 'org.eclipse.pde.SchemaBuilder'
     buildCommand 'edu.umd.cs.findbugs.plugin.eclipse.findbugsBuilder'
-    
+
     // Link default settings to all eclipse projects, see #380
     // Don't link settings to the test cases - they contain broken code (on purpose)
     if (!testCasesProject) {
-        linkedResource name: '.settings', type: '2', locationUri: '$%7BPARENT-1-PROJECT_LOC%7D/gradle/.settings-templates'
+      linkedResource name: '.settings', type: '2', locationUri: '$%7BPARENT-1-PROJECT_LOC%7D/gradle/.settings-templates'
     }
   }
 
@@ -33,7 +33,9 @@ eclipse {
 
     file {
       whenMerged {
-        ClasspathEntry jre = entries.find { ClasspathEntry entry -> entry.path.contains 'org.eclipse.jdt.launching.JRE_CONTAINER' }
+        ClasspathEntry jre = entries.find { ClasspathEntry entry ->
+          entry.path.contains 'org.eclipse.jdt.launching.JRE_CONTAINER'
+        }
         jre.accessRules.add(new AccessRule('accessible', 'com/sun/management/*'))
         jre.accessRules.add(new AccessRule('nonaccessible', 'com/sun/**'))
         jre.accessRules.add(new AccessRule('accessible', 'com/apple/eawt/*'))

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -16,10 +16,10 @@ tasks.withType(AbstractArchiveTask).configureEach {
   preserveFileTimestamps = false
   reproducibleFileOrder = true
   dirPermissions {
-    unix (0775)
+    unix(0775)
   }
   filePermissions {
-    unix (0664)
+    unix(0664)
   }
 }
 

--- a/gradle/javadoc.gradle
+++ b/gradle/javadoc.gradle
@@ -15,6 +15,6 @@ tasks.withType(Javadoc).configureEach {
     splitIndex = true
     use = true
     version = true
-    tags = ['ant.task','noinspection']
+    tags = ['ant.task', 'noinspection']
   }
 }

--- a/gradle/sonar.gradle
+++ b/gradle/sonar.gradle
@@ -16,7 +16,7 @@ tasks.named('sonar').configure {
 }
 
 allprojects {
-    tasks.matching { task -> task.name == 'sonarResolver' }.configureEach {
-        dependsOn tasks.matching { task -> task.name == 'classes' }
-    }
+  tasks.matching { task -> task.name == 'sonarResolver' }.configureEach {
+    dependsOn tasks.matching { task -> task.name == 'classes' }
+  }
 }

--- a/gradle/sonar.gradle
+++ b/gradle/sonar.gradle
@@ -16,7 +16,11 @@ tasks.named('sonar').configure {
 }
 
 allprojects {
-  tasks.matching { task -> task.name == 'sonarResolver' }.configureEach {
-    dependsOn tasks.matching { task -> task.name == 'classes' }
+  tasks.matching { task ->
+    task.name == 'sonarResolver'
+  }.configureEach {
+    dependsOn tasks.matching { task ->
+      task.name == 'classes'
+    }
   }
 }

--- a/gradle/spotless.gradle
+++ b/gradle/spotless.gradle
@@ -7,4 +7,11 @@ spotless {
     eclipse().configFile "${rootProject.projectDir}/gradle/eclipse-formatter.xml"
     endWithNewline()
   }
+  groovyGradle {
+    target '*.gradle'
+    greclipse()
+    leadingTabsToSpaces(2)
+    trimTrailingWhitespace()
+    endWithNewline()
+  }
 }

--- a/gradle/spotless.gradle
+++ b/gradle/spotless.gradle
@@ -9,7 +9,16 @@ spotless {
   }
   groovyGradle {
     target '**/*.gradle'
-    greclipse()
+    greclipse().configProperties("""
+      org.eclipse.jdt.core.formatter.alignment_for_logical_operator=48
+      org.eclipse.jdt.core.formatter.tabulation.char=space
+      org.eclipse.jdt.core.formatter.tabulation.size=2
+      org.eclipse.jdt.core.formatter.indentation.size=2
+      groovy.formatter.multiline.indentation=2
+      groovy.formatter.line.maxlength=120
+      groovy.formatter.longListLength=30
+      groovy.formatter.remove.unnecessary.semicolons=true
+    """)
     leadingTabsToSpaces(2)
     trimTrailingWhitespace()
     endWithNewline()

--- a/gradle/spotless.gradle
+++ b/gradle/spotless.gradle
@@ -9,6 +9,7 @@ spotless {
   }
   groovyGradle {
     target '**/*.gradle'
+    targetExclude 'lib/**', '.libs/**'
     greclipse().configProperties("""
       org.eclipse.jdt.core.formatter.alignment_for_logical_operator=48
       org.eclipse.jdt.core.formatter.tabulation.char=space

--- a/gradle/spotless.gradle
+++ b/gradle/spotless.gradle
@@ -8,7 +8,7 @@ spotless {
     endWithNewline()
   }
   groovyGradle {
-    target '*.gradle'
+    target '**/*.gradle'
     greclipse()
     leadingTabsToSpaces(2)
     trimTrailingWhitespace()

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -13,7 +13,8 @@ tasks.withType(Test) {
   }
   doFirst {
     jvmArgs += [
-      '--add-opens', 'java.base/java.lang=ALL-UNNAMED',
+      '--add-opens',
+      'java.base/java.lang=ALL-UNNAMED',
       "-javaagent:${configurations.mockitoAgent.asPath}"
     ]
   }

--- a/spotbugs-annotations/build.gradle
+++ b/spotbugs-annotations/build.gradle
@@ -19,11 +19,11 @@ dependencies {
 
 Manifest manifestSpec = java.manifest {
   attributes 'Bundle-Name': 'spotbugs-annotations',
-               'Bundle-SymbolicName': 'spotbugs-annotations',
-               'Bundle-Version': project.version.replace('-', '.'),
-               'Export-Package': 'edu.umd.cs.findbugs.annotations',
-               'Bundle-RequiredExecutionEnvironment': 'JavaSE-1.8',
-               'Bundle-ManifestVersion': '2'
+  'Bundle-SymbolicName': 'spotbugs-annotations',
+  'Bundle-Version': project.version.replace('-', '.'),
+  'Export-Package': 'edu.umd.cs.findbugs.annotations',
+  'Bundle-RequiredExecutionEnvironment': 'JavaSE-1.8',
+  'Bundle-ManifestVersion': '2'
 }
 
 TaskProvider<Task> updateManifest = tasks.register('updateManifest') {
@@ -39,11 +39,11 @@ TaskProvider<Jar> jar = tasks.named('jar', Jar) {
   archiveFileName = archiveBaseName.get() + '.' + archiveExtension.get()
   manifest {
     attributes 'Bundle-Name': 'spotbugs-annotations',
-               'Bundle-SymbolicName': 'spotbugs-annotations',
-               'Bundle-Version': project.version.replace('-', '.'),
-               'Export-Package': 'edu.umd.cs.findbugs.annotations',
-               'Bundle-RequiredExecutionEnvironment': 'JavaSE-1.8',
-               'Bundle-ManifestVersion': '2'
+    'Bundle-SymbolicName': 'spotbugs-annotations',
+    'Bundle-Version': project.version.replace('-', '.'),
+    'Export-Package': 'edu.umd.cs.findbugs.annotations',
+    'Bundle-RequiredExecutionEnvironment': 'JavaSE-1.8',
+    'Bundle-ManifestVersion': '2'
   }
 }
 

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -37,8 +37,12 @@ sourceSets {
       /*
        * Because why put everything in a single folder when you can split it
        * and mix it with other files you don't actually need together
-      */
-      srcDirs = ['src/xsl', 'etc', 'src/main/java']
+       */
+      srcDirs = [
+        'src/xsl',
+        'etc',
+        'src/main/java'
+      ]
       include '*.xsd'
       include 'bugrank.txt'
       include 'findbugs.xml'
@@ -93,7 +97,7 @@ dependencies {
   implementation 'jaxen:jaxen:2.0.6' // only transitive through org.dom4j:dom4j:2.1.4, which has an *optional* dependency on jaxen:jaxen.
   implementation 'net.sf.saxon:Saxon-HE:12.10'
   implementation libs.log4j.core
-  logBinding (libs.log4j.slf4j2.impl) {
+  logBinding(libs.log4j.slf4j2.impl) {
     exclude group: 'org.slf4j'
   }
 
@@ -119,8 +123,8 @@ project(':spotbugs-annotations') {
     dependsOn(jarTask)
 
     inputs.file(jarTask.flatMap { Jar jar -> jar.archiveFile })
-          .withPathSensitivity(PathSensitivity.RELATIVE)
-          .withPropertyName('spotbugsJarInput')
+    .withPathSensitivity(PathSensitivity.RELATIVE)
+    .withPropertyName('spotbugsJarInput')
   }
 }
 
@@ -136,9 +140,15 @@ tasks.withType(Jar).configureEach {
 
 eclipse.classpath.file {
   whenMerged { Classpath classpath ->
-    List<String> removeLibPaths = ['build/classes/', 'build/resources/', 'xml-apis']
+    List<String> removeLibPaths = [
+      'build/classes/',
+      'build/resources/',
+      'xml-apis'
+    ]
     classpath.entries.removeAll { ClasspathEntry entry ->
-      entry.kind == 'lib' && removeLibPaths.any { String pathPart -> entry.path.contains(pathPart) }
+      entry.kind == 'lib' && removeLibPaths.any { String pathPart ->
+        entry.path.contains(pathPart)
+      }
     }
     classpath.entries.forEach { ClasspathEntry entry ->
       if (entry.kind == 'lib' && !entry.path.contains('spotbugs-annotations') && !Files.isDirectory(Path.of(entry.path))) {
@@ -146,7 +156,9 @@ eclipse.classpath.file {
         entry.exported = true
       }
     }
-    Map<String, List<ClasspathEntry>> entryByPath = classpath.entries.groupBy { ClasspathEntry entry -> entry.path }
+    Map<String, List<ClasspathEntry>> entryByPath = classpath.entries.groupBy { ClasspathEntry entry ->
+      entry.path
+    }
     entryByPath.each { String key, List<ClasspathEntry> values ->
       if (values.size() > 1) {
         ClasspathEntry entry = values.first()
@@ -179,7 +191,9 @@ TaskProvider<Task> updateManifest = tasks.register('updateManifest') {
   String version = project.version.replace('-', '.')
   String mainClass = 'edu.umd.cs.findbugs.LaunchAppropriateUI'
   Provider<String> bundleClassPath = provider {
-    List<String> libs = fileTree(dir: '.libs').collect { File file -> projectDir.toPath().relativize(file.toPath()).toString() }
+    List<String> libs = fileTree(dir: '.libs').collect { File file ->
+      projectDir.toPath().relativize(file.toPath()).toString()
+    }
     return 'spotbugs.jar,' + libs.join(',')
   }
   inputs.file manifestTemplate
@@ -189,8 +203,8 @@ TaskProvider<Task> updateManifest = tasks.register('updateManifest') {
     Manifest manifestSpec = java.manifest {
       from manifestTemplate
       attributes 'Main-Class': mainClass,
-                 'Bundle-Version': version,
-                 'Bundle-ClassPath': bundleClassPath.get()
+      'Bundle-Version': version,
+      'Bundle-ClassPath': bundleClassPath.get()
     }
     // write manifests
     manifestSpec.writeTo(manifestOutput)
@@ -208,8 +222,12 @@ TaskProvider<Jar> jar = tasks.named('jar', Jar) {
   Set<File> jarInClasspath = project.configurations.runtimeClasspath + project.configurations.logBinding
   manifest {
     attributes 'Main-Class': 'edu.umd.cs.findbugs.LaunchAppropriateUI',
-               'Bundle-Version': project.version,
-               'Class-Path': project.providers.provider { jarInClasspath.collect { File file -> file.getName() }.join(' ') + ' config/' }
+    'Bundle-Version': project.version,
+    'Class-Path': project.providers.provider {
+      jarInClasspath.collect { File file ->
+        file.getName()
+      }.join(' ') + ' config/'
+    }
   }
   dependsOn tasks.named('updateManifest')
 }
@@ -255,7 +273,7 @@ TaskProvider<Copy> scripts = tasks.register('scripts', Copy) {
   into(layout.buildDirectory.dir('bin'))
   duplicatesStrategy = DuplicatesStrategy.FAIL
   filePermissions {
-    unix (0755)
+    unix(0755)
   }
 }
 
@@ -296,12 +314,18 @@ distributions {
         into 'plugin'
         include 'README'
       }
-      from('licenses')
-      from([configurations.runtimeClasspath, configurations.logBinding]) {
+      from 'licenses'
+      from([
+        configurations.runtimeClasspath,
+        configurations.logBinding
+      ]) {
         into 'lib'
         include '**/*.jar'
       }
-      from([jar, project(':spotbugs-ant').jar]) {
+      from([
+        jar,
+        project(':spotbugs-ant').jar
+      ]) {
         into 'lib'
       }
       from('log4j2.xml') {
@@ -322,7 +346,7 @@ tasks.named('distTar', Tar) {
 TaskProvider<Zip> distZip = tasks.named('distZip', Zip) {
   duplicatesStrategy = DuplicatesStrategy.FAIL
   filePermissions {
-    unix (0755)
+    unix(0755)
   }
 }
 tasks.named('jar') {
@@ -335,7 +359,7 @@ TaskProvider<Exec> distSrcZip = tasks.register('distSrcZip', Exec) {
   String out = "${resolvedBuildDir}/distributions/spotbugs-${project.version}-source.zip"
   outputs.file out
   commandLine 'git', 'archive', '-o', out,
-    '--prefix', "spotbugs-${project.version}/", 'HEAD'
+      '--prefix', "spotbugs-${project.version}/", 'HEAD'
 
   onlyIf {
     file("${rootDir}/.git").isDirectory()
@@ -370,27 +394,27 @@ smokeTest.configure {
     TaskProvider<JavaCompile> compileJava = tasks.named('compileJava', JavaCompile)
 
     ant.taskdef(
-      name: 'spotbugs',
-      classname: 'edu.umd.cs.findbugs.anttask.FindBugsTask',
-      classpath: jarTask.get().outputs.files.asPath
-    )
+        name: 'spotbugs',
+        classname: 'edu.umd.cs.findbugs.anttask.FindBugsTask',
+        classpath: jarTask.get().outputs.files.asPath
+        )
 
     ant.spotbugs(
-      home: "${resolvedBuildDir}/smoketest/",
-      output: 'xml:withMessages',
-      jvmargs: '-ea -Xmx1200m',
-      excludeFilter: 'findbugsExclude.xml',
-      projectName: 'spotbugs',
-      maxRank: '20',
-      timeout: '1800000',
-      outputFile: "${resolvedBuildDir}/smoketest/findbugscheckAll.xml"
-    ) {
-      sourcePath(path: 'src/main/java:src/gui/main:src/tools')
-      'class'(location: compileJava.get().destinationDirectory.get().asFile)
-      configurations.compileClasspath.each { File file ->
-        auxClasspath(path: file.path)
-      }
-    }
+        home: "${resolvedBuildDir}/smoketest/",
+        output: 'xml:withMessages',
+        jvmargs: '-ea -Xmx1200m',
+        excludeFilter: 'findbugsExclude.xml',
+        projectName: 'spotbugs',
+        maxRank: '20',
+        timeout: '1800000',
+        outputFile: "${resolvedBuildDir}/smoketest/findbugscheckAll.xml"
+        ) {
+          sourcePath(path: 'src/main/java:src/gui/main:src/tools')
+          'class'(location: compileJava.get().destinationDirectory.get().asFile)
+          configurations.compileClasspath.each { File file ->
+            auxClasspath(path: file.path)
+          }
+        }
   }
 }
 

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -1,5 +1,8 @@
+import com.github.spotbugs.snom.SpotBugsTask
+
 import java.nio.file.Files
 import java.nio.file.Path
+
 import org.gradle.plugins.ide.eclipse.model.Classpath
 import org.gradle.plugins.ide.eclipse.model.ClasspathEntry
 
@@ -113,7 +116,7 @@ dependencies {
   guiCompileOnly 'jakarta.annotation:jakarta.annotation-api:3.0.0'
 }
 
-clean {
+tasks.named('clean', Delete).configure {
   delete '.libs', 'META-INF/MANIFEST.MF'
 }
 
@@ -200,7 +203,7 @@ TaskProvider<Task> updateManifest = tasks.register('updateManifest') {
   }
   inputs.file manifestTemplate
   outputs.file manifestOutput
-  dependsOn configurations.runtimeClasspath, copyLibsForEclipse
+  dependsOn copyLibsForEclipse
   doLast {
     Manifest manifestSpec = java.manifest {
       from manifestTemplate
@@ -212,7 +215,9 @@ TaskProvider<Task> updateManifest = tasks.register('updateManifest') {
     manifestSpec.writeTo(manifestOutput)
   }
 }
-tasks.eclipse.dependsOn(updateManifest)
+tasks.named('eclipse').configure {
+  dependsOn updateManifest
+}
 
 // Manually define what goes into the default jar, since it's not only main sourceset
 TaskProvider<Jar> jar = tasks.named('jar', Jar) {
@@ -235,7 +240,7 @@ TaskProvider<Jar> jar = tasks.named('jar', Jar) {
 }
 tasks.spotbugsMain.dependsOn(jar)
 tasks.spotbugsGui.dependsOn(jar)
-tasks.withType(com.github.spotbugs.snom.SpotBugsTask).configureEach {
+tasks.withType(SpotBugsTask).configureEach {
   reports {
     html {
       // we use local spotbugs.jar, we cannot reference stylesheet from the published jar
@@ -251,7 +256,9 @@ TaskProvider<Copy> scripts = tasks.register('scripts', Copy) {
   inputs.file "${projectDir}/etc/script.properties"
 
   doFirst {
-    props.load(Files.newInputStream(Path.of("${projectDir}/etc/script.properties")))
+    Files.newInputStream(projectDir.toPath().resolve('etc').resolve('script.properties')).withCloseable { InputStream input ->
+      props.load(input)
+    }
 
     filesNotMatching('**/*.ico') {
       filter(org.apache.tools.ant.filters.ReplaceTokens, tokens: [
@@ -351,14 +358,11 @@ TaskProvider<Zip> distZip = tasks.named('distZip', Zip) {
     unix(0755)
   }
 }
-tasks.named('jar') {
-  dependsOn tasks.named('updateManifest')
-}
 
 File resolvedBuildDir = project.layout.buildDirectory.asFile.get()
 
 TaskProvider<Exec> distSrcZip = tasks.register('distSrcZip', Exec) {
-  String out = "${resolvedBuildDir}/distributions/spotbugs-${project.version}-source.zip"
+  File out = resolvedBuildDir.toPath().resolve('distributions').resolve("spotbugs-${project.version}-source.zip").toFile()
   outputs.file out
   commandLine 'git', 'archive', '-o', out,
       '--prefix', "spotbugs-${project.version}/", 'HEAD'

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -122,7 +122,9 @@ project(':spotbugs-annotations') {
   tasks.named('spotbugsMain') {
     dependsOn(jarTask)
 
-    inputs.file(jarTask.flatMap { Jar jar -> jar.archiveFile })
+    inputs.file(jarTask.flatMap { Jar jar ->
+      jar.archiveFile
+    })
     .withPathSensitivity(PathSensitivity.RELATIVE)
     .withPropertyName('spotbugsJarInput')
   }
@@ -375,7 +377,9 @@ tasks.named('assemble') {
 String version = project.version
 TaskProvider<Copy> unzipDist = tasks.register('unzipDist', Copy) {
   dependsOn distZip
-  from distZip.map { Zip zipTask -> zipTree(zipTask.outputs.files.singleFile) }
+  from distZip.map { Zip zipTask ->
+    zipTree(zipTask.outputs.files.singleFile)
+  }
   into file("${resolvedBuildDir}/smoketest/")
   // Remove prefix
   eachFile { FileCopyDetails details ->

--- a/spotbugsTestCases/build.gradle
+++ b/spotbugsTestCases/build.gradle
@@ -57,7 +57,7 @@ tasks.register('exportClasspath') {
   ConfigurationContainer configurations = project.configurations
   doLast {
     dependenciesFile.delete()
-    dependenciesFile.getParentFile().mkdirs();
+    dependenciesFile.getParentFile().mkdirs()
 
     configurations.getByName('runtimeClasspath').resolvedConfiguration.resolvedArtifacts.each { ResolvedArtifact artifact ->
       dependenciesFile << artifact.file

--- a/spotbugsTestCases/build.gradle
+++ b/spotbugsTestCases/build.gradle
@@ -8,7 +8,11 @@ plugins {
 sourceSets {
   main {
     java {
-      srcDirs = ['src/java', 'src/fakeAnnotations', 'src/fakeLibraries']
+      srcDirs = [
+        'src/java',
+        'src/fakeAnnotations',
+        'src/fakeLibraries'
+      ]
     }
     groovy {
       srcDirs = ['src/groovy']
@@ -61,7 +65,7 @@ tasks.register('exportClasspath') {
     }
   }
   doLast {
-      logger.lifecycle("Exported classpath to: ${dependenciesFile}")
+    logger.lifecycle("Exported classpath to: ${dependenciesFile}")
   }
 }
 

--- a/test-harness-core/build.gradle
+++ b/test-harness-core/build.gradle
@@ -3,7 +3,7 @@ apply from: "${rootDir}/gradle/javadoc.gradle"
 apply from: "${rootDir}/gradle/maven.gradle"
 
 dependencies {
-  api (project(':spotbugs')) {
+  api(project(':spotbugs')) {
     transitive = true
   }
   compileOnly 'jakarta.annotation:jakarta.annotation-api:3.0.0'


### PR DESCRIPTION
No change log as build only change.  gradle files now will be formatted by spotless and are formatted here.  underlying scripts with file leaks, duplication, incorrect no-op usage have been resolved.

** Note **
For many months, maybe last year, I had been having issues running spotless in general from my machine.  Java 25, windows 11, whatever gradle we are on at the given moment.  This likely affected others but no one raised a concern likely thinking their environment issue.  That has been fixed as well here and was due to a compliance mismatch in the eclipse formatter config file.

To review this PR, make sure to ignore whitespace.