### PR TITLE
Fix resource tracking after PrintWriter.append

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ## Unreleased - 2026-??-??
 ### Fixed
+- Fix `OS_OPEN_STREAM` false positive when the result of `PrintWriter.append()` is reassigned before closing the writer ([#4274](https://github.com/spotbugs/spotbugs/issues/4274))
 - Fix `UR_UNINIT_READ` false negative for compound assignment to a field (e.g. `m_iType |= e`) ([#4233](https://github.com/spotbugs/spotbugs/pull/4233))
 - Fix `NP_BOOLEAN_RETURN_NULL` false negative when `null` is returned via a local variable ([#4234](https://github.com/spotbugs/spotbugs/pull/4234))
 - Fix `MS_EXPOSE_BUF` and `EI_EXPOSE_BUF` false negative when returning `Buffer.array()` ([#4235](https://github.com/spotbugs/spotbugs/pull/4235))

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue4274Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue4274Test.java
@@ -1,0 +1,26 @@
+package edu.umd.cs.findbugs.detect;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+
+class Issue4274Test extends AbstractIntegrationTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = { "appendCharSequence", "appendChar", "appendSubsequence", "appendChain", "closeAlias" })
+    void appendPreservesClosedWriter(String method) {
+        performAnalysis("ghIssues/Issue4274.class", "ghIssues/Issue4274$OtherWriter.class");
+
+        assertNoBugInMethod("OS_OPEN_STREAM", "Issue4274", method);
+        assertNoBugInMethod("OS_OPEN_STREAM_EXCEPTION_PATH", "Issue4274", method);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "missingClose", "closeOtherWriter", "appendReturnsOtherWriter", "upcastAppendReturnsOtherWriter" })
+    void stillReportsUnclosedWriter(String method) {
+        performAnalysis("ghIssues/Issue4274.class", "ghIssues/Issue4274$OtherWriter.class");
+
+        assertBugInMethod("OS_OPEN_STREAM", "Issue4274", method);
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/StreamFrameModelingVisitor.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/StreamFrameModelingVisitor.java
@@ -100,6 +100,27 @@ public class StreamFrameModelingVisitor extends ResourceValueFrameModelingVisito
     }
 
     @Override
+    public void modelNormalInstruction(Instruction ins, int numWordsConsumed, int numWordsProduced) {
+        // Subclasses may override append to return a different writer, even when
+        // the receiver's declared type is PrintWriter.
+        if ("java.io.PrintWriter".equals(stream.getResourceClass()) && ins.getOpcode() == Const.INVOKEVIRTUAL) {
+            InvokeInstruction inv = (InvokeInstruction) ins;
+            if ("java.io.PrintWriter".equals(inv.getClassName(cpg)) && "append".equals(inv.getMethodName(cpg))) {
+                String signature = inv.getSignature(cpg);
+                if ("(C)Ljava/io/PrintWriter;".equals(signature)
+                        || "(Ljava/lang/CharSequence;)Ljava/io/PrintWriter;".equals(signature)
+                        || "(Ljava/lang/CharSequence;II)Ljava/io/PrintWriter;".equals(signature)) {
+                    ResourceValueFrame frame = getFrame();
+                    ResourceValue receiver = frame.getValue(frame.getNumSlots() - numWordsConsumed);
+                    modelInstruction(ins, numWordsConsumed, numWordsProduced, receiver);
+                    return;
+                }
+            }
+        }
+        super.modelNormalInstruction(ins, numWordsConsumed, numWordsProduced);
+    }
+
+    @Override
     protected boolean instanceEscapes(InvokeInstruction inv, int instanceArgNum) {
         ConstantPoolGen cpg = getCPG();
         String className = inv.getClassName(cpg);

--- a/spotbugsTestCases/src/java/ghIssues/Issue4274.java
+++ b/spotbugsTestCases/src/java/ghIssues/Issue4274.java
@@ -1,0 +1,104 @@
+package ghIssues;
+
+import java.io.FileNotFoundException;
+import java.io.PrintWriter;
+
+public class Issue4274 {
+    public void appendCharSequence() throws FileNotFoundException {
+        PrintWriter writer = null;
+        try {
+            writer = new PrintWriter("file.txt");
+            writer = writer.append(null);
+        } finally {
+            if (writer != null) {
+                writer.close();
+            }
+        }
+    }
+
+    public void appendChar() throws FileNotFoundException {
+        PrintWriter writer = null;
+        try {
+            writer = new PrintWriter("file.txt");
+            writer = writer.append('a');
+        } finally {
+            if (writer != null) {
+                writer.close();
+            }
+        }
+    }
+
+    public void appendSubsequence() throws FileNotFoundException {
+        PrintWriter writer = null;
+        try {
+            writer = new PrintWriter("file.txt");
+            writer = writer.append("abc", 0, 2);
+        } finally {
+            if (writer != null) {
+                writer.close();
+            }
+        }
+    }
+
+    public void appendChain() throws FileNotFoundException {
+        PrintWriter writer = null;
+        try {
+            writer = new PrintWriter("file.txt");
+            writer = writer.append("abc").append('d').append("efg", 0, 2);
+        } finally {
+            if (writer != null) {
+                writer.close();
+            }
+        }
+    }
+
+    public void closeAlias() throws FileNotFoundException {
+        PrintWriter alias = null;
+        try {
+            PrintWriter writer = new PrintWriter("file.txt");
+            alias = writer;
+            alias = alias.append("abc");
+        } finally {
+            if (alias != null) {
+                alias.close();
+            }
+        }
+    }
+
+    public void missingClose() throws FileNotFoundException {
+        PrintWriter writer = new PrintWriter("file.txt");
+        writer = writer.append("abc");
+        writer.flush();
+    }
+
+    public void closeOtherWriter() throws FileNotFoundException {
+        PrintWriter writer = new PrintWriter("file.txt");
+        PrintWriter other = new PrintWriter("other.txt");
+        other = other.append("abc");
+        other.close();
+        writer.flush();
+    }
+
+    public void appendReturnsOtherWriter() throws FileNotFoundException {
+        OtherWriter writer = new OtherWriter();
+        PrintWriter other = writer.append("abc");
+        other.close();
+    }
+
+    public void upcastAppendReturnsOtherWriter() throws FileNotFoundException {
+        PrintWriter writer = new OtherWriter();
+        PrintWriter other = writer.append("abc");
+        other.close();
+    }
+
+    public static class OtherWriter extends PrintWriter {
+        public OtherWriter() throws FileNotFoundException {
+            super("file.txt");
+        }
+
+        @Override
+        public PrintWriter append(CharSequence sequence) {
+            return new PrintWriter(System.out);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #4274.

Assigning the result of `PrintWriter.append()` back to a local variable loses the writer's resource identity, so `FindOpenStream` reports a leak even when the writer is closed in `finally`.

Preserve the receiver's resource value for the three `PrintWriter.append` overloads. Limit this behavior to resources created as `PrintWriter`, since subclasses can override `append` to return a different writer, including when called through a `PrintWriter` variable. Other calls and resource-escape handling remain unchanged.

Add regression coverage for all three overloads, chaining, closing through an alias, missing closes, closing a different writer, and subclass overrides with both subclass and superclass variable types.

Validation on JDK 21:

- Before the fix: 5 closed-writer cases reproduce the false positive; 4 genuine-leak cases pass.
- After the fix: all 9 regression cases pass.
- Complete `:spotbugs-tests:test` suite: 1,149 passed, 11 skipped, no failures or errors.
- `./gradlew spotlessApply build smoketest --no-daemon --no-scan --max-workers=4`: `BUILD SUCCESSFUL`.
- `git diff --check` passes.

- [x] Added an entry into `CHANGELOG.md`.
