### PR TITLE
fix: make -conserveSpace equivalent to -effort:min (#4268)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Fix SARIF output writing source-location URI syntax exceptions to stderr when source filenames are unknown ([#1412](https://github.com/spotbugs/spotbugs/issues/1412))
 - Narrow the definition of singletons ([#2985](https://github.com/spotbugs/spotbugs/issues/2985))
 - Fix `NP_LOAD_OF_KNOWN_NULL_VALUE` false negative when null check uses `instanceof` ([#3916](https://github.com/spotbugs/spotbugs/issues/3916))
+- Fix CLI launcher scripts intercepting `-conserveSpace` with a JVM system property instead passing it to Java Application as equivalent to `-effort:min` ([#4268](https://github.com/spotbugs/spotbugs/pull/4289)) 
 
 ## 4.10.4 - 2026-08-19
 ### Fixed

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/TextUICommandLineTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/TextUICommandLineTest.java
@@ -127,4 +127,39 @@ class TextUICommandLineTest {
         String xml = Files.readString(file, StandardCharsets.UTF_8);
         assertThat(xml, containsString("BugCollection"));
     }
+
+    /**
+     * Regression test for Issue 4268:
+     * {@code -conserveSpace} must set the same analysis effort settings as
+     * {@code -effort:min}.
+     */
+    @Test
+    void conserveSpaceSetsMinEffort() {
+        TextUICommandLine conserveSpace = new TextUICommandLine();
+        conserveSpace.handleOption("-conserveSpace", "");
+
+        TextUICommandLine effortMin = new TextUICommandLine();
+        effortMin.handleOption("-effort", "min");
+
+        assertThat("Both flags must resolve to the same MIN_EFFORT setting array",
+                conserveSpace.getSettingList(), is(effortMin.getSettingList()));
+    }
+
+    /**
+     * Regression test for Issue 4268:
+     * {@code -conserveSpace} starts from {@link FindBugs#MIN_EFFORT} and must
+     * not interfere with the default effort level.
+     */
+    @Test
+    void conserveSpaceDoesNotUseDefaultEffort() {
+        TextUICommandLine commandLine = new TextUICommandLine();
+
+        assertThat("Default settingList should be DEFAULT_EFFORT before any option",
+                commandLine.getSettingList(), is(FindBugs.DEFAULT_EFFORT));
+
+        commandLine.handleOption("-conserveSpace", "");
+
+        assertThat("After -conserveSpace, settingList must be MIN_EFFORT",
+                commandLine.getSettingList(), is(FindBugs.MIN_EFFORT));
+    }
 }

--- a/spotbugs/src/scripts/standard/fb
+++ b/spotbugs/src/scripts/standard/fb
@@ -22,7 +22,6 @@ fb_mainclass="edu.umd.cs.findbugs.workflow.FB"
 user_jvmargs=''
 ea_arg=''
 debug_arg=''
-conservespace_arg=''
 workhard_arg=''
 user_props=''
 
@@ -54,10 +53,6 @@ while [ $# -gt 0 ]; do
 
 	-debug)
 		debug_arg="-Dfindbugs.debug=true"
-		;;
-
-	-conserveSpace)
-		conservespace_arg="-Dfindbugs.conserveSpace=true"
 		;;
 
 	-property)
@@ -93,7 +88,7 @@ while [ $# -gt 0 ]; do
 	shift
 done
 
-fb_jvmargs="$user_jvmargs $debug_arg $conservespace_arg $workhard_arg $user_props $ea_arg"
+fb_jvmargs="$user_jvmargs $debug_arg $workhard_arg $user_props $ea_arg"
 if [ $maxheap ]; then
   fb_maxheap="-Xmx${maxheap}m"
 fi

--- a/spotbugs/src/scripts/standard/spotbugs
+++ b/spotbugs/src/scripts/standard/spotbugs
@@ -21,7 +21,6 @@ fb_mainclass="edu.umd.cs.findbugs.LaunchAppropriateUI"
 user_jvmargs=''
 ea_arg=''
 debug_arg=''
-conservespace_arg=''
 workhard_arg=''
 user_props=''
 
@@ -63,10 +62,6 @@ while [ $# -gt 0 ]; do
 		debug_arg="-Dfindbugs.debug=true"
 		;;
 
-	-conserveSpace)
-		conservespace_arg="-Dfindbugs.conserveSpace=true"
-		;;
-
 	-property)
 		shift
 		user_props="-D$1 $user_props"
@@ -100,7 +95,7 @@ while [ $# -gt 0 ]; do
 	shift
 done
 
-fb_jvmargs="$user_jvmargs $debug_arg $conservespace_arg $workhard_arg $user_props $ea_arg"
+fb_jvmargs="$user_jvmargs $debug_arg $workhard_arg $user_props $ea_arg"
 if [ $maxheap ]; then
   fb_maxheap="-Xmx${maxheap}m"
 fi

--- a/spotbugs/src/scripts/standard/spotbugs2
+++ b/spotbugs/src/scripts/standard/spotbugs2
@@ -18,7 +18,6 @@ fb_launchui="2"
 jvm_debug=""
 jvm_maxheap="-Xmx768m"
 jvm_ea=""
-jvm_conservespace=""
 jvm_user_props=""
 
 #
@@ -67,11 +66,6 @@ while [ $# -gt 0 ] && [ "$finishedArgs" = "false" ]; do
 			jvm_debug="-Dfindbugs.debug=true"
 			;;
 
-		-conserveSpace)
-			shift
-			jvm_conservespace="-Dfindbugs.conserveSpace=true"
-			;;
-
 		-property)
 			shift
 			jvm_user_props="-D$1 $jvm_user_props"
@@ -115,7 +109,7 @@ fi
 exec "$fb_javacmd" \
 	-classpath "$fb_appjar$fb_pathsep$CLASSPATH" \
 	-Dspotbugs.home="$spotbugs_home" \
-	$jvm_debug $jvm_maxheap $jvm_ea $jvm_conservespace $jvm_user_props \
+	$jvm_debug $jvm_maxheap $jvm_ea $jvm_user_props \
 	-Dfindbugs.launchUI=$fb_launchui \
 	-jar "$spotbugs_home/lib/spotbugs.jar" \
 	${@:+"$@"}

--- a/spotbugs/src/scripts/windows/spotbugs.bat
+++ b/spotbugs/src/scripts/windows/spotbugs.bat
@@ -15,7 +15,6 @@ set launcher=java.exe
 set start=start "SpotBugs"
 set jvmargs=
 set debugArg=
-set conserveSpaceArg=
 set workHardArg=
 set args=
 set javaProps=
@@ -186,9 +185,6 @@ if "%firstArg%"=="-jvmArgs" goto shift2
 
 if "%firstArg%"=="-maxHeap" set maxheap=%secondArg%
 if "%firstArg%"=="-maxHeap" goto shift2
-
-if "%firstArg%"=="-conserveSpace" set conserveSpaceArg=-Dfindbugs.conserveSpace=true
-if "%firstArg%"=="-conserveSpace" goto shift1
 
 if "%firstArg%"=="-workHard" set workHardArg=-Dfindbugs.workHard=true
 if "%firstArg%"=="-workHard" goto shift1


### PR DESCRIPTION
Fixes #4268

Previously, the launcher scripts (spotbugs, fb, spotbugs2, spotbugs.bat) intercepted `-conserveSpace` at the shell level and injected a JVM system property (`-Dfindbugs.conserveSpace=true`) while never forwarding the flag to the Java process. This caused FindBugsCommandLine to never apply `MIN_EFFORT` settings, resulting in different analysis results compared to `-effort:min`.

**Fix**: pass `-conserveSpace` through to the Java application so it reaches `FindBugsCommandLine.handleOption()`, which already correctly maps it to `FindBugs.MIN_EFFORT` which is identical to `-effort:min`. Remove the now-redundant JVM property injection and associated dead variables (conservespace_arg / jvm_conservespace / conserveSpaceArg).

**Test**
`./gradlew :spotbugs-tests:test --tests "edu.umd.cs.findbugs.TextUICommandLineTest.conserveSpaceSetsMinEffort"`

`./gradlew :spotbugs-tests:test --tests "edu.umd.cs.findbugs.TextUICommandLineTest.conserveSpaceDoesNotUseDefaultEffort"`