### PR TITLE
chore(build): Correct binary compatible checks and raise eclipse build to 4.33.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ import org.gradle.api.NamedDomainObjectSet
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.ResolvedArtifact
 import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Provider
 import org.gradle.api.publish.PublishingExtension
@@ -78,70 +79,58 @@ subprojects {
       group = 'verification'
       description = 'Enforces that production dependency binaries are fully compatible with Java 11 (Major version <= 55)'
 
-      Provider<NamedDomainObjectSet> runtimeConfigs = provider {
-        configurations.matching {
-          it.name.endsWith('RuntimeClasspath') && it.canBeResolved
-        }
-      }
+      Provider<Configuration> runtimeClasspath = configurations.named('runtimeClasspath')
 
-      inputs.files(runtimeConfigs)
+      inputs.files(runtimeClasspath)
 
       doLast {
         int maxAllowedMajorVersion = 55 // Java 11
         Map<String, List<String>> illegalDependencies = [:]
 
-        NamedDomainObjectSet<Configuration> configsToScan = runtimeConfigs.get()
+        Configuration config = runtimeClasspath.get()
 
-        configsToScan.each { config ->
-          config.resolvedConfiguration.resolvedArtifacts.each { artifact ->
-            File file = artifact.file
-            String artifactId = artifact.moduleVersion.id.toString()
+        config.resolvedConfiguration.resolvedArtifacts.each { ResolvedArtifact artifact ->
+          File file = artifact.file
 
-            // SKIPS TEST-ONLY UTILITIES AND TEST FRAMEWORKS
-            if (artifactId.contains("org.junit")) {
-              return
-            }
+          if (file.name.endsWith('.jar') && file.exists()) {
+            file.withInputStream { inputStream ->
+              BufferedInputStream bufferedStream = new BufferedInputStream(inputStream)
+              ZipInputStream zip = new ZipInputStream(bufferedStream)
+              ZipEntry entry = zip.nextEntry
 
-            if (file.name.endsWith('.jar') && file.exists()) {
-              file.withInputStream { inputStream ->
-                BufferedInputStream bufferedStream = new BufferedInputStream(inputStream)
-                ZipInputStream zip = new ZipInputStream(bufferedStream)
-                ZipEntry entry = zip.nextEntry
+              while (entry != null) {
+                if (entry.name.endsWith('.class')) {
 
-                while (entry != null) {
-                  if (entry.name.endsWith('.class')) {
+                  // Skip module-info and Multi-Release multi-version class folders
+                  if (entry.name.endsWith('module-info.class') || entry.name.startsWith('META-INF/versions/')) {
+                    entry = zip.nextEntry
+                    continue
+                  }
 
-                    // Skip module-info and Multi-Release multi-version class folders
-                    if (entry.name.endsWith('module-info.class') || entry.name.startsWith('META-INF/versions/')) {
-                      entry = zip.nextEntry
-                      continue
-                    }
+                  int byte1 = zip.read()
+                  int byte2 = zip.read()
+                  int byte3 = zip.read()
+                  int byte4 = zip.read()
 
-                    int byte1 = zip.read()
-                    int byte2 = zip.read()
-                    int byte3 = zip.read()
-                    int byte4 = zip.read()
+                  long magic = ((long) (byte1 << 24 | byte2 << 16 | byte3 << 8 | byte4)) & 0xFFFFFFFFL
 
-                    long magic = ((long) (byte1 << 24 | byte2 << 16 | byte3 << 8 | byte4)) & 0xFFFFFFFFL
+                  if (magic == 0xCAFEBABE) {
+                    int minor = (zip.read() << 8) | zip.read()
+                    int major = (zip.read() << 8) | zip.read()
 
-                    if (magic == 0xCAFEBABE) {
-                      int minor = (zip.read() << 8) | zip.read()
-                      int major = (zip.read() << 8) | zip.read()
+                    if (major> maxAllowedMajorVersion) {
+                      String id = "${artifact.moduleVersion.id} (${file.name})"
+                      String details = "      - ${entry.name} (Compiled for Java ${major - 44} / Major: ${major})"
 
-                      if (major> maxAllowedMajorVersion) {
-                        String id = "${artifact.moduleVersion.id} (${file.name})"
-                        String details = "      - ${entry.name} (Compiled for Java ${major - 44} / Major: ${major})"
-
-                        if (!illegalDependencies.containsKey(id)) {
-                          illegalDependencies[id] = []
-                        }
-                        illegalDependencies[id] << details
-                        break
+                      if (!illegalDependencies.containsKey(id)) {
+                        illegalDependencies[id] = []
                       }
+                      illegalDependencies[id] << details
+                      break
                     }
                   }
-                  entry = zip.nextEntry
                 }
+                entry = zip.nextEntry
               }
             }
           }

--- a/buildSrc/src/main/kotlin/eclipse-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/eclipse-convention.gradle.kts
@@ -8,7 +8,7 @@ val pdeTool = configurations.create("pdeTool") {
 
 eclipseMavenCentral {
   silenceEquoIDE()
-  release("4.24.0") {
+  release("4.33.0") {
     compileOnly("org.eclipse.ant.core")
     compileOnly("org.eclipse.core.resources")
     compileOnly("org.eclipse.core.runtime")


### PR DESCRIPTION
The project currently requires Java 17 or later to build, while the Eclipse version used by the plugin was still based on Java 11 and is considerably outdated.

Moving the Eclipse baseline to 4.33.0 exposed that our binary compatibility check was overly broad. It was scanning test-related runtime configurations, which included Eclipse binaries that are not part of the production runtime. The check already excluded our test modules and attempted to filter out JUnit dependencies, but it was still scanning dependencies that were not relevant to the production runtime.

The binary compatibility check has been rewritten to explicitly scan only the production `runtimeClasspath`. The updated logic was then validated by upgrading to the latest Saxon version, which requires Java 17, confirming that the check continues to correctly detect actual production dependencies while ignoring test-only dependencies.

Before opening a 'pull request'

* Search existing issues and pull requests to see if the issue was already discussed.
* Check our discussions to see if the issue was already discussed.
* Check for specific project we support to raise the issue on, under [spotbugs](https://github.com/spotbugs)
* Do not open intellij plugin issues here, open them at [intellij-plugin](https://github.com/JetBrains/spotbugs-intellij-plugin)

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [ ] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
