### PR TITLE
chore(build): Update build eclipse copy to 4.33

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -56,6 +56,7 @@ jobs:
           Expand-Archive "eclipse-sdk/eclipse.zip" -DestinationPath "." -Force
           $escapedPwd = $pwd.Path -replace '\\', '\\'
           [System.IO.File]::WriteAllLines("$pwd\\eclipsePlugin\\local.properties", "eclipseRoot.dir=$escapedPwd\\eclipse")
+          $ini = ".\eclipse\eclipse.ini"
           $lines = Get-Content $ini
           $lines | Where-Object { $_ -ne "-Djava.security.manager=allow" } |
             Set-Content $ini

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -57,9 +57,8 @@ jobs:
           $escapedPwd = $pwd.Path -replace '\\', '\\'
           [System.IO.File]::WriteAllLines("$pwd\\eclipsePlugin\\local.properties", "eclipseRoot.dir=$escapedPwd\\eclipse")
           $ini = ".\eclipse\eclipse.ini"
-          $lines = Get-Content $ini
-          $lines | Where-Object { $_ -ne "-Djava.security.manager=allow" } |
-            Set-Content $ini
+          $lines = [System.IO.File]::ReadAllLines($ini)
+          [System.IO.File]::WriteAllLines($ini, ($lines | Where-Object { $_ -ne "-Djava.security.manager=allow" }))
         shell: powershell
       - name: Download Eclipse on Mac
         if: matrix.os == 'macos-latest'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,6 +47,8 @@ jobs:
           curl --continue-at - --create-dirs --location 'https://archive.eclipse.org/eclipse/downloads/drops4/R-${{ env.eclipse-version }}-${{ env.eclipse-date }}/eclipse-SDK-${{ env.eclipse-version }}-linux-gtk-x86_64.tar.gz' --output eclipse-sdk/eclipse.tar.gz
           tar xzf eclipse-sdk/eclipse.tar.gz eclipse
           echo "eclipseRoot.dir=$(pwd)/eclipse" | tee eclipsePlugin/local.properties
+          grep -q '^-Djava\.security\.manager=allow$' ./eclipse/eclipse.ini
+          sed -i '/^-Djava\.security\.manager=allow$/d' ./eclipse/eclipse.ini
       - name: Download Eclipse on Windows
         if: matrix.os == 'windows-latest'
         run: |
@@ -55,6 +57,13 @@ jobs:
           Expand-Archive "eclipse-sdk/eclipse.zip" -DestinationPath "." -Force
           $escapedPwd = $pwd.Path -replace '\\', '\\'
           [System.IO.File]::WriteAllLines("$pwd\\eclipsePlugin\\local.properties", "eclipseRoot.dir=$escapedPwd\\eclipse")
+          $ini = ".\eclipse\eclipse.ini"
+          $lines = Get-Content $ini
+          if (-not ($lines -contains "-Djava.security.manager=allow")) {
+            throw "Expected Java Security Manager option was not found in $ini"
+          }
+          $lines | Where-Object { $_ -ne "-Djava.security.manager=allow" } |
+            Set-Content $ini
         shell: powershell
       - name: Download Eclipse on Mac
         if: matrix.os == 'macos-latest'
@@ -65,6 +74,8 @@ jobs:
           cp -r /Volumes/Eclipse/Eclipse.app /Applications/
           hdiutil detach /Volumes/Eclipse
           echo "eclipseRoot.dir=/Applications/Eclipse.app" | tee eclipsePlugin/local.properties
+          grep -q '^-Djava\.security\.manager=allow$' /Applications/Eclipse.app/Contents/Eclipse/eclipse.ini
+          sed -i '' '/^-Djava\.security\.manager=allow$/d' /Applications/Eclipse.app/Contents/Eclipse/eclipse.ini
       # Disable gpg decryption of certificate for time being until we get new keys established
       #- name: Pre-build setup
       #  if: github.repository_owner == 'spotbugs'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,8 +9,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  eclipse-version: 4.24
-  eclipse-date: 202206070700
+  eclipse-version: 4.33
+  eclipse-date: 202409030240
 
 jobs:
   build:
@@ -44,14 +44,14 @@ jobs:
       - name: Download Eclipse on Ubuntu
         if: matrix.os == 'ubuntu-latest'
         run: |
-          curl --continue-at - --create-dirs --location 'https://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops4/R-${{ env.eclipse-version }}-${{ env.eclipse-date }}/eclipse-SDK-${{ env.eclipse-version }}-linux-gtk-x86_64.tar.gz&mirror_id=1' --output eclipse-sdk/eclipse.tar.gz
+          curl --continue-at - --create-dirs --location 'https://archive.eclipse.org/eclipse/downloads/drops4/R-${{ env.eclipse-version }}-${{ env.eclipse-date }}/eclipse-SDK-${{ env.eclipse-version }}-linux-gtk-x86_64.tar.gz' --output eclipse-sdk/eclipse.tar.gz
           tar xzf eclipse-sdk/eclipse.tar.gz eclipse
           echo "eclipseRoot.dir=$(pwd)/eclipse" | tee eclipsePlugin/local.properties
       - name: Download Eclipse on Windows
         if: matrix.os == 'windows-latest'
         run: |
           Remove-item alias:curl
-          curl --continue-at - --create-dirs --location 'https://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops4/R-${{ env.eclipse-version }}-${{ env.eclipse-date }}/eclipse-SDK-${{ env.eclipse-version }}-win32-x86_64.zip&mirror_id=1' -o eclipse-sdk/eclipse.zip
+          curl --continue-at - --create-dirs --location 'https://archive.eclipse.org/eclipse/downloads/drops4/R-${{ env.eclipse-version }}-${{ env.eclipse-date }}/eclipse-SDK-${{ env.eclipse-version }}-win32-x86_64.zip' -o eclipse-sdk/eclipse.zip
           Expand-Archive "eclipse-sdk/eclipse.zip" -DestinationPath "." -Force
           $escapedPwd = $pwd.Path -replace '\\', '\\'
           [System.IO.File]::WriteAllLines("$pwd\\eclipsePlugin\\local.properties", "eclipseRoot.dir=$escapedPwd\\eclipse")
@@ -59,7 +59,7 @@ jobs:
       - name: Download Eclipse on Mac
         if: matrix.os == 'macos-latest'
         run: |
-          curl --continue-at - --create-dirs --location 'https://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops4/R-${{ env.eclipse-version }}-${{ env.eclipse-date }}/eclipse-SDK-${{ env.eclipse-version }}-macosx-cocoa-aarch64.dmg&mirror_id=1' --output eclipse-sdk/eclipse.dmg
+          curl --continue-at - --create-dirs --location 'https://archive.eclipse.org/eclipse/downloads/drops4/R-${{ env.eclipse-version }}-${{ env.eclipse-date }}/eclipse-SDK-${{ env.eclipse-version }}-macosx-cocoa-aarch64.dmg' --output eclipse-sdk/eclipse.dmg
           hdiutil attach eclipse-sdk/eclipse.dmg
           # Mac uses BSD cp which doesn't have --recursive therefore -R is required
           cp -r /Volumes/Eclipse/Eclipse.app /Applications/

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,7 +47,6 @@ jobs:
           curl --continue-at - --create-dirs --location 'https://archive.eclipse.org/eclipse/downloads/drops4/R-${{ env.eclipse-version }}-${{ env.eclipse-date }}/eclipse-SDK-${{ env.eclipse-version }}-linux-gtk-x86_64.tar.gz' --output eclipse-sdk/eclipse.tar.gz
           tar xzf eclipse-sdk/eclipse.tar.gz eclipse
           echo "eclipseRoot.dir=$(pwd)/eclipse" | tee eclipsePlugin/local.properties
-          grep -q '^-Djava\.security\.manager=allow$' ./eclipse/eclipse.ini
           sed -i '/^-Djava\.security\.manager=allow$/d' ./eclipse/eclipse.ini
       - name: Download Eclipse on Windows
         if: matrix.os == 'windows-latest'
@@ -57,11 +56,7 @@ jobs:
           Expand-Archive "eclipse-sdk/eclipse.zip" -DestinationPath "." -Force
           $escapedPwd = $pwd.Path -replace '\\', '\\'
           [System.IO.File]::WriteAllLines("$pwd\\eclipsePlugin\\local.properties", "eclipseRoot.dir=$escapedPwd\\eclipse")
-          $ini = ".\eclipse\eclipse.ini"
           $lines = Get-Content $ini
-          if (-not ($lines -contains "-Djava.security.manager=allow")) {
-            throw "Expected Java Security Manager option was not found in $ini"
-          }
           $lines | Where-Object { $_ -ne "-Djava.security.manager=allow" } |
             Set-Content $ini
         shell: powershell
@@ -74,7 +69,6 @@ jobs:
           cp -r /Volumes/Eclipse/Eclipse.app /Applications/
           hdiutil detach /Volumes/Eclipse
           echo "eclipseRoot.dir=/Applications/Eclipse.app" | tee eclipsePlugin/local.properties
-          grep -q '^-Djava\.security\.manager=allow$' /Applications/Eclipse.app/Contents/Eclipse/eclipse.ini
           sed -i '' '/^-Djava\.security\.manager=allow$/d' /Applications/Eclipse.app/Contents/Eclipse/eclipse.ini
       # Disable gpg decryption of certificate for time being until we get new keys established
       #- name: Pre-build setup

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,8 +13,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  eclipse-version: 4.24
-  eclipse-date: 202206070700
+  eclipse-version: 4.33
+  eclipse-date: 202409030240
 
 jobs:
   build:
@@ -65,7 +65,7 @@ jobs:
       - uses: gradle/actions/wrapper-validation@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6
       - name: Download Eclipse
         run: |
-          curl --continue-at - --create-dirs --location 'https://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops4/R-${{ env.eclipse-version }}-${{ env.eclipse-date }}/eclipse-SDK-${{ env.eclipse-version }}-linux-gtk-x86_64.tar.gz&mirror_id=1' --output eclipse-sdk/eclipse.tar.gz
+          curl --continue-at - --create-dirs --location 'https://archive.eclipse.org/eclipse/downloads/drops4/R-${{ env.eclipse-version }}-${{ env.eclipse-date }}/eclipse-SDK-${{ env.eclipse-version }}-linux-gtk-x86_64.tar.gz' --output eclipse-sdk/eclipse.tar.gz
           tar xzf eclipse-sdk/eclipse.tar.gz eclipse
           echo "eclipseRoot.dir=$(pwd)/eclipse" | tee eclipsePlugin/local.properties
       - name: Build on tag


### PR DESCRIPTION
prior #4290 confirmed decoupling and running compilation allowed old eclipse usage.  this PR increases the version.  The download urls have additionally been updated to the direct archives.  Additionally, at some point eclipse ini files contained security manager which breaks jdk 24 and above so that has been removed with intent.