### PR TITLE
make Issue4274Test efficient

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue4274Test.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/Issue4274Test.java
@@ -1,26 +1,19 @@
 package edu.umd.cs.findbugs.detect;
 
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.api.Test;
 
 import edu.umd.cs.findbugs.AbstractIntegrationTest;
 
 class Issue4274Test extends AbstractIntegrationTest {
-
-    @ParameterizedTest
-    @ValueSource(strings = { "appendCharSequence", "appendChar", "appendSubsequence", "appendChain", "closeAlias" })
-    void appendPreservesClosedWriter(String method) {
+    @Test
+    void test() {
         performAnalysis("ghIssues/Issue4274.class", "ghIssues/Issue4274$OtherWriter.class");
 
-        assertNoBugInMethod("OS_OPEN_STREAM", "Issue4274", method);
-        assertNoBugInMethod("OS_OPEN_STREAM_EXCEPTION_PATH", "Issue4274", method);
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = { "missingClose", "closeOtherWriter", "appendReturnsOtherWriter", "upcastAppendReturnsOtherWriter" })
-    void stillReportsUnclosedWriter(String method) {
-        performAnalysis("ghIssues/Issue4274.class", "ghIssues/Issue4274$OtherWriter.class");
-
-        assertBugInMethod("OS_OPEN_STREAM", "Issue4274", method);
+        assertBugInMethod("OS_OPEN_STREAM", "Issue4274", "missingClose");
+        assertBugInMethod("OS_OPEN_STREAM", "Issue4274", "closeOtherWriter");
+        assertBugInMethod("OS_OPEN_STREAM", "Issue4274", "appendReturnsOtherWriter");
+        assertBugInMethod("OS_OPEN_STREAM", "Issue4274", "upcastAppendReturnsOtherWriter");
+        assertBugTypeCount("OS_OPEN_STREAM", 4);
+        assertNoBugType("OS_OPEN_STREAM_EXCEPTION_PATH");
     }
 }


### PR DESCRIPTION
Making Issue4274Test introduced in https://github.com/spotbugs/spotbugs/pull/4288 more efficient. In the original solution the same class files are analyzed several times unnecessarily. One analysis with multiple asserts is more efficient.
Since only changed tests, I did not add a changelog entry.