### PR TITLE
Fix SARIF handling of unknown source paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Fix `MS_EXPOSE_BUF` and `EI_EXPOSE_BUF` false negative when returning `Buffer.array()` ([#4235](https://github.com/spotbugs/spotbugs/pull/4235))
 - Fix `OBL_UNSATISFIED_OBLIGATION` false negatives for unclosed `CallableStatement`s returned by `Connection.prepareCall` ([#4148](https://github.com/spotbugs/spotbugs/issues/4148))
 - Fix `LI_LAZY_INIT_STATIC` false negative when field is lazily initialized using a method call ([#4276](https://github.com/spotbugs/spotbugs/issues/4276))
+- Fix SARIF output writing source-location URI syntax exceptions to stderr when source filenames are unknown ([#1412](https://github.com/spotbugs/spotbugs/issues/1412))
 
 ## 4.10.4 - 2026-08-19
 ### Fixed

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/sarif/SarifBugReporterTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/sarif/SarifBugReporterTest.java
@@ -1,6 +1,7 @@
 package edu.umd.cs.findbugs.sarif;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.Matchers.not;
@@ -8,11 +9,14 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
@@ -37,6 +41,7 @@ import edu.umd.cs.findbugs.Plugin;
 import edu.umd.cs.findbugs.PluginLoader;
 import edu.umd.cs.findbugs.Priorities;
 import edu.umd.cs.findbugs.Project;
+import edu.umd.cs.findbugs.SourceLineAnnotation;
 import edu.umd.cs.findbugs.Version;
 import edu.umd.cs.findbugs.ba.AnalysisContext;
 import edu.umd.cs.findbugs.ba.SourceFinder;
@@ -459,6 +464,64 @@ class SarifBugReporterTest {
         assertThat(invocation.get("exitCode").getAsInt(), is(1));
         assertThat(invocation.get("exitCodeDescription").getAsString(), is("BUGS FOUND"));
         assertThat(invocation.get("executionSuccessful").getAsBoolean(), is(true));
+    }
+
+    @Test
+    void testUnknownSourceFileDoesNotWriteStackTraceToStderr() {
+        BugPattern bugPattern = new BugPattern("TYPE", "abbrev", "category", false, "shortDescription",
+                "longDescription", "detailText", "https://example.com/help.html", 0);
+        DetectorFactoryCollection.instance().registerBugPattern(bugPattern);
+
+        ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+        PrintStream originalErr = System.err;
+        try {
+            System.setErr(new PrintStream(stderr, true, StandardCharsets.UTF_8));
+            reporter.reportBug(new BugInstance(bugPattern.getType(), 0)
+                    .addClass("org.hsqldb.lib.SampleClass")
+                    .addSourceLine(new SourceLineAnnotation("org.hsqldb.lib.SampleClass",
+                            SourceLineAnnotation.UNKNOWN_SOURCE_FILE, 1, 1, 0, 0)));
+            reporter.finish();
+        } finally {
+            System.setErr(originalErr);
+        }
+
+        String stderrOutput = stderr.toString(StandardCharsets.UTF_8);
+        assertThat(stderrOutput, not(containsString("URISyntaxException")));
+        assertThat(stderrOutput, not(containsString("Location$ArtifactLocation")));
+
+        String json = writer.toString();
+        JsonObject jsonObject = new Gson().fromJson(json, JsonObject.class);
+        JsonObject result = jsonObject.getAsJsonArray("runs").get(0).getAsJsonObject()
+                .getAsJsonArray("results").get(0).getAsJsonObject();
+        JsonObject location = result.getAsJsonArray("locations").get(0).getAsJsonObject();
+
+        assertFalse(location.has("physicalLocation"));
+        assertThat(location.getAsJsonArray("logicalLocations").get(0).getAsJsonObject()
+                .get("fullyQualifiedName").getAsString(), is("org.hsqldb.lib.SampleClass"));
+    }
+
+    @Test
+    void testKnownSourceFileWithoutSourceBaseUsesFullFormattedPathWithoutLineSuffix() {
+        BugPattern bugPattern = new BugPattern("TYPE", "abbrev", "category", false, "shortDescription",
+                "longDescription", "detailText", "https://example.com/help.html", 0);
+        DetectorFactoryCollection.instance().registerBugPattern(bugPattern);
+
+        reporter.reportBug(new BugInstance(bugPattern.getType(), 0)
+                .addClass("org.hsqldb.lib.SampleClass", "SampleClass.java")
+                .addSourceLine(new SourceLineAnnotation("org.hsqldb.lib.SampleClass",
+                        "SampleClass.java", 1, 1, 0, 0)));
+        reporter.finish();
+
+        String json = writer.toString();
+        JsonObject jsonObject = new Gson().fromJson(json, JsonObject.class);
+        JsonObject artifactLocation = jsonObject.getAsJsonArray("runs").get(0).getAsJsonObject()
+                .getAsJsonArray("results").get(0).getAsJsonObject()
+                .getAsJsonArray("locations").get(0).getAsJsonObject()
+                .getAsJsonObject("physicalLocation")
+                .getAsJsonObject("artifactLocation");
+
+        assertThat(artifactLocation.get("uri").getAsString(), is("org/hsqldb/lib/SampleClass.java"));
+        assertFalse(artifactLocation.has("uriBaseId"));
     }
 
     Optional<String> takeFirstKey(JsonObject object) {

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Location.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/sarif/Location.java
@@ -152,14 +152,23 @@ class Location {
                 return location;
             }
 
-            try {
-                String path = bugAnnotation.format("full", classAnnotation);
-                String pathWithoutLine = path.contains(":") ? path.split(":")[0] : path;
-                return Optional.of(new ArtifactLocation(new URI(pathWithoutLine), null));
-            } catch (URISyntaxException e) {
-                e.printStackTrace();
+            if (!bugAnnotation.isSourceFileKnown()) {
                 return Optional.empty();
             }
+
+            try {
+                String path = bugAnnotation.format("full", classAnnotation);
+                String pathWithoutLine = removeLineSuffix(path);
+                return Optional.of(new ArtifactLocation(new URI(pathWithoutLine), null));
+            } catch (URISyntaxException ignored) {
+                // Omit invalid physical locations; logical locations remain available.
+                return Optional.empty();
+            }
+        }
+
+        private static String removeLineSuffix(String path) {
+            int lineSuffixIndex = path.indexOf(":[");
+            return lineSuffixIndex >= 0 ? path.substring(0, lineSuffixIndex) : path;
         }
 
         static Optional<ArtifactLocation> fromStackTraceElement(StackTraceElement element, SourceFinder sourceFinder, Map<URI, String> baseToId) {


### PR DESCRIPTION
## Summary

- skip invalid SARIF physical locations when a source filename is unknown
- avoid writing `URISyntaxException` stack traces directly to stderr during SARIF generation
- preserve logical locations and add regression coverage for unknown and known source filenames
- add a changelog entry for the fix

## Testing

- `JAVA_HOME=/home/ubuntu/.local/jdks/jdk-17.0.20.1+1 PATH=/home/ubuntu/.local/jdks/jdk-17.0.20.1+1/bin:$PATH ./gradlew :spotbugs-tests:test --tests edu.umd.cs.findbugs.sarif.SarifBugReporterTest`
- `JAVA_HOME=/home/ubuntu/.local/jdks/jdk-17.0.20.1+1 PATH=/home/ubuntu/.local/jdks/jdk-17.0.20.1+1/bin:$PATH ./gradlew :spotbugs:spotlessJavaCheck :spotbugs-tests:spotlessJavaCheck`
- `git diff --check`

Notes: `./gradlew spotlessApply build smoketest` was attempted locally, but this aarch64 environment fails resolving the Eclipse SWT artifact for `:eclipsePlugin:compileJava`, unrelated to this SARIF change.

Fixes #1412
