### PR TITLE
chore(cleanup): Use public API not internals in eclipse plugin abstract test

### DIFF
--- a/eclipsePlugin-test/src/de/tobject/findbugs/test/AbstractPluginTest.java
+++ b/eclipsePlugin-test/src/de/tobject/findbugs/test/AbstractPluginTest.java
@@ -45,7 +45,7 @@ import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
-import org.eclipse.jdt.internal.junit.buildpath.BuildPathSupport;
+import org.eclipse.jdt.junit.JUnitCore;
 import org.eclipse.jdt.testplugin.JavaProjectHelper;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.swt.widgets.Display;
@@ -106,7 +106,7 @@ public abstract class AbstractPluginTest {
     }
 
     protected static void addJUnitToProjectClasspath() throws JavaModelException {
-        IClasspathEntry cpe = BuildPathSupport.getJUnit4ClasspathEntry();
+        IClasspathEntry cpe = JavaCore.newContainerEntry(JUnitCore.JUNIT4_CONTAINER_PATH);
         JavaProjectHelper.addToClasspath(getJavaProject(), cpe);
     }
 


### PR DESCRIPTION
we should avoid internals of libraries as not for public consumption, in this case fixing this was simple.

no change log as just test update.