### PR TITLE
core(cleanup): Use StringBuilder instead of StringBuffer

### DIFF
--- a/eclipsePlugin/src/de/tobject/findbugs/properties/DetectorConfigurationTab.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/properties/DetectorConfigurationTab.java
@@ -388,7 +388,7 @@ public class DetectorConfigurationTab extends Composite {
         if (factory == null) {
             return "";
         }
-        StringBuffer sb = new StringBuffer(factory.getFullName());
+        StringBuilder sb = new StringBuilder(factory.getFullName());
         sb.append("\n");
         sb.append(getDescriptionWithoutHtml(factory));
         sb.append("\n\nReported patterns:\n");
@@ -680,7 +680,7 @@ public class DetectorConfigurationTab extends Composite {
 
     @Nonnull
     private String createBugsAbbreviation(DetectorFactory factory) {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         Collection<BugPattern> patterns = factory.getReportedBugPatterns();
         LinkedHashSet<String> abbrs = new LinkedHashSet<>();
         for (Iterator<BugPattern> iter = patterns.iterator(); iter.hasNext();) {


### PR DESCRIPTION
did not add change log as only changing 2 internal methods of string buffer with string builder.