### PR TITLE
chore(migrate): migrate EclipsePlugin nullness annotations to JSpecify

### DIFF
--- a/eclipsePlugin/build.gradle
+++ b/eclipsePlugin/build.gradle
@@ -103,7 +103,7 @@ dependencies {
   api(project(':spotbugs')) {
     transitive = true
   }
-  compileOnly 'jakarta.annotation:jakarta.annotation-api:3.0.0'
+  compileOnly 'org.jspecify:jspecify:1.0.1'
 }
 
 tasks.named('clean', Delete).configure {

--- a/eclipsePlugin/src/de/tobject/findbugs/DetectorsExtensionHelper.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/DetectorsExtensionHelper.java
@@ -149,8 +149,7 @@ public class DetectorsExtensionHelper {
      * "bin" directory. It doesn't work if the plugin build.properties are not
      * existing or contain invalid content
      */
-    @Nullable
-    private static String resolvePluginClassesDir(String bundleName, File sourceDir) {
+    private static @Nullable String resolvePluginClassesDir(String bundleName, File sourceDir) {
         if (sourceDir.listFiles() == null) {
             FindbugsPlugin.getDefault().logException(new IllegalStateException("No files in the bundle!"),
                     "Failed to create temporary detector package for bundle " + sourceDir);
@@ -183,8 +182,7 @@ public class DetectorsExtensionHelper {
     /**
      * @return possible deployment root directory of a plugin project
      */
-    @NonNull
-    private static String getBuildDirectory(String bundleName, File sourceDir) {
+    private static @NonNull String getBuildDirectory(String bundleName, File sourceDir) {
         Properties props = new Properties();
         File buildProps = new File(sourceDir, "build.properties");
         if (buildProps.isFile()) {

--- a/eclipsePlugin/src/de/tobject/findbugs/DetectorsExtensionHelper.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/DetectorsExtensionHelper.java
@@ -108,8 +108,7 @@ public class DetectorsExtensionHelper {
      *            non null
      * @return resolved absolute path for the detector package
      */
-    @Nullable
-    private static String resolveRelativePath(IContributor contributor, String libPathAsString) {
+    private static @Nullable String resolveRelativePath(IContributor contributor, String libPathAsString) {
         String bundleName = contributor.getName();
         Bundle bundle = Platform.getBundle(bundleName);
         if (bundle == null) {

--- a/eclipsePlugin/src/de/tobject/findbugs/DetectorsExtensionHelper.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/DetectorsExtensionHelper.java
@@ -27,15 +27,14 @@ import java.util.Properties;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
-import javax.annotation.CheckForNull;
-import jakarta.annotation.Nonnull;
-
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IContributor;
 import org.eclipse.core.runtime.IExtensionRegistry;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.osgi.framework.Bundle;
 
 /**
@@ -109,7 +108,7 @@ public class DetectorsExtensionHelper {
      *            non null
      * @return resolved absolute path for the detector package
      */
-    @CheckForNull
+    @Nullable
     private static String resolveRelativePath(IContributor contributor, String libPathAsString) {
         String bundleName = contributor.getName();
         Bundle bundle = Platform.getBundle(bundleName);
@@ -151,7 +150,7 @@ public class DetectorsExtensionHelper {
      * "bin" directory. It doesn't work if the plugin build.properties are not
      * existing or contain invalid content
      */
-    @CheckForNull
+    @Nullable
     private static String resolvePluginClassesDir(String bundleName, File sourceDir) {
         if (sourceDir.listFiles() == null) {
             FindbugsPlugin.getDefault().logException(new IllegalStateException("No files in the bundle!"),
@@ -185,7 +184,7 @@ public class DetectorsExtensionHelper {
     /**
      * @return possible deployment root directory of a plugin project
      */
-    @Nonnull
+    @NonNull
     private static String getBuildDirectory(String bundleName, File sourceDir) {
         Properties props = new Properties();
         File buildProps = new File(sourceDir, "build.properties");

--- a/eclipsePlugin/src/de/tobject/findbugs/FindbugsPlugin.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/FindbugsPlugin.java
@@ -42,8 +42,6 @@ import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
-import javax.annotation.CheckForNull;
-
 import org.dom4j.DocumentException;
 import org.eclipse.core.internal.preferences.EclipsePreferences;
 import org.eclipse.core.resources.IFile;
@@ -77,6 +75,7 @@ import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.eclipse.ui.preferences.ScopedPreferenceStore;
+import org.jspecify.annotations.Nullable;
 import org.osgi.framework.BundleContext;
 
 import de.tobject.findbugs.builder.FindBugsBuilder;
@@ -622,7 +621,7 @@ public class FindbugsPlugin extends AbstractUIPlugin {
         project.setSessionProperty(SESSION_PROPERTY_BUG_COLLECTION_DIRTY, isDirty ? Boolean.TRUE : Boolean.FALSE);
     }
 
-    @CheckForNull
+    @Nullable
     public static SortedBugCollection getBugCollectionIfSet(IProject project) {
         try {
             return (SortedBugCollection) project.getSessionProperty(SESSION_PROPERTY_BUG_COLLECTION);
@@ -831,7 +830,7 @@ public class FindbugsPlugin extends AbstractUIPlugin {
     }
 
     public static void setProjectSettingsEnabled(IProject project,
-            @CheckForNull IPreferenceStore store, boolean enabled) {
+            @Nullable IPreferenceStore store, boolean enabled) {
         try {
             project.setSessionProperty(SESSION_PROPERTY_SETTINGS_ON, Boolean.valueOf(enabled));
         } catch (CoreException e) {
@@ -854,7 +853,7 @@ public class FindbugsPlugin extends AbstractUIPlugin {
      *
      * @return the preferences for the project or prefs from workspace
      */
-    public static UserPreferences getCorePreferences(@CheckForNull IProject project, boolean forceRead) {
+    public static UserPreferences getCorePreferences(@Nullable IProject project, boolean forceRead) {
         if (project == null || !isProjectSettingsEnabled(project)) {
             // read workspace (user) settings from instance area
             return getWorkspacePreferences();
@@ -874,7 +873,7 @@ public class FindbugsPlugin extends AbstractUIPlugin {
      *
      * @return the preferences for the project or prefs from workspace
      */
-    public static IPreferenceStore getPluginPreferences(@CheckForNull IProject project) {
+    public static IPreferenceStore getPluginPreferences(@Nullable IProject project) {
         if (project == null || !isProjectSettingsEnabled(project)) {
             // read workspace (user) settings from instance area
             return new ScopedPreferenceStore(InstanceScope.INSTANCE, FindbugsPlugin.PLUGIN_ID);

--- a/eclipsePlugin/src/de/tobject/findbugs/FindbugsPlugin.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/FindbugsPlugin.java
@@ -621,8 +621,7 @@ public class FindbugsPlugin extends AbstractUIPlugin {
         project.setSessionProperty(SESSION_PROPERTY_BUG_COLLECTION_DIRTY, isDirty ? Boolean.TRUE : Boolean.FALSE);
     }
 
-    @Nullable
-    public static SortedBugCollection getBugCollectionIfSet(IProject project) {
+    public static @Nullable SortedBugCollection getBugCollectionIfSet(IProject project) {
         try {
             return (SortedBugCollection) project.getSessionProperty(SESSION_PROPERTY_BUG_COLLECTION);
         } catch (CoreException ignored) {

--- a/eclipsePlugin/src/de/tobject/findbugs/actions/MarkerRulerAction.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/actions/MarkerRulerAction.java
@@ -210,8 +210,7 @@ public class MarkerRulerAction implements IEditorActionDelegate, IUpdate, MouseL
      *
      * @return AbstractMarkerAnnotatiosnModel from the editor
      */
-    @Nullable
-    protected AbstractMarkerAnnotationModel getModel() {
+    protected @Nullable AbstractMarkerAnnotationModel getModel() {
         if (editor == null) {
             return null;
         }

--- a/eclipsePlugin/src/de/tobject/findbugs/actions/MarkerRulerAction.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/actions/MarkerRulerAction.java
@@ -64,8 +64,7 @@ public class MarkerRulerAction implements IEditorActionDelegate, IUpdate, MouseL
 
     private IVerticalRulerInfo ruler;
 
-    @Nullable
-    private ITextEditor editor;
+    private @Nullable ITextEditor editor;
 
     /** Contains the markers of the currently selected line in the ruler margin. */
     private final List<IMarker> markers;

--- a/eclipsePlugin/src/de/tobject/findbugs/actions/MarkerRulerAction.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/actions/MarkerRulerAction.java
@@ -21,8 +21,6 @@ package de.tobject.findbugs.actions;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.annotation.CheckForNull;
-
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IResource;
@@ -47,6 +45,7 @@ import org.eclipse.ui.texteditor.IDocumentProvider;
 import org.eclipse.ui.texteditor.ITextEditor;
 import org.eclipse.ui.texteditor.ITextEditorExtension;
 import org.eclipse.ui.texteditor.IUpdate;
+import org.jspecify.annotations.Nullable;
 
 import de.tobject.findbugs.FindbugsPlugin;
 import de.tobject.findbugs.reporter.MarkerUtil;
@@ -65,7 +64,7 @@ public class MarkerRulerAction implements IEditorActionDelegate, IUpdate, MouseL
 
     private IVerticalRulerInfo ruler;
 
-    @CheckForNull
+    @Nullable
     private ITextEditor editor;
 
     /** Contains the markers of the currently selected line in the ruler margin. */
@@ -211,7 +210,7 @@ public class MarkerRulerAction implements IEditorActionDelegate, IUpdate, MouseL
      *
      * @return AbstractMarkerAnnotatiosnModel from the editor
      */
-    @CheckForNull
+    @Nullable
     protected AbstractMarkerAnnotationModel getModel() {
         if (editor == null) {
             return null;

--- a/eclipsePlugin/src/de/tobject/findbugs/builder/ResourceUtils.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/builder/ResourceUtils.java
@@ -324,8 +324,7 @@ public class ResourceUtils {
      *            IResource
      * @return resource object or null
      */
-    @Nullable
-    public static WorkItem getWorkItem(Object element) {
+    public static @Nullable WorkItem getWorkItem(Object element) {
         if (element instanceof IResource) {
             IResource resource = (IResource) element;
             if (resource.getType() == IResource.FILE && !Util.isJavaArtifact(resource) || !resource.isAccessible()) {
@@ -368,8 +367,7 @@ public class ResourceUtils {
      *            IResource
      * @return resource object or null
      */
-    @Nullable
-    public static IResource getResource(Object element) {
+    public static @Nullable IResource getResource(Object element) {
         if (element instanceof IJavaElement) {
             return ((IJavaElement) element).getResource();
         }

--- a/eclipsePlugin/src/de/tobject/findbugs/builder/ResourceUtils.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/builder/ResourceUtils.java
@@ -30,8 +30,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 
-import javax.annotation.CheckForNull;
-
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
@@ -48,6 +46,7 @@ import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.team.internal.core.subscribers.ChangeSet;
 import org.eclipse.ui.IAggregateWorkingSet;
 import org.eclipse.ui.IWorkingSet;
+import org.jspecify.annotations.Nullable;
 
 import de.tobject.findbugs.util.ProjectUtilities;
 import de.tobject.findbugs.util.Util;
@@ -325,7 +324,7 @@ public class ResourceUtils {
      *            IResource
      * @return resource object or null
      */
-    @CheckForNull
+    @Nullable
     public static WorkItem getWorkItem(Object element) {
         if (element instanceof IResource) {
             IResource resource = (IResource) element;
@@ -369,7 +368,7 @@ public class ResourceUtils {
      *            IResource
      * @return resource object or null
      */
-    @javax.annotation.CheckForNull
+    @Nullable
     public static IResource getResource(Object element) {
         if (element instanceof IJavaElement) {
             return ((IJavaElement) element).getResource();

--- a/eclipsePlugin/src/de/tobject/findbugs/builder/WorkItem.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/builder/WorkItem.java
@@ -27,10 +27,6 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.regex.Pattern;
 
-import javax.annotation.CheckForNull;
-import jakarta.annotation.Nonnull;
-import jakarta.annotation.Nullable;
-
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IMarker;
@@ -46,6 +42,8 @@ import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import de.tobject.findbugs.FindbugsPlugin;
 import de.tobject.findbugs.reporter.MarkerUtil;
@@ -227,7 +225,7 @@ public class WorkItem {
         return classNamePattern;
     }
 
-    public @CheckForNull IResource getCorespondingResource() {
+    public @Nullable IResource getCorespondingResource() {
         if (resource != null) {
             return resource;
         }
@@ -246,7 +244,7 @@ public class WorkItem {
         return null;
     }
 
-    public @CheckForNull IJavaElement getCorespondingJavaElement() {
+    public @Nullable IJavaElement getCorespondingJavaElement() {
         if (javaElt != null) {
             return javaElt;
         }
@@ -259,7 +257,7 @@ public class WorkItem {
      *         null. The return value can be absolutely unrelated to the
      *         {@link #getCorespondingResource()}.
      */
-    public @Nonnull IResource getMarkerTarget() {
+    public @NonNull IResource getMarkerTarget() {
         IResource res = getCorespondingResource();
         if (res != null) {
             return res;
@@ -345,7 +343,7 @@ public class WorkItem {
      *         java element (method, inner class etc), results are undefined
      *         yet.
      */
-    public @CheckForNull IPath getPath() {
+    public @Nullable IPath getPath() {
         IResource corespondingResource = getCorespondingResource();
         if (corespondingResource != null) {
             return corespondingResource.getLocation();

--- a/eclipsePlugin/src/de/tobject/findbugs/io/IO.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/io/IO.java
@@ -26,8 +26,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
 
-import jakarta.annotation.Nonnull;
-
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
@@ -35,6 +33,7 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
+import org.jspecify.annotations.NonNull;
 
 import de.tobject.findbugs.FindbugsPlugin;
 
@@ -83,7 +82,7 @@ public abstract class IO {
      *            non null
      * @throws CoreException
      */
-    private static void mkdirs(@Nonnull IResource resource, IProgressMonitor monitor) throws CoreException {
+    private static void mkdirs(@NonNull IResource resource, IProgressMonitor monitor) throws CoreException {
         IContainer container = resource.getParent();
         if (container.getType() == IResource.FOLDER && !container.exists()) {
             if (!container.getParent().exists()) {

--- a/eclipsePlugin/src/de/tobject/findbugs/marker/FindBugsMarker.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/marker/FindBugsMarker.java
@@ -162,8 +162,7 @@ public interface FindBugsMarker {
          *            name as defined by {@link #name()}
          * @return matching confidence, never null
          */
-        @NonNull
-        public static MarkerConfidence getConfidence(int bugPrio) {
+        public static @NonNull MarkerConfidence getConfidence(int bugPrio) {
             Confidence con = Confidence.getConfidence(bugPrio);
             MarkerConfidence[] values = MarkerConfidence.values();
             for (MarkerConfidence mc : values) {
@@ -178,8 +177,7 @@ public interface FindBugsMarker {
          * @param confidence name as defined by {@link #name()}
          * @return matching confidence, never null
          */
-        @NonNull
-        public static MarkerConfidence getConfidence(String confidence) {
+        public static @NonNull MarkerConfidence getConfidence(String confidence) {
             try {
                 return MarkerConfidence.valueOf(confidence);
             } catch (IllegalArgumentException e) {

--- a/eclipsePlugin/src/de/tobject/findbugs/marker/FindBugsMarker.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/marker/FindBugsMarker.java
@@ -20,9 +20,8 @@
 
 package de.tobject.findbugs.marker;
 
-import jakarta.annotation.Nonnull;
-
 import org.eclipse.jdt.core.IJavaElement;
+import org.jspecify.annotations.NonNull;
 
 import edu.umd.cs.findbugs.BugRankCategory;
 import edu.umd.cs.findbugs.annotations.Confidence;
@@ -163,7 +162,7 @@ public interface FindBugsMarker {
          *            name as defined by {@link #name()}
          * @return matching confidence, never null
          */
-        @Nonnull
+        @NonNull
         public static MarkerConfidence getConfidence(int bugPrio) {
             Confidence con = Confidence.getConfidence(bugPrio);
             MarkerConfidence[] values = MarkerConfidence.values();
@@ -179,7 +178,7 @@ public interface FindBugsMarker {
          * @param confidence name as defined by {@link #name()}
          * @return matching confidence, never null
          */
-        @Nonnull
+        @NonNull
         public static MarkerConfidence getConfidence(String confidence) {
             try {
                 return MarkerConfidence.valueOf(confidence);

--- a/eclipsePlugin/src/de/tobject/findbugs/properties/DetectorConfigurationTab.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/properties/DetectorConfigurationTab.java
@@ -677,7 +677,7 @@ public class DetectorConfigurationTab extends Composite {
         return abbr;
     }
 
-    private String @NonNull createBugsAbbreviation(DetectorFactory factory) {
+    private @NonNull String createBugsAbbreviation(DetectorFactory factory) {
         StringBuilder sb = new StringBuilder();
         Collection<BugPattern> patterns = factory.getReportedBugPatterns();
         LinkedHashSet<String> abbrs = new LinkedHashSet<>();

--- a/eclipsePlugin/src/de/tobject/findbugs/properties/DetectorConfigurationTab.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/properties/DetectorConfigurationTab.java
@@ -677,8 +677,7 @@ public class DetectorConfigurationTab extends Composite {
         return abbr;
     }
 
-    @NonNull
-    private String createBugsAbbreviation(DetectorFactory factory) {
+    private String @NonNull createBugsAbbreviation(DetectorFactory factory) {
         StringBuilder sb = new StringBuilder();
         Collection<BugPattern> patterns = factory.getReportedBugPatterns();
         LinkedHashSet<String> abbrs = new LinkedHashSet<>();

--- a/eclipsePlugin/src/de/tobject/findbugs/properties/DetectorConfigurationTab.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/properties/DetectorConfigurationTab.java
@@ -29,8 +29,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
-import jakarta.annotation.Nonnull;
-
 import org.eclipse.core.resources.IProject;
 import org.eclipse.jface.viewers.CheckboxTableViewer;
 import org.eclipse.jface.viewers.IColorProvider;
@@ -59,6 +57,7 @@ import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.swt.widgets.TableItem;
 import org.eclipse.swt.widgets.Text;
+import org.jspecify.annotations.NonNull;
 
 import de.tobject.findbugs.FindbugsPlugin;
 import edu.umd.cs.findbugs.BugPattern;
@@ -678,7 +677,7 @@ public class DetectorConfigurationTab extends Composite {
         return abbr;
     }
 
-    @Nonnull
+    @NonNull
     private String createBugsAbbreviation(DetectorFactory factory) {
         StringBuilder sb = new StringBuilder();
         Collection<BugPattern> patterns = factory.getReportedBugPatterns();

--- a/eclipsePlugin/src/de/tobject/findbugs/properties/DetectorValidator.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/properties/DetectorValidator.java
@@ -21,10 +21,9 @@ package de.tobject.findbugs.properties;
 import java.io.File;
 import java.net.URI;
 
-import jakarta.annotation.Nonnull;
-
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
+import org.jspecify.annotations.NonNull;
 
 import de.tobject.findbugs.FindbugsPlugin;
 import edu.umd.cs.findbugs.Plugin;
@@ -50,7 +49,7 @@ public class DetectorValidator {
         /**
          * @return the sum
          */
-        @Nonnull
+        @NonNull
         public Summary getSummary() {
             return sum;
         }
@@ -70,7 +69,7 @@ public class DetectorValidator {
      *         error status in case anything goes wrong or file at given path is
      *         not considered as a valid plugin.
      */
-    @Nonnull
+    @NonNull
     public ValidationStatus validate(String path) {
         File file = new File(path);
         Summary sum = null;

--- a/eclipsePlugin/src/de/tobject/findbugs/properties/DetectorValidator.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/properties/DetectorValidator.java
@@ -49,8 +49,7 @@ public class DetectorValidator {
         /**
          * @return the sum
          */
-        @NonNull
-        public Summary getSummary() {
+        public @NonNull Summary getSummary() {
             return sum;
         }
     }
@@ -69,8 +68,7 @@ public class DetectorValidator {
      *         error status in case anything goes wrong or file at given path is
      *         not considered as a valid plugin.
      */
-    @NonNull
-    public ValidationStatus validate(String path) {
+    public @NonNull ValidationStatus validate(String path) {
         File file = new File(path);
         Summary sum = null;
         try {

--- a/eclipsePlugin/src/de/tobject/findbugs/properties/FindbugsPropertyPage.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/properties/FindbugsPropertyPage.java
@@ -132,8 +132,7 @@ public class FindbugsPropertyPage extends PropertyPage implements IWorkbenchPref
     private boolean projectPropsInitiallyEnabled;
 
     //  Nonnull if there is a current project
-    @Nullable
-    private ScopedPreferenceStore projectStore;
+    private @Nullable ScopedPreferenceStore projectStore;
 
     /** never null */
     private ScopedPreferenceStore workspaceStore;

--- a/eclipsePlugin/src/de/tobject/findbugs/properties/FindbugsPropertyPage.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/properties/FindbugsPropertyPage.java
@@ -25,9 +25,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import jakarta.annotation.Nonnull;
-import jakarta.annotation.Nullable;
-
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ProjectScope;
 import org.eclipse.core.resources.ResourcesPlugin;
@@ -59,6 +56,8 @@ import org.eclipse.ui.IWorkbenchPreferencePage;
 import org.eclipse.ui.dialogs.PreferencesUtil;
 import org.eclipse.ui.dialogs.PropertyPage;
 import org.eclipse.ui.preferences.ScopedPreferenceStore;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import de.tobject.findbugs.FindBugsJob;
 import de.tobject.findbugs.FindbugsPlugin;
@@ -587,7 +586,7 @@ public class FindbugsPropertyPage extends PropertyPage implements IWorkbenchPref
      * Triggers FB analysis on given project
      * @param myProject opened project with FindBugs nature
      */
-    private static void runBuild(@Nonnull IProject myProject) {
+    private static void runBuild(@NonNull IProject myProject) {
         StructuredSelection selection = new StructuredSelection(myProject);
         FindBugsAction action = new FindBugsAction();
         action.selectionChanged(null, selection);

--- a/eclipsePlugin/src/de/tobject/findbugs/properties/PathElementLabelProvider.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/properties/PathElementLabelProvider.java
@@ -29,7 +29,7 @@ public class PathElementLabelProvider extends LabelProvider implements IColorPro
         return null;
     }
 
-    public String @NonNull getToolTip(Object element) {
+    public @NonNull String getToolTip(Object element) {
         if (!(element instanceof IPathElement)) {
             return "";
         }

--- a/eclipsePlugin/src/de/tobject/findbugs/properties/PathElementLabelProvider.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/properties/PathElementLabelProvider.java
@@ -1,13 +1,12 @@
 package de.tobject.findbugs.properties;
 
-import jakarta.annotation.Nonnull;
-
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.jface.viewers.IColorProvider;
 import org.eclipse.jface.viewers.LabelProvider;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.widgets.Display;
+import org.jspecify.annotations.NonNull;
 
 public class PathElementLabelProvider extends LabelProvider implements IColorProvider {
 
@@ -30,7 +29,7 @@ public class PathElementLabelProvider extends LabelProvider implements IColorPro
         return null;
     }
 
-    @Nonnull
+    @NonNull
     public String getToolTip(Object element) {
         if (!(element instanceof IPathElement)) {
             return "";

--- a/eclipsePlugin/src/de/tobject/findbugs/properties/PathElementLabelProvider.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/properties/PathElementLabelProvider.java
@@ -29,8 +29,7 @@ public class PathElementLabelProvider extends LabelProvider implements IColorPro
         return null;
     }
 
-    @NonNull
-    public String getToolTip(Object element) {
+    public String @NonNull getToolTip(Object element) {
         if (!(element instanceof IPathElement)) {
             return "";
         }

--- a/eclipsePlugin/src/de/tobject/findbugs/reporter/MarkerReporter.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/reporter/MarkerReporter.java
@@ -36,9 +36,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import javax.annotation.CheckForNull;
-import jakarta.annotation.Nonnull;
-
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
@@ -47,6 +44,8 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jface.preference.IPreferenceStore;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import de.tobject.findbugs.FindbugsPlugin;
 import de.tobject.findbugs.marker.FindBugsMarker.MarkerConfidence;
@@ -132,7 +131,7 @@ public class MarkerReporter implements IWorkspaceRunnable {
         newMarker.setAttributes(attributes);
     }
 
-    private static @CheckForNull IMarker findSameBug(Map<String, Object> attributes, IMarker[] existingMarkers) throws CoreException {
+    private static @Nullable IMarker findSameBug(Map<String, Object> attributes, IMarker[] existingMarkers) throws CoreException {
         Object bugId = attributes.get(UNIQUE_ID);
         if (bugId == null) {
             return null;
@@ -160,7 +159,7 @@ public class MarkerReporter implements IWorkspaceRunnable {
      * @return attributes map which should be assigned to the given marker. If the map is empty,
      * the marker shouldn't be generated
      */
-    @Nonnull
+    @NonNull
     private Map<String, Object> createMarkerAttributes(MarkerParameter mp) {
         Map<String, Object> attributes = new HashMap<>(23);
         attributes.put(IMarker.LINE_NUMBER, mp.startLine);

--- a/eclipsePlugin/src/de/tobject/findbugs/reporter/MarkerReporter.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/reporter/MarkerReporter.java
@@ -159,8 +159,7 @@ public class MarkerReporter implements IWorkspaceRunnable {
      * @return attributes map which should be assigned to the given marker. If the map is empty,
      * the marker shouldn't be generated
      */
-    @NonNull
-    private Map<String, Object> createMarkerAttributes(MarkerParameter mp) {
+    private @NonNull Map<String, Object> createMarkerAttributes(MarkerParameter mp) {
         Map<String, Object> attributes = new HashMap<>(23);
         attributes.put(IMarker.LINE_NUMBER, mp.startLine);
         attributes.put(PRIMARY_LINE, mp.primaryLine);

--- a/eclipsePlugin/src/de/tobject/findbugs/reporter/MarkerUtil.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/reporter/MarkerUtil.java
@@ -29,9 +29,6 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.annotation.CheckForNull;
-import jakarta.annotation.Nonnull;
-
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IProject;
@@ -67,6 +64,8 @@ import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.texteditor.ITextEditor;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import de.tobject.findbugs.FindBugsJob;
 import de.tobject.findbugs.FindbugsPlugin;
@@ -275,7 +274,7 @@ public final class MarkerUtil {
      *            the project
      * @return the IResource representing the Java class
      */
-    private static @CheckForNull IJavaElement getJavaElement(BugInstance bug, IJavaProject project) throws JavaModelException {
+    private static @Nullable IJavaElement getJavaElement(BugInstance bug, IJavaProject project) throws JavaModelException {
 
         SourceLineAnnotation primarySourceLineAnnotation = bug.getPrimarySourceLineAnnotation();
         String qualifiedClassName = primarySourceLineAnnotation.getClassName();
@@ -338,7 +337,7 @@ public final class MarkerUtil {
     }
 
     private static void completeFieldInfo(String qualifiedClassName,
-            @Nonnull IType type, @Nonnull BugInstance bug, @Nonnull FieldAnnotation field) {
+            @NonNull IType type, @NonNull BugInstance bug, @NonNull FieldAnnotation field) {
 
         IField ifield = type.getField(field.getFieldName());
         ISourceRange sourceRange = null;
@@ -386,7 +385,7 @@ public final class MarkerUtil {
         return sourceFileStr;
     }
 
-    private static void completeInnerClassInfo(String qualifiedClassName, String innerName, @Nonnull IType type, BugInstance bug)
+    private static void completeInnerClassInfo(String qualifiedClassName, String innerName, @NonNull IType type, BugInstance bug)
             throws JavaModelException {
         int lineNbr = findChildSourceLine(type, innerName, bug);
         if (lineNbr > 0) {
@@ -574,7 +573,7 @@ public final class MarkerUtil {
         job.scheduleInteractive();
     }
 
-    public static @CheckForNull BugCode findBugCodeForMarker(IMarker marker) {
+    public static @Nullable BugCode findBugCodeForMarker(IMarker marker) {
         try {
             Object bugCode = marker.getAttribute(FindBugsMarker.PATTERN_TYPE);
             if (bugCode instanceof String) {
@@ -606,7 +605,7 @@ public final class MarkerUtil {
                 MarkerConfidence.Ignore.name()));
     }
 
-    @CheckForNull
+    @Nullable
     public static BugPattern findBugPatternForMarker(IMarker marker) {
         String patternId = getBugPatternString(marker);
         if (patternId != null) {
@@ -615,7 +614,7 @@ public final class MarkerUtil {
         return null;
     }
 
-    @CheckForNull
+    @Nullable
     public static String getBugPatternString(IMarker marker) {
         try {
             return (String) marker.getAttribute(FindBugsMarker.BUG_TYPE);
@@ -628,7 +627,7 @@ public final class MarkerUtil {
         }
     }
 
-    public static @CheckForNull IJavaElement findJavaElementForMarker(IMarker marker) {
+    public static @Nullable IJavaElement findJavaElementForMarker(IMarker marker) {
         try {
             Object elementId = marker.getAttribute(FindBugsMarker.UNIQUE_JAVA_ID);
             if (elementId instanceof String) {
@@ -644,7 +643,7 @@ public final class MarkerUtil {
         return null;
     }
 
-    public static @CheckForNull Plugin findDetectorPluginFor(IMarker marker) {
+    public static @Nullable Plugin findDetectorPluginFor(IMarker marker) {
         try {
             Object pluginId = marker.getAttribute(FindBugsMarker.DETECTOR_PLUGIN_ID);
             if (pluginId instanceof String) {
@@ -714,7 +713,7 @@ public final class MarkerUtil {
             return bugInstance;
         }
 
-        public BugCollectionAndInstance(@Nonnull BugCollection bugCollection, @Nonnull BugInstance bugInstance) {
+        public BugCollectionAndInstance(@NonNull BugCollection bugCollection, @NonNull BugInstance bugInstance) {
             if (bugCollection == null) {
                 throw new NullPointerException("Null bug collection");
             }
@@ -743,7 +742,7 @@ public final class MarkerUtil {
      * @return the BugInstance associated with the marker, or null if we can't
      *         find the BugInstance
      */
-    public static @CheckForNull BugInstance findBugInstanceForMarker(IMarker marker) {
+    public static @Nullable BugInstance findBugInstanceForMarker(IMarker marker) {
         BugCollectionAndInstance bci = findBugCollectionAndInstanceForMarker(marker);
         if (bci == null) {
             return null;
@@ -759,7 +758,7 @@ public final class MarkerUtil {
      * @return the BugInstance associated with the marker, or null if we can't
      *         find the BugInstance
      */
-    public static @CheckForNull BugCollectionAndInstance findBugCollectionAndInstanceForMarker(IMarker marker) {
+    public static @Nullable BugCollectionAndInstance findBugCollectionAndInstanceForMarker(IMarker marker) {
 
         IResource resource = marker.getResource();
         IProject project = resource.getProject();
@@ -979,8 +978,8 @@ public final class MarkerUtil {
      * @param marker marker to check for plugin id
      * @return detector plugin id, or empty string if the detector plugin is unknown
      */
-    @Nonnull
-    public static String getPluginId(@Nonnull IMarker marker) {
+    @NonNull
+    public static String getPluginId(@NonNull IMarker marker) {
         return marker.getAttribute(FindBugsMarker.DETECTOR_PLUGIN_ID, "");
     }
 
@@ -1002,7 +1001,7 @@ public final class MarkerUtil {
      * @return never null (empty array if nothing there or exception happens).
      *         Exception will be logged
      */
-    @Nonnull
+    @NonNull
     public static IMarker[] getMarkers(IResource fileOrFolder, int depth) {
         if (fileOrFolder.getType() == IResource.PROJECT && !fileOrFolder.isAccessible()) {
             // user just closed the project decorator is working on, avoid exception here

--- a/eclipsePlugin/src/de/tobject/findbugs/reporter/MarkerUtil.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/reporter/MarkerUtil.java
@@ -605,8 +605,7 @@ public final class MarkerUtil {
                 MarkerConfidence.Ignore.name()));
     }
 
-    @Nullable
-    public static BugPattern findBugPatternForMarker(IMarker marker) {
+    public static @Nullable BugPattern findBugPatternForMarker(IMarker marker) {
         String patternId = getBugPatternString(marker);
         if (patternId != null) {
             return DetectorFactoryCollection.instance().lookupBugPattern(patternId);
@@ -614,8 +613,7 @@ public final class MarkerUtil {
         return null;
     }
 
-    @Nullable
-    public static String getBugPatternString(IMarker marker) {
+    public static @Nullable String getBugPatternString(IMarker marker) {
         try {
             return (String) marker.getAttribute(FindBugsMarker.BUG_TYPE);
         } catch (CoreException e) {
@@ -978,8 +976,7 @@ public final class MarkerUtil {
      * @param marker marker to check for plugin id
      * @return detector plugin id, or empty string if the detector plugin is unknown
      */
-    @NonNull
-    public static String getPluginId(@NonNull IMarker marker) {
+    public static @NonNull String getPluginId(@NonNull IMarker marker) {
         return marker.getAttribute(FindBugsMarker.DETECTOR_PLUGIN_ID, "");
     }
 
@@ -1001,8 +998,7 @@ public final class MarkerUtil {
      * @return never null (empty array if nothing there or exception happens).
      *         Exception will be logged
      */
-    @NonNull
-    public static IMarker[] getMarkers(IResource fileOrFolder, int depth) {
+    public static @NonNull IMarker[] getMarkers(IResource fileOrFolder, int depth) {
         if (fileOrFolder.getType() == IResource.PROJECT && !fileOrFolder.isAccessible()) {
             // user just closed the project decorator is working on, avoid exception here
             return EMPTY;

--- a/eclipsePlugin/src/de/tobject/findbugs/reporter/ThrottledProgressMonitor.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/reporter/ThrottledProgressMonitor.java
@@ -2,11 +2,11 @@ package de.tobject.findbugs.reporter;
 
 import java.util.function.LongSupplier;
 
-import jakarta.annotation.Nonnull;
 import javax.annotation.concurrent.NotThreadSafe;
 
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.jspecify.annotations.NonNull;
 
 /**
  * <p>SpotBugs Eclipse Plugin uses {@link IProgressMonitor#setTaskName(String)} to tell what it is working for.
@@ -31,7 +31,7 @@ class ThrottledProgressMonitor implements IProgressMonitor {
     private long lastWorked = NOT_TRIGGERED;
     private int accumulatedWork;
 
-    ThrottledProgressMonitor(@Nonnull IProgressMonitor delegate, @Nonnull LongSupplier currentTimeMillis) {
+    ThrottledProgressMonitor(@NonNull IProgressMonitor delegate, @NonNull LongSupplier currentTimeMillis) {
         Assert.isNotNull(delegate);
         Assert.isNotNull(currentTimeMillis);
 

--- a/eclipsePlugin/src/de/tobject/findbugs/util/ProjectUtilities.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/util/ProjectUtilities.java
@@ -22,14 +22,13 @@ package de.tobject.findbugs.util;
 import java.util.ArrayList;
 import java.util.List;
 
-import jakarta.annotation.Nonnull;
-
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.core.JavaCore;
+import org.jspecify.annotations.NonNull;
 
 import de.tobject.findbugs.FindbugsPlugin;
 
@@ -97,7 +96,7 @@ public class ProjectUtilities {
     /**
      * @return a (possibly empty) list of existing and opened projects with the FindBugs nature
      */
-    @Nonnull
+    @NonNull
     public static List<IProject> getFindBugsProjects() {
         IProject[] projects = ResourcesPlugin.getWorkspace().getRoot().getProjects();
         List<IProject> fbProj = new ArrayList<>();

--- a/eclipsePlugin/src/de/tobject/findbugs/util/ProjectUtilities.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/util/ProjectUtilities.java
@@ -96,8 +96,7 @@ public class ProjectUtilities {
     /**
      * @return a (possibly empty) list of existing and opened projects with the FindBugs nature
      */
-    @NonNull
-    public static List<IProject> getFindBugsProjects() {
+    public static @NonNull List<IProject> getFindBugsProjects() {
         IProject[] projects = ResourcesPlugin.getWorkspace().getRoot().getProjects();
         List<IProject> fbProj = new ArrayList<>();
         for (IProject aProject : projects) {

--- a/eclipsePlugin/src/de/tobject/findbugs/util/Util.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/util/Util.java
@@ -24,8 +24,6 @@ import java.util.Iterator;
 import java.util.Map.Entry;
 import java.util.TreeMap;
 
-import javax.annotation.CheckForNull;
-
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.IAdaptable;
@@ -35,6 +33,7 @@ import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.swt.dnd.Clipboard;
 import org.eclipse.swt.dnd.TextTransfer;
 import org.eclipse.swt.widgets.Display;
+import org.jspecify.annotations.Nullable;
 
 import edu.umd.cs.findbugs.util.Archive;
 
@@ -192,7 +191,7 @@ public class Util {
     }
 
     @SuppressWarnings("unchecked")
-    @CheckForNull
+    @Nullable
     public static <V> V getAdapter(Class<V> adapter, Object obj) {
         if (obj == null) {
             return null;

--- a/eclipsePlugin/src/de/tobject/findbugs/util/Util.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/util/Util.java
@@ -191,8 +191,7 @@ public class Util {
     }
 
     @SuppressWarnings("unchecked")
-    @Nullable
-    public static <V> V getAdapter(Class<V> adapter, Object obj) {
+    public static <V> @Nullable V getAdapter(Class<V> adapter, Object obj) {
         if (obj == null) {
             return null;
         }

--- a/eclipsePlugin/src/de/tobject/findbugs/view/explorer/BugGroup.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/view/explorer/BugGroup.java
@@ -212,13 +212,11 @@ public class BugGroup implements IAdaptable, IActionFilter, Comparable<BugGroup>
         return null;
     }
 
-    @NonNull
-    public GroupType getType() {
+    public @NonNull GroupType getType() {
         return type;
     }
 
-    @Nullable
-    public Object getData() {
+    public @Nullable Object getData() {
         return identifier;
     }
 

--- a/eclipsePlugin/src/de/tobject/findbugs/view/explorer/BugGroup.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/view/explorer/BugGroup.java
@@ -40,14 +40,11 @@ public class BugGroup implements IAdaptable, IActionFilter, Comparable<BugGroup>
 
     private Set<IMarker> allMarkers;
 
-    @Nullable
-    private Object parent;
+    private @Nullable Object parent;
 
-    @Nullable
-    private final Object identifier;
+    private final @Nullable Object identifier;
 
-    @NonNull
-    private final GroupType type;
+    private final @NonNull GroupType type;
 
     public BugGroup(Object parent, Object identifier, @NonNull GroupType type) {
         super();

--- a/eclipsePlugin/src/de/tobject/findbugs/view/explorer/BugGroup.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/view/explorer/BugGroup.java
@@ -21,14 +21,13 @@ package de.tobject.findbugs.view.explorer;
 import java.util.HashSet;
 import java.util.Set;
 
-import javax.annotation.CheckForNull;
-import jakarta.annotation.Nonnull;
-
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.ui.IActionFilter;
 import org.eclipse.ui.views.tasklist.ITaskListResourceAdapter;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 /**
  * @author Andrei
@@ -41,16 +40,16 @@ public class BugGroup implements IAdaptable, IActionFilter, Comparable<BugGroup>
 
     private Set<IMarker> allMarkers;
 
-    @CheckForNull
+    @Nullable
     private Object parent;
 
-    @CheckForNull
+    @Nullable
     private final Object identifier;
 
-    @Nonnull
+    @NonNull
     private final GroupType type;
 
-    public BugGroup(Object parent, Object identifier, @Nonnull GroupType type) {
+    public BugGroup(Object parent, Object identifier, @NonNull GroupType type) {
         super();
         this.parent = parent;
         Assert.isNotNull(type, "Group type cannot be null");
@@ -213,12 +212,12 @@ public class BugGroup implements IAdaptable, IActionFilter, Comparable<BugGroup>
         return null;
     }
 
-    @Nonnull
+    @NonNull
     public GroupType getType() {
         return type;
     }
 
-    @CheckForNull
+    @Nullable
     public Object getData() {
         return identifier;
     }

--- a/eclipsePlugin/src/de/tobject/findbugs/view/explorer/BugLabelProvider.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/view/explorer/BugLabelProvider.java
@@ -25,8 +25,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import javax.annotation.CheckForNull;
-
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
@@ -42,6 +40,7 @@ import org.eclipse.ui.IMemento;
 import org.eclipse.ui.model.WorkbenchLabelProvider;
 import org.eclipse.ui.navigator.ICommonContentExtensionSite;
 import org.eclipse.ui.navigator.ICommonLabelProvider;
+import org.jspecify.annotations.Nullable;
 
 import de.tobject.findbugs.FindbugsPlugin;
 import de.tobject.findbugs.marker.FindBugsMarker.MarkerConfidence;
@@ -64,7 +63,7 @@ public class BugLabelProvider implements /* IStyledLabelProvider, */ ICommonLabe
     }
 
     @Override
-    public @CheckForNull Image getImage(Object element) {
+    public @Nullable Image getImage(Object element) {
         if (element instanceof BugGroup) {
             BugGroup group = (BugGroup) element;
             switch (group.getType()) {

--- a/eclipsePlugin/src/de/tobject/findbugs/view/explorer/Grouping.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/view/explorer/Grouping.java
@@ -48,23 +48,19 @@ public class Grouping {
         return createFrom(order);
     }
 
-    @NonNull
-    public static Grouping createFrom(List<GroupType> types) {
+    public static @NonNull Grouping createFrom(List<GroupType> types) {
         return new Grouping(types);
     }
 
-    @NonNull
-    public List<GroupType> asList() {
+    public @NonNull List<GroupType> asList() {
         return new LinkedList<>(groupOrder);
     }
 
-    @NonNull
-    public GroupType getFirstType() {
+    public @NonNull GroupType getFirstType() {
         return groupOrder.isEmpty() ? GroupType.Undefined : groupOrder.getFirst();
     }
 
-    @NonNull
-    public GroupType getChildType(GroupType parent) {
+    public @NonNull GroupType getChildType(GroupType parent) {
         if (parent == GroupType.Marker) {
             return parent;
         }

--- a/eclipsePlugin/src/de/tobject/findbugs/view/explorer/Grouping.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/view/explorer/Grouping.java
@@ -24,7 +24,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.StringTokenizer;
 
-import jakarta.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 public class Grouping {
 
@@ -48,22 +48,22 @@ public class Grouping {
         return createFrom(order);
     }
 
-    @Nonnull
+    @NonNull
     public static Grouping createFrom(List<GroupType> types) {
         return new Grouping(types);
     }
 
-    @Nonnull
+    @NonNull
     public List<GroupType> asList() {
         return new LinkedList<>(groupOrder);
     }
 
-    @Nonnull
+    @NonNull
     public GroupType getFirstType() {
         return groupOrder.isEmpty() ? GroupType.Undefined : groupOrder.getFirst();
     }
 
-    @Nonnull
+    @NonNull
     public GroupType getChildType(GroupType parent) {
         if (parent == GroupType.Marker) {
             return parent;

--- a/eclipsePlugin/src/edu/umd/cs/findbugs/plugin/eclipse/quickfix/BugResolution.java
+++ b/eclipsePlugin/src/edu/umd/cs/findbugs/plugin/eclipse/quickfix/BugResolution.java
@@ -11,9 +11,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-import javax.annotation.CheckForNull;
-import jakarta.annotation.Nonnull;
-
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IProject;
@@ -44,6 +41,8 @@ import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.texteditor.ITextEditor;
 import org.eclipse.ui.views.markers.WorkbenchMarkerResolution;
 import org.eclipse.ui.views.markers.internal.Util;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import de.tobject.findbugs.FindbugsPlugin;
 import de.tobject.findbugs.reporter.MarkerUtil;
@@ -100,7 +99,7 @@ public abstract class BugResolution extends WorkbenchMarkerResolution {
      * Called on initialization
      * @param options optional arguments
      */
-    public void setOptions(@Nonnull Map<String, String> options) {
+    public void setOptions(@NonNull Map<String, String> options) {
         // noop
     }
 
@@ -116,7 +115,7 @@ public abstract class BugResolution extends WorkbenchMarkerResolution {
      * The visitor is only used to scan once, the result being cached on subsequent visits.
      */
     @Override
-    @Nonnull
+    @NonNull
     public String getLabel() {
         ASTVisitor labelFixingVisitor = getCustomLabelVisitor();
         if (labelFixingVisitor instanceof CustomLabelVisitor) {
@@ -130,7 +129,7 @@ public abstract class BugResolution extends WorkbenchMarkerResolution {
     }
 
 
-    @Nonnull
+    @NonNull
     private String findLabelReplacement(ASTVisitor labelFixingVisitor) {
         IMarker marker = getMarker();
         try {
@@ -156,12 +155,12 @@ public abstract class BugResolution extends WorkbenchMarkerResolution {
      * Override this to give a resolution a custom label.
      * @return
      */
-    @CheckForNull
+    @Nullable
     protected ASTVisitor getCustomLabelVisitor() {
         return null;
     }
 
-    @CheckForNull
+    @Nullable
     protected ASTNode getNodeForMarker(IMarker marker) throws JavaModelException, ASTNodeNotFoundException {
         BugInstance bug = MarkerUtil.findBugInstanceForMarker(marker);
         if (bug == null) {
@@ -213,7 +212,7 @@ public abstract class BugResolution extends WorkbenchMarkerResolution {
         return retVal;
     }
 
-    @CheckForNull
+    @Nullable
     public IProgressMonitor getMonitor() {
         return monitor;
     }
@@ -243,7 +242,7 @@ public abstract class BugResolution extends WorkbenchMarkerResolution {
         //TODO reenable automatically running FindBugs if appropriate
     }
 
-    @CheckForNull
+    @Nullable
     private IRegion completeRewrite(PendingRewrite p) {
         try {
             if (p != null) {
@@ -255,7 +254,7 @@ public abstract class BugResolution extends WorkbenchMarkerResolution {
         return null;
     }
 
-    @CheckForNull
+    @Nullable
     private PendingRewrite resolveWithoutWriting(IMarker marker) {
         requireNonNull(marker, "marker");
         ICompilationUnit originalUnit = null;
@@ -294,7 +293,7 @@ public abstract class BugResolution extends WorkbenchMarkerResolution {
         }
     }
 
-    private CompilationUnit makeOrReuseWorkingCopy(@Nonnull ICompilationUnit originalUnit) throws JavaModelException {
+    private CompilationUnit makeOrReuseWorkingCopy(@NonNull ICompilationUnit originalUnit) throws JavaModelException {
         if (originalUnit.equals(cachedCompilationUnitKey)) {
             return cachedCompilationUnit;
         }
@@ -390,7 +389,7 @@ public abstract class BugResolution extends WorkbenchMarkerResolution {
      * @return The compilation unit for the marker, or null if the file was not
      *         accessible or was not a Java file.
      */
-    @CheckForNull
+    @Nullable
     protected ICompilationUnit getCompilationUnit(IMarker marker) {
         IResource res = marker.getResource();
         if (res instanceof IFile && res.isAccessible()) {
@@ -416,8 +415,8 @@ public abstract class BugResolution extends WorkbenchMarkerResolution {
         MessageDialog.openError(FindbugsPlugin.getShell(), "BugResolution failed.", e.getLocalizedMessage());
     }
 
-    @Nonnull
-    protected final CompilationUnit createWorkingCopy(@Nonnull ICompilationUnit unit) throws JavaModelException {
+    @NonNull
+    protected final CompilationUnit createWorkingCopy(@NonNull ICompilationUnit unit) throws JavaModelException {
         unit.becomeWorkingCopy(monitor);
         ASTParser parser = createAstParser();
         parser.setSource(unit);
@@ -457,12 +456,12 @@ public abstract class BugResolution extends WorkbenchMarkerResolution {
      * @return the bug type we started to work with (can be different on different resolution instances
      * if the resolution class supports multiple bug patterns)
      */
-    @CheckForNull
+    @Nullable
     public String getBugPattern() {
         return bugPattern;
     }
 
-    public void setBugPattern(@Nonnull String pattern) {
+    public void setBugPattern(@NonNull String pattern) {
         Objects.requireNonNull(pattern);
         this.bugPattern = pattern;
     }

--- a/eclipsePlugin/src/edu/umd/cs/findbugs/plugin/eclipse/quickfix/BugResolution.java
+++ b/eclipsePlugin/src/edu/umd/cs/findbugs/plugin/eclipse/quickfix/BugResolution.java
@@ -115,8 +115,7 @@ public abstract class BugResolution extends WorkbenchMarkerResolution {
      * The visitor is only used to scan once, the result being cached on subsequent visits.
      */
     @Override
-    @NonNull
-    public String getLabel() {
+    public @NonNull String getLabel() {
         ASTVisitor labelFixingVisitor = getCustomLabelVisitor();
         if (labelFixingVisitor instanceof CustomLabelVisitor) {
             if (customizedLabel == null) {
@@ -129,8 +128,7 @@ public abstract class BugResolution extends WorkbenchMarkerResolution {
     }
 
 
-    @NonNull
-    private String findLabelReplacement(ASTVisitor labelFixingVisitor) {
+    private @NonNull String findLabelReplacement(ASTVisitor labelFixingVisitor) {
         IMarker marker = getMarker();
         try {
             ASTNode node = getNodeForMarker(marker);
@@ -155,13 +153,11 @@ public abstract class BugResolution extends WorkbenchMarkerResolution {
      * Override this to give a resolution a custom label.
      * @return
      */
-    @Nullable
-    protected ASTVisitor getCustomLabelVisitor() {
+    protected @Nullable ASTVisitor getCustomLabelVisitor() {
         return null;
     }
 
-    @Nullable
-    protected ASTNode getNodeForMarker(IMarker marker) throws JavaModelException, ASTNodeNotFoundException {
+    protected @Nullable ASTNode getNodeForMarker(IMarker marker) throws JavaModelException, ASTNodeNotFoundException {
         BugInstance bug = MarkerUtil.findBugInstanceForMarker(marker);
         if (bug == null) {
             return null;
@@ -212,8 +208,7 @@ public abstract class BugResolution extends WorkbenchMarkerResolution {
         return retVal;
     }
 
-    @Nullable
-    public IProgressMonitor getMonitor() {
+    public @Nullable IProgressMonitor getMonitor() {
         return monitor;
     }
 
@@ -242,8 +237,7 @@ public abstract class BugResolution extends WorkbenchMarkerResolution {
         //TODO reenable automatically running FindBugs if appropriate
     }
 
-    @Nullable
-    private IRegion completeRewrite(PendingRewrite p) {
+    private @Nullable IRegion completeRewrite(PendingRewrite p) {
         try {
             if (p != null) {
                 return rewriteCompilationUnit(p.rewrite, p.doc, p.originalUnit);
@@ -254,8 +248,7 @@ public abstract class BugResolution extends WorkbenchMarkerResolution {
         return null;
     }
 
-    @Nullable
-    private PendingRewrite resolveWithoutWriting(IMarker marker) {
+    private @Nullable PendingRewrite resolveWithoutWriting(IMarker marker) {
         requireNonNull(marker, "marker");
         ICompilationUnit originalUnit = null;
         try {
@@ -389,8 +382,7 @@ public abstract class BugResolution extends WorkbenchMarkerResolution {
      * @return The compilation unit for the marker, or null if the file was not
      *         accessible or was not a Java file.
      */
-    @Nullable
-    protected ICompilationUnit getCompilationUnit(IMarker marker) {
+    protected @Nullable ICompilationUnit getCompilationUnit(IMarker marker) {
         IResource res = marker.getResource();
         if (res instanceof IFile && res.isAccessible()) {
             IJavaElement element = JavaCore.create((IFile) res);
@@ -415,8 +407,7 @@ public abstract class BugResolution extends WorkbenchMarkerResolution {
         MessageDialog.openError(FindbugsPlugin.getShell(), "BugResolution failed.", e.getLocalizedMessage());
     }
 
-    @NonNull
-    protected final CompilationUnit createWorkingCopy(@NonNull ICompilationUnit unit) throws JavaModelException {
+    protected final @NonNull CompilationUnit createWorkingCopy(@NonNull ICompilationUnit unit) throws JavaModelException {
         unit.becomeWorkingCopy(monitor);
         ASTParser parser = createAstParser();
         parser.setSource(unit);
@@ -456,8 +447,7 @@ public abstract class BugResolution extends WorkbenchMarkerResolution {
      * @return the bug type we started to work with (can be different on different resolution instances
      * if the resolution class supports multiple bug patterns)
      */
-    @Nullable
-    public String getBugPattern() {
+    public @Nullable String getBugPattern() {
         return bugPattern;
     }
 

--- a/eclipsePlugin/src/edu/umd/cs/findbugs/plugin/eclipse/quickfix/BugResolutionAssociations.java
+++ b/eclipsePlugin/src/edu/umd/cs/findbugs/plugin/eclipse/quickfix/BugResolutionAssociations.java
@@ -104,8 +104,7 @@ public class BugResolutionAssociations {
         return fixes;
     }
 
-    @Nullable
-    private static BugResolution instantiateBugResolution(QuickFixContribution qf) {
+    private static @Nullable BugResolution instantiateBugResolution(QuickFixContribution qf) {
         try {
             BugResolution br = qf.producer.call();
             br.setLabel(qf.label);

--- a/eclipsePlugin/src/edu/umd/cs/findbugs/plugin/eclipse/quickfix/BugResolutionAssociations.java
+++ b/eclipsePlugin/src/edu/umd/cs/findbugs/plugin/eclipse/quickfix/BugResolutionAssociations.java
@@ -28,11 +28,10 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import javax.annotation.CheckForNull;
-
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.ui.IMarkerResolution;
+import org.jspecify.annotations.Nullable;
 
 import de.tobject.findbugs.FindbugsPlugin;
 
@@ -105,7 +104,7 @@ public class BugResolutionAssociations {
         return fixes;
     }
 
-    @CheckForNull
+    @Nullable
     private static BugResolution instantiateBugResolution(QuickFixContribution qf) {
         try {
             BugResolution br = qf.producer.call();

--- a/eclipsePlugin/src/edu/umd/cs/findbugs/plugin/eclipse/quickfix/CorrectOddnessCheckResolution.java
+++ b/eclipsePlugin/src/edu/umd/cs/findbugs/plugin/eclipse/quickfix/CorrectOddnessCheckResolution.java
@@ -26,8 +26,6 @@ import static java.lang.Integer.parseInt;
 import static org.eclipse.jdt.core.dom.InfixExpression.Operator.EQUALS;
 import static org.eclipse.jdt.core.dom.InfixExpression.Operator.REMAINDER;
 
-import javax.annotation.CheckForNull;
-
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ASTVisitor;
@@ -37,6 +35,7 @@ import org.eclipse.jdt.core.dom.InfixExpression;
 import org.eclipse.jdt.core.dom.NumberLiteral;
 import org.eclipse.jdt.core.dom.ParenthesizedExpression;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
+import org.jspecify.annotations.Nullable;
 
 import edu.umd.cs.findbugs.BugInstance;
 import edu.umd.cs.findbugs.plugin.eclipse.quickfix.exception.BugResolutionException;
@@ -78,14 +77,14 @@ public abstract class CorrectOddnessCheckResolution extends BugResolution {
         rewrite.replace(oddnessCheck, correctOddnessCheck, null);
     }
 
-    @CheckForNull
+    @Nullable
     protected InfixExpression findOddnessCheck(ASTNode node) {
         OddnessCheckFinder finder = new OddnessCheckFinder();
         node.accept(finder);
         return finder.getOddnessCheck();
     }
 
-    @CheckForNull
+    @Nullable
     protected Expression findNumberExpression(InfixExpression oddnessCheck) {
         NumberExpressionFinder finder = new NumberExpressionFinder();
         oddnessCheck.accept(finder);

--- a/eclipsePlugin/src/edu/umd/cs/findbugs/plugin/eclipse/quickfix/CorrectOddnessCheckResolution.java
+++ b/eclipsePlugin/src/edu/umd/cs/findbugs/plugin/eclipse/quickfix/CorrectOddnessCheckResolution.java
@@ -77,15 +77,13 @@ public abstract class CorrectOddnessCheckResolution extends BugResolution {
         rewrite.replace(oddnessCheck, correctOddnessCheck, null);
     }
 
-    @Nullable
-    protected InfixExpression findOddnessCheck(ASTNode node) {
+    protected @Nullable InfixExpression findOddnessCheck(ASTNode node) {
         OddnessCheckFinder finder = new OddnessCheckFinder();
         node.accept(finder);
         return finder.getOddnessCheck();
     }
 
-    @Nullable
-    protected Expression findNumberExpression(InfixExpression oddnessCheck) {
+    protected @Nullable Expression findNumberExpression(InfixExpression oddnessCheck) {
         NumberExpressionFinder finder = new NumberExpressionFinder();
         oddnessCheck.accept(finder);
         return finder.getNumberExpression();

--- a/eclipsePlugin/src/edu/umd/cs/findbugs/plugin/eclipse/quickfix/CreateDoPrivilegedBlockResolution.java
+++ b/eclipsePlugin/src/edu/umd/cs/findbugs/plugin/eclipse/quickfix/CreateDoPrivilegedBlockResolution.java
@@ -375,15 +375,13 @@ public class CreateDoPrivilegedBlockResolution extends BugResolution {
         return methodBody;
     }
 
-    @Nullable
-    private ClassInstanceCreation findClassLoaderCreation(ASTNode node) {
+    private @Nullable ClassInstanceCreation findClassLoaderCreation(ASTNode node) {
         ClassLoaderCreationFinder finder = new ClassLoaderCreationFinder();
         node.accept(finder);
         return finder.getClassLoaderCreation();
     }
 
-    @Nullable
-    private MethodDeclaration findMethodDeclaration(ASTNode node) {
+    private @Nullable MethodDeclaration findMethodDeclaration(ASTNode node) {
         if (node == null || node instanceof MethodDeclaration) {
             return (MethodDeclaration) node;
         }

--- a/eclipsePlugin/src/edu/umd/cs/findbugs/plugin/eclipse/quickfix/CreateDoPrivilegedBlockResolution.java
+++ b/eclipsePlugin/src/edu/umd/cs/findbugs/plugin/eclipse/quickfix/CreateDoPrivilegedBlockResolution.java
@@ -35,8 +35,6 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
-import javax.annotation.CheckForNull;
-
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
@@ -65,6 +63,7 @@ import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
 import org.eclipse.jdt.core.dom.VariableDeclarationStatement;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 import org.eclipse.jdt.core.dom.rewrite.ListRewrite;
+import org.jspecify.annotations.Nullable;
 
 import edu.umd.cs.findbugs.BugInstance;
 import edu.umd.cs.findbugs.plugin.eclipse.quickfix.exception.BugResolutionException;
@@ -376,14 +375,14 @@ public class CreateDoPrivilegedBlockResolution extends BugResolution {
         return methodBody;
     }
 
-    @CheckForNull
+    @Nullable
     private ClassInstanceCreation findClassLoaderCreation(ASTNode node) {
         ClassLoaderCreationFinder finder = new ClassLoaderCreationFinder();
         node.accept(finder);
         return finder.getClassLoaderCreation();
     }
 
-    @CheckForNull
+    @Nullable
     private MethodDeclaration findMethodDeclaration(ASTNode node) {
         if (node == null || node instanceof MethodDeclaration) {
             return (MethodDeclaration) node;

--- a/eclipsePlugin/src/edu/umd/cs/findbugs/plugin/eclipse/quickfix/CreateSuperCallResolution.java
+++ b/eclipsePlugin/src/edu/umd/cs/findbugs/plugin/eclipse/quickfix/CreateSuperCallResolution.java
@@ -26,8 +26,6 @@ import static edu.umd.cs.findbugs.plugin.eclipse.quickfix.util.ASTUtil.getTypeDe
 
 import java.util.Map;
 
-import jakarta.annotation.Nonnull;
-
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.Block;
@@ -39,6 +37,7 @@ import org.eclipse.jdt.core.dom.SuperMethodInvocation;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 import org.eclipse.jdt.core.dom.rewrite.ListRewrite;
+import org.jspecify.annotations.NonNull;
 
 import edu.umd.cs.findbugs.BugInstance;
 import edu.umd.cs.findbugs.plugin.eclipse.quickfix.exception.BugResolutionException;
@@ -72,7 +71,7 @@ public class CreateSuperCallResolution extends BugResolution {
      * @param options optional arguments
      */
     @Override
-    public void setOptions(@Nonnull Map<String, String> options) {
+    public void setOptions(@NonNull Map<String, String> options) {
         insertFirst = Boolean.parseBoolean(options.get("insertFirst"));
     }
 

--- a/eclipsePlugin/src/edu/umd/cs/findbugs/plugin/eclipse/quickfix/CustomLabelVisitor.java
+++ b/eclipsePlugin/src/edu/umd/cs/findbugs/plugin/eclipse/quickfix/CustomLabelVisitor.java
@@ -17,7 +17,7 @@
  */
 package edu.umd.cs.findbugs.plugin.eclipse.quickfix;
 
-import javax.annotation.CheckForNull;
+import org.jspecify.annotations.Nullable;
 
 /**
  * This visitor should traverse the AST as much as needed to determine if a proposed resolution
@@ -36,6 +36,6 @@ public interface CustomLabelVisitor {
      *
      * @return the string that should replace YYY in the label to make a complete message.
      */
-    @CheckForNull
+    @Nullable
     String getLabelReplacement();
 }

--- a/eclipsePlugin/src/edu/umd/cs/findbugs/plugin/eclipse/quickfix/QuickFixContribution.java
+++ b/eclipsePlugin/src/edu/umd/cs/findbugs/plugin/eclipse/quickfix/QuickFixContribution.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
 
-import jakarta.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 public class QuickFixContribution {
     private static final int PRIME = 31;
@@ -39,8 +39,8 @@ public class QuickFixContribution {
 
     final Map<String, String> args;
 
-    public QuickFixContribution(@Nonnull String clazzFqn, @Nonnull String label, @Nonnull String pattern,
-            @Nonnull Set<String> args, @Nonnull Callable<BugResolution> producer) {
+    public QuickFixContribution(@NonNull String clazzFqn, @NonNull String label, @NonNull String pattern,
+            @NonNull Set<String> args, @NonNull Callable<BugResolution> producer) {
         this.clazzFqn = clazzFqn;
         this.label = label;
         this.pattern = pattern;

--- a/eclipsePlugin/src/edu/umd/cs/findbugs/plugin/eclipse/quickfix/UseValueOfResolution.java
+++ b/eclipsePlugin/src/edu/umd/cs/findbugs/plugin/eclipse/quickfix/UseValueOfResolution.java
@@ -88,8 +88,7 @@ public class UseValueOfResolution extends BugResolution {
         rewrite.replace(primitiveTypeCreation, valueOfInvocation, null);
     }
 
-    @Nullable
-    protected ClassInstanceCreation findPrimitiveTypeCreation(ASTNode node) {
+    protected @Nullable ClassInstanceCreation findPrimitiveTypeCreation(ASTNode node) {
         PrimitiveTypeCreationFinder visitor = new PrimitiveTypeCreationFinder();
         node.accept(visitor);
         return visitor.getPrimitiveTypeCreation();

--- a/eclipsePlugin/src/edu/umd/cs/findbugs/plugin/eclipse/quickfix/UseValueOfResolution.java
+++ b/eclipsePlugin/src/edu/umd/cs/findbugs/plugin/eclipse/quickfix/UseValueOfResolution.java
@@ -28,9 +28,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import javax.annotation.CheckForNull;
-import jakarta.annotation.Nonnull;
-
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
@@ -41,6 +38,8 @@ import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.MethodInvocation;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import edu.umd.cs.findbugs.BugInstance;
 import edu.umd.cs.findbugs.plugin.eclipse.quickfix.exception.BugResolutionException;
@@ -89,7 +88,7 @@ public class UseValueOfResolution extends BugResolution {
         rewrite.replace(primitiveTypeCreation, valueOfInvocation, null);
     }
 
-    @CheckForNull
+    @Nullable
     protected ClassInstanceCreation findPrimitiveTypeCreation(ASTNode node) {
         PrimitiveTypeCreationFinder visitor = new PrimitiveTypeCreationFinder();
         node.accept(visitor);
@@ -133,7 +132,7 @@ public class UseValueOfResolution extends BugResolution {
     }
 
     @Override
-    public void setOptions(@Nonnull Map<String, String> options) {
+    public void setOptions(@NonNull Map<String, String> options) {
         // This setup (having two separate plugin.xml entries) is done to show off the
         // ApplicabilityVisitor, although it could be done without, just by having a
         // slightly fancier (and uglier) getLabelReplacement()

--- a/eclipsePlugin/src/edu/umd/cs/findbugs/plugin/eclipse/quickfix/util/ASTUtil.java
+++ b/eclipsePlugin/src/edu/umd/cs/findbugs/plugin/eclipse/quickfix/util/ASTUtil.java
@@ -402,8 +402,7 @@ public class ASTUtil {
         return statement;
     }
 
-    @Nullable
-    protected static ASTNode searchASTNode(CompilationUnit compilationUnit, int startLine, int endLine) {
+    protected static @Nullable ASTNode searchASTNode(CompilationUnit compilationUnit, int startLine, int endLine) {
         Assert.isNotNull(compilationUnit);
         isTrue(startLine <= endLine);
 
@@ -412,8 +411,7 @@ public class ASTUtil {
         return visitor.getASTNode();
     }
 
-    @Nullable
-    protected static TypeDeclaration searchTypeDeclaration(List<?> declarations, String typeName) {
+    protected static @Nullable TypeDeclaration searchTypeDeclaration(List<?> declarations, String typeName) {
         Assert.isNotNull(declarations);
         Assert.isNotNull(typeName);
 
@@ -440,8 +438,7 @@ public class ASTUtil {
         return null;
     }
 
-    @Nullable
-    protected static MethodDeclaration searchMethodDeclaration(AST ast, MethodDeclaration[] methods, String methodName,
+    protected static @Nullable MethodDeclaration searchMethodDeclaration(AST ast, MethodDeclaration[] methods, String methodName,
             String methodSignature) {
         Assert.isNotNull(methods);
         Assert.isNotNull(methodName);
@@ -460,8 +457,7 @@ public class ASTUtil {
         return null;
     }
 
-    @Nullable
-    protected static Statement searchStatement(CompilationUnit compilationUnit, List<?> statements, int startLine, int endLine) {
+    protected static @Nullable Statement searchStatement(CompilationUnit compilationUnit, List<?> statements, int startLine, int endLine) {
         Assert.isNotNull(compilationUnit);
         Assert.isNotNull(statements);
 

--- a/eclipsePlugin/src/edu/umd/cs/findbugs/plugin/eclipse/quickfix/util/ASTUtil.java
+++ b/eclipsePlugin/src/edu/umd/cs/findbugs/plugin/eclipse/quickfix/util/ASTUtil.java
@@ -34,8 +34,6 @@ import java.util.Objects;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
-import javax.annotation.CheckForNull;
-
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
@@ -56,6 +54,7 @@ import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 import org.eclipse.jdt.core.dom.rewrite.ListRewrite;
+import org.jspecify.annotations.Nullable;
 
 import edu.umd.cs.findbugs.ClassAnnotation;
 import edu.umd.cs.findbugs.FieldAnnotation;
@@ -403,7 +402,7 @@ public class ASTUtil {
         return statement;
     }
 
-    @CheckForNull
+    @Nullable
     protected static ASTNode searchASTNode(CompilationUnit compilationUnit, int startLine, int endLine) {
         Assert.isNotNull(compilationUnit);
         isTrue(startLine <= endLine);
@@ -413,7 +412,7 @@ public class ASTUtil {
         return visitor.getASTNode();
     }
 
-    @CheckForNull
+    @Nullable
     protected static TypeDeclaration searchTypeDeclaration(List<?> declarations, String typeName) {
         Assert.isNotNull(declarations);
         Assert.isNotNull(typeName);
@@ -441,7 +440,7 @@ public class ASTUtil {
         return null;
     }
 
-    @CheckForNull
+    @Nullable
     protected static MethodDeclaration searchMethodDeclaration(AST ast, MethodDeclaration[] methods, String methodName,
             String methodSignature) {
         Assert.isNotNull(methods);
@@ -461,7 +460,7 @@ public class ASTUtil {
         return null;
     }
 
-    @CheckForNull
+    @Nullable
     protected static Statement searchStatement(CompilationUnit compilationUnit, List<?> statements, int startLine, int endLine) {
         Assert.isNotNull(compilationUnit);
         Assert.isNotNull(statements);


### PR DESCRIPTION
No change log added due to

* No runtime behavior change.
* No user-facing feature or bug fix.
* No API change intended.
* JSpecify is compileOnly.
* Removing jakarta.annotation-api from the EclipsePlugin build doesn't change what users experience.