### PR TITLE
chore(migrate): migrate EclipsePlugin from jsr305 NotThreadSafe to jcip NotThreadSafe 

### DIFF
--- a/eclipsePlugin/src/de/tobject/findbugs/reporter/ThrottledProgressMonitor.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/reporter/ThrottledProgressMonitor.java
@@ -2,11 +2,11 @@ package de.tobject.findbugs.reporter;
 
 import java.util.function.LongSupplier;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.jspecify.annotations.NonNull;
+
+import net.jcip.annotations.NotThreadSafe;
 
 /**
  * <p>SpotBugs Eclipse Plugin uses {@link IProgressMonitor#setTaskName(String)} to tell what it is working for.


### PR DESCRIPTION
no change log added as build only.  moved to this annotation to get off jsr305 as last one using it in this module.  since spotbugs still is using jsr305, the actual eclipse plugin will still result in containing it for now as it does with jcip already.