### PR TITLE
chore(cleanup): Update deprecation on PossiblyNull to inform user to use modern Jspecify Nullable

### DIFF
--- a/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/PossiblyNull.java
+++ b/spotbugs-annotations/src/main/java/edu/umd/cs/findbugs/annotations/PossiblyNull.java
@@ -28,15 +28,13 @@ import javax.annotation.meta.TypeQualifierNickname;
 import javax.annotation.meta.When;
 
 /**
- * The annotated element should might be null, and uses of the element should
+ * The annotated element might be null, and uses of the element should
  * check for null.
  *
  * When this annotation is applied to a method it applies to the method return
  * value.
  *
- * @deprecated - use CheckForNull instead; the name of which more clearly
- *             indicates that not only could the value be null, but that good
- *             coding practice requires that the value be checked for null.
+ * @deprecated Use {@code org.jspecify.annotations.Nullable} instead.
  */
 @Documented
 @Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE })


### PR DESCRIPTION
no change log, document guidance change in javadoc only along with fix to wording.